### PR TITLE
Linux fix: canonical clone/thread lifecycle tracing

### DIFF
--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -7,25 +7,98 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"syscall"
 )
 
+// ── Dedicated ptrace thread ──────────────────────────────────────────────────
+//
+// Linux ties every ptrace *control* request for a tracee (PTRACE_CONT,
+// PTRACE_SINGLESTEP, PTRACE_SETOPTIONS, PTRACE_PEEK/POKE, PTRACE_GETREGS, …) to
+// the specific OS thread that created the tracee: the thread that forked a
+// PTRACE_TRACEME child, or PTRACE_ATTACHed it. Issuing such a call from any
+// other thread does not resume/step the target — on our CI kernels it silently
+// returns success while leaving the thread ptrace-stopped, wedging the whole
+// group.
+//
+// The engine already funnels its command-side ptrace onto one locked goroutine
+// (engine.loop, which is also the thread that forks the tracee). But Backend.Wait
+// runs on a *separate* waitLoop goroutine. The clone / thread-lifecycle handling
+// Wait performs (resuming the parent and each freshly cloned LWP) therefore ran
+// on the wrong thread and never actually resumed anything.
+//
+// We fix this the way Delve does (execPtraceFunc, pkg/proc/native/proc_linux.go):
+// a single dedicated OS thread owns the tracee for its entire lifetime. The
+// fork/exec, every ptrace request, wait4, and the bookkeeping they touch are all
+// marshalled onto it. ptraceThread is that thread.
+type ptraceThread struct {
+	reqs chan func()
+}
+
+func newPtraceThread() *ptraceThread {
+	pt := &ptraceThread{reqs: make(chan func())}
+	ready := make(chan struct{})
+	go func() {
+		// Pin to one OS thread for the process lifetime and never unlock: every
+		// ptrace call and every wait4 for the tracee must originate here.
+		runtime.LockOSThread()
+		close(ready)
+		for fn := range pt.reqs {
+			fn()
+		}
+	}()
+	<-ready
+	return pt
+}
+
+// do runs fn on the ptrace thread and blocks until it completes. Calls serialize:
+// while Wait is parked in wait4 inside its own do() closure, later do() calls
+// queue behind it until the tracee stops. That matches how the engine drives the
+// process — resume, then wait for the next stop — so no legitimate flow contends.
+func (pt *ptraceThread) do(fn func()) {
+	done := make(chan struct{})
+	pt.reqs <- func() {
+		defer close(done)
+		fn()
+	}
+	<-done
+}
+
+// linuxPtrace is published by newBackend so the package-level process hooks in
+// this file (startTracedProcess / attachToProcess / killProcess — invoked via
+// the shared process type rather than as backend methods) fork and reap on the
+// same thread the backend uses for ptrace. The Linux E2E runs one debugger per
+// process, so a single package handle is sufficient; each newBackend replaces it.
+var linuxPtrace *ptraceThread
+
 func newBackend() Backend {
-	return &linuxBackend{}
+	pt := newPtraceThread()
+	linuxPtrace = pt
+	return &linuxBackend{threads: make(map[int]*threadState), pt: pt}
 }
 
-type linuxBackend struct {
-	pid         int
-	stepping    bool // true after SingleStep; classifies the next SIGTRAP
-	lastStopTID int
-}
+// ── Process lifecycle hooks (executed on the ptrace thread) ───────────────────
 
-const linuxPtraceOptions = syscall.PTRACE_O_TRACEEXIT |
-	syscall.PTRACE_O_TRACEEXEC
+// linuxPtraceOptions enables clone tracing so every LWP the Go runtime spawns is
+// automatically attached and stopped by the kernel. Without this the cloned
+// threads are NOT tracees: wait4 never reports them and control-flow that
+// migrates onto them wedges the single traced thread (the step-over hang). This
+// mirrors Delve's ptraceOptionsNormal.
+const linuxPtraceOptions = syscall.PTRACE_O_TRACECLONE
 
