### PR TITLE
Linux fix: unify ptrace onto a single tracer thread

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,10 +118,16 @@ This is the most fragile code in the repo. Read this section before changing
 anything in [internal/debugger/](internal/debugger/).
 
 1. **All ptrace/Mach calls run on a single OS thread.** The engine event loop
-   (`engine.loop`) calls `runtime.LockOSThread()` and never unlocks. ptrace
-   on Linux is thread-specific — calling it from a different OS thread fails.
-   Public `Debugger` methods (`Continue`, `SetBreakpoint`, …) submit a closure
-   to `cmdCh`; the loop executes it. They don't make ptrace calls themselves.
+   (`engine.loop`) calls `runtime.LockOSThread()` and never unlocks. Public
+   `Debugger` methods (`Continue`, `SetBreakpoint`, …) submit a closure to
+   `cmdCh`; the loop executes it. They don't make ptrace calls themselves.
+   ptrace is thread-bound on Linux, so the linux backend goes further: it owns
+   a **dedicated tracer thread** (`tracerThread`) and funnels *every* ptrace
+   control op through `execPtrace`, because they must issue from the exact
+   thread that forked/attached the tracee. `wait4` is the one exception — legal
+   from any thread of the tracer process, so `Wait` runs it directly off the
+   tracer thread. On Darwin the ptrace/Mach calls run on the engine-loop thread
+   itself (Mach ports are task-wide). Mirrors Delve's `execPtraceFunc`.
 
 2. **`waitLoop` is a one-shot, locked goroutine.** Every time the process is
    resumed, a fresh `waitLoop` goroutine is started. It calls `Backend.Wait()`
@@ -184,6 +190,14 @@ Per-arch in [trap_amd64.go](internal/debugger/trap_amd64.go) and
 | amd64 | `INT3` (1 byte, 0xCC) | RIP = bp+1 (advanced past INT3) | subtract 1 |
 | arm64 | `BRK #0` (4 bytes) | PC = bp (at the BRK) | identity |
 
+On a matched software-BP stop the engine calls `rewindToBreakpoint` to write
+the rewound PC back into the tracee's **live** register (not just the local
+`StopEvent`). On amd64 the CPU leaves RIP one byte past the `INT3`, so every
+resume path — plain continue and the restore→single-step→reinstall step-over
+dance — would otherwise start mid-instruction and corrupt the tracee (this
+manifested as a hung `StepOver`). No-op on arm64/Darwin, whose rewind is
+identity.
+
 Be careful: spurious SIGTRAPs (Go runtime internal traps, libc assertions)
 arrive as `StopBreakpoint` with no entry in our table. On ARM64, calling
 `ContinueProcess` with PC unchanged re-executes the BRK — infinite loop. The
@@ -216,9 +230,21 @@ engine advances PC by `len(archTrapInstruction())` and resumes. See the
 
 ### Linux / amd64 ([backend_linux_amd64.go](internal/debugger/backend_linux_amd64.go))
 
-- Pure ptrace. `startTracedProcess` enables `PTRACE_O_TRACEEXIT |
-  PTRACE_O_TRACEEXEC`; clone-thread tracing is intentionally not enabled until
-  the backend can resume Go runtime clone stops without parking the thread group.
+- Pure ptrace, funnelled through one dedicated tracer thread
+  (`tracerThread` / `execPtrace`) because ptrace is thread-bound: the initial
+  fork/exec, attach, and every control op (`CONT` / `SINGLESTEP` /
+  `GET`·`SETREGS` / `PEEK`·`POKEDATA` / `SETOPTIONS`) must originate from the
+  one thread that became the tracer. `wait4` runs off that thread (valid from
+  any tracer thread). Splitting the wait from the control ops was the original
+  step-over hang: cross-thread `PTRACE_SINGLESTEP` failed with `ESRCH`.
+- `startTracedProcess` enables `PTRACE_O_TRACEEXIT | PTRACE_O_TRACEEXEC |
+  PTRACE_O_TRACECLONE`. Clone tracing is set at the single-threaded execve stop
+  so every later Go-runtime worker thread inherits it; without it a goroutine
+  migrated (e.g. by `time.Sleep`) onto an untraced clone thread would deliver
+  its breakpoint `SIGTRAP` to the Go runtime ("fatal: trace trap") instead of
+  the tracer. Each new thread's initial `SIGSTOP` is resumed **individually** —
+  never a group-continue, which would let a thread parked at a breakpoint run
+  away (the "parking the thread group" hazard).
 - `Wait` uses `Wait4(-1, …, WALL)` to receive events for any thread.
   `PTRACE_EVENT_*` stops are absorbed (resumed and looped) and never surface
   to the engine.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,8 +251,17 @@ engine advances PC by `len(archTrapInstruction())` and resumes. See the
 - ptrace stops are per-thread. The backend records the last stopped TID and
   targets `ContinueProcess` / memory reads / memory writes at that TID, not
   blindly at the process PID. Non-main thread exits are absorbed inside `Wait`.
+- Single-step vs breakpoint disambiguation uses **both** `stepping` and
+  `stepTID` (the exact TID `SingleStep` was issued against). Only a `cause==0`
+  SIGTRAP on `stepTID` is the step's completion; the same stop on any other
+  thread is that thread hitting an INT3 and is reported as a breakpoint. This
+  matters because `Wait4(-1, …)` can return a sibling thread's concurrent
+  breakpoint (or SIGURG) while a step is in flight — keying off `stepping`
+  alone would misclassify it and corrupt the engine's step-over state machine.
 - `g` pointer for goroutine inspection lives at `FS_BASE` on amd64.
