### PR TITLE
Linux fix: classify traps and forward signals on resume

### DIFF
--- a/internal/debugger/backend.go
+++ b/internal/debugger/backend.go
@@ -30,6 +30,22 @@ type pidSetter interface {
 	setPID(pid int)
 }
 
+// signalResumer is an optional Backend capability for platforms (Linux) where
+// ptrace resume commands are restricted to the tracer thread — the engine's
+// event-loop goroutine — and therefore cannot be issued from the wait
+// goroutine. When a real (non-trap) signal stops the tracee, Wait returns a
+// StopSignal event and the engine calls ResumeSignal from its own goroutine to
+// re-step or continue, forwarding or deferring the signal. Backends whose
+// ptrace is process-wide (Darwin/Mach) don't implement this; the engine falls
+// back to a plain continue for them.
+type signalResumer interface {
+	// ResumeSignal resumes tracee thread tid after a non-trap signal. When
+	// stepping is true the tracee was mid single-step and must be re-stepped
+	// (fault signals delivered on the step, async signals deferred to the next
+	// continue); otherwise the signal is forwarded on a plain continue.
+	ResumeSignal(tid, signal int, stepping bool) error
+}
+
 func setPID(b Backend, pid int) {
 	if ps, ok := b.(pidSetter); ok {
 		ps.setPID(pid)
@@ -52,6 +68,7 @@ type StopEvent struct {
 	Reason   StopReason
 	TID      int
 	PC       uint64
-	ExitCode int // StopExited only
-	Signal   int // StopSignal only
+	ExitCode int  // StopExited only
+	Signal   int  // StopSignal only
+	Stepping bool // StopSignal only: the signal interrupted an in-flight single-step
 }

--- a/internal/debugger/backend.go
+++ b/internal/debugger/backend.go
@@ -30,20 +30,28 @@ type pidSetter interface {
 	setPID(pid int)
 }
 
-// signalResumer is an optional Backend capability for platforms (Linux) where
+// ptraceResumer is an optional Backend capability for platforms (Linux) where
 // ptrace resume commands are restricted to the tracer thread — the engine's
 // event-loop goroutine — and therefore cannot be issued from the wait
-// goroutine. When a real (non-trap) signal stops the tracee, Wait returns a
-// StopSignal event and the engine calls ResumeSignal from its own goroutine to
-// re-step or continue, forwarding or deferring the signal. Backends whose
-// ptrace is process-wide (Darwin/Mach) don't implement this; the engine falls
-// back to a plain continue for them.
-type signalResumer interface {
-	// ResumeSignal resumes tracee thread tid after a non-trap signal. When
-	// stepping is true the tracee was mid single-step and must be re-stepped
-	// (fault signals delivered on the step, async signals deferred to the next
-	// continue); otherwise the signal is forwarded on a plain continue.
+// goroutine. When Wait observes a stop that needs a ptrace resume (a real
+// signal, or a clone/thread lifecycle event under PTRACE_O_TRACECLONE), it
+// hands the stop back to the engine, which calls back here from its own
+// goroutine. Backends whose ptrace is process-wide (Darwin/Mach) don't
+// implement this; the engine falls back to a plain continue for them.
+type ptraceResumer interface {
+	// ResumeSignal resumes tracee thread tid after a non-trap signal that
+	// interrupted the single-step we issued. Fault signals are delivered on the
+	// re-step, async signals (SIGURG) are deferred to the next continue.
 	ResumeSignal(tid, signal int, stepping bool) error
+
+	// ResumeThread resumes a thread stopped for a clone/thread lifecycle event
+	// (a freshly cloned thread's initial SIGSTOP, a PTRACE_EVENT stop, or a
+	// signal delivered to a non-debug thread). signal is forwarded to the
+	// thread (0 for lifecycle stops); a bare SIGSTOP is never re-delivered.
+	// Keeping every tracee thread traced means a goroutine that migrated onto a
+	// fresh OS thread and hits a breakpoint there is caught, not lost to a
+	// runtime crash.
+	ResumeThread(tid, signal int) error
 }
 
 func setPID(b Backend, pid int) {
@@ -60,6 +68,11 @@ const (
 	StopSignal                       // any other signal
 	StopExited                       // process exit()
 	StopKilled                       // killed externally
+	// StopThreadEvent is internal to the Linux backend: a clone/thread
+	// lifecycle stop (new-thread SIGSTOP, PTRACE_EVENT_*, or a signal delivered
+	// to a non-debug thread) that the engine must resume from its tracer
+	// goroutine via ptraceResumer.ResumeThread. It never surfaces to clients.
+	StopThreadEvent
 )
 
 // StopEvent is what Backend.Wait returns. PC may be zero; the engine resolves
@@ -69,6 +82,6 @@ type StopEvent struct {
 	TID      int
 	PC       uint64
 	ExitCode int  // StopExited only
-	Signal   int  // StopSignal only
+	Signal   int  // StopSignal / StopThreadEvent: signal to forward on resume
 	Stepping bool // StopSignal only: the signal interrupted an in-flight single-step
 }

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -18,6 +18,13 @@ type linuxBackend struct {
 	pid         int
 	stepping    bool // true after SingleStep; classifies the next SIGTRAP
 	lastStopTID int
+
+	// delayedSignal holds a non-fault signal (e.g. SIGURG async preemption)
+	// observed mid-single-step. It is deferred and injected on the next
+	// ContinueProcess/SingleStep rather than dropped. Mirrors Delve's
+	// nativeThread.delayedSignal / resumeWithSig so signals are forwarded to
+	// the tracee instead of being swallowed.
+	delayedSignal int
 }
 
 const linuxPtraceOptions = syscall.PTRACE_O_TRACEEXIT |
@@ -89,17 +96,21 @@ func isAlreadyExited(err error) bool {
 
 func (b *linuxBackend) ContinueProcess() error {
 	b.stepping = false
+	sig := b.delayedSignal
+	b.delayedSignal = 0
 	tid := b.traceTID()
-	if err := syscall.PtraceCont(tid, 0); err != nil {
-		return fmt.Errorf("PTRACE_CONT tid %d: %w", tid, err)
+	if err := syscall.PtraceCont(tid, sig); err != nil {
+		return fmt.Errorf("PTRACE_CONT tid %d (sig %d): %w", tid, sig, err)
 	}
 	return nil
 }
 
 func (b *linuxBackend) SingleStep(tid int) error {
 	b.stepping = true
-	if err := syscall.PtraceSingleStep(tid); err != nil {
-		return fmt.Errorf("PTRACE_SINGLESTEP tid %d: %w", tid, err)
+	sig := b.delayedSignal
+	b.delayedSignal = 0
+	if err := ptraceSingleStepSig(tid, sig); err != nil {
+		return fmt.Errorf("PTRACE_SINGLESTEP tid %d (sig %d): %w", tid, sig, err)
 	}
 	return nil
 }
@@ -290,34 +301,49 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 			continue
 		}
 
-		// SIGURG is Go's goroutine-preemption signal; SIGCONT may be injected
-		// above to release clone-child SIGSTOP. Both should stay transparent.
-		if sig == syscall.SIGURG {
-			if b.stepping {
-				if err := singleStepIfTraceeExists(tid); err != nil {
-					return StopEvent{}, fmt.Errorf("PTRACE_SINGLESTEP after SIGURG tid %d: %w", tid, err)
+		// Any non-SIGTRAP stop is a real signal delivered to the tracee.
+		// Forward it instead of swallowing it (Delve's resumeWithSig /
+		// singleStep). Dropping a synchronous fault (SIGSEGV/SIGBUS/... from
+		// e.g. the Go runtime's nil-check machinery) makes the faulting
+		// instruction re-execute forever and wedges the tracee; dropping
+		// SIGURG breaks Go's async goroutine preemption.
+		if b.stepping {
+			// Mid single-step: classify like Delve's singleStep() loop.
+			switch sig {
+			case syscall.SIGILL, syscall.SIGBUS, syscall.SIGFPE, syscall.SIGSEGV, syscall.SIGSTKFLT:
+				// Fault triggered by the instruction being stepped: re-issue
+				// the step WITH the signal so the tracee's handler observes it.
+				if err := singleStepSig(tid, int(sig)); err != nil {
+					return StopEvent{}, fmt.Errorf("PTRACE_SINGLESTEP fault %d tid %d: %w", sig, tid, err)
 				}
-			} else {
-				if err := continueIfTraceeExists(tid, int(sig)); err != nil {
-					return StopEvent{}, fmt.Errorf("PTRACE_CONT SIGURG tid %d: %w", tid, err)
+			case syscall.SIGSTOP:
+				// Spurious/late SIGSTOP: swallow it and keep stepping.
+				if err := singleStepSig(tid, 0); err != nil {
+					return StopEvent{}, fmt.Errorf("PTRACE_SINGLESTEP after SIGSTOP tid %d: %w", tid, err)
+				}
+			default:
+				// Asynchronous signal (SIGURG preemption, SIGCHLD, ...): defer
+				// delivery to the next resume and keep stepping so the trap PC
+				// is not perturbed by entering a signal handler mid-step.
+				b.delayedSignal = int(sig)
+				if err := singleStepSig(tid, 0); err != nil {
+					return StopEvent{}, fmt.Errorf("PTRACE_SINGLESTEP deferring %d tid %d: %w", sig, tid, err)
 				}
 			}
 			continue
 		}
 
-		if sig == syscall.SIGCONT {
-			if err := continueIfTraceeExists(tid, 0); err != nil {
-				return StopEvent{}, fmt.Errorf("PTRACE_CONT SIGCONT tid %d: %w", tid, err)
-			}
-			continue
+		// Running (continue): forward the signal transparently so the tracee's
+		// own handlers/runtime see it. Never re-deliver a bare SIGSTOP — it
+		// would immediately re-stop the thread.
+		forward := int(sig)
+		if sig == syscall.SIGSTOP {
+			forward = 0
 		}
-
-		b.recordStop(tid)
-		return StopEvent{
-			Reason: StopSignal,
-			TID:    tid,
-			Signal: int(sig),
-		}, nil
+		if err := continueIfTraceeExists(tid, forward); err != nil {
+			return StopEvent{}, fmt.Errorf("PTRACE_CONT forwarding signal %d tid %d: %w", sig, tid, err)
+		}
+		continue
 	}
 }
 
@@ -393,11 +419,23 @@ func taskTIDs(pid int) ([]int, error) {
 	return tids, nil
 }
 
-func singleStepIfTraceeExists(tid int) error {
+// ptraceSingleStepSig issues PTRACE_SINGLESTEP delivering signal sig to the
+// tracee (the syscall.PtraceSingleStep wrapper always passes signal 0, which
+// would drop a pending signal). Mirrors Delve's ptraceSingleStep(pid, sig).
+func ptraceSingleStepSig(tid, sig int) error {
+	_, _, errno := syscall.Syscall6(syscall.SYS_PTRACE,
+		uintptr(syscall.PTRACE_SINGLESTEP), uintptr(tid), 0, uintptr(sig), 0, 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func singleStepSig(tid, sig int) error {
 	if tid == 0 {
 		return nil
 	}
-	if err := syscall.PtraceSingleStep(tid); err != nil && !isNoSuchProcess(err) {
+	if err := ptraceSingleStepSig(tid, sig); err != nil && !isNoSuchProcess(err) {
 		return err
 	}
 	return nil

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -5,10 +5,22 @@ package debugger
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
+	"sync/atomic"
 	"syscall"
 )
+
+// E2EDBG temporary instrumentation (removed before final). Logs at Info so it
+// surfaces in CI without BINGO_E2E_DEBUG. Capped to avoid flooding on livelock.
+var dbgWaitN atomic.Int64
+
+func dbgLog(msg string, args ...any) {
+	if dbgWaitN.Add(1) <= 600 {
+		slog.Info("E2EDBG "+msg, args...)
+	}
+}
 
 func newBackend() Backend {
 	return &linuxBackend{}
@@ -99,6 +111,7 @@ func (b *linuxBackend) ContinueProcess() error {
 	sig := b.delayedSignal
 	b.delayedSignal = 0
 	tid := b.traceTID()
+	dbgLog("ContinueProcess", "tid", tid, "sig", sig)
 	if err := syscall.PtraceCont(tid, sig); err != nil {
 		return fmt.Errorf("PTRACE_CONT tid %d (sig %d): %w", tid, sig, err)
 	}
@@ -109,6 +122,7 @@ func (b *linuxBackend) SingleStep(tid int) error {
 	b.stepping = true
 	sig := b.delayedSignal
 	b.delayedSignal = 0
+	dbgLog("SingleStep", "tid", tid, "sig", sig)
 	if err := ptraceSingleStepSig(tid, sig); err != nil {
 		return fmt.Errorf("PTRACE_SINGLESTEP tid %d (sig %d): %w", tid, sig, err)
 	}
@@ -207,6 +221,10 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 		var ws syscall.WaitStatus
 		// WALL includes clone()d threads.
 		tid, err := syscall.Wait4(-1, &ws, syscall.WALL, nil)
+		dbgLog("wait4 return", "tid", tid, "err", err, "raw", uint32(ws),
+			"stopped", ws.Stopped(), "stopsig", int(ws.StopSignal()),
+			"cause", ws.TrapCause(), "exited", ws.Exited(),
+			"signaled", ws.Signaled(), "stepping", b.stepping, "pid", b.pid)
 		if err != nil {
 			if isNoChildProcess(err) {
 				return StopEvent{Reason: StopExited, TID: b.pid}, nil
@@ -272,9 +290,11 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 
 				if b.stepping {
 					b.stepping = false
+					dbgLog("-> StopSingleStep", "tid", tid)
 					return StopEvent{Reason: StopSingleStep, TID: tid}, nil
 				}
 
+				dbgLog("-> StopBreakpoint", "tid", tid)
 				return StopEvent{
 					Reason: StopBreakpoint,
 					TID:    tid,
@@ -309,6 +329,7 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 		// SIGURG breaks Go's async goroutine preemption.
 		if b.stepping {
 			// Mid single-step: classify like Delve's singleStep() loop.
+			dbgLog("signal mid-step", "tid", tid, "sig", int(sig))
 			switch sig {
 			case syscall.SIGILL, syscall.SIGBUS, syscall.SIGFPE, syscall.SIGSEGV, syscall.SIGSTKFLT:
 				// Fault triggered by the instruction being stepped: re-issue
@@ -340,6 +361,7 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 		if sig == syscall.SIGSTOP {
 			forward = 0
 		}
+		dbgLog("signal running-forward", "tid", tid, "sig", int(sig), "forward", forward)
 		if err := continueIfTraceeExists(tid, forward); err != nil {
 			return StopEvent{}, fmt.Errorf("PTRACE_CONT forwarding signal %d tid %d: %w", sig, tid, err)
 		}

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -5,22 +5,10 @@ package debugger
 import (
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"os/exec"
-	"sync/atomic"
 	"syscall"
 )
-
-// E2EDBG temporary instrumentation (removed before final). Logs at Info so it
-// surfaces in CI without BINGO_E2E_DEBUG. Capped to avoid flooding on livelock.
-var dbgWaitN atomic.Int64
-
-func dbgLog(msg string, args ...any) {
-	if dbgWaitN.Add(1) <= 600 {
-		slog.Info("E2EDBG "+msg, args...)
-	}
-}
 
 func newBackend() Backend {
 	return &linuxBackend{}
@@ -119,7 +107,6 @@ func (b *linuxBackend) ContinueProcess() error {
 	sig := b.delayedSignal
 	b.delayedSignal = 0
 	tid := b.traceTID()
-	dbgLog("ContinueProcess", "tid", tid, "sig", sig)
 	if err := syscall.PtraceCont(tid, sig); err != nil {
 		return fmt.Errorf("PTRACE_CONT tid %d (sig %d): %w", tid, sig, err)
 	}
@@ -129,7 +116,6 @@ func (b *linuxBackend) ContinueProcess() error {
 func (b *linuxBackend) SingleStep(tid int) error {
 	b.stepping = true
 	b.stepTID = tid
-	dbgLog("SingleStep", "tid", tid)
 	if err := ptraceSingleStepSig(tid, 0); err != nil {
 		return fmt.Errorf("PTRACE_SINGLESTEP tid %d: %w", tid, err)
 	}
@@ -217,10 +203,14 @@ func (b *linuxBackend) Threads() ([]int, error) {
 	return tids, nil
 }
 
-// Wait blocks until the tracee produces a meaningful debug stop. Single-step
-// vs breakpoint disambiguation uses b.stepping (reliable because ptrace is
-// serialised). PTRACE_EVENT stops (clone/exec/exit) are handled internally
-// and don't surface to the engine.
+// Wait blocks until the tracee produces a debug stop and classifies it. The
+// single-step SIGTRAP is disambiguated from a breakpoint (INT3) SIGTRAP by
+// stepTID (the thread the step was issued against). Stops that require a ptrace
+// resume from the tracer goroutine — clone/thread lifecycle events and signals
+// delivered to non-debug threads — are handed back as StopThreadEvent (or a
+// mid-step StopSignal); the engine resumes them via ptraceResumer. Wait itself
+// only reaps exited/killed siblings and never issues a ptrace resume, since
+// PTRACE_CONT/SINGLESTEP from this (non-tracer) goroutine would return ESRCH.
 //
 //nolint:gocognit,gocyclo // The wait loop is one serialized ptrace state machine.
 func (b *linuxBackend) Wait() (StopEvent, error) {
@@ -228,10 +218,6 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 		var ws syscall.WaitStatus
 		// WALL includes clone()d threads.
 		tid, err := syscall.Wait4(-1, &ws, syscall.WALL, nil)
-		dbgLog("wait4 return", "tid", tid, "err", err, "raw", uint32(ws),
-			"stopped", ws.Stopped(), "stopsig", int(ws.StopSignal()),
-			"cause", ws.TrapCause(), "exited", ws.Exited(),
-			"signaled", ws.Signaled(), "stepping", b.stepping, "pid", b.pid)
 		if err != nil {
 			if isNoChildProcess(err) {
 				return StopEvent{Reason: StopExited, TID: b.pid}, nil
@@ -271,7 +257,6 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 				// transparent thread event. Do NOT recordStop — that would
 				// repoint traceTID at an unrelated churn thread and misdirect
 				// the next ContinueProcess.
-				dbgLog("-> StopThreadEvent (ptrace-event)", "tid", tid, "cause", ws.TrapCause())
 				return StopEvent{Reason: StopThreadEvent, TID: tid}, nil
 			}
 			// Genuine trap. If it is the completion of the single-step we
@@ -282,17 +267,14 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 			b.recordStop(tid)
 			if b.stepping && tid == b.stepTID {
 				b.stepping = false
-				dbgLog("-> StopSingleStep", "tid", tid)
 				return StopEvent{Reason: StopSingleStep, TID: tid}, nil
 			}
-			dbgLog("-> StopBreakpoint", "tid", tid)
 			return StopEvent{Reason: StopBreakpoint, TID: tid}, nil
 		}
 
 		// A freshly cloned thread reports an initial SIGSTOP before it runs
 		// (PTRACE_O_TRACECLONE). Resume it from the tracer goroutine.
 		if sig == syscall.SIGSTOP && tid != b.pid {
-			dbgLog("-> StopThreadEvent (clone-sigstop)", "tid", tid)
 			return StopEvent{Reason: StopThreadEvent, TID: tid}, nil
 		}
 
@@ -312,10 +294,8 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 		if b.stepping && tid == b.stepTID {
 			b.stepping = false
 			b.recordStop(tid)
-			dbgLog("-> StopSignal (mid-step)", "tid", tid, "sig", int(sig))
 			return StopEvent{Reason: StopSignal, TID: tid, Signal: int(sig), Stepping: true}, nil
 		}
-		dbgLog("-> StopThreadEvent (signal-forward)", "tid", tid, "sig", int(sig))
 		return StopEvent{Reason: StopThreadEvent, TID: tid, Signal: int(sig)}, nil
 	}
 }
@@ -336,18 +316,15 @@ func (b *linuxBackend) ResumeSignal(tid, signal int, stepping bool) error {
 			int(syscall.SIGSEGV), int(syscall.SIGSTKFLT):
 			// Synchronous fault from the stepped instruction: re-issue the
 			// step delivering the signal so the tracee's handler observes it.
-			dbgLog("ResumeSignal re-step fault", "tid", tid, "sig", signal)
 			return singleStepSig(tid, signal)
 		case int(syscall.SIGSTOP):
 			// Spurious/late SIGSTOP: swallow and keep stepping.
-			dbgLog("ResumeSignal re-step drop-stop", "tid", tid)
 			return singleStepSig(tid, 0)
 		default:
 			// Asynchronous signal (SIGURG preemption, SIGCHLD, ...): defer to
 			// the next continue so entering a handler mid-step doesn't perturb
 			// the step's trap PC; re-step suppressing it now.
 			b.delayedSignal = signal
-			dbgLog("ResumeSignal re-step defer", "tid", tid, "sig", signal)
 			return singleStepSig(tid, 0)
 		}
 	}
@@ -358,7 +335,6 @@ func (b *linuxBackend) ResumeSignal(tid, signal int, stepping bool) error {
 		forward = 0
 	}
 	b.stepping = false
-	dbgLog("ResumeSignal continue-forward", "tid", tid, "sig", signal, "forward", forward)
 	return continueIfTraceeExists(tid, forward)
 }
 
@@ -378,7 +354,6 @@ func (b *linuxBackend) ResumeThread(tid, signal int) error {
 	if forward == int(syscall.SIGSTOP) {
 		forward = 0
 	}
-	dbgLog("ResumeThread", "tid", tid, "sig", signal, "forward", forward)
 	return continueIfTraceeExists(tid, forward)
 }
 

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -29,6 +29,7 @@ func newBackend() Backend {
 type linuxBackend struct {
 	pid         int
 	stepping    bool // true after SingleStep; classifies the next SIGTRAP
+	stepTID     int  // thread the in-flight single-step was issued against
 	lastStopTID int
 
 	// delayedSignal holds a non-fault signal (e.g. SIGURG async preemption)
@@ -39,8 +40,15 @@ type linuxBackend struct {
 	delayedSignal int
 }
 
-const linuxPtraceOptions = syscall.PTRACE_O_TRACEEXIT |
-	syscall.PTRACE_O_TRACEEXEC
+// PTRACE_O_TRACECLONE auto-traces every thread the Go runtime spawns. Without
+// it only the main thread is traced, so when the goroutine under inspection is
+// async-preempted onto a fresh OS thread and hits a breakpoint there, the
+// SIGTRAP escapes ptrace and the Go runtime aborts with "unexpected signal:
+// trace/breakpoint trap". The option is inherited by cloned children (the
+// kernel copies the tracer's ptrace flags to each new thread), so setting it
+// once on the main thread covers the whole thread tree. Mirrors Delve's
+// ptraceOptionsNormal.
+const linuxPtraceOptions = syscall.PTRACE_O_TRACECLONE
 
 // startTracedProcess forks under ptrace. The child is stopped at its first
 // instruction (execve SIGTRAP) ready for the engine to set breakpoints.
@@ -120,6 +128,7 @@ func (b *linuxBackend) ContinueProcess() error {
 
 func (b *linuxBackend) SingleStep(tid int) error {
 	b.stepping = true
+	b.stepTID = tid
 	dbgLog("SingleStep", "tid", tid)
 	if err := ptraceSingleStepSig(tid, 0); err != nil {
 		return fmt.Errorf("PTRACE_SINGLESTEP tid %d: %w", tid, err)
@@ -252,87 +261,62 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 
 		sig := ws.StopSignal()
 
-		// PTRACE_EVENT stops are encoded as SIGTRAP | (event << 8).
+		// SIGTRAP is either a genuine trap (INT3 breakpoint or the completion
+		// of a single-step) or a PTRACE_EVENT stop (clone/exec/exit) encoded as
+		// SIGTRAP | (event << 8).
 		if sig == syscall.SIGTRAP {
-			cause := ws.TrapCause()
-
-			switch cause {
-			case syscall.PTRACE_EVENT_CLONE:
-				if err := continueIfTraceeExists(tid, 0); err != nil {
-					return StopEvent{}, fmt.Errorf("PTRACE_CONT clone parent tid %d: %w", tid, err)
-				}
-				continue
-
-			case syscall.PTRACE_EVENT_EXIT:
-				if tid != b.pid {
-					if err := continueIfTraceeExists(tid, 0); err != nil {
-						return StopEvent{}, fmt.Errorf("PTRACE_CONT exiting thread tid %d: %w", tid, err)
-					}
-					continue
-				}
-				// Main thread is about to call exit_group — let it actually exit.
-				if err := continueIfTraceeExists(tid, 0); err != nil {
-					return StopEvent{}, fmt.Errorf("PTRACE_CONT exiting process tid %d: %w", tid, err)
-				}
-				b.recordStop(tid)
-				return StopEvent{Reason: StopExited, TID: tid, ExitCode: 0}, nil
-
-			case syscall.PTRACE_EVENT_EXEC:
-				if err := syscall.PtraceCont(tid, 0); err != nil {
-					return StopEvent{}, fmt.Errorf("PTRACE_CONT exec tid %d: %w", tid, err)
-				}
-				continue
-
-			case 0:
-				b.recordStop(tid)
-
-				if b.stepping {
-					b.stepping = false
-					dbgLog("-> StopSingleStep", "tid", tid)
-					return StopEvent{Reason: StopSingleStep, TID: tid}, nil
-				}
-
-				dbgLog("-> StopBreakpoint", "tid", tid)
-				return StopEvent{
-					Reason: StopBreakpoint,
-					TID:    tid,
-				}, nil
-
-			default:
-				if err := continueIfTraceeExists(tid, 0); err != nil {
-					return StopEvent{}, fmt.Errorf("PTRACE_CONT trap cause %d tid %d: %w", cause, tid, err)
-				}
-				continue
+			if ws.TrapCause() != 0 {
+				// PTRACE_EVENT stop. The stopped thread must be resumed by the
+				// tracer goroutine (the engine loop), so hand it back as a
+				// transparent thread event. Do NOT recordStop — that would
+				// repoint traceTID at an unrelated churn thread and misdirect
+				// the next ContinueProcess.
+				dbgLog("-> StopThreadEvent (ptrace-event)", "tid", tid, "cause", ws.TrapCause())
+				return StopEvent{Reason: StopThreadEvent, TID: tid}, nil
 			}
+			// Genuine trap. If it is the completion of the single-step we
+			// issued (same thread), report a single-step; otherwise a
+			// breakpoint (INT3) was hit — in these targets only the goroutine
+			// under inspection executes breakpoint addresses, on whichever OS
+			// thread it currently occupies.
+			b.recordStop(tid)
+			if b.stepping && tid == b.stepTID {
+				b.stepping = false
+				dbgLog("-> StopSingleStep", "tid", tid)
+				return StopEvent{Reason: StopSingleStep, TID: tid}, nil
+			}
+			dbgLog("-> StopBreakpoint", "tid", tid)
+			return StopEvent{Reason: StopBreakpoint, TID: tid}, nil
 		}
 
+		// A freshly cloned thread reports an initial SIGSTOP before it runs
+		// (PTRACE_O_TRACECLONE). Resume it from the tracer goroutine.
 		if sig == syscall.SIGSTOP && tid != b.pid {
-			if err := syscall.PtraceSetOptions(tid, linuxPtraceOptions); err != nil && !isNoSuchProcess(err) {
-				return StopEvent{}, fmt.Errorf("PTRACE_SETOPTIONS clone child tid %d: %w", tid, err)
-			}
-			if err := syscall.Kill(b.pid, syscall.SIGCONT); err != nil && !isNoSuchProcess(err) {
-				return StopEvent{}, fmt.Errorf("SIGCONT tracee pid %d: %w", b.pid, err)
-			}
-			if err := continueTraceeGroup(b.pid, 0); err != nil {
-				return StopEvent{}, err
-			}
-			continue
+			dbgLog("-> StopThreadEvent (clone-sigstop)", "tid", tid)
+			return StopEvent{Reason: StopThreadEvent, TID: tid}, nil
 		}
 
-		// A real (non-SIGTRAP) signal was delivered to the tracee. On Linux
-		// ptrace resume commands (PTRACE_CONT/SINGLESTEP) are restricted to the
-		// tracer thread — the engine's event-loop goroutine — so this wait
-		// goroutine must NOT resume here (doing so returns ESRCH and wedges the
-		// tracee). Hand the signal to the engine, which re-steps or continues
-		// from the tracer goroutine via ResumeSignal, forwarding a synchronous
-		// fault or deferring an async signal (SIGURG preemption) — mirroring
-		// Delve's singleStep() / resumeWithSig(). Report whether we were mid
-		// single-step so the engine re-issues the right resume.
-		stepping := b.stepping
-		b.stepping = false
-		b.recordStop(tid)
-		dbgLog("-> StopSignal", "tid", tid, "sig", int(sig), "stepping", stepping)
-		return StopEvent{Reason: StopSignal, TID: tid, Signal: int(sig), Stepping: stepping}, nil
+		// A real (non-trap) signal. On Linux ptrace resume commands
+		// (PTRACE_CONT/SINGLESTEP) are restricted to the tracer thread — the
+		// engine's event-loop goroutine — so this wait goroutine must NOT
+		// resume here (doing so returns ESRCH and wedges the tracee).
+		//
+		// If the signal interrupted the single-step we issued (same thread),
+		// hand it back as a StopSignal so the engine re-steps from the tracer
+		// goroutine, forwarding a synchronous fault or deferring an async
+		// signal (SIGURG preemption) — mirroring Delve's singleStep() /
+		// resumeWithSig(). A signal delivered to any OTHER thread (e.g. a churn
+		// worker being async-preempted) is forwarded to that thread as a
+		// transparent thread event, without disturbing the debug thread's
+		// step-over state or traceTID.
+		if b.stepping && tid == b.stepTID {
+			b.stepping = false
+			b.recordStop(tid)
+			dbgLog("-> StopSignal (mid-step)", "tid", tid, "sig", int(sig))
+			return StopEvent{Reason: StopSignal, TID: tid, Signal: int(sig), Stepping: true}, nil
+		}
+		dbgLog("-> StopThreadEvent (signal-forward)", "tid", tid, "sig", int(sig))
+		return StopEvent{Reason: StopThreadEvent, TID: tid, Signal: int(sig)}, nil
 	}
 }
 
@@ -378,8 +362,28 @@ func (b *linuxBackend) ResumeSignal(tid, signal int, stepping bool) error {
 	return continueIfTraceeExists(tid, forward)
 }
 
+// ResumeThread resumes a thread that stopped for a clone/thread lifecycle event
+// (a freshly cloned thread's initial SIGSTOP, a PTRACE_EVENT stop) or a signal
+// delivered to a thread other than the one under active step/continue. It runs
+// on the engine (tracer) goroutine because Linux restricts ptrace resume to the
+// tracer thread. Any signal is forwarded so the tracee's runtime observes it; a
+// bare SIGSTOP is never re-delivered (it would immediately re-stop the thread).
+// Do NOT touch stepping/lastStopTID here — the debug thread's state must be
+// preserved across churn-thread events.
+func (b *linuxBackend) ResumeThread(tid, signal int) error {
+	if tid == 0 {
+		return nil
+	}
+	forward := signal
+	if forward == int(syscall.SIGSTOP) {
+		forward = 0
+	}
+	dbgLog("ResumeThread", "tid", tid, "sig", signal, "forward", forward)
+	return continueIfTraceeExists(tid, forward)
+}
+
 var _ Backend = (*linuxBackend)(nil)
-var _ signalResumer = (*linuxBackend)(nil)
+var _ ptraceResumer = (*linuxBackend)(nil)
 
 func (b *linuxBackend) setPID(pid int) {
 	b.pid = pid
@@ -415,40 +419,6 @@ func continueIfTraceeExists(tid int, signal int) error {
 		return err
 	}
 	return nil
-}
-
-func continueTraceeGroup(pid int, signal int) error {
-	tids, err := taskTIDs(pid)
-	if err != nil {
-		if isNoSuchProcess(err) {
-			return nil
-		}
-		return err
-	}
-	if len(tids) == 0 {
-		return continueIfTraceeExists(pid, signal)
-	}
-	for _, tid := range tids {
-		if err := continueIfTraceeExists(tid, signal); err != nil {
-			return fmt.Errorf("PTRACE_CONT tid %d: %w", tid, err)
-		}
-	}
-	return nil
-}
-
-func taskTIDs(pid int) ([]int, error) {
-	entries, err := os.ReadDir(fmt.Sprintf("/proc/%d/task", pid))
-	if err != nil {
-		return nil, err
-	}
-	tids := make([]int, 0, len(entries))
-	for _, entry := range entries {
-		var tid int
-		if _, err := fmt.Sscanf(entry.Name(), "%d", &tid); err == nil {
-			tids = append(tids, tid)
-		}
-	}
-	return tids, nil
 }
 
 // ptraceSingleStepSig issues PTRACE_SINGLESTEP delivering signal sig to the

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -120,11 +120,9 @@ func (b *linuxBackend) ContinueProcess() error {
 
 func (b *linuxBackend) SingleStep(tid int) error {
 	b.stepping = true
-	sig := b.delayedSignal
-	b.delayedSignal = 0
-	dbgLog("SingleStep", "tid", tid, "sig", sig)
-	if err := ptraceSingleStepSig(tid, sig); err != nil {
-		return fmt.Errorf("PTRACE_SINGLESTEP tid %d (sig %d): %w", tid, sig, err)
+	dbgLog("SingleStep", "tid", tid)
+	if err := ptraceSingleStepSig(tid, 0); err != nil {
+		return fmt.Errorf("PTRACE_SINGLESTEP tid %d: %w", tid, err)
 	}
 	return nil
 }
@@ -321,55 +319,67 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 			continue
 		}
 
-		// Any non-SIGTRAP stop is a real signal delivered to the tracee.
-		// Forward it instead of swallowing it (Delve's resumeWithSig /
-		// singleStep). Dropping a synchronous fault (SIGSEGV/SIGBUS/... from
-		// e.g. the Go runtime's nil-check machinery) makes the faulting
-		// instruction re-execute forever and wedges the tracee; dropping
-		// SIGURG breaks Go's async goroutine preemption.
-		if b.stepping {
-			// Mid single-step: classify like Delve's singleStep() loop.
-			dbgLog("signal mid-step", "tid", tid, "sig", int(sig))
-			switch sig {
-			case syscall.SIGILL, syscall.SIGBUS, syscall.SIGFPE, syscall.SIGSEGV, syscall.SIGSTKFLT:
-				// Fault triggered by the instruction being stepped: re-issue
-				// the step WITH the signal so the tracee's handler observes it.
-				if err := singleStepSig(tid, int(sig)); err != nil {
-					return StopEvent{}, fmt.Errorf("PTRACE_SINGLESTEP fault %d tid %d: %w", sig, tid, err)
-				}
-			case syscall.SIGSTOP:
-				// Spurious/late SIGSTOP: swallow it and keep stepping.
-				if err := singleStepSig(tid, 0); err != nil {
-					return StopEvent{}, fmt.Errorf("PTRACE_SINGLESTEP after SIGSTOP tid %d: %w", tid, err)
-				}
-			default:
-				// Asynchronous signal (SIGURG preemption, SIGCHLD, ...): defer
-				// delivery to the next resume and keep stepping so the trap PC
-				// is not perturbed by entering a signal handler mid-step.
-				b.delayedSignal = int(sig)
-				if err := singleStepSig(tid, 0); err != nil {
-					return StopEvent{}, fmt.Errorf("PTRACE_SINGLESTEP deferring %d tid %d: %w", sig, tid, err)
-				}
-			}
-			continue
-		}
-
-		// Running (continue): forward the signal transparently so the tracee's
-		// own handlers/runtime see it. Never re-deliver a bare SIGSTOP — it
-		// would immediately re-stop the thread.
-		forward := int(sig)
-		if sig == syscall.SIGSTOP {
-			forward = 0
-		}
-		dbgLog("signal running-forward", "tid", tid, "sig", int(sig), "forward", forward)
-		if err := continueIfTraceeExists(tid, forward); err != nil {
-			return StopEvent{}, fmt.Errorf("PTRACE_CONT forwarding signal %d tid %d: %w", sig, tid, err)
-		}
-		continue
+		// A real (non-SIGTRAP) signal was delivered to the tracee. On Linux
+		// ptrace resume commands (PTRACE_CONT/SINGLESTEP) are restricted to the
+		// tracer thread — the engine's event-loop goroutine — so this wait
+		// goroutine must NOT resume here (doing so returns ESRCH and wedges the
+		// tracee). Hand the signal to the engine, which re-steps or continues
+		// from the tracer goroutine via ResumeSignal, forwarding a synchronous
+		// fault or deferring an async signal (SIGURG preemption) — mirroring
+		// Delve's singleStep() / resumeWithSig(). Report whether we were mid
+		// single-step so the engine re-issues the right resume.
+		stepping := b.stepping
+		b.stepping = false
+		b.recordStop(tid)
+		dbgLog("-> StopSignal", "tid", tid, "sig", int(sig), "stepping", stepping)
+		return StopEvent{Reason: StopSignal, TID: tid, Signal: int(sig), Stepping: stepping}, nil
 	}
 }
 
+// ResumeSignal resumes the tracee after a non-trap signal. It runs on the
+// engine goroutine (the ptrace tracer thread), which is why Wait defers signal
+// resumes here instead of issuing them itself. Mirrors Delve: fault signals are
+// re-delivered on the next single-step, asynchronous signals are deferred to the
+// next continue, and a signal that interrupted a continue is forwarded.
+func (b *linuxBackend) ResumeSignal(tid, signal int, stepping bool) error {
+	if tid == 0 {
+		tid = b.traceTID()
+	}
+	if stepping {
+		b.stepping = true
+		switch signal {
+		case int(syscall.SIGILL), int(syscall.SIGBUS), int(syscall.SIGFPE),
+			int(syscall.SIGSEGV), int(syscall.SIGSTKFLT):
+			// Synchronous fault from the stepped instruction: re-issue the
+			// step delivering the signal so the tracee's handler observes it.
+			dbgLog("ResumeSignal re-step fault", "tid", tid, "sig", signal)
+			return singleStepSig(tid, signal)
+		case int(syscall.SIGSTOP):
+			// Spurious/late SIGSTOP: swallow and keep stepping.
+			dbgLog("ResumeSignal re-step drop-stop", "tid", tid)
+			return singleStepSig(tid, 0)
+		default:
+			// Asynchronous signal (SIGURG preemption, SIGCHLD, ...): defer to
+			// the next continue so entering a handler mid-step doesn't perturb
+			// the step's trap PC; re-step suppressing it now.
+			b.delayedSignal = signal
+			dbgLog("ResumeSignal re-step defer", "tid", tid, "sig", signal)
+			return singleStepSig(tid, 0)
+		}
+	}
+	// The signal interrupted a continue: forward it transparently so the
+	// tracee's runtime/handlers see it. Never re-deliver a bare SIGSTOP.
+	forward := signal
+	if signal == int(syscall.SIGSTOP) {
+		forward = 0
+	}
+	b.stepping = false
+	dbgLog("ResumeSignal continue-forward", "tid", tid, "sig", signal, "forward", forward)
+	return continueIfTraceeExists(tid, forward)
+}
+
 var _ Backend = (*linuxBackend)(nil)
+var _ signalResumer = (*linuxBackend)(nil)
 
 func (b *linuxBackend) setPID(pid int) {
 	b.pid = pid

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -354,9 +354,6 @@ func (e *engine) waitLoop() {
 
 //nolint:gocognit,gocyclo // Stop handling is a single serialized debugger state machine.
 func (e *engine) handleStop(stop StopEvent) {
-	slog.Info("E2EDBG handleStop", "reason", stop.Reason, "tid", stop.TID,
-		"pc", fmt.Sprintf("0x%x", stop.PC), "signal", stop.Signal,
-		"steppingOverBP", e.steppingOverBP != nil, "bpResume", e.bpResume)
 	switch stop.Reason {
 	case StopExited:
 		if e.getState() == stateExited {
@@ -840,18 +837,17 @@ func (e *engine) resumeFromBreakpoint(action bpResumeAction, retAddr uint64) err
 	}
 	e.lastBPTID = 0
 
-	// Rewind the tracee's PC to the breakpoint address before stepping. On
-	// amd64 the INT3 trap leaves RIP one byte PAST bp.addr, so single-stepping
-	// now (after restoring the original byte) would execute from the middle of
-	// the original instruction, corrupting the stream. Put PC back at bp.addr
-	// so the restored instruction runs from its first byte. On arm64 the CPU
-	// stops with PC already AT the BRK (archRewindPC is identity), so the
-	// read-back PC equals bp.addr and the guard makes this a no-op. Mirrors
-	// Delve's (*nativeThread).SetCurrentBreakpoint -> setPC(bp.Addr) when
+	// Backstop PC rewind. On amd64 the INT3 trap leaves RIP one byte PAST
+	// bp.addr, so single-stepping now (after restoring the original byte) would
+	// execute from the middle of the original instruction and corrupt the
+	// stream. rewindTraceePC already put the register PC back at bp.addr when
+	// the breakpoint was hit, so this guard is normally false here; it is kept
+	// so any future path that sets lastBP without pre-rewinding still resumes
+	// correctly. On arm64/darwin PC is already AT the trap (archRewindPC is the
+	// identity) and the guard is a no-op. Mirrors Delve's
+	// (*nativeThread).SetCurrentBreakpoint -> setPC(bp.Addr) when
 	// Arch.BreakInstrMovesPC() is true.
 	if regs, gerr := e.backend.GetRegisters(tid); gerr == nil && regs.PC != bp.addr {
-		slog.Info("E2EDBG resumeFromBreakpoint rewind", "tid", tid,
-			"oldPC", fmt.Sprintf("0x%x", regs.PC), "bpAddr", fmt.Sprintf("0x%x", bp.addr), "action", action)
 		regs.PC = bp.addr
 		if serr := e.backend.SetRegisters(tid, regs); serr != nil {
 			_ = e.backend.WriteMemory(bp.addr, archTrapInstruction())
@@ -859,9 +855,6 @@ func (e *engine) resumeFromBreakpoint(action bpResumeAction, retAddr uint64) err
 			e.steppingOverBP = nil
 			return fmt.Errorf("resume BP: rewind PC to 0x%x: %w", bp.addr, serr)
 		}
-	} else {
-		slog.Info("E2EDBG resumeFromBreakpoint no-rewind", "tid", tid, "gerr", gerr,
-			"bpAddr", fmt.Sprintf("0x%x", bp.addr), "action", action)
 	}
 
 	if err := e.backend.SingleStep(tid); err != nil {

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -500,7 +500,40 @@ func (e *engine) handleStop(stop StopEvent) {
 		e.emitStepped(stop)
 
 	case StopSignal:
-		// Reinstall any in-flight step-over BP before resuming.
+		if sr, ok := e.backend.(signalResumer); ok {
+			// Linux: ptrace resume must run on this (tracer) goroutine, not the
+			// wait goroutine. If a signal interrupted an in-flight single-step,
+			// re-issue the step (deferring async / forwarding fault signals)
+			// WITHOUT reinstalling the trap — the step-over is still in flight
+			// and its StopSingleStep will reinstall and finish the action.
+			// Otherwise a continue was interrupted: reinstall any pending
+			// step-over trap and forward the signal on the next continue.
+			if !stop.Stepping {
+				if sob := e.steppingOverBP; sob != nil {
+					e.steppingOverBP = nil
+					if rerr := e.bps.reinstall(e.backend, sob); rerr != nil {
+						e.setState(stateSuspended)
+						e.emitError(protocol.CmdNone, fmt.Errorf("reinstall breakpoint 0x%x after signal: %w", sob.addr, rerr))
+						return
+					}
+				}
+			}
+			if err := sr.ResumeSignal(stop.TID, stop.Signal, stop.Stepping); err != nil {
+				if sob := e.steppingOverBP; sob != nil {
+					e.steppingOverBP = nil
+					_ = e.bps.reinstall(e.backend, sob)
+				}
+				e.setState(stateSuspended)
+				e.emitError(protocol.CmdNone, fmt.Errorf("resume from signal %d: %w", stop.Signal, err))
+				return
+			}
+			e.setState(stateRunning)
+			go e.waitLoop()
+			return
+		}
+		// Non-Linux fallback (Darwin handles signals inside Wait and only
+		// surfaces StopSignal as a last resort): reinstall any in-flight
+		// step-over BP before resuming, then continue.
 		if sob := e.steppingOverBP; sob != nil {
 			e.steppingOverBP = nil
 			if rerr := e.bps.reinstall(e.backend, sob); rerr != nil {

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -752,6 +752,26 @@ func (e *engine) resumeFromBreakpoint(action bpResumeAction, retAddr uint64) err
 		tid = threads[0]
 	}
 	e.lastBPTID = 0
+
+	// Rewind the tracee's PC to the breakpoint address before stepping. On
+	// amd64 the INT3 trap leaves RIP one byte PAST bp.addr, so single-stepping
+	// now (after restoring the original byte) would execute from the middle of
+	// the original instruction, corrupting the stream. Put PC back at bp.addr
+	// so the restored instruction runs from its first byte. On arm64 the CPU
+	// stops with PC already AT the BRK (archRewindPC is identity), so the
+	// read-back PC equals bp.addr and the guard makes this a no-op. Mirrors
+	// Delve's (*nativeThread).SetCurrentBreakpoint -> setPC(bp.Addr) when
+	// Arch.BreakInstrMovesPC() is true.
+	if regs, gerr := e.backend.GetRegisters(tid); gerr == nil && regs.PC != bp.addr {
+		regs.PC = bp.addr
+		if serr := e.backend.SetRegisters(tid, regs); serr != nil {
+			_ = e.backend.WriteMemory(bp.addr, archTrapInstruction())
+			e.bps.addToTable(bp)
+			e.steppingOverBP = nil
+			return fmt.Errorf("resume BP: rewind PC to 0x%x: %w", bp.addr, serr)
+		}
+	}
+
 	if err := e.backend.SingleStep(tid); err != nil {
 		_ = e.backend.WriteMemory(bp.addr, archTrapInstruction())
 		e.bps.addToTable(bp)

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -354,6 +354,9 @@ func (e *engine) waitLoop() {
 
 //nolint:gocognit,gocyclo // Stop handling is a single serialized debugger state machine.
 func (e *engine) handleStop(stop StopEvent) {
+	slog.Info("E2EDBG handleStop", "reason", stop.Reason, "tid", stop.TID,
+		"pc", fmt.Sprintf("0x%x", stop.PC), "signal", stop.Signal,
+		"steppingOverBP", e.steppingOverBP != nil, "bpResume", e.bpResume)
 	switch stop.Reason {
 	case StopExited:
 		if e.getState() == stateExited {
@@ -763,6 +766,8 @@ func (e *engine) resumeFromBreakpoint(action bpResumeAction, retAddr uint64) err
 	// Delve's (*nativeThread).SetCurrentBreakpoint -> setPC(bp.Addr) when
 	// Arch.BreakInstrMovesPC() is true.
 	if regs, gerr := e.backend.GetRegisters(tid); gerr == nil && regs.PC != bp.addr {
+		slog.Info("E2EDBG resumeFromBreakpoint rewind", "tid", tid,
+			"oldPC", fmt.Sprintf("0x%x", regs.PC), "bpAddr", fmt.Sprintf("0x%x", bp.addr), "action", action)
 		regs.PC = bp.addr
 		if serr := e.backend.SetRegisters(tid, regs); serr != nil {
 			_ = e.backend.WriteMemory(bp.addr, archTrapInstruction())
@@ -770,6 +775,9 @@ func (e *engine) resumeFromBreakpoint(action bpResumeAction, retAddr uint64) err
 			e.steppingOverBP = nil
 			return fmt.Errorf("resume BP: rewind PC to 0x%x: %w", bp.addr, serr)
 		}
+	} else {
+		slog.Info("E2EDBG resumeFromBreakpoint no-rewind", "tid", tid, "gerr", gerr,
+			"bpAddr", fmt.Sprintf("0x%x", bp.addr), "action", action)
 	}
 
 	if err := e.backend.SingleStep(tid); err != nil {

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -402,6 +402,16 @@ func (e *engine) handleStop(stop StopEvent) {
 		}
 		slog.Debug("StopBreakpoint matched", "file", bp.file, "line", bp.line,
 			"addr", fmt.Sprintf("0x%x", bp.addr))
+		// Rewind the stopped thread's PC to the breakpoint address. On amd64 the
+		// INT3 trap leaves the register PC one byte PAST bp.addr; populate*Stop
+		// only rewinds the *reported* StopEvent.PC, never the tracee register.
+		// User breakpoints get their register rewound later in
+		// resumeFromBreakpoint, but the temporary <stepover-next>/<stepout-return>
+		// breakpoints are cleared here and resumed with a plain ContinueProcess
+		// that does NOT go through resumeFromBreakpoint — so without this the
+		// thread would resume one byte into the restored instruction and corrupt
+		// the stream. Guarded by archRewindPC so it is a no-op on arm64/darwin.
+		e.rewindTraceePC(stop.TID, bp.addr)
 		if bp.file == stepOverNextFile {
 			_ = e.bps.clear(e.backend, bp.id)
 			e.lastBP = nil
@@ -499,8 +509,25 @@ func (e *engine) handleStop(stop StopEvent) {
 		e.setState(stateSuspended)
 		e.emitStepped(stop)
 
+	case StopThreadEvent:
+		// Linux with PTRACE_O_TRACECLONE: a clone/thread lifecycle stop (a new
+		// thread's initial SIGSTOP, a PTRACE_EVENT stop, or a signal delivered
+		// to a thread other than the one under active step/continue). ptrace
+		// resume must run on this (tracer) goroutine, so the wait goroutine
+		// handed it back. Resume the thread transparently — forwarding any
+		// signal — and keep waiting. No user-visible state change: the debug
+		// thread's step-over/continue is still in flight on another thread.
+		if sr, ok := e.backend.(ptraceResumer); ok {
+			if err := sr.ResumeThread(stop.TID, stop.Signal); err != nil {
+				slog.Warn("resume thread event failed",
+					"tid", stop.TID, "signal", stop.Signal, "err", err)
+			}
+		}
+		go e.waitLoop()
+		return
+
 	case StopSignal:
-		if sr, ok := e.backend.(signalResumer); ok {
+		if sr, ok := e.backend.(ptraceResumer); ok {
 			// Linux: ptrace resume must run on this (tracer) goroutine, not the
 			// wait goroutine. If a signal interrupted an in-flight single-step,
 			// re-issue the step (deferring async / forwarding fault signals)
@@ -755,6 +782,30 @@ func (e *engine) stepOut() error {
 	e.setState(stateRunning)
 	go e.waitLoop()
 	return nil
+}
+
+// rewindTraceePC moves a stopped thread's register PC back to a software
+// breakpoint's address. On amd64 the INT3 trap leaves PC one byte past the
+// breakpoint, so a subsequent resume (after the original byte is restored) would
+// execute from the middle of that instruction. The guard makes this a no-op on
+// arm64/darwin, where the CPU stops with PC already AT the trap and archRewindPC
+// is the identity. Mirrors Delve's setPC(bp.Addr) when Arch.BreakInstrMovesPC().
+func (e *engine) rewindTraceePC(tid int, addr uint64) {
+	if tid == 0 {
+		return
+	}
+	regs, err := e.backend.GetRegisters(tid)
+	if err != nil {
+		return
+	}
+	if regs.PC == addr || archRewindPC(regs.PC) != addr {
+		return
+	}
+	regs.PC = addr
+	if err := e.backend.SetRegisters(tid, regs); err != nil {
+		slog.Warn("rewind tracee PC to breakpoint failed",
+			"tid", tid, "addr", fmt.Sprintf("0x%x", addr), "err", err)
+	}
 }
 
 // resumeFromBreakpoint runs the step-over-software-BP sequence:


### PR DESCRIPTION
## What's distinct about this fix

Every Linux `StepOver` solution has to solve the same two problems — the amd64
`INT3` PC-rewind and the cross-thread ptrace `ESRCH`. **This PR solves the
cross-thread problem with a `StopThreadEvent` round-trip on the tracer goroutine
plus explicit trap/signal classification keyed on `stepTID`**, rather than by
having the wait goroutine single-step / resume the trapped thread in place.

Concretely:

- **`Wait()` only *classifies*; it never resumes.** It labels each stop —
  single-step-completion `SIGTRAP`, `INT3` `SIGTRAP`, `PTRACE_EVENT` clone stop,
  clone-child `SIGSTOP`, or a real signal — using `stepTID` (the thread the step
  was issued against) to tell the step's own trap apart from a breakpoint or a
  churn thread's async signal. This is the disambiguation centerpiece.
- **Resumes are round-tripped back to the tracer goroutine.** Anything needing a
  ptrace resume (clone/thread-lifecycle stops, and signals on non-debug threads)
  is handed up as a new `StopThreadEvent`; the engine loop — the one
  `LockOSThread`'d goroutine that owns ptrace — resumes it via
  `ptraceResumer.ResumeThread` and re-arms the wait loop. Nothing outside that
  goroutine ever issues `PTRACE_CONT`/`SINGLESTEP`.

The alternative "just single-step the trapped thread from the waiter" avoids
`ESRCH` by construction; this design instead keeps a single serialized ptrace
owner and moves *events*, not *control*, across goroutines. That makes the
trap/signal classification explicit and centralizes every resume decision in the
engine, at the cost of one extra event round-trip per thread stop.

## Root cause (three compounding defects in `internal/debugger`)

1. **INT3 PC never rewound into the tracee.** On amd64 `INT3` leaves
   `RIP = bp.addr+1`; the engine computed the rewind only for the *reported*
   `StopEvent.PC` and never wrote it back. `resumeFromBreakpoint` then
   single-stepped from mid-instruction → `SIGSEGV`, which the `StopSignal` path
   swallowed (continued with signal 0) → infinite re-fault → **hang**. Hidden on
   arm64 (`archRewindPC` is identity there).
2. **Cross-thread ptrace `ESRCH`.** `wait4(-1,…,WALL)` reaps from any thread, but
   ptrace *control* is restricted to the tracer thread. Our per-resume `waitLoop`
   goroutine resuming there returned `ESRCH` and wedged the tracee.
3. **Untraced migration.** With only the main thread traced, when the
   goroutine-under-inspection migrated OS threads and hit the INT3 there, the
   `SIGTRAP` escaped the tracer and the Go runtime aborted
   (`trace/breakpoint trap`) → `ProcessExited`.

## The fix

**`backend_linux_amd64.go`**
- `PTRACE_O_TRACECLONE` (was `TRACEEXIT|TRACEEXEC`): every clone child is
  auto-traced, so a migrated breakpoint is always caught, never escaping (fixes 3).
- `Wait()` classification via `stepTID` (see above); issues no ptrace resume.
- `ResumeThread(tid, signal)` — new tracer-goroutine resume for clone/thread
  events and non-debug-thread signals; forwards the signal, never re-delivers a
  bare `SIGSTOP`.
- `ResumeSignal` — forwards synchronous faults (`SEGV/BUS/ILL/FPE/STKFLT`) on the
  re-issued single-step and defers async signals (`SIGURG`) via `delayedSignal`
  for the next continue (Delve's `singleStep()`/`resumeWithSig()` model). Signals
  are never swallowed.

**`engine.go`**
- `case StopThreadEvent:` resumes via `ptraceResumer.ResumeThread` on the engine
  goroutine and re-arms `waitLoop` — no session-state change, no event emitted.
- `rewindTraceePC(tid, addr)` writes the rewound PC back into the tracee at every
  software-breakpoint hit (fixes 1). Guarded by `archRewindPC`, so it is a no-op
  on arm64/darwin. Covers user breakpoints *and* the temporary
  `<stepover-next>`/`<stepout-return>` breakpoints.

**`backend.go`**
- `signalResumer` → `ptraceResumer` (`ResumeSignal` + `ResumeThread`); new
  `StopThreadEvent` reason; `StopEvent.Signal` documented for the forward path.

## Why darwin still builds (no stub needed)

`ResumeThread`/`ResumeSignal` were **not** added to the core `Backend` interface.
They live on a separate, optional **`ptraceResumer`** interface, and the engine
reaches them only through a runtime type assertion —
`if sr, ok := e.backend.(ptraceResumer); ok { … }`. The darwin backend
(`backend_darwin_arm64.go`) implements neither method and needs no stub: the
assertion is simply `false` there, and darwin's `Wait` never produces
`StopThreadEvent`/`Stepping` signals, so those branches are inert. The package
compiles cleanly on darwin (`go build -tags bingonative ./...`) with the darwin
backend completely untouched — this PR fixes Linux only.

## Verification

No local Linux ptrace is available (docker emulation is broken), so correctness
is proven by the immutable CI gate.

- **`Debugger E2E` → `Linux amd64 E2E (ptrace)`: GREEN** on the final commit.
  - `E2E BASIC PASS: 25 continue+stepover iterations`.
  - `E2E CHURN PASS: 200 continue+stepover iterations under thread churn`
    (8 churn goroutines; migration tolerated; no hang/exit/error).
  - Green run: https://github.com/bingosuite/bingo/actions/runs/28494208708
- Local: `gofmt` clean; `GOOS=linux GOARCH=amd64 go vet ./internal/debugger/` +
  `go build ./...` clean; darwin `go build -tags bingonative ./...` clean; unit
  tests for `internal/debugger`, `internal/hub`, `internal/server`,
  `pkg/protocol` pass.

The darwin E2E job is pre-existing flaky (documented parked-M race) and is
`continue-on-error`; A/B runs confirm these changes don't regress it. Out of
scope here. The E2E harness (`e2e_integration_test.go`, `debugger-e2e.yml`) is
untouched.

## Delve references

- `pkg/proc/native/proc_linux.go` — `trapWait` (clone-stop handling, `addThread`),
  `ptraceOptionsNormal = PTRACE_O_TRACECLONE`.
- `pkg/proc/native/threads_linux.go` — `(*nativeThread).resumeWithSig`,
  `singleStep` (signal forwarding on resume/step).
- `pkg/proc/native/proc_linux.go` `setCurrentBreakpoint` / `BreakInstrMovesPC` —
  `setPC(bp.Addr)` after an INT3 stop (the PC-rewind this fix ports to amd64).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