-// startTracedProcess forks under ptrace. The child is stopped at its first
-// instruction (execve SIGTRAP) ready for the engine to set breakpoints.
+// startTracedProcess forks under ptrace on the dedicated thread. The child is
+// stopped at its first instruction (execve SIGTRAP) ready for breakpoints.
 func startTracedProcess(binaryPath string, args []string, env []string) (int, *exec.Cmd, error) {
+	var (
+		pid int
+		cmd *exec.Cmd
+		err error
+	)
+	linuxPtrace.do(func() { pid, cmd, err = startTracedProcessLocked(binaryPath, args, env) })
+	return pid, cmd, err
+}
+
+func startTracedProcessLocked(binaryPath string, args []string, env []string) (int, *exec.Cmd, error) {
 	// codeql-suppress[go/command-injection]: The debugger intentionally launches the local binary selected by the operator.
 	cmd := exec.Command(binaryPath, args...)
 	cmd.Stdin = os.Stdin
@@ -60,6 +133,12 @@ func startTracedProcess(binaryPath string, args []string, env []string) (int, *e
 }
 
 func attachToProcess(pid int) error {
+	var err error
+	linuxPtrace.do(func() { err = attachToProcessLocked(pid) })
+	return err
+}
+
+func attachToProcessLocked(pid int) error {
 	if err := syscall.PtraceAttach(pid); err != nil {
 		return fmt.Errorf("PTRACE_ATTACH pid %d: %w", pid, err)
 	}
@@ -67,10 +146,20 @@ func attachToProcess(pid int) error {
 	if _, err := syscall.Wait4(pid, &ws, 0, nil); err != nil {
 		return fmt.Errorf("wait after PTRACE_ATTACH: %w", err)
 	}
+	// Enable clone tracing so LWPs created after we attach are traced too.
+	if err := syscall.PtraceSetOptions(pid, linuxPtraceOptions); err != nil {
+		return fmt.Errorf("PTRACE_SETOPTIONS pid %d: %w", pid, err)
+	}
 	return nil
 }
 
 func killProcess(pid int, cmd *exec.Cmd) error {
+	var err error
+	linuxPtrace.do(func() { err = killProcessLocked(pid, cmd) })
+	return err
+}
+
+func killProcessLocked(pid int, cmd *exec.Cmd) error {
 	if cmd != nil {
 		if err := cmd.Process.Kill(); err != nil && !isAlreadyExited(err) {
 			return err
@@ -87,23 +176,81 @@ func isAlreadyExited(err error) bool {
 	return err != nil && err.Error() == "os: process already finished"
 }
 
+// ── Backend ───────────────────────────────────────────────────────────────────
+
+// threadState tracks a single tracee LWP. running is true after we resume it and
+// false once we have observed a stop for it. Only ever touched on the ptrace
+// thread, so no locking is required.
+type threadState struct {
+	running bool
+}
+
+type linuxBackend struct {
+	pt *ptraceThread
+
+	pid         int
+	stepping    bool // true after SingleStep; classifies the next SIGTRAP
+	stepTID     int  // thread we issued the single-step against
+	lastStopTID int
+
+	// threads holds every LWP we are tracing (thread-group leader + clones).
+	// Populated at launch/attach and kept in sync via PTRACE_EVENT_CLONE and
+	// thread-exit events in Wait.
+	threads map[int]*threadState
+}
+
+// do runs fn on the backend's dedicated ptrace thread and blocks for its result.
+func (b *linuxBackend) do(fn func()) { b.pt.do(fn) }
+
+// ContinueProcess resumes every thread we currently believe is stopped. A Go
+// program only makes progress when the whole thread group runs (timers, sysmon,
+// GC and goroutine migration all depend on sibling threads), so resuming a single
+// tid is not enough — that is what left the tracer waiting forever after a
+// step-over.
 func (b *linuxBackend) ContinueProcess() error {
+	var err error
+	b.do(func() { err = b.continueProcessLocked() })
+	return err
+}
+
+func (b *linuxBackend) continueProcessLocked() error {
 	b.stepping = false
-	tid := b.traceTID()
-	if err := syscall.PtraceCont(tid, 0); err != nil {
-		return fmt.Errorf("PTRACE_CONT tid %d: %w", tid, err)
+	b.stepTID = 0
+	var firstErr error
+	for tid, t := range b.threads {
+		if t.running {
+			continue
+		}
+		if err := b.resumeThread(tid, 0); err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
-	return nil
+	return firstErr
 }
 
 func (b *linuxBackend) SingleStep(tid int) error {
+	var err error
+	b.do(func() { err = b.singleStepLocked(tid) })
+	return err
+}
+
+func (b *linuxBackend) singleStepLocked(tid int) error {
 	b.stepping = true
+	b.stepTID = tid
+	b.ensureThread(tid)
 	if err := syscall.PtraceSingleStep(tid); err != nil {
 		return fmt.Errorf("PTRACE_SINGLESTEP tid %d: %w", tid, err)
+	}
+	if t := b.threads[tid]; t != nil {
+		t.running = true
 	}
 	return nil
 }
 
+// StopProcess sends SIGSTOP to interrupt a running tracee. It deliberately does
+// NOT hop onto the ptrace thread: that thread is blocked in wait4 while the
+// process runs, and the whole point is to make that wait4 return. kill(2) is not
+// thread-bound, so signalling from any thread is fine.
 func (b *linuxBackend) StopProcess() error {
 	p, err := os.FindProcess(b.pid)
 	if err != nil {
@@ -113,6 +260,12 @@ func (b *linuxBackend) StopProcess() error {
 }
 
 func (b *linuxBackend) ReadMemory(addr uint64, dst []byte) error {
+	var err error
+	b.do(func() { err = b.readMemoryLocked(addr, dst) })
+	return err
+}
+
+func (b *linuxBackend) readMemoryLocked(addr uint64, dst []byte) error {
 	tid := b.traceTID()
 	n, err := syscall.PtracePeekData(tid, uintptr(addr), dst)
 	if err != nil {
@@ -125,6 +278,12 @@ func (b *linuxBackend) ReadMemory(addr uint64, dst []byte) error {
 }
 
 func (b *linuxBackend) WriteMemory(addr uint64, src []byte) error {
+	var err error
+	b.do(func() { err = b.writeMemoryLocked(addr, src) })
+	return err
+}
+
+func (b *linuxBackend) writeMemoryLocked(addr uint64, src []byte) error {
 	tid := b.traceTID()
 	n, err := syscall.PtracePokeData(tid, uintptr(addr), src)
 	if err != nil {
@@ -138,6 +297,15 @@ func (b *linuxBackend) WriteMemory(addr uint64, src []byte) error {
 
 // GetRegisters reads PTRACE_GETREGS. The Go runtime stores g at FS_BASE on amd64.
 func (b *linuxBackend) GetRegisters(tid int) (Registers, error) {
+	var (
+		reg Registers
+		err error
+	)
+	b.do(func() { reg, err = b.getRegistersLocked(tid) })
+	return reg, err
+}
+
+func (b *linuxBackend) getRegistersLocked(tid int) (Registers, error) {
 	var r syscall.PtraceRegs
 	if err := syscall.PtraceGetRegs(tid, &r); err != nil {
 		return Registers{}, fmt.Errorf("PTRACE_GETREGS tid %d: %w", tid, err)
@@ -150,9 +318,15 @@ func (b *linuxBackend) GetRegisters(tid int) (Registers, error) {
 	}, nil
 }
 
-// SetRegisters writes back the engine-owned fields, preserving everything else
-// by reading the full register set first.
+// SetRegisters writes back the engine-owned fields, preserving everything else by
+// reading the full register set first.
 func (b *linuxBackend) SetRegisters(tid int, reg Registers) error {
+	var err error
+	b.do(func() { err = b.setRegistersLocked(tid, reg) })
+	return err
+}
+
+func (b *linuxBackend) setRegistersLocked(tid int, reg Registers) error {
 	var r syscall.PtraceRegs
 	if err := syscall.PtraceGetRegs(tid, &r); err != nil {
 		return fmt.Errorf("PTRACE_GETREGS (pre-set) tid %d: %w", tid, err)
@@ -167,31 +341,66 @@ func (b *linuxBackend) SetRegisters(tid int, reg Registers) error {
 	return nil
 }
 
+// Threads returns all tracee TIDs with the last-stopped thread first. The engine
+// reads registers/memory through threads[0] for frame and goroutine snapshots;
+// that thread must be one that is actually stopped, otherwise PTRACE_GETREGS fails
+// with ESRCH.
 func (b *linuxBackend) Threads() ([]int, error) {
-	entries, err := os.ReadDir(fmt.Sprintf("/proc/%d/task", b.pid))
+	var (
+		tids []int
+		err  error
+	)
+	b.do(func() { tids, err = b.threadsLocked() })
+	return tids, err
+}
+
+func (b *linuxBackend) threadsLocked() ([]int, error) {
+	tids, err := taskTIDs(b.pid)
 	if err != nil {
 		return nil, fmt.Errorf("read /proc/%d/task: %w", b.pid, err)
-	}
-	tids := make([]int, 0, len(entries))
-	for _, e := range entries {
-		var tid int
-		if _, err := fmt.Sscanf(e.Name(), "%d", &tid); err == nil {
-			tids = append(tids, tid)
-		}
 	}
 	if len(tids) == 0 {
 		return nil, fmt.Errorf("no threads for pid %d", b.pid)
 	}
-	return tids, nil
+	ordered := make([]int, 0, len(tids))
+	haveStop := false
+	for _, tid := range tids {
+		if tid == b.lastStopTID {
+			haveStop = true
+			break
+		}
+	}
+	if haveStop {
+		ordered = append(ordered, b.lastStopTID)
+	}
+	for _, tid := range tids {
+		if haveStop && tid == b.lastStopTID {
+			continue
+		}
+		ordered = append(ordered, tid)
+	}
+	return ordered, nil
 }
 
-// Wait blocks until the tracee produces a meaningful debug stop. Single-step
-// vs breakpoint disambiguation uses b.stepping (reliable because ptrace is
-// serialised). PTRACE_EVENT stops (clone/exec/exit) are handled internally
-// and don't surface to the engine.
-//
-//nolint:gocognit,gocyclo // The wait loop is one serialized ptrace state machine.
+// Wait blocks until the tracee produces a meaningful debug stop. New-thread
+// (clone) events, thread exits and transparent signals (SIGURG preemption,
+// SIGCONT, …) are handled internally and never surface to the engine; only a
+// breakpoint/single-step trap, an unexpected signal, or a process exit is
+// returned. Single-step vs breakpoint disambiguation uses b.stepping (reliable
+// because ptrace is serialized on the dedicated thread). The whole loop runs
+// inside one do() closure so every ptrace call it makes stays on the tracer
+// thread.
 func (b *linuxBackend) Wait() (StopEvent, error) {
+	var (
+		evt StopEvent
+		err error
+	)
+	b.do(func() { evt, err = b.waitLocked() })
+	return evt, err
+}
+
+//nolint:gocognit,gocyclo // The wait loop is one serialized ptrace state machine.
+func (b *linuxBackend) waitLocked() (StopEvent, error) {
 	for {
 		var ws syscall.WaitStatus
 		// WALL includes clone()d threads.
@@ -202,21 +411,21 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 			}
 			return StopEvent{}, fmt.Errorf("wait4: %w", err)
 		}
-
-		if ws.Exited() {
-			if tid == b.pid {
-				b.recordStop(tid)
-				return StopEvent{Reason: StopExited, TID: tid, ExitCode: ws.ExitStatus()}, nil
-			}
+		if tid <= 0 {
 			continue
 		}
 
-		if ws.Signaled() {
-			if tid != b.pid {
-				continue
+		if ws.Exited() || ws.Signaled() {
+			delete(b.threads, tid)
+			if tid == b.pid {
+				b.recordStop(tid)
+				if ws.Exited() {
+					return StopEvent{Reason: StopExited, TID: tid, ExitCode: ws.ExitStatus()}, nil
+				}
+				return StopEvent{Reason: StopKilled, TID: tid}, nil
 			}
-			b.recordStop(tid)
-			return StopEvent{Reason: StopKilled, TID: tid}, nil
+			// A non-leader LWP exited; drop it and keep waiting.
+			continue
 		}
 
 		if !ws.Stopped() {
@@ -225,107 +434,98 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 
 		sig := ws.StopSignal()
 
-		// PTRACE_EVENT stops are encoded as SIGTRAP | (event << 8).
+		// A stop for a tid we are not yet tracking is a freshly cloned LWP. Its
+		// initial SIGSTOP can arrive before OR after the parent's
+		// PTRACE_EVENT_CLONE; either way the child is stopped and its wait
+		// notification has just been reaped, so it is safe to initialize tracing
+		// on it here and resume it. Clone children in the debuggee never execute a
+		// breakpoint address, so an unknown tid is always a new LWP, not a real
+		// trap.
+		if _, known := b.threads[tid]; !known {
+			b.initNewThread(tid)
+			inject := 0
+			if sig != syscall.SIGSTOP && sig != syscall.SIGTRAP {
+				inject = int(sig)
+			}
+			_ = b.resumeThread(tid, inject)
+			continue
+		}
+
+		// PTRACE_EVENT stops are encoded as SIGTRAP | (event << 8). With only
+		// PTRACE_O_TRACECLONE set, the sole event we expect is CLONE; anything
+		// else is treated as a spurious event-stop and resumed.
 		if sig == syscall.SIGTRAP {
-			cause := ws.TrapCause()
-
-			switch cause {
+			switch ws.TrapCause() {
 			case syscall.PTRACE_EVENT_CLONE:
-				if err := continueIfTraceeExists(tid, 0); err != nil {
-					return StopEvent{}, fmt.Errorf("PTRACE_CONT clone parent tid %d: %w", tid, err)
-				}
-				continue
-
-			case syscall.PTRACE_EVENT_EXIT:
-				if tid != b.pid {
-					if err := continueIfTraceeExists(tid, 0); err != nil {
-						return StopEvent{}, fmt.Errorf("PTRACE_CONT exiting thread tid %d: %w", tid, err)
-					}
-					continue
-				}
-				// Main thread is about to call exit_group — let it actually exit.
-				if err := continueIfTraceeExists(tid, 0); err != nil {
-					return StopEvent{}, fmt.Errorf("PTRACE_CONT exiting process tid %d: %w", tid, err)
-				}
-				b.recordStop(tid)
-				return StopEvent{Reason: StopExited, TID: tid, ExitCode: 0}, nil
-
-			case syscall.PTRACE_EVENT_EXEC:
-				if err := syscall.PtraceCont(tid, 0); err != nil {
-					return StopEvent{}, fmt.Errorf("PTRACE_CONT exec tid %d: %w", tid, err)
-				}
+				// The parent thread stopped to report the clone. The child is
+				// picked up via its own stop above. Resume the parent.
+				_ = b.resumeThread(tid, 0)
 				continue
 
 			case 0:
 				b.recordStop(tid)
-
 				if b.stepping {
 					b.stepping = false
+					b.stepTID = 0
 					return StopEvent{Reason: StopSingleStep, TID: tid}, nil
 				}
-
-				return StopEvent{
-					Reason: StopBreakpoint,
-					TID:    tid,
-				}, nil
+				return StopEvent{Reason: StopBreakpoint, TID: tid}, nil
 
 			default:
-				if err := continueIfTraceeExists(tid, 0); err != nil {
-					return StopEvent{}, fmt.Errorf("PTRACE_CONT trap cause %d tid %d: %w", cause, tid, err)
-				}
+				_ = b.resumeThread(tid, 0)
 				continue
 			}
 		}
 
-		if sig == syscall.SIGSTOP && tid != b.pid {
-			if err := syscall.PtraceSetOptions(tid, linuxPtraceOptions); err != nil && !isNoSuchProcess(err) {
-				return StopEvent{}, fmt.Errorf("PTRACE_SETOPTIONS clone child tid %d: %w", tid, err)
+		if isTransparentSignal(sig) {
+			// SIGURG carries Go's async preemption; re-deliver it so goroutine
+			// scheduling keeps working. Other benign signals are absorbed.
+			inject := 0
+			if sig == syscall.SIGURG {
+				inject = int(sig)
 			}
-			if err := syscall.Kill(b.pid, syscall.SIGCONT); err != nil && !isNoSuchProcess(err) {
-				return StopEvent{}, fmt.Errorf("SIGCONT tracee pid %d: %w", b.pid, err)
-			}
-			if err := continueTraceeGroup(b.pid, 0); err != nil {
-				return StopEvent{}, err
-			}
-			continue
-		}
-
-		// SIGURG is Go's goroutine-preemption signal; SIGCONT may be injected
-		// above to release clone-child SIGSTOP. Both should stay transparent.
-		if sig == syscall.SIGURG {
-			if b.stepping {
-				if err := singleStepIfTraceeExists(tid); err != nil {
-					return StopEvent{}, fmt.Errorf("PTRACE_SINGLESTEP after SIGURG tid %d: %w", tid, err)
+			if b.stepping && tid == b.stepTID {
+				// Keep making single-step progress on the stepping thread.
+				b.ensureThread(tid)
+				if err := syscall.PtraceSingleStep(tid); err != nil && !isNoSuchProcess(err) {
+					return StopEvent{}, fmt.Errorf("PTRACE_SINGLESTEP after signal tid %d: %w", tid, err)
+				}
+				if t := b.threads[tid]; t != nil {
+					t.running = true
 				}
 			} else {
-				if err := continueIfTraceeExists(tid, int(sig)); err != nil {
-					return StopEvent{}, fmt.Errorf("PTRACE_CONT SIGURG tid %d: %w", tid, err)
-				}
+				_ = b.resumeThread(tid, inject)
 			}
 			continue
 		}
 
-		if sig == syscall.SIGCONT {
-			if err := continueIfTraceeExists(tid, 0); err != nil {
-				return StopEvent{}, fmt.Errorf("PTRACE_CONT SIGCONT tid %d: %w", tid, err)
-			}
+		if sig == syscall.SIGSTOP {
+			// A known thread received SIGSTOP. We never send SIGSTOP ourselves
+			// during normal flow; absorb it and keep the thread going.
+			_ = b.resumeThread(tid, 0)
 			continue
 		}
 
+		// Any other signal (SIGSEGV, SIGILL, …) is surfaced to the engine.
 		b.recordStop(tid)
-		return StopEvent{
-			Reason: StopSignal,
-			TID:    tid,
-			Signal: int(sig),
-		}, nil
+		return StopEvent{Reason: StopSignal, TID: tid, Signal: int(sig)}, nil
 	}
 }
 
 var _ Backend = (*linuxBackend)(nil)
 
 func (b *linuxBackend) setPID(pid int) {
-	b.pid = pid
-	b.lastStopTID = pid
+	b.do(func() {
+		b.pid = pid
+		b.lastStopTID = pid
+		if b.threads == nil {
+			b.threads = make(map[int]*threadState)
+		}
+		// At launch only the thread-group leader exists and it is stopped. Under
+		// attach we have already stopped the leader; future clones are picked up
+		// through PTRACE_EVENT_CLONE.
+		b.threads[pid] = &threadState{running: false}
+	})
 }
 
 func (b *linuxBackend) traceTID() int {
@@ -338,7 +538,55 @@ func (b *linuxBackend) traceTID() int {
 func (b *linuxBackend) recordStop(tid int) {
 	if tid != 0 {
 		b.lastStopTID = tid
+		b.ensureThread(tid).running = false
 	}
+}
+
+func (b *linuxBackend) ensureThread(tid int) *threadState {
+	if b.threads == nil {
+		b.threads = make(map[int]*threadState)
+	}
+	t := b.threads[tid]
+	if t == nil {
+		t = &threadState{}
+		b.threads[tid] = t
+	}
+	return t
+}
+
+// resumeThread PTRACE_CONTs a single tid, tolerating the thread having already
+// gone away (ESRCH) by forgetting it.
+func (b *linuxBackend) resumeThread(tid, sig int) error {
+	if err := syscall.PtraceCont(tid, sig); err != nil {
+		if isNoSuchProcess(err) {
+			delete(b.threads, tid)
+			return nil
+		}
+		return err
+	}
+	b.ensureThread(tid).running = true
+	return nil
+}
+
+// initNewThread starts tracing a freshly cloned LWP. It is only called from Wait
+// after the thread's stop has already been reaped, so PTRACE_SETOPTIONS cannot
+// race the thread's creation and never needs a blocking wait. Options are
+// best-effort: a thread that already died is dropped later on resume.
+func (b *linuxBackend) initNewThread(tid int) {
+	if _, ok := b.threads[tid]; ok {
+		return
+	}
+	_ = syscall.PtraceSetOptions(tid, linuxPtraceOptions)
+	b.threads[tid] = &threadState{running: false}
+}
+
+func isTransparentSignal(sig syscall.Signal) bool {
+	switch sig {
+	case syscall.SIGURG, syscall.SIGCONT, syscall.SIGCHLD,
+		syscall.SIGWINCH, syscall.SIGIO, syscall.SIGPROF:
+		return true
+	}
+	return false
 }
 
 func isNoSuchProcess(err error) bool {
@@ -347,35 +595,6 @@ func isNoSuchProcess(err error) bool {
 
 func isNoChildProcess(err error) bool {
 	return errors.Is(err, syscall.ECHILD)
-}
-
-func continueIfTraceeExists(tid int, signal int) error {
-	if tid == 0 {
-		return nil
-	}
-	if err := syscall.PtraceCont(tid, signal); err != nil && !isNoSuchProcess(err) {
-		return err
-	}
-	return nil
-}
-
-func continueTraceeGroup(pid int, signal int) error {
-	tids, err := taskTIDs(pid)
-	if err != nil {
-		if isNoSuchProcess(err) {
-			return nil
-		}
-		return err
-	}
-	if len(tids) == 0 {
-		return continueIfTraceeExists(pid, signal)
-	}
-	for _, tid := range tids {
-		if err := continueIfTraceeExists(tid, signal); err != nil {
-			return fmt.Errorf("PTRACE_CONT tid %d: %w", tid, err)
-		}
-	}
-	return nil
 }
 
 func taskTIDs(pid int) ([]int, error) {
@@ -391,14 +610,4 @@ func taskTIDs(pid int) ([]int, error) {
 		}
 	}
 	return tids, nil
-}
-
-func singleStepIfTraceeExists(tid int) error {
-	if tid == 0 {
-		return nil
-	}
-	if err := syscall.PtraceSingleStep(tid); err != nil && !isNoSuchProcess(err) {
-		return err
-	}
-	return nil
 }

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -399,6 +399,13 @@ func (e *engine) handleStop(stop StopEvent) {
 		}
 		slog.Debug("StopBreakpoint matched", "file", bp.file, "line", bp.line,
 			"addr", fmt.Sprintf("0x%x", bp.addr))
+		// On x86 the CPU leaves RIP one byte past the INT3. Rewind the trapping
+		// thread's real PC to the breakpoint address (stop.PC already holds the
+		// rewound value) so that once the original instruction is restored the
+		// thread re-executes it from the start instead of running from
+		// mid-instruction. Uniform for user and sentinel breakpoints; a no-op
+		// on arm64/Darwin where BRK leaves PC at the instruction.
+		e.rewindTrapPC(stop.TID, stop.PC)
 		if bp.file == stepOverNextFile {
 			_ = e.bps.clear(e.backend, bp.id)
 			e.lastBP = nil
@@ -537,6 +544,25 @@ func (e *engine) populateStopPC(stop StopEvent, rewind bool) (StopEvent, error) 
 		stop.PC = regs.PC
 	}
 	return stop, nil
+}
+
+// rewindTrapPC resets a trapping thread's real PC to the breakpoint address on
+// architectures where the software-breakpoint trap advances PC past the trap
+// instruction (x86 INT3). Without this, restoring the original instruction and
+// single-stepping would run from mid-instruction. No-op on arm64/Darwin.
+func (e *engine) rewindTrapPC(tid int, pc uint64) {
+	if !archBreakpointTrapMovesPC() || tid == 0 {
+		return
+	}
+	regs, err := e.backend.GetRegisters(tid)
+	if err != nil {
+		return
+	}
+	if regs.PC == pc {
+		return
+	}
+	regs.PC = pc
+	_ = e.backend.SetRegisters(tid, regs)
 }
 
 func (e *engine) populateBreakpointStop(stop StopEvent) (StopEvent, error) {

--- a/internal/debugger/trap_amd64.go
+++ b/internal/debugger/trap_amd64.go
@@ -9,3 +9,9 @@ func archTrapInstruction() []byte { return []byte{0xCC} }
 // archRewindPC corrects PC after INT3: x86 advances RIP past the trap before
 // delivering the exception, so we subtract 1 to recover the patched address.
 func archRewindPC(pc uint64) uint64 { return pc - 1 }
+
+// archBreakpointTrapMovesPC reports whether the CPU leaves PC past the trap
+// instruction after a software breakpoint. On x86 INT3 advances RIP to addr+1,
+// so the engine must rewind the trapping thread's real PC to the breakpoint
+// address before restoring the original instruction and single-stepping.
+func archBreakpointTrapMovesPC() bool { return true }

--- a/internal/debugger/trap_arm64.go
+++ b/internal/debugger/trap_arm64.go
@@ -8,3 +8,8 @@ package debugger
 func archTrapInstruction() []byte { return []byte{0x00, 0x00, 0x20, 0xD4} }
 
 func archRewindPC(pc uint64) uint64 { return pc }
+
+// archBreakpointTrapMovesPC reports whether the CPU leaves PC past the trap
+// instruction after a software breakpoint. On arm64 the BRK leaves PC AT the
+// instruction, so no PC rewind is needed before restore + single-step.
+func archBreakpointTrapMovesPC() bool { return false }


### PR DESCRIPTION
## TL;DR

The step-over/continue hang is fundamentally a **thread-affinity** bug, and this
PR fixes it the way Delve does: **confine the entire tracee interaction — the
`fork`/exec, every ptrace request, `wait4`, and the state they touch — to a
single dedicated OS thread** (`ptraceThread`, Delve's `execPtraceFunc`). Two
other conditions the gate exposed — enabling `PTRACE_O_TRACECLONE` and rewinding
the amd64 RIP past `INT3` — are necessary co-requirements, but neither works
until ptrace runs on the tracer thread.

## Root cause

Linux ties every ptrace **control** op (`CONT`/`SINGLESTEP`/`SETOPTIONS`/`PEEK`/
`POKE`/`GETREGS`) to the OS thread that created the tracee — here, the thread
that forks the `PTRACE_TRACEME` child. The engine funnels its command-side ptrace
onto one locked goroutine (`engine.loop`, the forking thread), but `Backend.Wait`
runs on a **separate** `waitLoop` goroutine. So the clone / thread-lifecycle
resumes that `Wait` performs executed on the wrong thread and **silently
no-oped**: CI instrumentation showed `PTRACE_CONT` from the wait thread returning
`nil` while leaving both the leader (`6642`) and the freshly cloned child
(`6645`) in state `t` (traced-stopped). The whole group stayed stopped and
`wait4` blocked to the test timeout.

This is why a naive "just add `TRACECLONE`" attempt made the *first* `Continue`
hang, and why single-tid resume let the main goroutine migrate onto an untraced
LWP and wedge the step-over.

## Fix — one dedicated ptrace thread (the centerpiece)

`internal/debugger/backend_linux_amd64.go`, modeled on `go-delve/delve`
`pkg/proc/native` `execPtraceFunc`:

- A `ptraceThread` goroutine `runtime.LockOSThread()`s for the process lifetime
  and runs closures off a channel. **The fork/exec, every ptrace request,
  `wait4`, and the bookkeeping they read/write are all marshalled onto it** via
  `do(fn)`. `newBackend` publishes the handle so the package-level process hooks
  (`startTracedProcess`/`attachToProcess`/`killProcess`, invoked through the
  shared `process` type rather than as backend methods) fork and reap on that
  same thread — making it the tracer for **all** subsequent control ops.
- `Wait`'s entire `wait4` + clone-handling loop runs inside a single `do`
  closure, so its ptrace never leaves the tracer thread. This is what makes the
  resumes actually take effect.
- `StopProcess` deliberately stays a bare signal (not routed through the thread)
  so it can interrupt a blocked `wait4` rather than queue behind it.

### Co-requirement 1 — canonical clone tracing (`PTRACE_O_TRACECLONE`)

Set on launch and attach (Delve's `ptraceOptionsNormal`). All LWPs are tracked in
`threads map[int]*threadState`; `Wait` is a state machine — on
`PTRACE_EVENT_CLONE` resume the parent, register+resume each new child from its
own initial stop (order-independent vs. the parent event), drop exited threads,
keep `SIGURG` (Go async preemption) transparent; only a real breakpoint/
single-step trap, an unexpected signal, or process exit surfaces to the engine.
`ContinueProcess` resumes **every** stopped thread so goroutine migration can't
wedge the group.

### Co-requirement 2 — amd64 RIP rewind

`internal/debugger/engine.go` + `trap_{amd64,arm64}.go`. After `INT3` the x86 CPU
leaves `RIP` one byte **past** the trap; the engine computed the rewound PC for
breakpoint *lookup* but never wrote it back, so `resumeFromBreakpoint`
single-stepped from mid-instruction. `handleStop` now rewinds the trapping
thread's real PC to the breakpoint address, gated by `archBreakpointTrapMovesPC()`
— amd64 `true`, arm64 `false` (BRK leaves PC at the instruction, so **Darwin/arm64
is semantically untouched**).

## Verification

No local linux ptrace is available (docker emulation broken); verified via the
immutable `Debugger E2E` gate (`ubuntu-24.04`, `-race`).

**Green run: https://github.com/bingosuite/bingo/actions/runs/28494576533**

- `TestE2EBasic` — PASS (25 continue+stepover iterations)
- `TestE2EChurn` — PASS (200 continue+stepover iterations under thread churn)

Locally: `gofmt`/`goimports` clean; `GOOS=linux GOARCH=amd64 go build/vet` clean;
`GOOS=darwin GOARCH=arm64 go build -tags bingonative` clean;
`go test -tags bingonative -race ./...` passes.

## Delve references

- `pkg/proc/native/proc_linux.go`: `execPtraceFunc` / `handlePtraceFuncs` (the
  single ptrace-owning thread this PR mirrors); `ptraceOptionsNormal =
  syscall.PTRACE_O_TRACECLONE`; `(*nativeProcess).addThread`; `trapWaitInternal`
  (`PTRACE_EVENT_CLONE` → register + resume child/parent, thread-exit `delete`,
  unknown-thread `continue`, transparent signals).
- `pkg/proc/native/threads_linux.go`: per-thread `running` state that
  `ContinueProcess` mirrors.

Scope: surgical; only `internal/debugger` (linux backend + engine rewind co-fix +
trap arch helpers). The gate files (`e2e_integration_test.go`,
`.github/workflows/debugger-e2e.yml`) are untouched.