-- `SIGURG` re-delivery is mandatory here too.
+- `SIGURG` re-delivery is mandatory here too — but only the `stepTID` thread is
+  re-single-stepped on SIGURG; a SIGURG on any other thread is re-delivered and
+  that thread continued.
 
 ## DWARF reader notes
 

--- a/internal/debugger/backend_darwin_arm64.go
+++ b/internal/debugger/backend_darwin_arm64.go
@@ -155,7 +155,7 @@ func ptrace(request, pid, addr, data uintptr) error {
 	return nil
 }
 
-func startTracedProcess(binaryPath string, args []string, env []string) (int, *exec.Cmd, error) {
+func startTracedProcess(_ Backend, binaryPath string, args []string, env []string) (int, *exec.Cmd, error) {
 	cmd := exec.Command(binaryPath, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -247,7 +247,7 @@ func godebugHasKey(godebug, key string) bool {
 	return false
 }
 
-func attachToProcess(pid int) error {
+func attachToProcess(_ Backend, pid int) error {
 	if err := ptrace(ptDarwinAttach, uintptr(pid), 0, 0); err != nil {
 		return fmt.Errorf("PT_ATTACH pid %d: %w", pid, err)
 	}
@@ -258,7 +258,7 @@ func attachToProcess(pid int) error {
 	return nil
 }
 
-func killProcess(pid int, cmd *exec.Cmd) error {
+func killProcess(_ Backend, pid int, cmd *exec.Cmd) error {
 	if cmd != nil {
 		if err := cmd.Process.Kill(); err != nil && !isAlreadyExited(err) {
 			return err

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -7,25 +7,117 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
+	"sync"
 	"syscall"
 )
 
 func newBackend() Backend {
-	return &linuxBackend{}
+	return &linuxBackend{tracer: newTracerThread()}
+}
+
+// tracerThread pins a single OS thread and runs every ptrace(2) control op on
+// it. On Linux ptrace is thread-bound: after a tracee is attached (via
+// PTRACE_TRACEME during fork, or PTRACE_ATTACH), *all* subsequent ptrace
+// requests for it must come from the exact thread that became the tracer, or
+// they fail with ESRCH. bingo previously issued control ops from two different
+// goroutines/threads (the engine loop and each waitLoop), so ops made from the
+// wait thread hit ESRCH and were silently swallowed, wedging step-over. This
+// mirrors Delve's execPtraceFunc / ptraceThread (pkg/proc/native/proc.go):
+// funnel fork/exec, attach, detach, cont, single-step, get/set-regs, peek/poke
+// and set-options through one thread. wait4 is NOT routed here — it is safe
+// from any thread of the tracer process (Delve calls sys.Wait4 directly), and
+// keeping it off-thread lets the engine issue control ops while a wait is
+// outstanding.
+type tracerThread struct {
+	funcCh chan func()
+	doneCh chan struct{}
+	quit   chan struct{}
+	once   sync.Once
+}
+
+func newTracerThread() *tracerThread {
+	t := &tracerThread{
+		funcCh: make(chan func()),
+		doneCh: make(chan struct{}),
+		quit:   make(chan struct{}),
+	}
+	go t.run()
+	return t
+}
+
+func (t *tracerThread) run() {
+	runtime.LockOSThread()
+	// Stays welded to its OS thread until quit, so the kernel keeps seeing the
+	// same tracer. Returning ends the goroutine and releases the locked thread.
+	for {
+		select {
+		case fn := <-t.funcCh:
+			fn()
+			t.doneCh <- struct{}{}
+		case <-t.quit:
+			return
+		}
+	}
+}
+
+// execPtrace runs fn on the dedicated tracer thread and blocks until it
+// completes. Concurrent callers (engine loop vs waitLoop) are serialised by the
+// unbuffered channels, so ptrace ops never interleave. After close() the op
+// becomes a no-op rather than blocking forever (the tracee is gone anyway).
+func (t *tracerThread) execPtrace(fn func()) {
+	select {
+	case t.funcCh <- fn:
+		<-t.doneCh
+	case <-t.quit:
+	}
+}
+
+// close stops the tracer goroutine so its locked OS thread is released. Only
+// funcCh's sole channel of control (quit) is closed — never funcCh itself — so
+// a racing execPtrace can never send on a closed channel. Callers must ensure
+// no execPtrace is in flight (the engine calls this only after its loop exits).
+func (t *tracerThread) close() {
+	t.once.Do(func() { close(t.quit) })
+}
+
+// tracerExecer is implemented by backends whose ptrace control ops must all run
+// on one dedicated thread. Only the linux backend implements it; the platform
+// free functions (startTracedProcess/attachToProcess/killProcess) use it to run
+// the fork/attach/detach on that thread. Darwin does not implement it.
+type tracerExecer interface {
+	execPtrace(fn func())
 }
 
 type linuxBackend struct {
 	pid         int
 	stepping    bool // true after SingleStep; classifies the next SIGTRAP
 	lastStopTID int
+	tracer      *tracerThread
 }
 
+func (b *linuxBackend) execPtrace(fn func()) { b.tracer.execPtrace(fn) }
+
+// closeTracer releases the dedicated tracer thread. The engine calls this after
+// its loop exits (process gone), when no further ptrace ops can be issued.
+func (b *linuxBackend) closeTracer() { b.tracer.close() }
+
 const linuxPtraceOptions = syscall.PTRACE_O_TRACEEXIT |
-	syscall.PTRACE_O_TRACEEXEC
+	syscall.PTRACE_O_TRACEEXEC |
+	syscall.PTRACE_O_TRACECLONE
 
 // startTracedProcess forks under ptrace. The child is stopped at its first
-// instruction (execve SIGTRAP) ready for the engine to set breakpoints.
-func startTracedProcess(binaryPath string, args []string, env []string) (int, *exec.Cmd, error) {
+// instruction (execve SIGTRAP) ready for the engine to set breakpoints. The
+// fork+exec, the reap of the initial execve stop and PTRACE_SETOPTIONS all run
+// on the backend's dedicated tracer thread: the forking thread becomes the
+// tracee's tracer, so every later ptrace op must originate from that same
+// thread.
+func startTracedProcess(b Backend, binaryPath string, args []string, env []string) (int, *exec.Cmd, error) {
+	tracer, ok := b.(tracerExecer)
+	if !ok {
+		return 0, nil, fmt.Errorf("startTracedProcess: backend does not support a tracer thread")
+	}
+
 	// codeql-suppress[go/command-injection]: The debugger intentionally launches the local binary selected by the operator.
 	cmd := exec.Command(binaryPath, args...)
 	cmd.Stdin = os.Stdin
@@ -35,43 +127,62 @@ func startTracedProcess(binaryPath string, args []string, env []string) (int, *e
 	if len(env) > 0 {
 		cmd.Env = append(os.Environ(), env...)
 	}
-	if err := cmd.Start(); err != nil {
-		return 0, nil, fmt.Errorf("exec %q: %w", binaryPath, err)
+
+	var startErr error
+	tracer.execPtrace(func() {
+		if err := cmd.Start(); err != nil {
+			startErr = fmt.Errorf("exec %q: %w", binaryPath, err)
+			return
+		}
+		pid := cmd.Process.Pid
+		var ws syscall.WaitStatus
+		if _, err := syscall.Wait4(pid, &ws, 0, nil); err != nil {
+			_ = cmd.Process.Kill()
+			startErr = fmt.Errorf("wait for execve stop: %w", err)
+			return
+		}
+		if !ws.Stopped() || ws.StopSignal() != syscall.SIGTRAP {
+			_ = cmd.Process.Kill()
+			startErr = fmt.Errorf("unexpected initial stop: %v", ws)
+			return
+		}
+		if err := syscall.PtraceSetOptions(pid, linuxPtraceOptions); err != nil {
+			_ = cmd.Process.Kill()
+			startErr = fmt.Errorf("PTRACE_SETOPTIONS: %w", err)
+			return
+		}
+	})
+	if startErr != nil {
+		return 0, nil, startErr
 	}
 
-	pid := cmd.Process.Pid
-
-	var ws syscall.WaitStatus
-	if _, err := syscall.Wait4(pid, &ws, 0, nil); err != nil {
-		_ = cmd.Process.Kill()
-		return 0, nil, fmt.Errorf("wait for execve stop: %w", err)
-	}
-	if !ws.Stopped() || ws.StopSignal() != syscall.SIGTRAP {
-		_ = cmd.Process.Kill()
-		return 0, nil, fmt.Errorf("unexpected initial stop: %v", ws)
-	}
-
-	if err := syscall.PtraceSetOptions(pid, linuxPtraceOptions); err != nil {
-		_ = cmd.Process.Kill()
-		return 0, nil, fmt.Errorf("PTRACE_SETOPTIONS: %w", err)
-	}
-
-	return pid, cmd, nil
+	return cmd.Process.Pid, cmd, nil
 }
 
-func attachToProcess(pid int) error {
-	if err := syscall.PtraceAttach(pid); err != nil {
-		return fmt.Errorf("PTRACE_ATTACH pid %d: %w", pid, err)
+func attachToProcess(b Backend, pid int) error {
+	tracer, ok := b.(tracerExecer)
+	if !ok {
+		return fmt.Errorf("attachToProcess: backend does not support a tracer thread")
 	}
-	var ws syscall.WaitStatus
-	if _, err := syscall.Wait4(pid, &ws, 0, nil); err != nil {
-		return fmt.Errorf("wait after PTRACE_ATTACH: %w", err)
-	}
-	return nil
+	var attachErr error
+	tracer.execPtrace(func() {
+		if err := syscall.PtraceAttach(pid); err != nil {
+			attachErr = fmt.Errorf("PTRACE_ATTACH pid %d: %w", pid, err)
+			return
+		}
+		var ws syscall.WaitStatus
+		if _, err := syscall.Wait4(pid, &ws, 0, nil); err != nil {
+			attachErr = fmt.Errorf("wait after PTRACE_ATTACH: %w", err)
+			return
+		}
+	})
+	return attachErr
 }
 
-func killProcess(pid int, cmd *exec.Cmd) error {
+func killProcess(b Backend, pid int, cmd *exec.Cmd) error {
 	if cmd != nil {
+		// SIGKILL via the OS handle is not a ptrace op, so it is safe from any
+		// thread and keeps Kill responsive even if the tracer thread is busy.
 		if err := cmd.Process.Kill(); err != nil && !isAlreadyExited(err) {
 			return err
 		}
@@ -79,7 +190,12 @@ func killProcess(pid int, cmd *exec.Cmd) error {
 		return nil
 	}
 	// Attached (not launched): detach, don't kill — we don't own the process.
-	_ = syscall.PtraceDetach(pid)
+	// PTRACE_DETACH must run on the tracer thread.
+	if tracer, ok := b.(tracerExecer); ok {
+		tracer.execPtrace(func() { _ = syscall.PtraceDetach(pid) })
+	} else {
+		_ = syscall.PtraceDetach(pid)
+	}
 	return nil
 }
 
@@ -90,7 +206,9 @@ func isAlreadyExited(err error) bool {
 func (b *linuxBackend) ContinueProcess() error {
 	b.stepping = false
 	tid := b.traceTID()
-	if err := syscall.PtraceCont(tid, 0); err != nil {
+	var err error
+	b.execPtrace(func() { err = syscall.PtraceCont(tid, 0) })
+	if err != nil {
 		return fmt.Errorf("PTRACE_CONT tid %d: %w", tid, err)
 	}
 	return nil
@@ -98,7 +216,9 @@ func (b *linuxBackend) ContinueProcess() error {
 
 func (b *linuxBackend) SingleStep(tid int) error {
 	b.stepping = true
-	if err := syscall.PtraceSingleStep(tid); err != nil {
+	var err error
+	b.execPtrace(func() { err = syscall.PtraceSingleStep(tid) })
+	if err != nil {
 		return fmt.Errorf("PTRACE_SINGLESTEP tid %d: %w", tid, err)
 	}
 	return nil
@@ -114,7 +234,9 @@ func (b *linuxBackend) StopProcess() error {
 
 func (b *linuxBackend) ReadMemory(addr uint64, dst []byte) error {
 	tid := b.traceTID()
-	n, err := syscall.PtracePeekData(tid, uintptr(addr), dst)
+	var n int
+	var err error
+	b.execPtrace(func() { n, err = syscall.PtracePeekData(tid, uintptr(addr), dst) })
 	if err != nil {
 		return fmt.Errorf("PTRACE_PEEKDATA tid %d 0x%x: %w", tid, addr, err)
 	}
@@ -126,7 +248,9 @@ func (b *linuxBackend) ReadMemory(addr uint64, dst []byte) error {
 
 func (b *linuxBackend) WriteMemory(addr uint64, src []byte) error {
 	tid := b.traceTID()
-	n, err := syscall.PtracePokeData(tid, uintptr(addr), src)
+	var n int
+	var err error
+	b.execPtrace(func() { n, err = syscall.PtracePokeData(tid, uintptr(addr), src) })
 	if err != nil {
 		return fmt.Errorf("PTRACE_POKEDATA tid %d 0x%x: %w", tid, addr, err)
 	}
@@ -139,7 +263,9 @@ func (b *linuxBackend) WriteMemory(addr uint64, src []byte) error {
 // GetRegisters reads PTRACE_GETREGS. The Go runtime stores g at FS_BASE on amd64.
 func (b *linuxBackend) GetRegisters(tid int) (Registers, error) {
 	var r syscall.PtraceRegs
-	if err := syscall.PtraceGetRegs(tid, &r); err != nil {
+	var err error
+	b.execPtrace(func() { err = syscall.PtraceGetRegs(tid, &r) })
+	if err != nil {
 		return Registers{}, fmt.Errorf("PTRACE_GETREGS tid %d: %w", tid, err)
 	}
 	return Registers{
@@ -154,15 +280,22 @@ func (b *linuxBackend) GetRegisters(tid int) (Registers, error) {
 // by reading the full register set first.
 func (b *linuxBackend) SetRegisters(tid int, reg Registers) error {
 	var r syscall.PtraceRegs
-	if err := syscall.PtraceGetRegs(tid, &r); err != nil {
-		return fmt.Errorf("PTRACE_GETREGS (pre-set) tid %d: %w", tid, err)
+	var getErr, setErr error
+	b.execPtrace(func() {
+		if getErr = syscall.PtraceGetRegs(tid, &r); getErr != nil {
+			return
+		}
+		r.Rip = reg.PC
+		r.Rsp = reg.SP
+		r.Rbp = reg.BP
+		r.Fs_base = reg.TLS
+		setErr = syscall.PtraceSetRegs(tid, &r)
+	})
+	if getErr != nil {
+		return fmt.Errorf("PTRACE_GETREGS (pre-set) tid %d: %w", tid, getErr)
 	}
-	r.Rip = reg.PC
-	r.Rsp = reg.SP
-	r.Rbp = reg.BP
-	r.Fs_base = reg.TLS
-	if err := syscall.PtraceSetRegs(tid, &r); err != nil {
-		return fmt.Errorf("PTRACE_SETREGS tid %d: %w", tid, err)
+	if setErr != nil {
+		return fmt.Errorf("PTRACE_SETREGS tid %d: %w", tid, setErr)
 	}
 	return nil
 }
@@ -189,6 +322,12 @@ func (b *linuxBackend) Threads() ([]int, error) {
 // vs breakpoint disambiguation uses b.stepping (reliable because ptrace is
 // serialised). PTRACE_EVENT stops (clone/exec/exit) are handled internally
 // and don't surface to the engine.
+//
+// wait4 runs on the calling (waitLoop) thread, NOT the tracer thread: waiting
+// for a tracee is legal from any thread of the tracer process, and keeping it
+// off the tracer thread lets the engine issue control ops concurrently. Every
+// ptrace CONTROL op below, however, is funnelled through b.execPtrace so it
+// executes on the one thread the kernel accepts ptrace requests from.
 //
 //nolint:gocognit,gocyclo // The wait loop is one serialized ptrace state machine.
 func (b *linuxBackend) Wait() (StopEvent, error) {
@@ -231,27 +370,27 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 
 			switch cause {
 			case syscall.PTRACE_EVENT_CLONE:
-				if err := continueIfTraceeExists(tid, 0); err != nil {
+				if err := b.continueIfTraceeExists(tid, 0); err != nil {
 					return StopEvent{}, fmt.Errorf("PTRACE_CONT clone parent tid %d: %w", tid, err)
 				}
 				continue
 
 			case syscall.PTRACE_EVENT_EXIT:
 				if tid != b.pid {
-					if err := continueIfTraceeExists(tid, 0); err != nil {
+					if err := b.continueIfTraceeExists(tid, 0); err != nil {
 						return StopEvent{}, fmt.Errorf("PTRACE_CONT exiting thread tid %d: %w", tid, err)
 					}
 					continue
 				}
 				// Main thread is about to call exit_group — let it actually exit.
-				if err := continueIfTraceeExists(tid, 0); err != nil {
+				if err := b.continueIfTraceeExists(tid, 0); err != nil {
 					return StopEvent{}, fmt.Errorf("PTRACE_CONT exiting process tid %d: %w", tid, err)
 				}
 				b.recordStop(tid)
 				return StopEvent{Reason: StopExited, TID: tid, ExitCode: 0}, nil
 
 			case syscall.PTRACE_EVENT_EXEC:
-				if err := syscall.PtraceCont(tid, 0); err != nil {
+				if err := b.continueIfTraceeExists(tid, 0); err != nil {
 					return StopEvent{}, fmt.Errorf("PTRACE_CONT exec tid %d: %w", tid, err)
 				}
 				continue
@@ -270,7 +409,7 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 				}, nil
 
 			default:
-				if err := continueIfTraceeExists(tid, 0); err != nil {
+				if err := b.continueIfTraceeExists(tid, 0); err != nil {
 					return StopEvent{}, fmt.Errorf("PTRACE_CONT trap cause %d tid %d: %w", cause, tid, err)
 				}
 				continue
@@ -278,27 +417,28 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 		}
 
 		if sig == syscall.SIGSTOP && tid != b.pid {
-			if err := syscall.PtraceSetOptions(tid, linuxPtraceOptions); err != nil && !isNoSuchProcess(err) {
-				return StopEvent{}, fmt.Errorf("PTRACE_SETOPTIONS clone child tid %d: %w", tid, err)
-			}
-			if err := syscall.Kill(b.pid, syscall.SIGCONT); err != nil && !isNoSuchProcess(err) {
-				return StopEvent{}, fmt.Errorf("SIGCONT tracee pid %d: %w", b.pid, err)
-			}
-			if err := continueTraceeGroup(b.pid, 0); err != nil {
-				return StopEvent{}, err
+			// A newly cloned thread's initial group-stop. With
+			// PTRACE_O_TRACECLONE the kernel auto-attaches it and it inherits
+			// our ptrace options, so we just resume THIS thread. Crucially we
+			// must NOT touch the rest of the group: another thread may be
+			// stopped at a breakpoint waiting for the engine, and a
+			// group-continue here would let it run away (the exact "parking the
+			// thread group" hazard that kept clone tracing disabled before).
+			if err := b.continueIfTraceeExists(tid, 0); err != nil {
+				return StopEvent{}, fmt.Errorf("PTRACE_CONT new thread tid %d: %w", tid, err)
 			}
 			continue
 		}
 
-		// SIGURG is Go's goroutine-preemption signal; SIGCONT may be injected
-		// above to release clone-child SIGSTOP. Both should stay transparent.
+		// SIGURG is Go's goroutine-preemption signal; it must be re-delivered
+		// transparently during both step and continue or scheduling breaks.
 		if sig == syscall.SIGURG {
 			if b.stepping {
-				if err := singleStepIfTraceeExists(tid); err != nil {
+				if err := b.singleStepIfTraceeExists(tid); err != nil {
 					return StopEvent{}, fmt.Errorf("PTRACE_SINGLESTEP after SIGURG tid %d: %w", tid, err)
 				}
 			} else {
-				if err := continueIfTraceeExists(tid, int(sig)); err != nil {
+				if err := b.continueIfTraceeExists(tid, int(sig)); err != nil {
 					return StopEvent{}, fmt.Errorf("PTRACE_CONT SIGURG tid %d: %w", tid, err)
 				}
 			}
@@ -306,7 +446,7 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 		}
 
 		if sig == syscall.SIGCONT {
-			if err := continueIfTraceeExists(tid, 0); err != nil {
+			if err := b.continueIfTraceeExists(tid, 0); err != nil {
 				return StopEvent{}, fmt.Errorf("PTRACE_CONT SIGCONT tid %d: %w", tid, err)
 			}
 			continue
@@ -349,55 +489,25 @@ func isNoChildProcess(err error) bool {
 	return errors.Is(err, syscall.ECHILD)
 }
 
-func continueIfTraceeExists(tid int, signal int) error {
+func (b *linuxBackend) continueIfTraceeExists(tid int, signal int) error {
 	if tid == 0 {
 		return nil
 	}
-	if err := syscall.PtraceCont(tid, signal); err != nil && !isNoSuchProcess(err) {
+	var err error
+	b.execPtrace(func() { err = syscall.PtraceCont(tid, signal) })
+	if err != nil && !isNoSuchProcess(err) {
 		return err
 	}
 	return nil
 }
 
-func continueTraceeGroup(pid int, signal int) error {
-	tids, err := taskTIDs(pid)
-	if err != nil {
-		if isNoSuchProcess(err) {
-			return nil
-		}
-		return err
-	}
-	if len(tids) == 0 {
-		return continueIfTraceeExists(pid, signal)
-	}
-	for _, tid := range tids {
-		if err := continueIfTraceeExists(tid, signal); err != nil {
-			return fmt.Errorf("PTRACE_CONT tid %d: %w", tid, err)
-		}
-	}
-	return nil
-}
-
-func taskTIDs(pid int) ([]int, error) {
-	entries, err := os.ReadDir(fmt.Sprintf("/proc/%d/task", pid))
-	if err != nil {
-		return nil, err
-	}
-	tids := make([]int, 0, len(entries))
-	for _, entry := range entries {
-		var tid int
-		if _, err := fmt.Sscanf(entry.Name(), "%d", &tid); err == nil {
-			tids = append(tids, tid)
-		}
-	}
-	return tids, nil
-}
-
-func singleStepIfTraceeExists(tid int) error {
+func (b *linuxBackend) singleStepIfTraceeExists(tid int) error {
 	if tid == 0 {
 		return nil
 	}
-	if err := syscall.PtraceSingleStep(tid); err != nil && !isNoSuchProcess(err) {
+	var err error
+	b.execPtrace(func() { err = syscall.PtraceSingleStep(tid) })
+	if err != nil && !isNoSuchProcess(err) {
 		return err
 	}
 	return nil

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -92,6 +92,7 @@ type tracerExecer interface {
 type linuxBackend struct {
 	pid         int
 	stepping    bool // true after SingleStep; classifies the next SIGTRAP
+	stepTID     int  // the exact thread SingleStep was issued against
 	lastStopTID int
 	tracer      *tracerThread
 }
@@ -205,6 +206,7 @@ func isAlreadyExited(err error) bool {
 
 func (b *linuxBackend) ContinueProcess() error {
 	b.stepping = false
+	b.stepTID = 0
 	tid := b.traceTID()
 	var err error
 	b.execPtrace(func() { err = syscall.PtraceCont(tid, 0) })
@@ -216,6 +218,7 @@ func (b *linuxBackend) ContinueProcess() error {
 
 func (b *linuxBackend) SingleStep(tid int) error {
 	b.stepping = true
+	b.stepTID = tid
 	var err error
 	b.execPtrace(func() { err = syscall.PtraceSingleStep(tid) })
 	if err != nil {
@@ -319,9 +322,11 @@ func (b *linuxBackend) Threads() ([]int, error) {
 }
 
 // Wait blocks until the tracee produces a meaningful debug stop. Single-step
-// vs breakpoint disambiguation uses b.stepping (reliable because ptrace is
-// serialised). PTRACE_EVENT stops (clone/exec/exit) are handled internally
-// and don't surface to the engine.
+// vs breakpoint disambiguation uses b.stepping AND b.stepTID: only a cause==0
+// SIGTRAP on the exact thread we stepped is the step's completion; the same
+// stop on any other thread is that thread hitting a software breakpoint.
+// PTRACE_EVENT stops (clone/exec/exit) are handled internally and don't
+// surface to the engine.
 //
 // wait4 runs on the calling (waitLoop) thread, NOT the tracer thread: waiting
 // for a tracee is legal from any thread of the tracer process, and keeping it
@@ -398,8 +403,15 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 			case 0:
 				b.recordStop(tid)
 
-				if b.stepping {
+				// Only the exact thread we single-stepped produces a
+				// single-step SIGTRAP. A cause==0 SIGTRAP on any OTHER thread
+				// while a step is in flight is that thread hitting a software
+				// breakpoint (INT3), not the step completing — classify it as a
+				// breakpoint so the engine's step-over state machine isn't fed a
+				// bogus StopSingleStep for the wrong thread.
+				if b.stepping && tid == b.stepTID {
 					b.stepping = false
+					b.stepTID = 0
 					return StopEvent{Reason: StopSingleStep, TID: tid}, nil
 				}
 
@@ -433,7 +445,10 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 		// SIGURG is Go's goroutine-preemption signal; it must be re-delivered
 		// transparently during both step and continue or scheduling breaks.
 		if sig == syscall.SIGURG {
-			if b.stepping {
+			// Re-issue the single-step only for the thread actually being
+			// stepped; a SIGURG on any other thread must be re-delivered and
+			// the thread continued, never single-stepped.
+			if b.stepping && tid == b.stepTID {
 				if err := b.singleStepIfTraceeExists(tid); err != nil {
 					return StopEvent{}, fmt.Errorf("PTRACE_SINGLESTEP after SIGURG tid %d: %w", tid, err)
 				}

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -135,7 +135,7 @@ func (e *engine) Events() <-chan protocol.Event { return e.events }
 
 func (e *engine) Launch(binaryPath string, args []string, env []string) error {
 	return e.dispatch(func() error {
-		if err := e.proc.launch(binaryPath, args, env); err != nil {
+		if err := e.proc.launch(e.backend, binaryPath, args, env); err != nil {
 			return err
 		}
 		setPID(e.backend, e.proc.pid)
@@ -150,7 +150,7 @@ func (e *engine) Launch(binaryPath string, args []string, env []string) error {
 
 func (e *engine) Attach(pid int, binaryPath string) error {
 	return e.dispatch(func() error {
-		if err := e.proc.attach(pid); err != nil {
+		if err := e.proc.attach(e.backend, pid); err != nil {
 			return err
 		}
 		setPID(e.backend, pid)
@@ -341,12 +341,19 @@ func (e *engine) Goroutines() ([]protocol.Goroutine, error) {
 }
 
 func (e *engine) loop() {
-	// All ptrace calls are made from dispatch closures running on this
-	// goroutine. Pin to one OS thread: ptrace is thread-specific on Linux.
+	// Pin to one OS thread. On Darwin the backend issues ptrace/Mach calls
+	// directly from these dispatch closures, so they must stay on one thread.
+	// On Linux the backend owns a dedicated tracer thread (see tracerThread)
+	// and this lock is merely belt-and-braces.
 	runtime.LockOSThread()
 	defer func() {
 		close(e.done)
 		close(e.events)
+		// Release the linux tracer thread now that no more ptrace ops can be
+		// issued (the loop has exited). No-op on backends without one.
+		if c, ok := e.backend.(interface{ closeTracer() }); ok {
+			c.closeTracer()
+		}
 	}()
 
 	for {
@@ -432,6 +439,7 @@ func (e *engine) handleStop(stop StopEvent) {
 		}
 		slog.Debug("StopBreakpoint matched", "file", bp.file, "line", bp.line,
 			"addr", fmt.Sprintf("0x%x", bp.addr))
+		e.rewindToBreakpoint(stop)
 		if bp.file == stepOverNextFile {
 			_ = e.bps.clear(e.backend, bp.id)
 			e.lastBP = nil
@@ -584,6 +592,37 @@ func (e *engine) populateStopPC(stop StopEvent, rewind bool) (StopEvent, error) 
 		stop.PC = regs.PC
 	}
 	return stop, nil
+}
+
+// rewindToBreakpoint writes the breakpoint address back into the tracee's live
+// PC register. On amd64 the CPU advances RIP past the INT3 before delivering
+// the trap, so after a software-breakpoint stop the register points one byte
+// past the patched instruction even though stop.PC has already been rewound
+// for table lookup. Every resume path (plain continue after a sentinel step
+// breakpoint, or the restore→single-step→reinstall step-over dance) would then
+// execute starting one byte into the original instruction, corrupting the
+// tracee and letting it run away — which manifests as a hung Continue/StepOver.
+// Writing the rewound PC back makes every resume start at the real
+// instruction. It is a no-op where the register already matches (e.g. arm64,
+// whose BRK leaves PC in place, and Darwin).
+func (e *engine) rewindToBreakpoint(stop StopEvent) {
+	if stop.TID == 0 {
+		return
+	}
+	regs, err := e.backend.GetRegisters(stop.TID)
+	if err != nil {
+		slog.Warn("rewindToBreakpoint: get registers failed",
+			"tid", stop.TID, "err", err)
+		return
+	}
+	if regs.PC == stop.PC {
+		return
+	}
+	regs.PC = stop.PC
+	if err := e.backend.SetRegisters(stop.TID, regs); err != nil {
+		slog.Warn("rewindToBreakpoint: set registers failed",
+			"tid", stop.TID, "pc", fmt.Sprintf("0x%x", stop.PC), "err", err)
+	}
 }
 
 func (e *engine) populateBreakpointStop(stop StopEvent) (StopEvent, error) {

--- a/internal/debugger/process.go
+++ b/internal/debugger/process.go
@@ -14,7 +14,7 @@ type process struct {
 	live bool
 }
 
-func (p *process) launch(binaryPath string, args []string, env []string) error {
+func (p *process) launch(b Backend, binaryPath string, args []string, env []string) error {
 	if p.live {
 		return ErrAlreadyRunning
 	}
@@ -23,7 +23,7 @@ func (p *process) launch(binaryPath string, args []string, env []string) error {
 		return fmt.Errorf("launch: %w", err)
 	}
 
-	pid, cmd, err := startTracedProcess(binaryPath, args, env)
+	pid, cmd, err := startTracedProcess(b, binaryPath, args, env)
 	if err != nil {
 		return fmt.Errorf("launch: %w", err)
 	}
@@ -33,11 +33,11 @@ func (p *process) launch(binaryPath string, args []string, env []string) error {
 	return nil
 }
 
-func (p *process) attach(pid int) error {
+func (p *process) attach(b Backend, pid int) error {
 	if p.live {
 		return ErrAlreadyRunning
 	}
-	if err := attachToProcess(pid); err != nil {
+	if err := attachToProcess(b, pid); err != nil {
 		return fmt.Errorf("attach: %w", err)
 	}
 	p.pid = pid
@@ -46,9 +46,10 @@ func (p *process) attach(pid int) error {
 	return nil
 }
 
-// kill terminates the tracee. The Backend argument is unused but kept for
-// interface symmetry with the engine's Kill path which also runs bps.clearAll.
-func (p *process) kill(_ Backend) error {
+// kill terminates the tracee. The Backend argument lets platform kill paths run
+// PTRACE_DETACH on the tracer thread; the engine's Kill path also runs
+// bps.clearAll.
+func (p *process) kill(b Backend) error {
 	if !p.live {
 		return nil
 	}
@@ -57,7 +58,7 @@ func (p *process) kill(_ Backend) error {
 		return nil
 	}
 	p.live = false
-	if err := killProcess(p.pid, p.cmd); err != nil {
+	if err := killProcess(b, p.pid, p.cmd); err != nil {
 		return fmt.Errorf("kill: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Root cause

On `linux/amd64` the engine could set a breakpoint and `Continue` to it, but the
first `StepOver` **hung**, and once that was unwedged the tracee later **crashed**.
Three independent low-level defects were in play:

1. **Cross-thread ptrace control ops (the step-over hang).** ptrace is
   thread-bound on Linux — every request for a tracee must be issued from the OS
   thread that became its tracer. The engine issued control ops from the engine
   loop's locked thread, but `Wait()`'s *internal* control ops (SIGURG
   re-delivery, clone/stop handling) ran on the wait goroutine's **separate**
   locked thread. Those cross-thread calls returned `ESRCH`, so the tracee was
   never resumed after the single-step and `StepOver` wedged.

2. **Missing PC rewind after a software breakpoint (correctness).** On amd64 the
   CPU advances `RIP` past the `INT3` before delivering the trap. The engine
   rewound PC only in its local `StopEvent` (for table lookup/display), never in
   the tracee's **live** register. Every resume path — plain continue after a
   sentinel step BP, and the restore→single-step→reinstall step-over dance —
   therefore restarted one byte into the original instruction, corrupting the
   tracee so it never reached the expected stop.

3. **Untraced cloned threads (crash on the second Continue).** Without
   `PTRACE_O_TRACECLONE`, Go-runtime worker threads created via `clone()` were
   not traced. When `time.Sleep` migrated goroutine 1 onto such a thread and it
   hit an `INT3`, the `SIGTRAP` was delivered to the Go runtime's signal handler
   (`fatal error: unexpected signal ... trace trap`) instead of the tracer,
   crashing the target.

## Fix

Centerpiece — **unify the ptrace lifecycle onto one dedicated locked OS thread**,
mirroring Delve's `execPtraceFunc`:

- New `tracerThread` in `backend_linux_amd64.go` owns a single `runtime.LockOSThread`'d
  goroutine. **Every** ptrace control op (`fork/exec`+`SETOPTIONS`, attach,
  detach, `CONT`, `SINGLESTEP`, `GET/SETREGS`, `PEEK/POKEDATA`, and `Wait()`'s
  internal resumes) is funnelled through `execPtrace(fn)`. `wait4` stays *off*
  that thread (legal from any thread of the tracer process). `fork`/`attach`/
  `kill` are routed by threading `Backend` through the platform free funcs
  (Darwin ignores it). Clean shutdown via `closeTracer()` from the engine loop's
  defer.
- **PC rewind:** `rewindToBreakpoint` writes the rewound PC back into the live
  register on every software-BP stop. No-op on arm64/Darwin (identity rewind).
- **Clone tracing:** enable `PTRACE_O_TRACECLONE` (inherited at the
  single-threaded execve stop, so it covers all later Go-runtime threads) and
  resume each new thread's initial `SIGSTOP` **individually**, without touching
  the rest of the group — avoiding the "parking the thread group" hazard that
  had kept clone tracing disabled.

### Consolidation (grafted from the sibling linux solutions)

This PR is the agreed consolidation of the five linux candidate fixes. Only one
change was non-destructive enough to fold in on top of the single-tracer-thread
foundation:

- **`stepTID` trapped-thread disambiguation (from the "exact trapped thread"
  solution).** `Wait4(-1, …, WALL)` can return a *sibling* thread's `cause==0`
  SIGTRAP (a real breakpoint) or a SIGURG while a single-step is in flight.
  Keying step-completion off `b.stepping` alone misclassifies that sibling stop
  as the step's completion (or re-single-steps the wrong thread). The step
  branch is now gated on `tid == b.stepTID` (recorded in `SingleStep`, cleared
  in `ContinueProcess`). The single-threaded path is unchanged (tid always ==
  stepTID during a step); only the concurrent-stop corner changes, mirroring
  Delve's per-stop trap-thread tracking.

The other candidates were **rejected as redundant or non-additive**: the
standalone PC-rewind fix is subsumed by `rewindToBreakpoint`; the trap-file
`archBreakpointTrapMovesPC()` helper duplicates the existing `archRewindPC`; and
the signal-forwarding/clone-lifecycle rewrites introduce an alternative
architecture (new resumer/event interfaces, resume-all semantics) rather than a
non-destructive add-on, so they were left out to protect this branch's verified
behaviour.

## Verification

- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./...` — clean.
- `GOOS=linux GOARCH=amd64 go vet ./internal/debugger/` — clean; linux/amd64
  test binary compiles.
- Darwin host: `go build -tags bingonative ./...` and
  `go test -tags bingonative ./internal/debugger/` — pass (shared engine
  unaffected by the linux-only change and the `stepTID` graft).
- The single-tracer-thread foundation was previously validated green on real
  ubuntu ptrace (`TestE2EBasic` + `TestE2EChurn`, `-race`) while the temporary
  E2E harness existed; that harness has since been removed from the tree by
  project direction, so this PR carries **no** test-harness or CI changes.
  Actual linux ptrace **runtime** re-validation needs a linux CI/host (it cannot
  run on the darwin dev machine).

## Delve references

- `pkg/proc/native/proc_linux.go` — `execPtraceFunc`/`handlePtraceFuncs` funnel
  every ptrace call through one goroutine locked to a single OS thread; `wait4`
  runs off that thread.
- `ptraceOptionsNormal = PTRACE_O_TRACECLONE`; `trapWaitInternal` clone handling
  auto-attaches and resumes new threads per-thread.
- `pkg/proc/native/threads_linux.go` — per-stop trapped-thread tracking (the
  `stepTID` analogue).

## Integration note

Base is `57-refactor-debugger-foundation`, which already contains the darwin
backend fix. This branch was rebased cleanly on top of it: it threads a
`Backend` argument through the shared `process.launch/attach/kill` and
`startTracedProcess/attachToProcess/killProcess` signatures, so it also touches
`backend_darwin_arm64.go` — but only to add an unused `_ Backend` parameter
(behaviour unchanged; required for the package to compile). The PR is
**mergeable/clean**; the darwin signature touch is the only cross-platform line
and is a no-op.
