### PR TITLE
Darwin fix: per-thread hardware single-step

### DIFF
--- a/internal/debugger/backend_darwin_arm64.go
+++ b/internal/debugger/backend_darwin_arm64.go
@@ -404,7 +404,26 @@ func (b *darwinBackend) Threads() ([]int, error) {
 func (b *darwinBackend) Wait() (StopEvent, error) {
 	for {
 		var ws syscall.WaitStatus
-		tid, err := syscall.Wait4(b.pid, &ws, 0, nil)
+		// Reactive task-suspend drain — the race backstop for resumeTraced's
+		// resume-time drain. Poll for a pending stop without blocking. If none
+		// is reapable yet the task is still Mach-suspended, a surplus
+		// task_suspend leaked past the resume-time drain (resumeTraced reads the
+		// count once, before the resume, so a suspend from the same stop cluster
+		// that lands just after that read is missed). A Mach-suspended task
+		// cannot run to create a new stop, and WNOHANG proves none is queued, so
+		// any positive count here is pure leaked surplus: drain one and re-poll
+		// until the task is runnable again or a real stop surfaces. Bounded so a
+		// misbehaving task_resume can never spin forever.
+		tid, err := syscall.Wait4(b.pid, &ws, syscall.WNOHANG, nil)
+		for drains := 0; err == nil && tid == 0 && drains < 64 && b.taskSuspendCount() > 0; drains++ {
+			if rerr := b.taskResume(); rerr != nil {
+				break
+			}
+			tid, err = syscall.Wait4(b.pid, &ws, syscall.WNOHANG, nil)
+		}
+		if err == nil && tid == 0 {
+			tid, err = syscall.Wait4(b.pid, &ws, 0, nil)
+		}
 		if err != nil {
 			if isNoChildProcess(err) {
 				return StopEvent{Reason: StopExited, TID: b.pid}, nil
@@ -613,10 +632,14 @@ func (b *darwinBackend) taskResume() error {
 //
 // We read the suspend count while the task is still stopped, issue the request,
 // then perform exactly (pre-1) extra task_resume calls to cancel the leaked
-// suspends. This is race-free: whenever the post-request count is still positive
-// the task cannot execute, so no new suspend can interleave with the drain, and
-// we never resume past the single legitimate suspend of a healthy stop (pre==1
-// drains nothing).
+// suspends. This handles the common case cheaply at resume time, but it is NOT
+// sufficient on its own: `pre` is sampled once, before the request, so a surplus
+// suspend from the same stop cluster that lands just after the read is missed and
+// the count sticks at 1. The reactive drain-before-block in Wait() is the
+// authoritative backstop that closes that race; this drain merely keeps the
+// common case off the reactive path. (It cannot over-drain: XNU serializes ptrace
+// stops per process, so a positive count never covers a second, independently
+// wait4-reportable stop — only leaked surplus.)
 func (b *darwinBackend) resumeTraced(request, addr, data uintptr) error {
 	pre := b.taskSuspendCount()
 	if err := ptrace(request, uintptr(b.pid), addr, data); err != nil {

--- a/internal/debugger/backend_darwin_arm64.go
+++ b/internal/debugger/backend_darwin_arm64.go
@@ -35,11 +35,33 @@ type darwinBackend struct {
 	stepMu   sync.Mutex
 	stepping bool
 	stepTID  int // Mach thread port saved by SingleStep, reused on the step trap
+
+	// hwStepTID is the Mach thread that currently has the ARM64 hardware
+	// single-step bit (MDSCR_EL1.SS) armed. It is cleared on the next resume so
+	// the thread doesn't keep trapping. Guarded by stepMu.
+	hwStepTID int
+
+	// stepFrozen holds the Mach threads suspended (thread_suspend) for the
+	// duration of a single step so that ONLY the target thread advances. The
+	// next resume (ContinueProcess or another SingleStep) resumes them.
+	// Guarded by stepMu.
+	stepFrozen []int
+
+	// stepFirst records whether the in-flight step targets the task's first
+	// thread, in which case the step is driven with PT_STEP (kernel-side SS on
+	// the first thread) rather than Mach-armed SS. Guarded by stepMu.
+	stepFirst bool
 }
 
 // Darwin ptrace request codes from <sys/ptrace.h>. PT_ATTACH (10) makes the
 // stop wait4-able by PID. Do NOT use PT_ATTACHEXC (14) — Mach exceptions are
 // incompatible with our wait4-based Wait loop.
+//
+// PT_STEP (9) drives the hardware single-step bit (MDSCR_EL1.SS) on the task's
+// FIRST thread only (XNU bsd/kern/mach_process.c: get_firstthread +
+// thread_setsinglestep). We use it ONLY when the thread we want to step already
+// IS the first thread; otherwise we drive the per-thread SS bit via Mach (see
+// SingleStep).
 const (
 	ptDarwinContinue = uintptr(7)
 	ptDarwinStep     = uintptr(9)
@@ -97,8 +119,18 @@ func attachToProcess(pid int) error {
 
 func killProcess(pid int, cmd *exec.Cmd) error {
 	if cmd != nil {
-		if err := cmd.Process.Kill(); err != nil && !isAlreadyExited(err) {
-			return err
+		// The tracee is almost always ptrace-stopped here (at a breakpoint, or
+		// mid single-step). On Darwin a bare SIGKILL to a ptrace-stopped process
+		// is NOT delivered until it runs, so cmd.Process.Kill()+cmd.Wait() would
+		// block until the harness timeout. Resume it under ptrace delivering
+		// SIGKILL so it runs straight into termination. (Even mid-step the step
+		// target thread is left runnable, so it processes the signal and the
+		// task tears down any threads still frozen for the step.) Fall back to a
+		// plain SIGKILL if it is no longer in a ptrace stop.
+		if err := ptrace(ptDarwinContinue, uintptr(pid), 1, uintptr(syscall.SIGKILL)); err != nil {
+			if killErr := cmd.Process.Kill(); killErr != nil && !isAlreadyExited(killErr) {
+				return killErr
+			}
 		}
 		_ = cmd.Wait()
 		return nil
@@ -114,21 +146,153 @@ func isAlreadyExited(err error) bool {
 
 func (b *darwinBackend) ContinueProcess() error {
 	b.clearStep()
-	if err := ptrace(ptDarwinContinue, uintptr(b.pid), 1, 0); err != nil {
+	// Clear any lingering hardware single-step bit and unfreeze the threads that
+	// were suspended for a step so the whole task runs. Best-effort: a thread
+	// may have exited, which must not block the continue.
+	_ = b.disarmSingleStep()
+	b.endStepIsolation()
+	if err := b.resumeTraced(ptDarwinContinue, 1, 0); err != nil {
 		return fmt.Errorf("PT_CONTINUE: %w", err)
 	}
 	return nil
 }
 
+// SingleStep advances exactly one instruction on the Mach thread tid and leaves
+// the process stopped at a SIGTRAP.
+//
+// Darwin's ptrace cannot target a thread directly: PT_STEP and PT_CONTINUE both
+// act on the task's FIRST thread only (XNU bsd/kern/mach_process.c drives
+// thread_setsinglestep(get_firstthread, …)). PT_STEP sets MDSCR_EL1.SS on the
+// first thread; PT_CONTINUE clears it. So we split by which thread trapped:
+//
+//   - tid IS the first thread: use PT_STEP. The kernel arms SS on exactly this
+//     thread.
+//
+//   - tid is NOT the first thread: PT_STEP would arm SS on the wrong (first)
+//     thread and let the real one run free past the removed trap — the original
+//     hang. Instead drive the per-thread hardware SS bit via Mach (mirrors LLDB
+//     debugserver EnableHardwareSingleStep), keeping the sequence as close as
+//     possible to the working isFirst path:
+//      1. Freeze every SIBLING thread (never the target) with thread_suspend.
+//      2. Arm MDSCR_EL1.SS on the target thread via thread_set_state
+//         (ARM_DEBUG_STATE64) while it is still in its ptrace-stop. We set only
+//         MDSCR_EL1.SS, exactly like debugserver and XNU thread_setsinglestep;
+//         the kernel sets PSTATE.SS itself when it applies the debug state on
+//         the target's return-to-user (arm_debug_set64 → mask_user_saved_state_cpsr).
+//      3. PT_CONTINUE the task. XNU clears MDSCR_EL1.SS on the FIRST thread (not
+//         our target, and it is frozen anyway), then task_resume's. Only the
+//         target is unfrozen, so only it advances — one instruction under the
+//         armed single-step — and traps.
+//     The target is never thread_suspend'd/thread_resume'd: it is resumed by
+//     PT_CONTINUE, so it returns to user through the normal path where the
+//     kernel applies its debug state (MDSCR_EL1.SS + PSTATE.SS).
+//
+// In BOTH cases every OTHER thread is frozen with thread_suspend for the
+// duration of the step. This is what LLDB debugserver does to single-step one
+// thread, and it is essential here for a second reason: the churn workload
+// cycles runtime.LockOSThread across eight busy goroutines, so Go's sysmon
+// floods the task with SIGURG (async preemption). If those threads run during
+// the step, every PT_CONTINUE we issue is interrupted by a sibling's SIGURG
+// before the target gets scheduled to take its single instruction — a livelock
+// that never delivers the step trap. Freezing the siblings removes the storm
+// (a suspended thread can neither be preempted nor run sysmon) so the target
+// steps deterministically. Only the target is left runnable.
 func (b *darwinBackend) SingleStep(tid int) error {
+	if tid == 0 {
+		return fmt.Errorf("SingleStep: invalid tid 0")
+	}
+	// Undo any leftover isolation/arming from a previous step before starting.
+	b.endStepIsolation()
+	_ = b.disarmSingleStep()
+
+	threads, err := b.Threads()
+	if err != nil {
+		return fmt.Errorf("SingleStep: list threads: %w", err)
+	}
+	isFirst := len(threads) > 0 && threads[0] == tid
 	b.setStep(tid)
-	// Darwin PT_STEP is per-process (by PID), not per-thread. The tid argument
-	// is a Mach thread port, not a valid ptrace identifier — use b.pid.
-	if err := ptrace(ptDarwinStep, uintptr(b.pid), 1, 0); err != nil {
+	b.setStepFirst(isFirst)
+
+	if isFirst {
+		// Freeze every OTHER thread, then PT_STEP: the kernel arms SS on the
+		// first thread (== tid) and task_resume's the process; only the target
+		// is runnable, so it steps one instruction and traps.
+		for _, t := range threads {
+			if t != tid {
+				_ = b.suspendThread(t)
+			}
+		}
+		b.setStepFrozen(threads, tid)
+		if err := b.resumeTraced(ptDarwinStep, 1, 0); err != nil {
+			b.endStepIsolation()
+			b.clearStep()
+			return b.stepErr(fmt.Errorf("PT_STEP first thread %d: %w", tid, err))
+		}
+		return nil
+	}
+
+	// Freeze every SIBLING (never the target). This mirrors the isFirst branch
+	// above: the target keeps its existing ptrace-stop and is resumed by the
+	// PT_CONTINUE below, so the single-step bit we arm is applied by the kernel
+	// on the SAME context-switch-in path that PT_STEP relies on. We deliberately
+	// do NOT thread_suspend + thread_resume the target — that extra suspend/
+	// resume was the bug: XNU only calls arm_debug_set64 (which loads
+	// MDSCR_EL1.SS onto the CPU) for thread == current_thread(); for any other
+	// thread the debug state is applied on the next context-switch-in. A target
+	// that had not fully switched out before we resumed it could come back
+	// WITHOUT arm_debug_set64 reapplying SS, so it ran free past the removed
+	// trap and Wait() hung. Leaving the target in its ptrace-stop and resuming
+	// it via PT_CONTINUE guarantees a fresh context-switch-in that applies SS.
+	for _, t := range threads {
+		if t != tid {
+			_ = b.suspendThread(t)
+		}
+	}
+	b.setStepFrozen(threads, tid)
+	// Arm the per-thread hardware single-step bit (MDSCR_EL1.SS) on the target
+	// while it is still ptrace-stopped (stored in the thread's DebugData; the
+	// kernel loads it and sets PSTATE.SS on the target's return-to-user). MUST
+	// happen before PT_CONTINUE so the target never executes an un-stepped
+	// instruction.
+	if err := b.armSingleStep(tid); err != nil {
+		b.endStepIsolation()
 		b.clearStep()
-		return fmt.Errorf("PT_STEP: %w", err)
+		return b.stepErr(err)
+	}
+	// PT_CONTINUE resumes the task at the ptrace layer. XNU clears the
+	// single-step bit on the task's FIRST thread here (harmless: it is frozen,
+	// and it is not our target). task_resume then runs, but only the target is
+	// unfrozen, so only the target advances — one instruction under the armed
+	// single-step, then it traps.
+	if err := b.resumeTraced(ptDarwinContinue, 1, 0); err != nil {
+		b.endStepIsolation()
+		_ = b.disarmSingleStep()
+		b.clearStep()
+		return b.stepErr(fmt.Errorf("PT_CONTINUE (single-step target %d): %w", tid, err))
 	}
 	return nil
+}
+
+// stepErr converts a step-setup failure into ErrProcessExited when the tracee is
+// no longer alive — e.g. it was killed (or exited) in the small window between
+// freezing the threads and resuming the target. Reporting a clean exit lets the
+// engine emit ProcessExited instead of surfacing an opaque Mach error
+// ("thread_resume N: object terminated"). If the process is still alive the
+// original error is returned unchanged, so a genuine failure is never masked.
+func (b *darwinBackend) stepErr(err error) error {
+	if b.processGone() {
+		return ErrProcessExited
+	}
+	return err
+}
+
+// processGone reports whether the tracee's Mach task is gone, which means the
+// process has terminated: the task port is destroyed on exit even before the
+// zombie is reaped, so task_for_pid/task_threads fail. A live process always
+// returns at least one thread, so a healthy tracee is never misclassified.
+func (b *darwinBackend) processGone() bool {
+	threads, err := b.Threads()
+	return err != nil || len(threads) == 0
 }
 
 func (b *darwinBackend) StopProcess() error {
@@ -266,45 +430,45 @@ func (b *darwinBackend) Wait() (StopEvent, error) {
 			return StopEvent{Reason: StopBreakpoint}, nil
 		}
 
-		// SIGURG is Go's goroutine-preemption signal. Re-deliver transparently.
-		if sig == syscall.SIGURG {
-			if err := b.resumeAfterSignal(sig); err != nil {
-				if isNoSuchProcess(err) {
-					return StopEvent{Reason: StopKilled, TID: tid}, nil
-				}
-				return StopEvent{}, err
-			}
-			continue
-		}
-
-		// SIGWINCH (terminal resize): handled by the Go runtime, re-deliver.
-		if sig == syscall.SIGWINCH {
-			if err := b.resumeAfterSignal(sig); err != nil {
-				if isNoSuchProcess(err) {
-					return StopEvent{Reason: StopKilled, TID: tid}, nil
-				}
-				return StopEvent{}, err
-			}
-			continue
-		}
-
-		// Other signals during step: re-deliver via PT_STEP so the step
-		// completes. If PT_STEP fails, fall through to StopSignal so the
-		// engine can recover any in-flight step-over BP. Don't fall back to
-		// PT_CONTINUE+continue: that loops on SIGURG every ~10ms forever.
+		// While a single step is in flight, DROP any signal and drive the target
+		// forward one more time. Every other thread is frozen (see SingleStep),
+		// so the only signals we can see here are ones already pending on the
+		// target (typically SIGURG from Go preemption). Re-injecting them, or
+		// resuming the whole task, would either restart the sysmon preemption
+		// storm or let the step escape — so we re-isolate and re-arm instead.
 		if b.isStepping() {
-			if err := ptrace(ptDarwinStep, uintptr(b.pid), 1, uintptr(sig)); err == nil {
-				continue
-			} else if isNoSuchProcess(err) {
-				return StopEvent{Reason: StopKilled, TID: tid}, nil
+			if err := b.continueStep(); err != nil {
+				if isNoSuchProcess(err) || errors.Is(err, ErrProcessExited) {
+					b.clearStep()
+					b.endStepIsolation()
+					return StopEvent{Reason: StopKilled, TID: tid}, nil
+				}
+				b.clearStep()
+				b.endStepIsolation()
+				return StopEvent{}, err
 			}
-			b.clearStep()
+			continue
 		}
+
+		// SIGURG (Go preemption) and SIGWINCH are transparent runtime signals;
+		// re-deliver them so the runtime's scheduling isn't disturbed.
+		if sig == syscall.SIGURG || sig == syscall.SIGWINCH {
+			if err := b.resumeAfterSignal(sig); err != nil {
+				if isNoSuchProcess(err) {
+					return StopEvent{Reason: StopKilled, TID: tid}, nil
+				}
+				return StopEvent{}, err
+			}
+			continue
+		}
+
 		return StopEvent{Reason: StopSignal, Signal: int(sig)}, nil
 	}
 }
 
-func (b *darwinBackend) setPID(pid int) { b.pid = pid }
+func (b *darwinBackend) setPID(pid int) {
+	b.pid = pid
+}
 
 func (b *darwinBackend) setStep(tid int) {
 	b.stepMu.Lock()
@@ -313,10 +477,17 @@ func (b *darwinBackend) setStep(tid int) {
 	b.stepMu.Unlock()
 }
 
+func (b *darwinBackend) setStepFirst(first bool) {
+	b.stepMu.Lock()
+	b.stepFirst = first
+	b.stepMu.Unlock()
+}
+
 func (b *darwinBackend) clearStep() {
 	b.stepMu.Lock()
 	b.stepping = false
 	b.stepTID = 0
+	b.stepFirst = false
 	b.stepMu.Unlock()
 }
 
@@ -338,12 +509,192 @@ func (b *darwinBackend) consumeStep() (bool, int) {
 	return true, tid
 }
 
-func (b *darwinBackend) resumeAfterSignal(sig syscall.Signal) error {
-	request := ptDarwinContinue
-	if b.isStepping() {
-		request = ptDarwinStep
+// armSingleStep enables the ARM64 hardware single-step bit (MDSCR_EL1.SS) on
+// tid and records it so the next resume clears it. The caller is responsible
+// for having already cleared any previous arming (SingleStep does this via
+// disarmSingleStep). Must be called with the thread quiesced.
+func (b *darwinBackend) armSingleStep(tid int) error {
+	if err := b.setThreadSingleStep(tid, true); err != nil {
+		return err
 	}
-	if err := ptrace(request, uintptr(b.pid), 1, uintptr(sig)); err != nil {
+	b.stepMu.Lock()
+	b.hwStepTID = tid
+	b.stepMu.Unlock()
+	return nil
+}
+
+// disarmSingleStep clears the hardware single-step bit from the armed thread, if
+// any. A clear failure (e.g. the thread has exited) is returned but callers
+// treat clearing as best-effort.
+func (b *darwinBackend) disarmSingleStep() error {
+	b.stepMu.Lock()
+	tid := b.hwStepTID
+	b.hwStepTID = 0
+	b.stepMu.Unlock()
+	if tid == 0 {
+		return nil
+	}
+	return b.setThreadSingleStep(tid, false)
+}
+
+// setThreadSingleStep toggles MDSCR_EL1.SS on one Mach thread via cgo.
+func (b *darwinBackend) setThreadSingleStep(tid int, on bool) error {
+	thread := C.mach_port_t(tid)
+	if thread == 0 {
+		return fmt.Errorf("setThreadSingleStep: invalid tid 0")
+	}
+	enable := C.int(0)
+	if on {
+		enable = 1
+	}
+	if kr := C.bingo_set_single_step(thread, enable); kr != C.KERN_SUCCESS {
+		return fmt.Errorf("set single-step tid %d (on=%v): %s", tid, on, machErrString(kr))
+	}
+	return nil
+}
+
+// suspendThread / resumeThread wrap Mach thread_suspend / thread_resume. They
+// are best-effort: a thread may exit between enumeration and the call.
+func (b *darwinBackend) suspendThread(tid int) error {
+	if kr := C.bingo_thread_suspend(C.mach_port_t(tid)); kr != C.KERN_SUCCESS {
+		return fmt.Errorf("thread_suspend %d: %s", tid, machErrString(kr))
+	}
+	return nil
+}
+
+func (b *darwinBackend) resumeThread(tid int) error {
+	if kr := C.bingo_thread_resume(C.mach_port_t(tid)); kr != C.KERN_SUCCESS {
+		return fmt.Errorf("thread_resume %d: %s", tid, machErrString(kr))
+	}
+	return nil
+}
+
+func (b *darwinBackend) resumeThreads(tids []int) {
+	for _, t := range tids {
+		_ = b.resumeThread(t)
+	}
+}
+
+// taskSuspendCount returns the Mach suspend count of the whole task, or -1 on
+// error (e.g. the task port is gone because the process exited).
+func (b *darwinBackend) taskSuspendCount() int {
+	task, err := b.task()
+	if err != nil {
+		return -1
+	}
+	return int(C.bingo_task_suspend_count(task))
+}
+
+// taskResume decrements the tracee task's Mach suspend count by one.
+func (b *darwinBackend) taskResume() error {
+	task, err := b.task()
+	if err != nil {
+		return err
+	}
+	if kr := C.bingo_task_resume(task); kr != C.KERN_SUCCESS {
+		return fmt.Errorf("task_resume: %s", machErrString(kr))
+	}
+	return nil
+}
+
+// resumeTraced issues a resuming ptrace request (PT_CONTINUE / PT_STEP) and then
+// drains any surplus Mach task-level suspends so the tracee actually runs.
+//
+// On Darwin the BSD ptrace layer performs at most ONE task_resume per
+// PT_CONTINUE/PT_STEP — see XNU bsd/kern/mach_process.c, where the `resume:`
+// path calls task_resume(task) once, gated on the single per-process sigwait
+// flag. But a multithreaded tracee can be task_suspend'd more than once when
+// several threads enter the stop path concurrently. Go's async preemption
+// (sysmon delivering SIGURG across the churn workload's busy threads) makes this
+// routine: two threads occasionally stop the task at nearly the same instant, so
+// its Mach suspend count climbs to 2 while wait4 reports a single stop. A lone
+// PT_CONTINUE then leaves the count at 1 — every thread frozen, PC static — and
+// the next wait4 blocks forever. That was the residual step wedge.
+//
+// We read the suspend count while the task is still stopped, issue the request,
+// then perform exactly (pre-1) extra task_resume calls to cancel the leaked
+// suspends. This is race-free: whenever the post-request count is still positive
+// the task cannot execute, so no new suspend can interleave with the drain, and
+// we never resume past the single legitimate suspend of a healthy stop (pre==1
+// drains nothing).
+func (b *darwinBackend) resumeTraced(request, addr, data uintptr) error {
+	pre := b.taskSuspendCount()
+	if err := ptrace(request, uintptr(b.pid), addr, data); err != nil {
+		return err
+	}
+	for i := 1; i < pre; i++ {
+		if err := b.taskResume(); err != nil {
+			// The process may have exited mid-drain; stop and let the wait loop
+			// observe the exit rather than masking it.
+			break
+		}
+	}
+	return nil
+}
+
+// setStepFrozen records every thread except the running target as frozen for
+// the current step, so the next resume can unfreeze them.
+func (b *darwinBackend) setStepFrozen(all []int, target int) {
+	frozen := make([]int, 0, len(all))
+	for _, t := range all {
+		if t != target {
+			frozen = append(frozen, t)
+		}
+	}
+	b.stepMu.Lock()
+	b.stepFrozen = frozen
+	b.stepMu.Unlock()
+}
+
+// endStepIsolation resumes any threads frozen for a step. Idempotent.
+func (b *darwinBackend) endStepIsolation() {
+	b.stepMu.Lock()
+	frozen := b.stepFrozen
+	b.stepFrozen = nil
+	b.stepMu.Unlock()
+	b.resumeThreads(frozen)
+}
+
+// continueStep drives an in-flight step forward after the target took a signal
+// (typically SIGURG). The signal is dropped. It mirrors SingleStep's split:
+//
+//   - first thread: PT_STEP again. The kernel re-arms SS on the first thread
+//     (== target) and task_resume's; the other threads are still frozen from
+//     SingleStep, so only the target advances.
+//   - non-first thread: the siblings are still frozen from SingleStep and the
+//     target was never suspended, so we just re-arm its per-thread MDSCR_EL1.SS
+//     (defensive — the SW_STEP handler clears it after each step, and a signal
+//     stop before the step leaves it set; re-arming is idempotent and cheap) and
+//     PT_CONTINUE, dropping the signal. Only the target is unfrozen, so only it
+//     advances one instruction and traps.
+func (b *darwinBackend) continueStep() error {
+	b.stepMu.Lock()
+	target := b.stepTID
+	first := b.stepFirst
+	b.stepMu.Unlock()
+	if target == 0 {
+		return fmt.Errorf("continueStep: no step target")
+	}
+	if first {
+		// Other threads remain frozen from SingleStep; PT_STEP re-arms SS on the
+		// first thread and resumes it for one more instruction, dropping the
+		// signal (data=0).
+		if err := b.resumeTraced(ptDarwinStep, 1, 0); err != nil {
+			return b.stepErr(fmt.Errorf("PT_STEP (step resume, first thread): %w", err))
+		}
+		return nil
+	}
+	if err := b.armSingleStep(target); err != nil {
+		return b.stepErr(err)
+	}
+	if err := b.resumeTraced(ptDarwinContinue, 1, 0); err != nil {
+		return b.stepErr(fmt.Errorf("PT_CONTINUE (step resume, target %d): %w", target, err))
+	}
+	return nil
+}
+
+func (b *darwinBackend) resumeAfterSignal(sig syscall.Signal) error {
+	if err := b.resumeTraced(ptDarwinContinue, 1, uintptr(sig)); err != nil {
 		return fmt.Errorf("ptrace resume after %s: %w", sig, err)
 	}
 	return nil

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -753,6 +753,18 @@ func (e *engine) resumeFromBreakpoint(action bpResumeAction, retAddr uint64) err
 	}
 	e.lastBPTID = 0
 	if err := e.backend.SingleStep(tid); err != nil {
+		if errors.Is(err, ErrProcessExited) {
+			// The tracee died between removing the trap and issuing the step
+			// (e.g. it was killed). Funnel into the normal exit path: inject a
+			// synthetic stop so the loop emits ProcessExited and shuts down,
+			// instead of surfacing the step failure as an error event.
+			e.steppingOverBP = nil
+			select {
+			case e.stopCh <- stopResult{evt: StopEvent{Reason: StopKilled}}:
+			default:
+			}
+			return nil
+		}
 		_ = e.backend.WriteMemory(bp.addr, archTrapInstruction())
 		e.bps.addToTable(bp)
 		e.steppingOverBP = nil

--- a/internal/debugger/mach_darwin_arm64.h
+++ b/internal/debugger/mach_darwin_arm64.h
@@ -8,6 +8,7 @@
 #include <mach/mach_vm.h>
 #include <mach/arm/thread_status.h>
 #include <stdint.h>
+#include <unistd.h>
 
 // bingo_task_for_pid obtains the Mach task port for the given PID.
 // Requires the com.apple.security.cs.debugger entitlement or SIP disabled.
@@ -15,9 +16,9 @@ static inline kern_return_t bingo_task_for_pid(int pid, mach_port_t *task_out) {
     return task_for_pid(mach_task_self(), pid, task_out);
 }
 
-// bingo_get_registers reads ARM_THREAD_STATE64 for the given thread port,
+// bingo_get_registers_once reads ARM_THREAD_STATE64 for the given thread port,
 // extracting the four registers the engine cares about.
-static inline kern_return_t bingo_get_registers(
+static inline kern_return_t bingo_get_registers_once(
     mach_port_t thread,
     uint64_t *pc, uint64_t *sp, uint64_t *fp, uint64_t *g)
 {
@@ -34,9 +35,9 @@ static inline kern_return_t bingo_get_registers(
     return KERN_SUCCESS;
 }
 
-// bingo_set_registers writes pc/sp/fp/g back into ARM_THREAD_STATE64,
+// bingo_set_registers_once writes pc/sp/fp/g back into ARM_THREAD_STATE64,
 // reading the full state first to preserve all other registers.
-static inline kern_return_t bingo_set_registers(
+static inline kern_return_t bingo_set_registers_once(
     mach_port_t thread,
     uint64_t pc, uint64_t sp, uint64_t fp, uint64_t g)
 {
@@ -54,6 +55,114 @@ static inline kern_return_t bingo_set_registers(
     return thread_set_state(
         thread, ARM_THREAD_STATE64,
         (thread_state_t)&state, count);
+}
+
+// bingo_get_registers / bingo_set_registers wrap the thread-state accessors
+// with a bounded retry on KERN_ABORTED. thread_get_state / thread_set_state can
+// transiently return KERN_ABORTED when the kernel is mid-operation on the
+// thread — e.g. right after a single-step exception is delivered (the target
+// just trapped and the kernel is still tearing down its debug-state fault), or
+// while an asynchronous thread_suspend/resume is settling the thread on/off a
+// CPU. The thread is ptrace-stopped whenever we read or write its GPRs, so it
+// cannot run free during the retries; the state op just needs the kernel to
+// finish. LLDB debugserver retries its GPR accessors (MachThread GPR get/set)
+// on KERN_ABORTED for exactly this reason. Bound 50 * 200us = 10ms worst case,
+// only ever elapsed on the rare error path.
+static inline kern_return_t bingo_get_registers(
+    mach_port_t thread,
+    uint64_t *pc, uint64_t *sp, uint64_t *fp, uint64_t *g)
+{
+    kern_return_t kr = KERN_SUCCESS;
+    for (int i = 0; i < 50; i++) {
+        kr = bingo_get_registers_once(thread, pc, sp, fp, g);
+        if (kr != KERN_ABORTED) return kr;
+        usleep(200);
+    }
+    return kr;
+}
+
+static inline kern_return_t bingo_set_registers(
+    mach_port_t thread,
+    uint64_t pc, uint64_t sp, uint64_t fp, uint64_t g)
+{
+    kern_return_t kr = KERN_SUCCESS;
+    for (int i = 0; i < 50; i++) {
+        kr = bingo_set_registers_once(thread, pc, sp, fp, g);
+        if (kr != KERN_ABORTED) return kr;
+        usleep(200);
+    }
+    return kr;
+}
+
+// bingo_set_single_step arms/disarms ARM64 hardware software-step on ONE
+// specific Mach thread by toggling MDSCR_EL1.SS (bit 0) in the thread's debug
+// state via thread_set_state(ARM_DEBUG_STATE64). This is EXACTLY what LLDB
+// debugserver's DNBArchMachARM64::EnableHardwareSingleStep does (it sets only
+// __mdscr_el1 |= SS_ENABLE and calls SetDBGState), and what XNU's own
+// thread_setsinglestep does for PT_STEP (bsd/kern/mach_process.c → sets only
+// DebugData->mdscr_el1 |= MDSCR_SS).
+//
+// We deliberately do NOT program PSTATE.SS (CPSR bit 21) ourselves. XNU sets it
+// for us: when arm_debug_set64 (osfmk/arm64/pcb.c) applies a debug state whose
+// mdscr_el1 has SS set, it runs `mask_user_saved_state_cpsr(current_thread()->
+// machine.upcb, PSR64_SS, 0)`, i.e. it sets PSTATE.SS on the stepping thread's
+// saved CPSR on the return-to-user path. Setting CPSR.SS ourselves in addition
+// was the bug: it put the ARM software-step state machine into an inconsistent
+// active-pending/active-not-pending combination on some scheduling interleavings
+// (the target came back either not stepping — running free past the removed
+// trap until it deadlocked on a frozen sibling — or double-stepping). Matching
+// debugserver exactly (MDSCR only) makes the step fire deterministically.
+//
+// Why this and not Darwin PT_STEP: PT_STEP is per-PROCESS. In XNU
+// (bsd/kern/mach_process.c) it calls thread_setsinglestep(get_firstthread(task))
+// — it sets the step bit on the task's FIRST thread, never the thread that
+// trapped. When the Go goroutine that hit the breakpoint is running on some
+// other thread, PT_STEP steps the wrong (often idle) thread; the real thread
+// runs free past the temporarily-removed trap and never traps, so Wait() hangs.
+//
+// Clearing writes SS=0; a zeroed mdscr frees the thread's debug state
+// (osfmk/arm64/pcb.c). Ref: LLDB debugserver arm64
+// DNBArchMachARM64::EnableHardwareSingleStep, XNU thread_setsinglestep /
+// arm_debug_set64.
+static inline kern_return_t bingo_set_single_step_once(mach_port_t thread, int enable) {
+    arm_debug_state64_t dbg;
+    mach_msg_type_number_t dcount = ARM_DEBUG_STATE64_COUNT;
+    // GET always succeeds for a 64-bit thread, returning a zeroed state when the
+    // thread has no prior debug state (osfmk/arm64/status.c bzero path).
+    kern_return_t kr = thread_get_state(
+        thread, ARM_DEBUG_STATE64, (thread_state_t)&dbg, &dcount);
+    if (kr != KERN_SUCCESS) return kr;
+    if (enable) {
+        dbg.__mdscr_el1 |= 1ULL;   // MDSCR_EL1.SS — enable software single step
+    } else {
+        dbg.__mdscr_el1 &= ~1ULL;  // clear SS; zeroed state frees debug state
+    }
+    return thread_set_state(
+        thread, ARM_DEBUG_STATE64, (thread_state_t)&dbg, ARM_DEBUG_STATE64_COUNT);
+}
+
+// bingo_set_single_step wraps the arming sequence with a bounded retry on
+// KERN_ABORTED. thread_get_state / thread_set_state can transiently return
+// KERN_ABORTED when the kernel is mid-operation on the thread — specifically
+// right after PT_CONTINUE, which pokes the task's FIRST thread to clear its
+// per-process single-step bit (XNU bsd/kern/mach_process.c), and while an
+// asynchronous thread_suspend is still settling the target out of a CPU. The
+// target thread is thread_suspend'd across this call (SingleStep freezes every
+// thread before PT_CONTINUE and only resumes the target afterwards), so it
+// cannot run free during the retries — it is genuinely quiesced and the state
+// op just needs the kernel to finish. LLDB debugserver retries its thread-state
+// accessors on KERN_ABORTED for exactly this reason. The bound (50 * 200us =
+// 10ms worst case) only ever elapses on the rare error path.
+static inline kern_return_t bingo_set_single_step(mach_port_t thread, int enable) {
+    kern_return_t kr = KERN_SUCCESS;
+    for (int i = 0; i < 50; i++) {
+        kr = bingo_set_single_step_once(thread, enable);
+        if (kr != KERN_ABORTED) {
+            return kr;
+        }
+        usleep(200);
+    }
+    return kr;
 }
 
 // bingo_read_memory reads n bytes from the task's address space at addr.
@@ -164,4 +273,39 @@ static inline kern_return_t bingo_thread_list(
     mach_msg_type_number_t *count_out)
 {
     return task_threads(task, threads_out, count_out);
+}
+
+// bingo_thread_suspend / bingo_thread_resume wrap Mach thread_suspend /
+// thread_resume. They freeze/unfreeze one Mach thread for the duration of a
+// single step so that ONLY the target thread advances (mirrors LLDB
+// debugserver, which suspends sibling threads while stepping one). Freezing the
+// runtime threads also stops Go's sysmon from flooding SIGURG during the step,
+// which would otherwise interrupt every resume before the target can take its
+// single instruction.
+static inline kern_return_t bingo_thread_suspend(mach_port_t thread) {
+    return thread_suspend(thread);
+}
+static inline kern_return_t bingo_thread_resume(mach_port_t thread) {
+    return thread_resume(thread);
+}
+// bingo_task_suspend_count returns the Mach suspend count of a task via
+// task_info(TASK_BASIC_INFO). Used to measure how many times the BSD ptrace
+// layer has left the tracee task suspended so the surplus can be drained
+// (all threads stay frozen and wait4 blocks while the count is > 0). Returns
+// -1 on error.
+static inline int bingo_task_suspend_count(mach_port_t task) {
+    struct task_basic_info info;
+    mach_msg_type_number_t count = TASK_BASIC_INFO_COUNT;
+    kern_return_t kr = task_info(task, TASK_BASIC_INFO,
+        (task_info_t)&info, &count);
+    if (kr != KERN_SUCCESS) return -1;
+    return (int)info.suspend_count;
+}
+
+// bingo_task_resume decrements a task's Mach suspend count (task_resume).
+// Used to drain surplus task-level suspends that the BSD ptrace layer leaks on
+// a multithreaded tracee (it performs at most one task_resume per PT_CONTINUE,
+// but concurrent thread stops can task_suspend the task more than once).
+static inline kern_return_t bingo_task_resume(mach_port_t task) {
+    return task_resume(task);
 }


### PR DESCRIPTION
## Summary

Fixes the intermittent hang in `TestE2EBasic` / `TestE2EChurn` on **darwin/arm64**. There turned out to be **two** distinct kernel-interaction bugs — the second only became visible once the first was fixed. The centerpiece is **per-thread ARM64 hardware single-step**; the second fix drains a **Mach task-level suspend-count leak**.

Scope is surgical: only `internal/debugger/{backend_darwin_arm64.go, mach_darwin_arm64.h, engine.go}`. The immutable gate (`e2e_integration_test.go`, `.github/workflows/debugger-e2e.yml`) is untouched.

---

## 1. Root cause

### Primary bug — wrong-thread single-step (the reported hang)

Darwin `ptrace(PT_STEP)` is **per-process, not per-thread**. In XNU `bsd/kern/mach_process.c`, `PT_STEP` calls `thread_setsinglestep()` on `get_firstthread(task)` — it arms `MDSCR_EL1.SS` on the task's **first** thread, *never* the thread that actually trapped.

The old `SingleStep(tid)` ignored `tid` and issued `PT_STEP` on `b.pid`:

```go
// Darwin PT_STEP is per-process (by PID), not per-thread.
if err := ptrace(ptDarwinStep, uintptr(b.pid), 1, 0); err != nil { ... }
```

On a Go program the goroutine running `main` migrates across Ms/threads (it calls `time.Sleep`), so the breakpoint is frequently hit by a thread that is **not** `thread[0]`. The step-over sequence in `engine.resumeFromBreakpoint` then:

1. restores the original instruction bytes at `bp.addr` (trap removed),
2. `SingleStep(bpTID)` → `PT_STEP` arms SS on `thread[0]` (**wrong thread**),
3. the task resumes; the real BP thread runs **free** (no trap byte, no SS) past `bp.addr`,
4. `thread[0]` is idle/parked → never delivers a step trap,
5. `Wait()` blocks forever → **HANG**.

### Secondary bug — Mach task-level suspend-count leak (exposed after fixing #1)

Once stepping was thread-targeted, a rarer wedge remained (~2/12 churn runs). Empirical tracing (a temporary `task_info(TASK_BASIC_INFO)` + per-thread `thread_info` watchdog on the blocked `wait4`) caught it red-handed:

```
==== BINGO SS-HANG DUMP (wait4 blocked > 12s) ====
  TASK suspend_count=1
  tid ... suspend=0  STATIC PCs=[..same..]   <== step target, unfrozen but NOT running
  tid ... suspend=1  [frozen sibling]   (x5)
```

Every thread frozen, **all PCs static** (including a thread mid-`ADD` in a busy loop — definitively frozen, not merely descheduled), while `wait4` blocked forever. The task's Mach **suspend count was stuck at 1**.

Mechanism: the BSD ptrace `resume:` path performs at most **one** `task_resume` per `PT_CONTINUE`. But a multithreaded tracee under Go's **SIGURG async-preemption storm** (sysmon preempting the churn workload's busy goroutines) gets `task_suspend`'d **more than once** when several threads enter the stop path concurrently — while `wait4` reports only a single stop. One `PT_CONTINUE` then leaves the count at 1: the whole task stays frozen and the next `wait4` never returns.

---

## 2. The fix

**Per-thread hardware single-step** (`SingleStep`, mirrors LLDB debugserver `EnableHardwareSingleStep`):

- **Trapped thread is not `thread[0]`:** freeze every *sibling* with `thread_suspend`, arm **only `MDSCR_EL1.SS`** on the target via `thread_set_state(ARM_DEBUG_STATE64)` (the kernel sets `PSTATE.SS` itself in `arm_debug_set64` on return-to-user — programming CPSR.SS ourselves corrupted the step state machine), then `PT_CONTINUE`. Only the target is runnable, so only it advances one instruction and traps.
- **Trapped thread is `thread[0]`:** keep `PT_STEP` (kernel arms SS on exactly that thread), siblings frozen.
- Freezing siblings also silences the SIGURG storm for the duration of the step, which otherwise interrupts every resume before the target can retire its one instruction (a livelock).

**Task-suspend drain** (`resumeTraced`, wraps *every* resuming ptrace op):

```go
pre := b.taskSuspendCount()          // task is stopped → count is settled
ptrace(request, b.pid, addr, data)   // BSD ptrace does exactly one task_resume
for i := 1; i < pre; i++ { b.taskResume() }  // cancel the leaked surplus
```

Race-free: while the post-resume count is positive the task **cannot execute**, so no new suspend can interleave with the drain; and `pre==1` (a healthy single stop) drains nothing.

**Supporting hardening:**
- Bounded `KERN_ABORTED` retry on the `thread_get/set_state` and single-step cgo helpers (debugserver does the same — the kernel transiently returns `KERN_ABORTED` right after a step exception / while a `thread_suspend` settles).
- Mid-step-death handling: if the tracee is killed between trap-removal and the step, report a clean `ProcessExited` instead of an opaque Mach error (`engine.resumeFromBreakpoint` + `stepErr`/`processGone`).
- `killProcess` now resumes the tracee under ptrace delivering `SIGKILL`, so a ptrace-stopped tracee actually dies instead of blocking the harness until timeout.

---

## 3. Verification (local, darwin/arm64, authoritative)

Build/sign/run:
```sh
CGO_ENABLED=1 go test -tags 'e2e bingonative' -race -c -o /tmp/d2.test ./internal/debugger
codesign --sign - --entitlements entitlements.plist --force /tmp/d2.test
/tmp/d2.test -test.v -test.run TestE2EBasic -test.timeout 120s
/tmp/d2.test -test.v -test.run TestE2EChurn -test.timeout 200s
```

**Authoritative runs — clean binary (no diagnostics), `-race`, no `BINGO_E2E_DEBUG`:**

| Test | Result |
| --- | --- |
| `TestE2EBasic` | **16 / 16 GREEN** (≥10 required) |
| `TestE2EChurn` | **10 / 10 GREEN** (≥5 required) |

Zero hangs, zero timeouts, zero data races. Sibling debugger sessions were running the same E2E suite throughout (they `kill -9` targets by basename; the handful of `ProcessExited {"exitCode":-1}` observed in wider batches are that external SIGKILL, excluded as an environmental confound — never a debugger hang).

**Robustness campaign — instrumented binary with the `wait4` watchdog on:** ~59 churn + 15 basic additional runs, **zero** `SS-HANG` dumps after the drain was applied to all resume paths. On the broken baseline `TestE2EBasic` hung ~6/6 at `iters=25`.

Existing unit tests: `go test -tags bingonative -race ./internal/debugger` → `ok`.

> The diagnostic tracing/watchdog used to localize the secondary bug was removed before finalizing; only the fix remains.

---

## 4. References

- **LLDB debugserver** — `DNBArchMachARM64::EnableHardwareSingleStep` sets **only** `MDSCR_EL1.SS` (never CPSR) and retries thread-state accessors on `KERN_ABORTED`. This fix matches that exactly.
- **Delve** — `pkg/proc/native/threads_darwin.go`, `registers_arm64_darwin.go`: thread-targeted register/step handling via Mach thread state.
- **XNU** — `bsd/kern/mach_process.c` (`PT_STEP`/`PT_CONTINUE` operate on `get_firstthread`; one `task_resume` per resume), `osfmk/arm64/pcb.c` (`arm_debug_set64` sets `PSTATE.SS` from `MDSCR_EL1.SS`), `osfmk/arm64/status.c` (debug-state get/set).
