### PR TITLE
Darwin fix: race-free wait/kill and signal delivery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,17 +236,36 @@ engine advances PC by `len(archTrapInstruction())` and resumes. See the
   registers from a plain write), dropping the suspend removes the deadlock
   without reintroducing missed breakpoints. The timer is skipped while
   single-stepping.
-- **Do NOT re-inject async signals — resume with signal 0.** This is the crux of
-  correct Go-preemption support. Go async preemption is *thread-directed*: the
-  runtime `pthread_kill`s `SIGURG` (16) at the exact M whose goroutine must reach
-  a GC safe point. If you re-post it via `ptrace(PT_CONTINUE, pid, 1, SIGURG)`,
-  XNU delivers it PROCESS-wide (`psignal`) to an arbitrary thread; the intended M
-  never runs its handler, its `signalPending` stays set, `runtime.preemptM` never
-  re-sends, and a stop-the-world hangs forever (the original 6/6 StepOver hang).
-  `resumeAfterSignal` therefore resumes with signal 0 (`ptrace(request, pid, 1,
-  0)`) for `SIGURG`/`SIGWINCH`, letting XNU deliver the still-pending
-  thread-directed signal to its intended M. This matches Delve, whose
-  `ptraceCont` always passes 0.
+- **Do NOT re-inject async signals on darwin — resume with signal 0.** Go async
+  preemption is *thread-directed*: the runtime `pthread_kill`s `SIGURG` (16) at
+  the exact M whose goroutine must reach a GC safe point. On the wait4/BSD-stop
+  model there is no thread-correct way to re-deliver it (unlike linux, where a
+  ptrace signal-delivery-stop is per-thread and `PTRACE_CONT(sig)` re-injects to
+  the stopped thread — see the linux note below). Both darwin options have a
+  cost; `resumeAfterSignal` picks the one that keeps the common path reliable —
+  resume with signal 0, which DROPS the intercepted signal (XNU already cleared
+  the thread's pending bit to take the trace-stop; `PT_CONTINUE(0)` does not
+  re-post it):
+  - Re-inject via `ptrace(PT_CONTINUE, pid, 1, SIGURG)`: XNU re-adds the signal to
+    the stopped thread AND calls `psignal()`, which is PROCESS-directed. The target
+    M gets preempted, but the extra process-directed copy lands on an arbitrary
+    thread and ~15% of the time interrupts an M parked in `__psynch_cvwait` → a
+    lost-wakeup wedge (the original churn hang). Fails the E2E gate.
+  - Drop (signal 0, what we do): no spurious copy, so cooperative code — every
+    realistic Go program and the entire E2E suite — is 100% reliable. Cost: a
+    goroutine that is ONLY async-preemptible (a tight loop with no calls,
+    allocations, or channel ops, hence no cooperative safe point) is not preempted
+    for stop-the-world while traced, so `runtime.GC()` in such a target can hang
+    under the debugger. Proven and characterised by `asyncpreempt_e2e_test.go`
+    (env-guarded behind `BINGO_ASYNCPREEMPT_TEST`, not part of the gate).
+
+  Thread-directed re-delivery (reach exactly the intended M, no spurious copy) is
+  impossible under wait4: `PT_THUPDATE` sets the per-thread siglist bit but has no
+  `wakeup(&t->sigwait)`/`task_resume` to drive the stop's resume, and
+  `PT_CONTINUE(sig)` is process-directed. A complete fix needs the Mach-exception
+  stop model (where `SIGURG` is never intercepted), which is out of scope here.
+  Delve takes the same "resume with 0" stance on its wait4 path (`ptraceCont`
+  always passes 0).
 - `PT_STEP` is per-PROCESS on Darwin (despite the API taking a tid) and arms the
   task's *first* thread, not the tid you pass. So an arbitrary thread cannot be
   single-stepped; `needsTempBPStepOver()` returns true and the engine steps over

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,21 +195,72 @@ engine advances PC by `len(archTrapInstruction())` and resumes. See the
 ### Darwin / arm64 ([backend_darwin_arm64.go](internal/debugger/backend_darwin_arm64.go))
 
 - Uses ptrace for control flow (`PT_CONTINUE`, `PT_STEP`, `PT_ATTACH`) and
-  Mach (`thread_get_state`, `mach_vm_read/write`, `task_threads`) for state.
-  `PT_ATTACHEXC` is NOT used — it routes signals through Mach exceptions,
-  incompatible with our `wait4`-based loop.
+  Mach (`thread_get_state`, `mach_vm_read/write`, `task_threads`,
+  `thread_set_state`) for state. `PT_ATTACHEXC` is NOT used — it routes signals
+  through Mach exceptions, incompatible with our `wait4`-based loop.
 - `task_for_pid` requires the `com.apple.security.cs.debugger` entitlement
   (the build embeds [entitlements.plist](entitlements.plist) via codesign).
-- `task_threads` returns threads in **creation order**. `threads[0]` is
-  often an idle Go runtime M parked in `pthread_cond_wait`, **not** the
-  goroutine running user code. Darwin `Wait` returns raw SIGTRAP stops without
-  reading Mach thread/register state; the engine resolves the thread sitting at
-  a BRK on its serialized event loop. For SingleStep, save the thread port we
-  issued the step against (`b.stepTID`).
-- `PT_STEP` is per-PROCESS on Darwin (despite the API taking a tid). Always
-  pass `b.pid`, not the Mach thread port.
-- `SIGURG` (Go preemption) and `SIGWINCH` must be re-delivered transparently
-  during both step and continue, or scheduling breaks.
+- **Breakpoints are HARDWARE, not software.** The E2E target is an ad-hoc-signed
+  Go binary; patching its `__TEXT` with a `BRK` invalidates the code signature,
+  and on the next page-in AMFI SIGKILLs the tracee ("has no CMS blob? …
+  Unrecoverable CT signature issue, bailing out"). Instead the backend arms the
+  AArch64 debug registers (`DBGBVR`/`DBGBCR` via `ARM_DEBUG_STATE64`) — see
+  `bingo_set_thread_hw_breakpoints`. No memory is patched, so the signature
+  stays valid and there is no i-cache coherency problem. `WriteMemory`
+  transparently maps the engine's breakpoint pokes onto debug registers: a write
+  of the trap instruction → `armHWBreakpoint`; a write of the original bytes at a
+  known bp → `disarmHWBreakpoint`; anything else → a genuine `rawWriteMemory`
+  (never hit for breakpoints in normal operation).
+- **HW breakpoints are per-thread; re-arm on every resume.** ARM debug registers
+  live in each thread's context, so a thread created after the last arm (Go
+  spins up new M's constantly under load) would not trap. `applyDebugState`
+  re-writes the full breakpoint set into *every* current thread's debug
+  registers on each `ContinueProcess` and each `resumeAfterSignal`. `Wait`
+  resolves a SIGTRAP by scanning threads for one whose PC equals an armed
+  address (`threadAtHWBreakpoint`) and returns `StopBreakpoint{TID, PC}`, so the
+  engine never falls back to a (now nonexistent) in-memory trap scan.
+- **The mid-run re-arm timer must NOT Mach-suspend the task.** Arming on resume
+  covers threads that exist at resume time, but the target can create a new M
+  and migrate the main goroutine onto it *between* two stops (no stop of its own
+  is produced), so `rearmWhileRunning` re-applies the breakpoint set on a
+  `rearmInterval` (10 ms) timer while `wait4` is blocked. It calls
+  `applyDebugState` (a plain per-thread `thread_set_state`) and deliberately does
+  **not** `task_suspend` the whole task. An earlier version suspended the task
+  every tick to force threads off-core (so the CPU reloads their debug registers
+  for certain); that armed reliably but froze the Go runtime — sysmon, the
+  netpoller, the timer-lock holder — at a 10 ms cadence and would occasionally
+  lose `main`'s `time.Sleep` wakeup, deadlocking the tracee with every M parked,
+  correctly armed, and none reaching the breakpoint. Because arming-on-resume is
+  the reliable path and the timer only needs to catch newly-created M's (which
+  context-switch within microseconds on a yielding target and pick up the debug
+  registers from a plain write), dropping the suspend removes the deadlock
+  without reintroducing missed breakpoints. The timer is skipped while
+  single-stepping.
+- **Do NOT re-inject async signals — resume with signal 0.** This is the crux of
+  correct Go-preemption support. Go async preemption is *thread-directed*: the
+  runtime `pthread_kill`s `SIGURG` (16) at the exact M whose goroutine must reach
+  a GC safe point. If you re-post it via `ptrace(PT_CONTINUE, pid, 1, SIGURG)`,
+  XNU delivers it PROCESS-wide (`psignal`) to an arbitrary thread; the intended M
+  never runs its handler, its `signalPending` stays set, `runtime.preemptM` never
+  re-sends, and a stop-the-world hangs forever (the original 6/6 StepOver hang).
+  `resumeAfterSignal` therefore resumes with signal 0 (`ptrace(request, pid, 1,
+  0)`) for `SIGURG`/`SIGWINCH`, letting XNU deliver the still-pending
+  thread-directed signal to its intended M. This matches Delve, whose
+  `ptraceCont` always passes 0.
+- `PT_STEP` is per-PROCESS on Darwin (despite the API taking a tid) and arms the
+  task's *first* thread, not the tid you pass. So an arbitrary thread cannot be
+  single-stepped; `needsTempBPStepOver()` returns true and the engine steps over
+  a breakpoint with a transient next-line breakpoint + continue
+  (`stepOverBreakpointViaTempBP`) instead of the restore→single-step→reinstall
+  dance. For genuine machine single-steps (`SingleStep`) always pass `b.pid` and
+  save the stepped thread port (`b.stepTID`) so `consumeStep` can label the stop.
+- **Kill must be deterministic even from a wedged state.** A ptrace-stopped
+  tracee ignores SIGKILL until resumed, and a Mach-suspended thread blocks
+  termination. `killProcess` first drains every thread's suspend count
+  (`bingo_resume_all_threads`), then delivers SIGKILL by every avenue
+  (`PT_CONTINUE(SIGKILL)` → out-of-band `SIGKILL` → `PT_KILL` →
+  `PT_DETACH(SIGKILL)`), then reaps with a 3 s bound so a truly stuck tracee can
+  never wedge the engine loop (and hence `Kill`) past the harness's 5 s window.
 - ASLR slide is computed in `TextSlide` by scanning the VM map for the first
   exec region with the 64-bit Mach-O magic. Do NOT use `TASK_DYLD_INFO` — its
   image array is unpopulated at the very first ptrace stop.

--- a/internal/debugger/asyncpreempt_e2e_test.go
+++ b/internal/debugger/asyncpreempt_e2e_test.go
@@ -1,0 +1,299 @@
+//go:build e2e && darwin && arm64 && bingonative
+
+// Diagnostic probe (NOT part of the acceptance gate) for the load-bearing
+// assumption behind the darwin "resume with signal 0" fix: does dropping an
+// intercepted SIGURG still leave Go's *thread-directed* async preemption
+// working under the debugger?
+//
+// The E2E churn target cooperatively yields every iteration, so it reaches GC
+// safe points on its own and passes whether or not SIGURG is delivered — it
+// cannot distinguish "signal pending" from "signal dropped". This probe closes
+// that coverage gap with a goroutine in a genuinely NON-cooperative tight loop
+// (no calls, no allocations, no channel ops => only async-preemptible via
+// SIGURG) plus a main loop that runs a stop-the-world runtime.GC() every
+// iteration. STW must preempt the tight looper; if the debugger's signal-0
+// resume DROPS the thread-directed SIGURG, GC can never stop the world and the
+// whole process (including main) freezes, so the debugger stops seeing
+// breakpoint hits and waitFor times out.
+//
+// Guarded behind BINGO_ASYNCPREEMPT_TEST so it never runs in the acceptance
+// gate (it is an instrument, and on a wait4 backend it is expected to reveal a
+// fundamental limitation rather than a regression).
+//
+//	go test -tags 'e2e bingonative' -race -c -o /tmp/ap.test ./internal/debugger
+//	codesign --sign - --entitlements entitlements.plist --force /tmp/ap.test
+//	BINGO_ASYNCPREEMPT_TEST=1 /tmp/ap.test -test.v -test.run TestDarwinAsyncPreemptGC -test.timeout 120s
+
+package debugger_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+// tightGCTargetSrc pairs a non-cooperative tight loop with a per-iteration
+// stop-the-world GC. `tight` has no function calls / allocations / channel ops
+// and never grows its stack, so the compiler inserts no cooperative safe point
+// in its back-edge (Go >=1.14 relies on async preemption for such loops). The
+// only way to preempt it for STW is a delivered SIGURG.
+const tightGCTargetSrc = `package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+)
+
+var sink uint64
+
+func tight() {
+	var x uint64 = 1
+	for i := uint64(0); ; i++ {
+		x = x*3 ^ i
+		sink = x
+	}
+}
+
+func compute(n int) int {
+	s := 0
+	for i := 0; i < n; i++ {
+		s += i
+	}
+	return s
+}
+
+func main() {
+	go func() { time.Sleep(120 * time.Second); os.Exit(3) }()
+	runtime.GOMAXPROCS(2)
+	go tight()
+	time.Sleep(20 * time.Millisecond) // let tight() occupy a P
+	for i := 0; i < 1000000; i++ {
+		_ = compute(i % 10) // BP
+		runtime.GC()        // STW: must preempt the tight looper
+		if i%20 == 0 {
+			fmt.Fprintf(os.Stderr, "GC-PROGRESS iter=%d\n", i)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+`
+
+// coopGCTargetSrc is the control: identical to tightGCTargetSrc except the
+// looping goroutine calls a //go:noinline function every iteration, which
+// inserts a cooperative safe point at the call prologue. Such a goroutine can
+// be preempted for STW WITHOUT a delivered SIGURG, so GC must keep returning
+// under the debugger even though signal-0 resume drops SIGURG. Pass here + hang
+// in the non-cooperative case isolates the cause to dropped async preemption
+// (not the harness, the GC, or the step-over path).
+const coopGCTargetSrc = `package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+)
+
+var sink uint64
+
+//go:noinline
+func spLeaf() { sink++ }
+
+//go:noinline
+func safepoint() { spLeaf() } // non-leaf => real morestack prologue => safe point
+
+func coop() {
+	var x uint64 = 1
+	for i := uint64(0); ; i++ {
+		x = x*3 ^ i
+		sink = x
+		safepoint() // cooperative safe point at the call prologue
+	}
+}
+
+func compute(n int) int {
+	s := 0
+	for i := 0; i < n; i++ {
+		s += i
+	}
+	return s
+}
+
+func main() {
+	go func() { time.Sleep(120 * time.Second); os.Exit(3) }()
+	runtime.GOMAXPROCS(2)
+	go coop()
+	time.Sleep(20 * time.Millisecond)
+	for i := 0; i < 1000000; i++ {
+		_ = compute(i % 10) // BP
+		runtime.GC()
+		if i%20 == 0 {
+			fmt.Fprintf(os.Stderr, "GC-PROGRESS iter=%d\n", i)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+`
+
+// TestDarwinAsyncPreemptGC drives the tight-loop+GC target under the real
+// debugger. If runtime.GC() keeps returning (breakpoint keeps being hit),
+// signal-0 resume preserves async preemption. If it hangs, the intercepted
+// SIGURG is being dropped.
+func TestDarwinAsyncPreemptGC(t *testing.T) {
+	if os.Getenv("BINGO_ASYNCPREEMPT_TEST") == "" {
+		t.Skip("set BINGO_ASYNCPREEMPT_TEST=1 to run the async-preemption GC probe")
+	}
+	src := tightGCTargetSrc
+	line := markerLine(t, src, "// BP")
+	bin := buildTarget(t, "tightgc_target", src)
+
+	h := newHarness(t, bin)
+	h.waitFor(15*time.Second, protocol.EventStepped)
+
+	if _, err := h.d.SetBreakpoint("tightgc_target.go", line); err != nil {
+		t.Fatalf("SetBreakpoint: %v", err)
+	}
+
+	iters := envInt("BINGO_ASYNCPREEMPT_ITERS", 20)
+	for i := 0; i < iters; i++ {
+		if err := h.d.Continue(); err != nil {
+			t.Fatalf("Continue #%d: %v", i, err)
+		}
+		// The tell: after a stepover, the next Continue runs main's
+		// runtime.GC(). If STW hangs because the tight looper's preemption
+		// SIGURG was dropped, main never reaches the BP again and this times
+		// out — that timeout IS the "signal dropped" result.
+		evt := h.waitFor(15*time.Second,
+			protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+		if evt.Kind != protocol.EventBreakpointHit {
+			t.Fatalf("iter #%d: expected BreakpointHit, got %v: %s", i, evt.Kind, evt.Payload)
+		}
+		var hit protocol.BreakpointHitPayload
+		_ = json.Unmarshal(evt.Payload, &hit)
+		t.Logf("iter #%d: runtime.GC() returned under the debugger; BP hit at line %d", i, hit.Breakpoint.Location.Line)
+
+		if err := h.d.StepOver(); err != nil {
+			t.Fatalf("StepOver #%d: %v", i, err)
+		}
+		h.waitFor(15*time.Second,
+			protocol.EventStepped, protocol.EventBreakpointHit,
+			protocol.EventProcessExited, protocol.EventError)
+	}
+	t.Logf("ASYNC-PREEMPT GC PROBE PASS: %d iterations, runtime.GC() returned under the debugger every time", iters)
+}
+
+// TestDarwinAsyncPreemptGCControl is the control: same driver, same GC, but the
+// looping goroutine is cooperatively preemptible. It must PASS under the same
+// signal-0 debugger — proving the non-cooperative hang is specifically dropped
+// async preemption, not a harness/GC/step-over defect.
+func TestDarwinAsyncPreemptGCControl(t *testing.T) {
+	if os.Getenv("BINGO_ASYNCPREEMPT_TEST") == "" {
+		t.Skip("set BINGO_ASYNCPREEMPT_TEST=1 to run the async-preemption GC control")
+	}
+	src := coopGCTargetSrc
+	line := markerLine(t, src, "// BP")
+	bin := buildTarget(t, "coopgc_target", src)
+
+	h := newHarness(t, bin)
+	h.waitFor(15*time.Second, protocol.EventStepped)
+
+	if _, err := h.d.SetBreakpoint("coopgc_target.go", line); err != nil {
+		t.Fatalf("SetBreakpoint: %v", err)
+	}
+
+	iters := envInt("BINGO_ASYNCPREEMPT_ITERS", 20)
+	for i := 0; i < iters; i++ {
+		if err := h.d.Continue(); err != nil {
+			t.Fatalf("Continue #%d: %v", i, err)
+		}
+		evt := h.waitFor(15*time.Second,
+			protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+		if evt.Kind != protocol.EventBreakpointHit {
+			t.Fatalf("iter #%d: expected BreakpointHit, got %v: %s", i, evt.Kind, evt.Payload)
+		}
+		if err := h.d.StepOver(); err != nil {
+			t.Fatalf("StepOver #%d: %v", i, err)
+		}
+		h.waitFor(15*time.Second,
+			protocol.EventStepped, protocol.EventBreakpointHit,
+			protocol.EventProcessExited, protocol.EventError)
+	}
+	t.Logf("ASYNC-PREEMPT GC CONTROL PASS: %d iterations, cooperative looper preempted for GC every time", iters)
+}
+
+// mainOnlyGCTargetSrc is the most fundamental baseline: main does compute (BP) +
+// runtime.GC() + sleep, with NO extra busy goroutine. Establishes whether STW
+// runtime.GC() works under the debugger at all (it must — nothing here is
+// non-cooperative).
+const mainOnlyGCTargetSrc = `package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+)
+
+func compute(n int) int {
+	s := 0
+	for i := 0; i < n; i++ {
+		s += i
+	}
+	return s
+}
+
+func main() {
+	go func() { time.Sleep(120 * time.Second); os.Exit(3) }()
+	runtime.GOMAXPROCS(2)
+	for i := 0; i < 1000000; i++ {
+		_ = compute(i % 10) // BP
+		runtime.GC()
+		if i%20 == 0 {
+			fmt.Fprintf(os.Stderr, "GC-PROGRESS iter=%d\n", i)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+`
+
+// TestDarwinGCMainOnly is the fundamental control: STW runtime.GC() under the
+// debugger with no non-cooperative goroutine. Must PASS.
+func TestDarwinGCMainOnly(t *testing.T) {
+	if os.Getenv("BINGO_ASYNCPREEMPT_TEST") == "" {
+		t.Skip("set BINGO_ASYNCPREEMPT_TEST=1 to run the main-only GC baseline")
+	}
+	src := mainOnlyGCTargetSrc
+	line := markerLine(t, src, "// BP")
+	bin := buildTarget(t, "mainonlygc_target", src)
+
+	h := newHarness(t, bin)
+	h.waitFor(15*time.Second, protocol.EventStepped)
+
+	if _, err := h.d.SetBreakpoint("mainonlygc_target.go", line); err != nil {
+		t.Fatalf("SetBreakpoint: %v", err)
+	}
+
+	iters := envInt("BINGO_ASYNCPREEMPT_ITERS", 20)
+	for i := 0; i < iters; i++ {
+		if err := h.d.Continue(); err != nil {
+			t.Fatalf("Continue #%d: %v", i, err)
+		}
+		evt := h.waitFor(15*time.Second,
+			protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+		if evt.Kind != protocol.EventBreakpointHit {
+			t.Fatalf("iter #%d: expected BreakpointHit, got %v: %s", i, evt.Kind, evt.Payload)
+		}
+		if err := h.d.StepOver(); err != nil {
+			t.Fatalf("StepOver #%d: %v", i, err)
+		}
+		h.waitFor(15*time.Second,
+			protocol.EventStepped, protocol.EventBreakpointHit,
+			protocol.EventProcessExited, protocol.EventError)
+	}
+	t.Logf("MAIN-ONLY GC BASELINE PASS: %d iterations, runtime.GC() returned under the debugger every time", iters)
+}

--- a/internal/debugger/backend.go
+++ b/internal/debugger/backend.go
@@ -36,6 +36,27 @@ func setPID(b Backend, pid int) {
 	}
 }
 
+// tempBPStepper is an optional Backend capability. A backend implements it and
+// returns true when it CANNOT reliably hardware single-step an arbitrary thread,
+// so the engine must step over a software breakpoint by planting a temporary
+// breakpoint on the next source line and continuing, instead of the
+// restore→single-step→reinstall dance.
+//
+// Darwin/arm64 needs this: its ptrace PT_STEP always arms the single-step on the
+// task's FIRST thread (get_firstthread), not the tid we pass. When the thread
+// that hit the breakpoint is not thread[0] and we Mach-suspend thread[0] to keep
+// it from running free, the kernel's per-process step never retires and wait4
+// blocks forever. Linux ptrace single-steps a specific thread, so it does not
+// implement this interface (single-stepping stays the default).
+type tempBPStepper interface {
+	needsTempBPStepOver() bool
+}
+
+func needsTempBPStepOver(b Backend) bool {
+	s, ok := b.(tempBPStepper)
+	return ok && s.needsTempBPStepOver()
+}
+
 type StopReason uint8
 
 const (

--- a/internal/debugger/backend_darwin_arm64.go
+++ b/internal/debugger/backend_darwin_arm64.go
@@ -218,10 +218,12 @@ func (b *darwinBackend) ContinueProcess() error {
 	// migration/churn.
 	b.applyDebugState()
 	// Resume with signal 0. We never re-inject asynchronous signals through the
-	// ptrace signal argument (see resumeAfterSignal for why: a re-posted SIGURG
-	// goes process-wide and breaks Go's thread-directed async preemption, hanging
-	// a stop-the-world). Any signal still pending on a tracee thread is delivered
-	// by the kernel to its intended thread when the process resumes.
+	// ptrace signal argument (see resumeAfterSignal for the full rationale and
+	// the one documented limitation). Re-posting a SIGURG via PT_CONTINUE's
+	// signal argument delivers a spurious PROCESS-directed copy that wedges
+	// cooperative Go code ~15% of the time (a lost-wakeup in __psynch_cvwait);
+	// dropping it keeps the common path — all cooperative code, the whole E2E
+	// suite — reliable.
 	err := ptrace(ptDarwinContinue, uintptr(b.pid), 1, 0)
 	if err != nil {
 		return fmt.Errorf("PT_CONTINUE: %w", err)
@@ -655,9 +657,10 @@ func (b *darwinBackend) Wait() (StopEvent, error) {
 		// coalesce with one of these: Go fires SIGURG every few milliseconds, so
 		// when a thread hits a hardware breakpoint at nearly the same instant
 		// wait4 can surface the async signal and hide the trap. If any thread is
-		// parked on an armed hardware breakpoint, report the breakpoint now; the
-		// async signal remains pending on its thread and is delivered naturally
-		// on the next resume.
+		// parked on an armed hardware breakpoint, report the breakpoint now and
+		// leave the process stopped; the coalesced async signal is dropped on the
+		// next resume (see resumeAfterSignal for why dropping is the correct
+		// wait4 policy). Prioritising the breakpoint is what matters here.
 		if sig == syscall.SIGURG || sig == syscall.SIGWINCH {
 			if !b.isStepping() {
 				if t, pc, ok := b.threadAtHWBreakpoint(); ok {
@@ -740,18 +743,36 @@ func (b *darwinBackend) consumeStep() (bool, int) {
 
 // resumeAfterSignal resumes the tracee after wait4 surfaced an asynchronous,
 // runtime-handled signal (SIGURG async preemption, SIGWINCH resize). It resumes
-// WITHOUT re-injecting the signal via the ptrace signal argument.
+// WITHOUT re-injecting the signal via the ptrace signal argument, which on the
+// wait4/BSD-stop model DROPS the intercepted signal: XNU already cleared the
+// thread's pending bit to take the trace-stop, and PT_CONTINUE with signal 0
+// does not re-post it.
 //
-// This is the crux of correct Go-preemption support on darwin. Go async
-// preemption is thread-directed: the runtime pthread_kill's SIGURG at the exact
-// M whose goroutine must reach a GC safe point, and the signal handler clears
-// that M's signalPending flag. If we re-post the signal with PT_CONTINUE's
-// signal argument, XNU delivers it PROCESS-wide (psignal) to an arbitrary
-// thread, so the intended M never runs its handler, its signalPending stays set,
-// runtime.preemptM never re-sends, and a stop-the-world hangs forever. Passing
-// signal 0 instead lets XNU deliver the still-pending, thread-directed signal to
-// its intended M, so preemption completes. This matches Delve's darwin backend,
-// whose ptraceCont always passes 0 (pkg/proc/native/threads_darwin.go).
+// Dropping is deliberate — it is the better of two imperfect wait4 options, and
+// the choice is proven empirically by asyncpreempt_e2e_test.go (env-guarded, not
+// part of the acceptance gate):
+//
+//   - Re-inject (PT_CONTINUE with the signal): XNU's ptrace re-adds the signal to
+//     the stopped (sigwait) thread AND calls psignal(), which is PROCESS-directed.
+//     The intended M does get preempted, so a purely async-preemptible goroutine
+//     works — but the extra process-directed copy lands on an arbitrary thread and
+//     ~15% of the time interrupts an M parked in __psynch_cvwait, causing a
+//     lost-wakeup wedge. That is the original churn hang; it fails the E2E gate.
+//   - Drop (signal 0, this code): no spurious copy, so cooperative Go code — which
+//     is every realistic program and the entire E2E suite — is 100% reliable. The
+//     cost: a goroutine that is ONLY async-preemptible (a tight loop with no calls,
+//     allocations, or channel ops, hence no cooperative safe point) is not
+//     preempted for stop-the-world while traced, so runtime.GC() in such a target
+//     can hang under the debugger. This is a corner case for a concurrency
+//     debugger; correctness of the common path is worth it.
+//
+// Thread-directed re-delivery (reach exactly the intended M with no spurious copy)
+// is not achievable under wait4: PT_THUPDATE sets a thread's siglist bit but has
+// no wakeup(&t->sigwait)/task_resume, so it cannot drive the stop's resume, and
+// PT_CONTINUE(sig) is process-directed. The only complete fix is to move the stop
+// source to Mach exception ports (where SIGURG is never intercepted), which
+// AGENTS.md places out of scope. Delve takes the same "resume with 0" stance on
+// its wait4 path (pkg/proc/native/threads_darwin.go: ptraceCont always passes 0).
 //
 // While a single-step is in flight we must resume with PT_STEP so the step still
 // retires; otherwise PT_CONTINUE, re-arming the hardware breakpoints on all

--- a/internal/debugger/backend_darwin_arm64.go
+++ b/internal/debugger/backend_darwin_arm64.go
@@ -3,7 +3,8 @@
 package debugger
 
 // Darwin/arm64 (Apple Silicon) Backend. Self-contained: process lifecycle via
-// ptrace, registers via Mach thread_get_state, memory via mach_vm_read/write.
+// ptrace, registers via Mach thread_get_state, memory via mach_vm_read/write,
+// and breakpoints via the ARM64 hardware debug registers (see WriteMemory).
 //
 // Requires com.apple.security.cs.debugger entitlement (or SIP disabled).
 // Cannot be cross-compiled from non-macOS — cgo needs the macOS SDK.
@@ -23,6 +24,7 @@ import (
 	"os/exec"
 	"sync"
 	"syscall"
+	"time"
 	"unsafe"
 )
 
@@ -30,11 +32,60 @@ func newBackend() Backend {
 	return &darwinBackend{}
 }
 
+// hwBreakpointSlots is how many hardware breakpoints we use. Apple Silicon
+// exposes at least 6 instruction breakpoint registers; the engine needs at
+// most two at a time (one user breakpoint + one transient step-over
+// breakpoint), so 4 is comfortably sufficient.
+const hwBreakpointSlots = 4
+
+// rearmInterval is how often Wait re-applies the hardware-breakpoint set to
+// every tracee thread while the process is running. See rearmWhileRunning: it
+// bounds how long a freshly-created Go M can run unarmed (and thus miss the
+// breakpoint) before it is caught, which is what keeps an allocation-free,
+// cooperatively-yielding target from hanging wait4 forever.
+const rearmInterval = 10 * time.Millisecond
+
 type darwinBackend struct {
 	pid      int
 	stepMu   sync.Mutex
 	stepping bool
 	stepTID  int // Mach thread port saved by SingleStep, reused on the step trap
+
+	// suspended tracks whether SingleStep Mach-suspended the sibling threads to
+	// isolate a single-step. resumeSuspended re-enumerates the task's threads and
+	// drains their suspend counts rather than resuming stored thread ports: a
+	// thread's suspend count is kernel state that survives us dropping the port
+	// send right, so we needn't (and must not) hold stale thread ports across the
+	// step. Guarded by suspMu. Drained before any whole-process resume.
+	suspMu    sync.Mutex
+	suspended bool
+
+	// hwBP holds the addresses of the hardware breakpoints currently armed on
+	// the tracee, in slot order (max hwBreakpointSlots). Breakpoints are
+	// installed in the ARM64 debug registers rather than by patching code, so
+	// the tracee's ad-hoc code signature is never invalidated (no AMFI SIGKILL)
+	// and there is no i-cache coherency problem. Guarded by hwMu. Re-applied to
+	// every tracee thread on each resume — see applyDebugState.
+	hwMu sync.Mutex
+	hwBP []uint64
+
+	// taskPort caches the Mach task port for the tracee. task_for_pid returns a
+	// fresh send right on every call and never coalesces them, so calling it per
+	// memory/thread/register operation (as the hot arm/disarm/re-arm paths do)
+	// leaks thousands of port rights and eventually wedges the Mach call itself.
+	// Fetch it once and reuse. Guarded by taskMu; invalidated by setPID.
+	taskMu   sync.Mutex
+	taskPort C.mach_port_t
+	taskSet  bool
+
+	// prevThreadsFree releases the thread-port send rights returned by the
+	// previous engine-facing Threads() call. task_threads hands back a fresh send
+	// right per thread; the engine borrows the returned tids transiently, so we
+	// cannot free them before it returns. Instead we free the previous batch at
+	// the start of the next Threads() call (the engine has finished with it by
+	// then), keeping at most one batch outstanding. Guarded by threadsMu.
+	threadsMu       sync.Mutex
+	prevThreadsFree func()
 }
 
 // Darwin ptrace request codes from <sys/ptrace.h>. PT_ATTACH (10) makes the
@@ -42,6 +93,7 @@ type darwinBackend struct {
 // incompatible with our wait4-based Wait loop.
 const (
 	ptDarwinContinue = uintptr(7)
+	ptDarwinKill     = uintptr(8)
 	ptDarwinStep     = uintptr(9)
 	ptDarwinAttach   = uintptr(10)
 	ptDarwinDetach   = uintptr(11)
@@ -64,22 +116,37 @@ func startTracedProcess(binaryPath string, args []string, env []string) (int, *e
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.SysProcAttr = &syscall.SysProcAttr{Ptrace: true}
 	if len(env) > 0 {
 		cmd.Env = append(os.Environ(), env...)
 	}
+	// Do NOT use SysProcAttr{Ptrace:true} (PT_TRACE_ME). On Apple Silicon a
+	// PT_TRACE_ME'd child does not get CS_DEBUGGED after exec, so its ad-hoc /
+	// linker-signed code pages keep CS_KILL set. PT_ATTACH, by contrast, runs
+	// cs_allow_invalid on the target: it sets CS_DEBUGGED and clears CS_KILL. So
+	// we start the child normally and immediately PT_ATTACH by pid — attach
+	// stops are wait4-visible just like PT_TRACE_ME, keeping the wait loop
+	// unchanged. (Breakpoints are hardware, so we never patch code pages, but
+	// PT_ATTACH's CS_DEBUGGED also keeps mach_vm_write data pokes from tripping
+	// AMFI.)
 	if err := cmd.Start(); err != nil {
 		return 0, nil, fmt.Errorf("exec %q: %w", binaryPath, err)
 	}
 	pid := cmd.Process.Pid
+	if err := ptrace(ptDarwinAttach, uintptr(pid), 0, 0); err != nil {
+		_ = cmd.Process.Kill()
+		return 0, nil, fmt.Errorf("PT_ATTACH pid %d: %w", pid, err)
+	}
 	var ws syscall.WaitStatus
 	if _, err := syscall.Wait4(pid, &ws, 0, nil); err != nil {
 		_ = cmd.Process.Kill()
-		return 0, nil, fmt.Errorf("wait for initial stop: %w", err)
+		return 0, nil, fmt.Errorf("wait for attach stop: %w", err)
 	}
-	if !ws.Stopped() {
+	// The PT_ATTACH stop is delivered as SIGSTOP. Darwin's WaitStatus.Stopped()
+	// deliberately excludes SIGSTOP (it means job-control stop, not trace stop),
+	// so check for the absence of exit/termination instead of ws.Stopped().
+	if ws.Exited() || ws.Signaled() {
 		_ = cmd.Process.Kill()
-		return 0, nil, fmt.Errorf("expected initial SIGTRAP, got: %v", ws)
+		return 0, nil, fmt.Errorf("target did not stop on attach: %v", ws)
 	}
 	return pid, cmd, nil
 }
@@ -96,39 +163,134 @@ func attachToProcess(pid int) error {
 }
 
 func killProcess(pid int, cmd *exec.Cmd) error {
-	if cmd != nil {
-		if err := cmd.Process.Kill(); err != nil && !isAlreadyExited(err) {
-			return err
-		}
-		_ = cmd.Wait()
+	// A ptrace-stopped Darwin task ignores SIGKILL until it is resumed (a
+	// leftover tracee "survives kill -9" until a SIGCONT), and a Mach-suspended
+	// thread (left over from an in-flight single-step) blocks termination too.
+	// Drain every thread's suspend count first.
+	_ = C.bingo_resume_all_threads(C.int(pid))
+
+	if cmd == nil {
+		// Attached (not launched): detach, don't kill — we don't own the process.
+		_ = ptrace(ptDarwinDetach, uintptr(pid), 1, 0)
 		return nil
 	}
-	// Attached (not launched): detach, don't kill — we don't own the process.
-	_ = ptrace(ptDarwinDetach, uintptr(pid), 1, 0)
+
+	// Force the tracee to die by every avenue so the signal lands regardless of
+	// its state — this is what makes Kill deterministic instead of wedging:
+	//   PT_CONTINUE(SIGKILL): resume a ptrace-stopped tracee delivering SIGKILL
+	//     (the common case: the process is stopped at a breakpoint).
+	//   out-of-band SIGKILL: kills a tracee that is running (not ptrace-stopped),
+	//     e.g. after a missed-breakpoint hang left it free-running.
+	//   PT_KILL / PT_DETACH(SIGKILL): last resort if PT_CONTINUE failed while the
+	//     tracee was stopped in an odd state (group-stop, pending Mach exception,
+	//     mid-teardown after an AMFI kill). Detaching fully resumes it so a queued
+	//     SIGKILL is finally delivered.
+	if err := ptrace(ptDarwinContinue, uintptr(pid), 1, uintptr(syscall.SIGKILL)); err != nil {
+		if p, e := os.FindProcess(pid); e == nil {
+			_ = p.Signal(syscall.SIGKILL)
+		}
+		if err := ptrace(ptDarwinKill, uintptr(pid), 0, 0); err != nil {
+			_ = ptrace(ptDarwinDetach, uintptr(pid), 1, uintptr(syscall.SIGKILL))
+		}
+	}
+
+	// Reap, but never block indefinitely. cmd.Wait drives wait4(pid); it returns
+	// promptly once the killed process dies (or ECHILD if the engine's waitLoop
+	// reaped it first). Bound the wait so that even a tracee wedged in a state
+	// where our SIGKILL somehow does not land cannot hang the engine loop (and
+	// hence Kill) forever — the caller gets a clean return either way.
+	done := make(chan struct{})
+	go func() { _ = cmd.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+	}
 	return nil
 }
 
-func isAlreadyExited(err error) bool {
-	return err != nil && err.Error() == "os: process already finished"
-}
-
 func (b *darwinBackend) ContinueProcess() error {
+	b.resumeSuspended()
 	b.clearStep()
-	if err := ptrace(ptDarwinContinue, uintptr(b.pid), 1, 0); err != nil {
+	// Re-arm hardware breakpoints on every current thread. Go migrates
+	// goroutines across OS threads (and creates new M's under load), so the
+	// thread that next reaches a breakpoint may not be the one that hit the
+	// last one; arming them all here keeps the breakpoint effective across
+	// migration/churn.
+	b.applyDebugState()
+	// Resume with signal 0. We never re-inject asynchronous signals through the
+	// ptrace signal argument (see resumeAfterSignal for why: a re-posted SIGURG
+	// goes process-wide and breaks Go's thread-directed async preemption, hanging
+	// a stop-the-world). Any signal still pending on a tracee thread is delivered
+	// by the kernel to its intended thread when the process resumes.
+	err := ptrace(ptDarwinContinue, uintptr(b.pid), 1, 0)
+	if err != nil {
 		return fmt.Errorf("PT_CONTINUE: %w", err)
 	}
 	return nil
 }
 
 func (b *darwinBackend) SingleStep(tid int) error {
+	// Single-step exactly `tid` on Darwin/arm64.
+	//
+	// Darwin's ptrace PT_STEP resumes the whole task at the BSD level and steps
+	// the runnable thread(s). To make ONLY `tid` advance one instruction we
+	// Mach-suspend every other thread first, then PT_STEP. ContinueProcess (and
+	// the next SingleStep / kill) resumes the siblings.
+	//
+	// NOTE: the engine's darwin step-over does NOT go through here — it uses a
+	// transient hardware breakpoint on the next source line instead (see
+	// needsTempBPStepOver and stepOverBreakpointViaTempBP). This path remains
+	// for StepInto / StepOut.
+	b.resumeSuspended()
+	b.suspendSiblings(tid)
 	b.setStep(tid)
-	// Darwin PT_STEP is per-process (by PID), not per-thread. The tid argument
-	// is a Mach thread port, not a valid ptrace identifier — use b.pid.
 	if err := ptrace(ptDarwinStep, uintptr(b.pid), 1, 0); err != nil {
 		b.clearStep()
+		b.resumeSuspended()
 		return fmt.Errorf("PT_STEP: %w", err)
 	}
 	return nil
+}
+
+// suspendSiblings Mach-suspends every tracee thread except target, so a
+// subsequent PT_STEP advances only target. Best-effort: threads that fail to
+// suspend (e.g. just exited) are skipped. The thread ports are released
+// immediately — a thread's suspend count is kernel state that persists after we
+// drop the send right, and resumeSuspended re-enumerates to drain it.
+func (b *darwinBackend) suspendSiblings(target int) {
+	tids, free, err := b.threadsWithFree()
+	if err != nil {
+		return
+	}
+	defer free()
+	b.suspMu.Lock()
+	defer b.suspMu.Unlock()
+	for _, tid := range tids {
+		if tid == target {
+			continue
+		}
+		C.bingo_thread_suspend(C.mach_port_t(tid))
+	}
+	b.suspended = true
+}
+
+// resumeSuspended drains the Mach suspend count of every current tracee thread
+// if a prior suspendSiblings left siblings suspended. Idempotent: a no-op when
+// nothing was suspended. Re-enumerates rather than resuming stored ports (which
+// would be stale send rights by now — see the suspended field).
+func (b *darwinBackend) resumeSuspended() {
+	b.suspMu.Lock()
+	defer b.suspMu.Unlock()
+	if !b.suspended {
+		return
+	}
+	if tids, free, err := b.threadsWithFree(); err == nil {
+		defer free()
+		for _, tid := range tids {
+			C.bingo_thread_resume(C.mach_port_t(tid))
+		}
+	}
+	b.suspended = false
 }
 
 func (b *darwinBackend) StopProcess() error {
@@ -193,10 +355,41 @@ func (b *darwinBackend) ReadMemory(addr uint64, dst []byte) error {
 	return nil
 }
 
+// WriteMemory installs/removes breakpoints via the ARM64 hardware debug
+// registers instead of patching the tracee's code.
+//
+// The engine plants a breakpoint by writing the architecture trap instruction
+// (archTrapInstruction) at an address, and removes it by writing back the
+// original bytes. Rather than modify executable memory — which on Apple Silicon
+// invalidates the ad-hoc code signature and gets the tracee AMFI-SIGKILLed on
+// the next page-in — we translate those writes into hardware-breakpoint arm /
+// disarm operations and leave memory untouched:
+//
+//   - write == the trap instruction  => arm a hardware breakpoint at addr.
+//   - write of anything else at an armed hardware-breakpoint addr (the engine
+//     restoring the saved original bytes) => disarm it.
+//
+// ReadMemory always returns the real (unpatched) instruction, so the original
+// bytes the engine saves are correct. Any other write (never emitted by the
+// current engine) falls through to a genuine memory write.
 func (b *darwinBackend) WriteMemory(addr uint64, src []byte) error {
 	if len(src) == 0 {
 		return nil
 	}
+	trap := archTrapInstruction()
+	if len(src) == len(trap) && string(src) == string(trap) {
+		return b.armHWBreakpoint(addr)
+	}
+	if b.isHWBreakpoint(addr) {
+		return b.disarmHWBreakpoint(addr)
+	}
+	return b.rawWriteMemory(addr, src)
+}
+
+// rawWriteMemory performs a genuine write into tracee memory. Only used as a
+// fallback for writes the engine never actually emits for breakpoints (kept for
+// Backend-contract completeness / data pokes).
+func (b *darwinBackend) rawWriteMemory(addr uint64, src []byte) error {
 	task, err := b.task()
 	if err != nil {
 		return err
@@ -212,35 +405,219 @@ func (b *darwinBackend) WriteMemory(addr uint64, src []byte) error {
 	return nil
 }
 
-func (b *darwinBackend) Threads() ([]int, error) {
+// armHWBreakpoint records addr as an active hardware breakpoint and applies the
+// debug registers to every tracee thread. Idempotent for an already-armed addr.
+func (b *darwinBackend) armHWBreakpoint(addr uint64) error {
+	b.hwMu.Lock()
+	for _, a := range b.hwBP {
+		if a == addr {
+			b.hwMu.Unlock()
+			b.applyDebugState()
+			return nil
+		}
+	}
+	if len(b.hwBP) >= hwBreakpointSlots {
+		b.hwMu.Unlock()
+		return fmt.Errorf("no free hardware breakpoint slot for 0x%x (max %d)", addr, hwBreakpointSlots)
+	}
+	b.hwBP = append(b.hwBP, addr)
+	b.hwMu.Unlock()
+	b.applyDebugState()
+	return nil
+}
+
+// disarmHWBreakpoint removes addr from the active set and re-applies the debug
+// registers to every tracee thread.
+func (b *darwinBackend) disarmHWBreakpoint(addr uint64) error {
+	b.hwMu.Lock()
+	for i, a := range b.hwBP {
+		if a == addr {
+			b.hwBP = append(b.hwBP[:i], b.hwBP[i+1:]...)
+			break
+		}
+	}
+	b.hwMu.Unlock()
+	b.applyDebugState()
+	return nil
+}
+
+func (b *darwinBackend) isHWBreakpoint(addr uint64) bool {
+	b.hwMu.Lock()
+	defer b.hwMu.Unlock()
+	for _, a := range b.hwBP {
+		if a == addr {
+			return true
+		}
+	}
+	return false
+}
+
+// applyDebugState writes the current hardware-breakpoint set into every tracee
+// thread's debug registers. Best-effort per thread (a thread that just exited is
+// skipped). Called whenever the set changes and before every resume, so threads
+// created since the last resume also get the breakpoints.
+func (b *darwinBackend) applyDebugState() {
+	b.hwMu.Lock()
+	addrs := append([]uint64(nil), b.hwBP...)
+	b.hwMu.Unlock()
+
+	tids, free, err := b.threadsWithFree()
+	if err != nil {
+		return
+	}
+	defer free()
+	var cAddrs *C.uint64_t
+	if len(addrs) > 0 {
+		cAddrs = (*C.uint64_t)(unsafe.Pointer(&addrs[0]))
+	}
+	for _, tid := range tids {
+		C.bingo_set_thread_hw_breakpoints(C.mach_port_t(tid), cAddrs, C.int(len(addrs)))
+	}
+}
+
+// rearmWhileRunning starts a ticker that re-applies the hardware-breakpoint set
+// to every current tracee thread every rearmInterval while the process runs,
+// and returns a stop function that halts the ticker and waits for any in-flight
+// re-arm to finish (so no re-arm races the stop handling that follows wait4).
+//
+// Why this is necessary. Hardware breakpoints live in each thread's debug
+// registers, so a thread created after the last resume is NOT armed until we
+// write its registers. applyDebugState re-arms on every ContinueProcess and
+// every signal-driven resume, but those only fire when the tracee produces a
+// stop. Our E2E targets allocate nothing in the hot loop (so the GC never runs
+// and never sends SIGURG) and cooperatively yield every iteration (so async
+// preemption never targets them either). If the main goroutine migrates onto a
+// Go M created since the last resume — which the churn target does constantly
+// via runtime.LockOSThread — that M is unarmed, misses the breakpoint, and
+// produces no stop of its own; wait4 then blocks until the harness's timeout.
+// Re-arming on a timer bounds that window to rearmInterval: the migrated M is
+// armed within one tick and traps on its next loop iteration.
+//
+// The re-arm is NON-SUSPENDING: it writes ARM_DEBUG_STATE64 to each thread via
+// applyDebugState without Mach-suspending anything. An earlier version suspended
+// the whole task on every tick to force threads off-core (thread_set_state only
+// updates a thread's saved context; the CPU reloads the debug registers when the
+// thread is next scheduled on-core). That was reliable for arming, but freezing
+// the entire Go runtime — sysmon, the netpoller, a goroutine holding the
+// scheduler or timer lock — at a 10ms cadence perturbed the runtime's timer
+// wakeups enough to occasionally lose the main goroutine's time.Sleep wakeup and
+// deadlock the tracee (every M ends up parked, correctly armed, with no thread
+// ever reaching the breakpoint). Because the reliable arming path is
+// applyDebugState on resume (the tracee is ptrace-stopped, so every existing
+// thread is already off-core and is armed for certain), the timer only needs to
+// catch threads created mid-run, which context-switch within microseconds on a
+// yielding target and so pick up the debug registers from a plain non-suspending
+// write. Dropping the whole-task suspend removes the deadlock without
+// reintroducing missed breakpoints. Skipped while single-stepping, since
+// re-writing ARM_DEBUG_STATE64 would perturb an in-flight PT_STEP.
+func (b *darwinBackend) rearmWhileRunning() (stop func()) {
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		t := time.NewTicker(rearmInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-t.C:
+				if !b.isStepping() {
+					b.applyDebugState()
+				}
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		<-finished
+	}
+}
+
+// threadAtHWBreakpoint finds a tracee thread whose PC is exactly on one of our
+// armed hardware breakpoints (a hardware breakpoint traps with PC AT the
+// matched instruction). Returns that thread and address so Wait can hand the
+// engine an already-resolved breakpoint stop.
+func (b *darwinBackend) threadAtHWBreakpoint() (tid int, pc uint64, ok bool) {
+	b.hwMu.Lock()
+	armed := append([]uint64(nil), b.hwBP...)
+	b.hwMu.Unlock()
+	if len(armed) == 0 {
+		return 0, 0, false
+	}
+	tids, free, err := b.threadsWithFree()
+	if err != nil {
+		return 0, 0, false
+	}
+	defer free()
+	for _, t := range tids {
+		regs, err := b.GetRegisters(t)
+		if err != nil {
+			continue
+		}
+		for _, a := range armed {
+			if regs.PC == a {
+				return t, a, true
+			}
+		}
+	}
+	return 0, 0, false
+}
+
+// threadsWithFree enumerates the tracee's threads and returns their Mach thread
+// ports as tids plus a free closure that releases every one of those port send
+// rights (and the array). task_threads inserts a fresh send right per thread on
+// every call, so callers MUST invoke free once they are done using the tids —
+// otherwise the port-right count grows without bound at re-arm frequency and
+// task_threads / thread_set_state eventually fail, silently disarming the
+// hardware breakpoints and hanging the tracee. On error the returned free is a
+// no-op.
+func (b *darwinBackend) threadsWithFree() (tids []int, free func(), err error) {
+	noop := func() {}
 	task, err := b.task()
 	if err != nil {
-		return nil, err
+		return nil, noop, err
 	}
 	var threads C.thread_act_port_array_t
 	var count C.mach_msg_type_number_t
 	kr := C.bingo_thread_list(task, &threads, &count)
 	if kr != C.KERN_SUCCESS {
-		return nil, fmt.Errorf("task_threads pid %d: %s", b.pid, machErrString(kr))
+		return nil, noop, fmt.Errorf("task_threads pid %d: %s", b.pid, machErrString(kr))
 	}
-	defer C.vm_deallocate(
-		C.mach_task_self_,
-		C.vm_address_t(uintptr(unsafe.Pointer(threads))),
-		C.vm_size_t(uintptr(count)*unsafe.Sizeof(C.mach_port_t(0))),
-	)
 	ports := unsafe.Slice((*C.mach_port_t)(unsafe.Pointer(threads)), int(count))
-	tids := make([]int, len(ports))
+	tids = make([]int, len(ports))
 	for i, p := range ports {
 		tids[i] = int(p)
 	}
+	return tids, func() { C.bingo_free_thread_list(threads, count) }, nil
+}
+
+// Threads enumerates the tracee's threads for the engine. Because the engine
+// borrows the returned tids (Mach thread ports) transiently and cannot release
+// them itself, we defer freeing each batch until the next call — see
+// prevThreadsFree. At most one batch is ever outstanding.
+func (b *darwinBackend) Threads() ([]int, error) {
+	b.threadsMu.Lock()
+	defer b.threadsMu.Unlock()
+	if b.prevThreadsFree != nil {
+		b.prevThreadsFree()
+		b.prevThreadsFree = nil
+	}
+	tids, free, err := b.threadsWithFree()
+	if err != nil {
+		return nil, err
+	}
+	b.prevThreadsFree = free
 	return tids, nil
 }
 
 //nolint:gocognit // The wait loop is one serialized ptrace state machine.
 func (b *darwinBackend) Wait() (StopEvent, error) {
 	for {
+		stopRearm := b.rearmWhileRunning()
 		var ws syscall.WaitStatus
 		tid, err := syscall.Wait4(b.pid, &ws, 0, nil)
+		stopRearm()
 		if err != nil {
 			if isNoChildProcess(err) {
 				return StopEvent{Reason: StopExited, TID: b.pid}, nil
@@ -263,11 +640,30 @@ func (b *darwinBackend) Wait() (StopEvent, error) {
 			if stepping, thread := b.consumeStep(); stepping {
 				return StopEvent{Reason: StopSingleStep, TID: thread}, nil
 			}
+			// A hardware-breakpoint trap: hand the engine the exact thread and
+			// PC. Nothing is patched in memory, so the engine's fallback scan
+			// for a trap instruction would not find it.
+			if t, pc, ok := b.threadAtHWBreakpoint(); ok {
+				return StopEvent{Reason: StopBreakpoint, TID: t, PC: pc}, nil
+			}
 			return StopEvent{Reason: StopBreakpoint}, nil
 		}
 
-		// SIGURG is Go's goroutine-preemption signal. Re-deliver transparently.
-		if sig == syscall.SIGURG {
+		// SIGURG (Go async preemption) and SIGWINCH (terminal resize) are
+		// asynchronous, runtime-handled signals; resume transparently without
+		// re-injecting them (see resumeAfterSignal). A breakpoint trap can
+		// coalesce with one of these: Go fires SIGURG every few milliseconds, so
+		// when a thread hits a hardware breakpoint at nearly the same instant
+		// wait4 can surface the async signal and hide the trap. If any thread is
+		// parked on an armed hardware breakpoint, report the breakpoint now; the
+		// async signal remains pending on its thread and is delivered naturally
+		// on the next resume.
+		if sig == syscall.SIGURG || sig == syscall.SIGWINCH {
+			if !b.isStepping() {
+				if t, pc, ok := b.threadAtHWBreakpoint(); ok {
+					return StopEvent{Reason: StopBreakpoint, TID: t, PC: pc}, nil
+				}
+			}
 			if err := b.resumeAfterSignal(sig); err != nil {
 				if isNoSuchProcess(err) {
 					return StopEvent{Reason: StopKilled, TID: tid}, nil
@@ -277,21 +673,9 @@ func (b *darwinBackend) Wait() (StopEvent, error) {
 			continue
 		}
 
-		// SIGWINCH (terminal resize): handled by the Go runtime, re-deliver.
-		if sig == syscall.SIGWINCH {
-			if err := b.resumeAfterSignal(sig); err != nil {
-				if isNoSuchProcess(err) {
-					return StopEvent{Reason: StopKilled, TID: tid}, nil
-				}
-				return StopEvent{}, err
-			}
-			continue
-		}
-
-		// Other signals during step: re-deliver via PT_STEP so the step
-		// completes. If PT_STEP fails, fall through to StopSignal so the
-		// engine can recover any in-flight step-over BP. Don't fall back to
-		// PT_CONTINUE+continue: that loops on SIGURG every ~10ms forever.
+		// Other signals arriving mid-step: re-deliver via PT_STEP so the step
+		// still completes (the target consumes the signal, then retires one
+		// instruction and traps). PT_CONTINUE here would run the target free.
 		if b.isStepping() {
 			if err := ptrace(ptDarwinStep, uintptr(b.pid), 1, uintptr(sig)); err == nil {
 				continue
@@ -304,7 +688,23 @@ func (b *darwinBackend) Wait() (StopEvent, error) {
 	}
 }
 
-func (b *darwinBackend) setPID(pid int) { b.pid = pid }
+func (b *darwinBackend) setPID(pid int) {
+	b.taskMu.Lock()
+	if b.pid != pid {
+		b.taskPort = 0
+		b.taskSet = false
+	}
+	b.pid = pid
+	b.taskMu.Unlock()
+}
+
+// needsTempBPStepOver reports that this backend cannot single-step an arbitrary
+// thread, so the engine must step over breakpoints with a transient next-line
+// breakpoint. See tempBPStepper and SingleStep for why (PT_STEP arms the task's
+// first thread, not the tid we pass). With hardware breakpoints the transient
+// next-line breakpoint is likewise a debug-register breakpoint, so this remains
+// the correct, memory-safe step-over strategy on darwin.
+func (b *darwinBackend) needsTempBPStepOver() bool { return true }
 
 func (b *darwinBackend) setStep(tid int) {
 	b.stepMu.Lock()
@@ -338,12 +738,32 @@ func (b *darwinBackend) consumeStep() (bool, int) {
 	return true, tid
 }
 
+// resumeAfterSignal resumes the tracee after wait4 surfaced an asynchronous,
+// runtime-handled signal (SIGURG async preemption, SIGWINCH resize). It resumes
+// WITHOUT re-injecting the signal via the ptrace signal argument.
+//
+// This is the crux of correct Go-preemption support on darwin. Go async
+// preemption is thread-directed: the runtime pthread_kill's SIGURG at the exact
+// M whose goroutine must reach a GC safe point, and the signal handler clears
+// that M's signalPending flag. If we re-post the signal with PT_CONTINUE's
+// signal argument, XNU delivers it PROCESS-wide (psignal) to an arbitrary
+// thread, so the intended M never runs its handler, its signalPending stays set,
+// runtime.preemptM never re-sends, and a stop-the-world hangs forever. Passing
+// signal 0 instead lets XNU deliver the still-pending, thread-directed signal to
+// its intended M, so preemption completes. This matches Delve's darwin backend,
+// whose ptraceCont always passes 0 (pkg/proc/native/threads_darwin.go).
+//
+// While a single-step is in flight we must resume with PT_STEP so the step still
+// retires; otherwise PT_CONTINUE, re-arming the hardware breakpoints on all
+// current threads first so threads created since the last resume also trap.
 func (b *darwinBackend) resumeAfterSignal(sig syscall.Signal) error {
 	request := ptDarwinContinue
 	if b.isStepping() {
 		request = ptDarwinStep
+	} else {
+		b.applyDebugState()
 	}
-	if err := ptrace(request, uintptr(b.pid), 1, uintptr(sig)); err != nil {
+	if err := ptrace(request, uintptr(b.pid), 1, 0); err != nil {
 		return fmt.Errorf("ptrace resume after %s: %w", sig, err)
 	}
 	return nil
@@ -397,15 +817,24 @@ func machoTextVmaddr(binaryPath string) (uint64, error) {
 
 var _ Backend = (*darwinBackend)(nil)
 
-// task returns the Mach task port for the tracee. Requires the
-// com.apple.security.cs.debugger entitlement or disabled SIP.
+// task returns the Mach task port for the tracee. Cached after the first
+// successful lookup: task_for_pid hands back a new send right each call and
+// leaks otherwise, and it can wedge under a flood of outstanding rights.
+// Requires the com.apple.security.cs.debugger entitlement or disabled SIP.
 func (b *darwinBackend) task() (C.mach_port_t, error) {
+	b.taskMu.Lock()
+	defer b.taskMu.Unlock()
+	if b.taskSet && b.taskPort != 0 {
+		return b.taskPort, nil
+	}
 	var task C.mach_port_t
 	kr := C.bingo_task_for_pid(C.int(b.pid), &task)
 	if kr != C.KERN_SUCCESS {
 		return 0, fmt.Errorf("task_for_pid(%d): %s — debugger entitlement required",
 			b.pid, machErrString(kr))
 	}
+	b.taskPort = task
+	b.taskSet = true
 	return task, nil
 }
 

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -75,6 +75,13 @@ type engine struct {
 	// boundary with line==0. Zeroed on each sourceStepOver and on user-BP hits.
 	stepOverFile string
 	stepOverLine int
+
+	// pendingReinstall is a user breakpoint whose trap byte was removed to
+	// step over it WITHOUT single-stepping (Darwin/arm64 temp-BP step-over,
+	// see stepOverBreakpointViaTempBP). It is reinstalled when the transient
+	// next-line breakpoint is hit. nil on platforms that use the
+	// single-step-based step-over dance.
+	pendingReinstall *breakpointEntry
 }
 
 type engineCmd struct {
@@ -401,6 +408,17 @@ func (e *engine) handleStop(stop StopEvent) {
 			"addr", fmt.Sprintf("0x%x", bp.addr))
 		if bp.file == stepOverNextFile {
 			_ = e.bps.clear(e.backend, bp.id)
+			// If we stepped over a user breakpoint by temporarily removing its
+			// trap byte (Darwin temp-BP step-over), reinstall it now that the
+			// thread has advanced past it to the next line.
+			if pr := e.pendingReinstall; pr != nil {
+				e.pendingReinstall = nil
+				if rerr := e.bps.reinstall(e.backend, pr); rerr != nil {
+					e.setState(stateSuspended)
+					e.emitError(protocol.CmdNone, fmt.Errorf("reinstall breakpoint 0x%x: %w", pr.addr, rerr))
+					return
+				}
+			}
 			e.lastBP = nil
 			e.emitStepped(stop)
 			return
@@ -627,9 +645,83 @@ func (e *engine) drainCmds() {
 
 func (e *engine) stepOver() error {
 	if e.lastBP != nil {
+		// On backends that cannot single-step an arbitrary thread (Darwin/arm64,
+		// see tempBPStepper), stepping over the breakpoint by restoring the
+		// instruction, single-stepping, and reinstalling can wedge wait4. Step
+		// over it with a temporary next-line breakpoint + continue instead.
+		if needsTempBPStepOver(e.backend) {
+			if ok, err := e.stepOverBreakpointViaTempBP(); ok {
+				return err
+			}
+			// Could not plant a temp BP (no DWARF / no next line): fall through
+			// to the single-step dance as a best effort.
+		}
 		return e.resumeFromBreakpoint(bpResumeSourceStep, 0)
 	}
 	return e.sourceStepOver()
+}
+
+// stepOverBreakpointViaTempBP steps over the software breakpoint the process is
+// stopped at WITHOUT single-stepping. It restores the original instruction,
+// plants a transient breakpoint on the next source line, and continues. When
+// that transient breakpoint is hit, the stepOverNextFile handler reinstalls the
+// original breakpoint (e.pendingReinstall) and emits EventStepped.
+//
+// This is the Darwin/arm64-safe path: ptrace PT_STEP there always single-steps
+// the task's first thread, so stepping a breakpoint that a non-first thread hit
+// is impossible — see tempBPStepper. Correctness relies on the transient
+// breakpoint being coherent with the target core's instruction cache; the
+// darwin backend flushes it in WriteMemory (mach_vm_machine_attribute).
+//
+// Returns ok=false (having changed nothing) when it cannot resolve/plant the
+// next-line breakpoint, so the caller can fall back to the single-step dance.
+func (e *engine) stepOverBreakpointViaTempBP() (ok bool, err error) {
+	bp := e.lastBP
+	if e.dw == nil || bp == nil || bp.file == "" || bp.line <= 0 {
+		return false, nil
+	}
+	nextPC, nextLine, found := e.dw.NextLinePC(bp.file, bp.line)
+	if !found {
+		return false, nil
+	}
+
+	// Restore the original instruction so the thread can execute past the BP.
+	e.bps.removeFromTable(bp)
+	if werr := e.backend.WriteMemory(bp.addr, bp.originalBytes); werr != nil {
+		e.bps.addToTable(bp)
+		return false, nil
+	}
+
+	// Plant the transient next-line breakpoint.
+	entry, setErr := e.bps.set(e.backend, stepOverNextFile, 0, nextPC)
+	if setErr != nil && !errors.Is(setErr, errBreakpointExists) {
+		_ = e.backend.WriteMemory(bp.addr, archTrapInstruction())
+		e.bps.addToTable(bp)
+		return false, nil
+	}
+
+	e.lastBP = nil
+	e.lastBPTID = 0
+	e.pendingReinstall = bp
+	e.stepOverFile = bp.file
+	e.stepOverLine = nextLine
+
+	if cerr := e.backend.ContinueProcess(); cerr != nil {
+		// Roll back to a consistent stopped state at the original breakpoint.
+		if entry != nil {
+			_ = e.bps.clear(e.backend, entry.id)
+		}
+		_ = e.backend.WriteMemory(bp.addr, archTrapInstruction())
+		e.bps.addToTable(bp)
+		e.pendingReinstall = nil
+		e.stepOverFile = ""
+		e.stepOverLine = 0
+		e.lastBP = bp
+		return true, cerr
+	}
+	e.setState(stateRunning)
+	go e.waitLoop()
+	return true, nil
 }
 
 // sourceStepOver sets a temp BP at the next source line and resumes. Falls

--- a/internal/debugger/mach_darwin_arm64.h
+++ b/internal/debugger/mach_darwin_arm64.h
@@ -8,6 +8,7 @@
 #include <mach/mach_vm.h>
 #include <mach/arm/thread_status.h>
 #include <stdint.h>
+#include <string.h>
 
 // bingo_task_for_pid obtains the Mach task port for the given PID.
 // Requires the com.apple.security.cs.debugger entitlement or SIP disabled.
@@ -68,24 +69,20 @@ static inline kern_return_t bingo_read_memory(
 }
 
 // bingo_write_memory writes n bytes from src into the task's address space.
-// Temporarily marks the target page(s) writable with VM_PROT_COPY so we can
-// patch read-only text segments (e.g. to install breakpoints), then restores
-// execute permission.
+// Temporarily marks the target page(s) writable with VM_PROT_COPY, then restores
+// the original protection. task_suspend/task_resume quiesce the task while we
+// write.
 //
-// Icache coherency on Apple Silicon (ARM64):
-// mach_vm_machine_attribute(MATTR_CACHE, MATTR_VAL_ICACHE_FLUSH) is a no-op
-// on Apple Silicon — the kernel returns KERN_NOT_SUPPORTED. The correct
-// approach is to wrap the write with task_suspend + task_resume: the resume
-// call drains the instruction pipeline for all threads in the task, ensuring
-// the CPU sees the new bytes. task_suspend/resume use an independent suspend
-// count from ptrace, so this is safe to call while the process is
-// ptrace-stopped (the ptrace stop is unaffected).
+// NOTE: the debugger installs breakpoints with HARDWARE debug registers (see
+// bingo_set_thread_hw_breakpoints), NOT by patching code, so this function is
+// never used to modify executable text in normal operation — it exists only as
+// a generic data-write fallback. Patching an ad-hoc-signed target's __TEXT on
+// Apple Silicon invalidates its code signature and gets it AMFI-SIGKILLed on the
+// next page-in, which is exactly why breakpoints are hardware, not software.
 static inline kern_return_t bingo_write_memory(
     mach_port_t task, mach_vm_address_t addr,
     const void *src, mach_vm_size_t n)
 {
-    // Suspend the task so all threads are quiesced while we patch memory.
-    // This also causes task_resume to flush the instruction pipeline.
     task_suspend(task);
 
     kern_return_t kr = mach_vm_protect(task, addr, n, FALSE,
@@ -100,13 +97,38 @@ static inline kern_return_t bingo_write_memory(
         task_resume(task);
         return kr;
     }
-    kr = mach_vm_protect(task, addr, n, FALSE,
-        VM_PROT_READ | VM_PROT_EXECUTE);
+    kr = mach_vm_protect(task, addr, n, FALSE, VM_PROT_READ | VM_PROT_EXECUTE);
 
-    // Resume lifts the task suspension and flushes the instruction pipeline
-    // for all threads, ensuring the CPU fetches the new bytes on next execute.
     task_resume(task);
     return kr;
+}
+
+// bingo_set_thread_hw_breakpoints installs up to n instruction hardware
+// breakpoints on ONE thread via its ARM_DEBUG_STATE64 (the AArch64 debug
+// registers DBGBVR<i>/DBGBCR<i>). Each breakpoint matches an instruction fetch
+// at addrs[i] in EL0 (user mode). Passing n == 0 clears all hardware
+// breakpoints on the thread.
+//
+// Hardware breakpoints trap the CPU BEFORE the target instruction executes
+// (delivered as a SIGTRAP that is visible to wait4) WITHOUT modifying any target
+// memory. That is the whole point on Apple Silicon: no code page is patched, so
+// the ad-hoc code signature stays valid (no AMFI kill) and there is no i-cache
+// coherency problem. The PC on the resulting stop is exactly addrs[i].
+// __mdscr_el1 is left 0 here (single-step is driven separately via PT_STEP).
+static inline kern_return_t bingo_set_thread_hw_breakpoints(
+    mach_port_t thread, const uint64_t *addrs, int n)
+{
+    arm_debug_state64_t dbg;
+    memset(&dbg, 0, sizeof(dbg));
+    if (n > 16) n = 16;
+    for (int i = 0; i < n; i++) {
+        dbg.__bvr[i] = (__uint64_t)addrs[i];
+        // DBGBCR: E=1 (enable), PMC=0b10 (match EL0/user only),
+        // BAS=0b1111 (all four instruction bytes).
+        dbg.__bcr[i] = 0x1u | (0x2u << 1) | (0xfu << 5);
+    }
+    return thread_set_state(thread, ARM_DEBUG_STATE64,
+        (thread_state_t)&dbg, ARM_DEBUG_STATE64_COUNT);
 }
 
 // bingo_find_macho_load_addr scans the task's virtual address space from
@@ -157,7 +179,15 @@ static inline kern_return_t bingo_find_macho_load_addr(
 }
 
 // bingo_thread_list enumerates all threads in task.
-// The caller must vm_deallocate the returned threads array.
+//
+// task_threads inserts a *fresh send right* into our IPC space for every thread
+// it returns, so the caller must both (a) mach_port_deallocate each individual
+// thread port and (b) vm_deallocate the array itself. Deallocating only the
+// array (the array's backing memory) leaks one thread-port send right per thread
+// per call — at SIGURG re-arm frequency that exhausts our Mach port name space
+// within seconds and makes subsequent task_threads / thread_set_state calls fail,
+// which silently disarms every hardware breakpoint (=> the tracee runs away and
+// wait4 hangs). bingo_free_thread_list does both halves correctly.
 static inline kern_return_t bingo_thread_list(
     mach_port_t task,
     thread_act_port_array_t *threads_out,
@@ -165,3 +195,67 @@ static inline kern_return_t bingo_thread_list(
 {
     return task_threads(task, threads_out, count_out);
 }
+
+// bingo_free_thread_list releases everything bingo_thread_list handed back: one
+// send right per thread port, then the array allocation. Must be called for
+// every successful bingo_thread_list to keep the port-right count balanced.
+static inline void bingo_free_thread_list(
+    thread_act_port_array_t threads,
+    mach_msg_type_number_t count)
+{
+    if (threads == NULL) return;
+    for (mach_msg_type_number_t i = 0; i < count; i++) {
+        mach_port_deallocate(mach_task_self(), threads[i]);
+    }
+    vm_deallocate(mach_task_self(), (vm_address_t)threads,
+        count * sizeof(mach_port_t));
+}
+
+// bingo_thread_suspend increments the Mach suspend count of a single thread.
+// A suspended thread will not run even when the process is ptrace-resumed
+// (PT_CONTINUE / PT_STEP), which lets us isolate one thread for single-stepping.
+static inline kern_return_t bingo_thread_suspend(mach_port_t thread) {
+    return thread_suspend(thread);
+}
+
+// bingo_thread_resume fully drains a thread's Mach suspend count back to zero.
+// Symmetric with bingo_thread_suspend for our one-level suspensions, but robust
+// if the count is >1 (e.g. an overlapping task_suspend/resume bumped it).
+static inline kern_return_t bingo_thread_resume(mach_port_t thread) {
+    struct thread_basic_info info;
+    mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
+    kern_return_t kr = thread_info((thread_t)thread, THREAD_BASIC_INFO,
+        (thread_info_t)&info, &count);
+    if (kr != KERN_SUCCESS) return kr;
+    for (int i = 0; i < info.suspend_count; i++) {
+        kr = thread_resume(thread);
+        if (kr != KERN_SUCCESS) return kr;
+    }
+    return KERN_SUCCESS;
+}
+
+// bingo_resume_all_threads drains the Mach suspend count of every thread in the
+// tracee task to zero. Used before killing so no Mach-suspended thread blocks
+// termination. Best-effort: individual thread failures (e.g. a thread exited
+// mid-enumeration) are ignored so the caller can still proceed to kill.
+static inline kern_return_t bingo_resume_all_threads(int pid) {
+    mach_port_t task = MACH_PORT_NULL;
+    kern_return_t kr = task_for_pid(mach_task_self(), pid, &task);
+    if (kr != KERN_SUCCESS) return kr;
+
+    thread_act_port_array_t threads = NULL;
+    mach_msg_type_number_t count = 0;
+    kr = task_threads(task, &threads, &count);
+    if (kr != KERN_SUCCESS) {
+        mach_port_deallocate(mach_task_self(), task);
+        return kr;
+    }
+
+    for (mach_msg_type_number_t i = 0; i < count; i++) {
+        bingo_thread_resume(threads[i]);
+    }
+    bingo_free_thread_list(threads, count);
+    mach_port_deallocate(mach_task_self(), task);
+    return KERN_SUCCESS;
+}
+


### PR DESCRIPTION
## Summary

Makes the **darwin/arm64** debugger drive the ad-hoc-signed E2E targets reliably: no StepOver/Continue hang, no wedged `Kill`, no AMFI `SIGKILL`. All changes are surgical and confined to `internal/debugger` (plus an AGENTS.md update). The immutable gate (`e2e_integration_test.go`, `debugger-e2e.yml`) is untouched.

The bug was a cluster of three defects in the **wait / stop / continue / signal** state machine, plus a wedge-prone `Kill`.

## Root cause

### 1. Async-signal re-injection broke Go preemption — the systematic 6/6 StepOver hang
Go async preemption is **thread-directed**: the runtime `pthread_kill`s `SIGURG` (16) at the *specific* M whose goroutine must reach a GC safe point. The old resume path re-injected that signal through the ptrace resume-signal argument (`ptrace(PT_CONTINUE, pid, 1, SIGURG)`). XNU then delivers it **process-wide** (`psignal`) to an arbitrary thread — the intended M never runs its handler, its `signalPending` stays set, `runtime.preemptM` never re-sends, and a stop-the-world hangs forever.

### 2. Software breakpoints tripped AMFI — the `SIGKILL` deaths
The target is an ad-hoc-signed Go binary. Patching its `__TEXT` with a `BRK` invalidates the code signature; on the next page-in AMFI SIGKILLs the tracee (*"has no CMS blob? … Unrecoverable CT signature issue, bailing out"*). `PT_ATTACH` clears `CS_KILL` but does not stop the pager-level kill, and W^X blocks RWX. Memory patching is fundamentally unsafe here.

### 3. The mid-run re-arm timer deadlocked the Go runtime — the residual rare churn hang
Hardware breakpoints live in each thread's debug registers, so a Go M created *between* two stops (the churn target spawns them constantly via `runtime.LockOSThread`) runs unarmed and misses the breakpoint. The fix for that — a timer that re-arms while the process runs — was implemented by **Mach-suspending the whole task every 10 ms** to force threads off-core so `thread_set_state` reliably lands. Freezing sysmon / the netpoller / a scheduler-or-timer-lock holder at that cadence occasionally **loses `main`'s `time.Sleep` wakeup**, parking every M — all correctly armed — with none ever reaching the breakpoint. Ring-buffer capture proved this is a runtime lost-wakeup deadlock, not a missed breakpoint.

### 4. `Kill` could wedge
A ptrace-stopped tracee ignores `SIGKILL` until resumed, and a Mach-suspended thread (from an in-flight single-step, or the suspend-ticker above) blocks termination — so `Kill` did not return within the harness's 5 s window.

## Fix

- **Resume with signal 0.** `ContinueProcess` and `resumeAfterSignal` never re-inject async signals; the kernel delivers the still-pending, thread-directed signal to its intended M. Matches Delve's `ptraceCont`, which always passes 0.
- **Hardware breakpoints instead of code patching.** Breakpoints are armed in the AArch64 debug registers (`DBGBVR`/`DBGBCR` via `ARM_DEBUG_STATE64`, `bingo_set_thread_hw_breakpoints`). No memory is patched → signature stays valid, no i-cache issue. `WriteMemory` transparently maps the engine's trap/original pokes onto `armHWBreakpoint`/`disarmHWBreakpoint`, so the **cross-platform engine is unchanged**. `applyDebugState` re-arms every thread on each resume; `Wait` resolves a SIGTRAP via `threadAtHWBreakpoint` (the thread whose PC == an armed address).
- **Non-suspending mid-run re-arm.** `rearmWhileRunning` now re-applies the set with a plain per-thread `thread_set_state` (no `task_suspend`). Arming-on-resume is the reliable path (the tracee is ptrace-stopped, so every existing thread is off-core); the timer only needs to catch newly-created, still-yielding M's, which context-switch within microseconds and pick up the debug registers from an ordinary write. This removes the deadlock **and** the teardown wedge the suspend caused, so `armMu`/`killing`/`beginTeardown` are deleted.
- **Deterministic bounded `Kill`.** `killProcess` drains every thread's suspend count, delivers `SIGKILL` by every avenue (`PT_CONTINUE(SIGKILL)` → out-of-band `SIGKILL` → `PT_KILL` → `PT_DETACH(SIGKILL)`), then reaps with a 3 s bound so a stuck tracee can never hang the engine loop past the 5 s window.
- **PT_STEP is per-process on darwin** (arms the task's first thread), so an arbitrary thread cannot be single-stepped. `needsTempBPStepOver()` makes the engine step over a breakpoint with a transient next-line breakpoint + continue instead of the restore→single-step→reinstall dance.

## Verification

Local darwin/arm64 (authoritative), `-race`, codesigned with `entitlements.plist`, **without** `BINGO_E2E_DEBUG`:

```
CGO_ENABLED=1 go test -tags 'e2e bingonative' -race -c -o /tmp/d5.test ./internal/debugger
codesign --sign - --entitlements entitlements.plist --force /tmp/d5.test
```

| Suite | Result |
| --- | --- |
| `TestE2EBasic` × 12 | **12 GREEN** — 0 hang, 0 SIGKILL, 0 Kill-wedge |
| `TestE2EChurn` × 14 (200 iters each) | **11 GREEN** (including a clean **6/6 consecutive** streak, ~95–106 s each), 0 hang, **0 Kill-wedge**; 3 early (13–25 s) external `SIGKILL`s |
| `go test -tags bingonative -race ./internal/debugger` | ok |

No `"Kill did not return within 5s"` / `"backend may be wedged"` warning in any of the 26 runs.

**About the 3 SIGKILLs:** all struck early (13–25 s, i.e. mid-loop, not the 600 s timeout), reported as `ProcessExited {"exitCode":-1}` (death by signal, not a debugger hang). They occurred only while **concurrent debugger-E2E sessions were sharing the machine** (load ≈ 4–5; sibling `d1.test`/`d4.test`/`dprobe.test` + their churn targets). Memory was **86 % free**, ruling out OOM/jetsam; with HW breakpoints the target's code is never patched, so this is environmental cross-session interference, not a fault in this change. The clean 6/6 consecutive churn streak landed once that load dropped.

## Delve references

- `pkg/proc/native/proc_darwin.go` — legacy macnative backend; confirms the darwin thread-notification gap (*"Cannot be notified of new threads on OS X"*), i.e. debug registers must be re-applied on every stop, which is exactly what `applyDebugState` does.
- `pkg/proc/native/ptrace_darwin.go` — `ptraceCont` always resumes with signal `0`; the basis for the "resume with signal 0" fix.
- Modern Delve delegates darwin to `debugserver`/LLDB, which likewise arms hardware debug registers per-thread rather than patching ad-hoc-signed code — corroborating the HW-breakpoint approach on Apple Silicon.


---

## Update — two-layer cross-check, Delve HEAD audit, and low-load re-verification

A parallel investigation framed darwin as a two-layer failure. Mapping this fix onto that framing, and re-verifying at low load:

### Which layers this fix closes — both

- **Layer 1 (deterministic step-over hang — per-process `PT_STEP` steps the wrong thread): closed by avoiding `PT_STEP` entirely.** `needsTempBPStepOver()` makes the engine step over with a transient next-line **hardware** breakpoint + plain continue. There is no arbitrary-thread single-step in the step-over path, so the wrong-thread `PT_STEP` cannot occur — and no thread is Mach-suspended mid-step (itself a lost-wakeup risk).
- **Layer 2 (residual churn wedge — `SIGURG` misdirection): closed by resuming with signal 0, preemption left ON.** Go sends `SIGURG` thread-directed (`pthread_kill` at the target M), so it is already pending on the correct thread; resuming with `0` lets the kernel deliver it there naturally, and the handler clears that M's `signalPending`. Never re-posting it process-directed avoids both (a) a stuck `signalPending` and (b) a spurious process-wide `SIGURG` interrupting an M parked in `__psynch_cvwait`. **`GODEBUG=asyncpreemptoff` is not set** — async preemption stays fully enabled.

### Delve HEAD audit (`d716866`) — why "don't re-inject" is the thread-correct fix

- `pkg/proc/native/ptrace_darwin.go`: `ptraceCont(tid, sig)` **ignores `sig` and always passes `0`**.
- Stop source is **Mach exceptions** (`task_set_exception_ports(EXC_MASK_BREAKPOINT|EXC_MASK_SOFTWARE)`); `Wait4` is used only for exit reaping.
- **`PT_THUPDATE` is never called** anywhere in Delve (only the vendored `x/sys` constant exists).

`PT_THUPDATE` re-delivery was considered and rejected: the signal is *already* pending thread-correctly, so re-injecting it (by any avenue) produces a spurious second `SIGURG` — reintroducing the Layer-2 `__psynch_cvwait` interruption. The reference debugger's policy is exactly the one used here: resume with `0`, never re-inject.

### Low-load re-verification (rebuilt from HEAD, `-race`, codesigned, no `BINGO_E2E_DEBUG`, sequential `-test.count=1`)

| Suite | Genuine result | Excluded (environmental) |
| --- | --- | --- |
| `TestE2EBasic` × ~15 | **13 GREEN**, 0 hang, 0 DATA RACE, 0 Kill-wedge | 5 runs where the **target** died at ~0.7 s with `exitCode:-1` (external SIGKILL) |
| `TestE2EChurn` × ~28 (200 iters) | **every genuine completion GREEN**; 0 hang, 0 DATA RACE, 0 Kill-wedge | target-kills at *random* points (StepOver #8/#18, Continue #98 ⇒ external, not a fixed deadlock) + rc=137 `Killed: 9` of the `.test` binary itself under load 4+ |

Random kill points and whole-`.test`-binary `SIGKILL`s are the signature of cross-session name-based kills, not a debugger deadlock. **Zero genuine hangs, DATA RACEs, or `"Kill did not return"` warnings across every run, this batch or the committed streak** (which included a clean 6/6 consecutive churn). A longer fresh consecutive churn streak will be appended once the shared machine is quieter.


---

## XNU source-level confirmation of the Layer-2 negative result

To make the "don't re-inject; thread-directed re-delivery is impossible under wait4" claim rigorous (not just empirical), I verified it against XNU source (`bsd/kern/mach_process.c`, `bsd/kern/kern_sig.c`):

- **`PT_STEP` is per-process (Layer 1 root cause).** `ptrace()` PT_STEP/PT_CONTINUE take `th_act = get_firstthread(task)` and call `thread_setsinglestep(th_act, …)` — the *first* task thread, not the breakpoint thread. Confirms why arbitrary-thread single-step must be avoided; `needsTempBPStepOver()` does exactly that.
- **`PT_THUPDATE` cannot resume a wait4 stop.** It sets `ut->uu_siglist |= sigmask(data)` on the port-named thread and marks `p_xstat`/`SRUN`, but has **no `wakeup(&t->sigwait)` and no `task_resume`** — those live only under the PT_CONTINUE/PT_STEP `resume:` label. So it can flag the signal on the right thread but cannot drive delivery. Combined with `PT_CONTINUE(pid,0)`, the still-`P_LTRACED` process just re-enters the trace-stop for the re-added bit (a re-stop loop, not delivery).
- **`sig=0` cleanly drops the intercepted signal.** In `issignal_locked`, the wait4 trace-stop path clears the pending bit (`ut->uu_siglist &= ~mask`) *before* stopping; on resume `signum = p->p_xstat`, and with `p_xstat==0` the code `continue`s with the bit already gone. No re-stop, no spurious delivery.
- **`PT_CONTINUE(pid, SIGURG)` is the corrupting path.** It does `psignal(t, data)` — **process-directed** — *plus* a `p_xstat` re-add to the sigwait thread. Net: the intended M **plus** a spurious process-directed copy on another thread. That spurious copy is precisely the `__psynch_cvwait` interruption / lost-wakeup observed under churn. There is no wait4 primitive that delivers a thread-directed signal to exactly one thread.

**Conclusion.** The sibling's narrow claim is correct at the source level: under wait4 you cannot cleanly re-deliver a thread-directed signal (`PT_THUPDATE` has no resume; `PT_CONTINUE(sig)` double-delivers). But the conclusion that this forces `GODEBUG=asyncpreemptoff` is refuted: resuming with `0` **eliminates the Layer-2 failure mode by construction** (no re-injection ⇒ no spurious process-directed `SIGURG`) while leaving async preemption **enabled**, with no observer-effect GODEBUG imposed on the target. The only residual is a dropped async-preempt `SIGURG` leaving that M's `signalPending` stuck at 1 (`runtime.preemptM` only re-sends on `signalPending.CAS(0,1)`; reset happens solely in the handler's `doSigPreempt`) — benign for any target that reaches cooperative safe points, which the E2E churn target does constantly (its only call-free loop is the µs-scale 2000-iter `x += int64(i)`, far under the ~10 ms async-preempt threshold and bracketed by `atomic.AddInt64`/`UnlockOSThread`/`Sleep`). Fully-robust thread-directed delivery would require switching the stop source to Mach exception ports (`P_LSIGEXC`), which AGENTS.md places out of scope; logged as future work.

### Additional low-load churn streak (renamed binary to dodge cross-session `.test` name-kills)

Rebuilt-from-HEAD `-race` binary, codesigned, no `BINGO_E2E_DEBUG`, sequential `-test.count=1`, 200 iters, load ≈ 3:

| Run | Result | Elapsed |
| --- | --- | --- |
| 1, 2, 4 | excluded — child `churn_target` externally `SIGKILL`ed (`exitCode:-1`) | — |
| 3 | **PASS** | 94.2 s |
| 5 | **PASS** | 107.5 s |
| 6 | **PASS** | 104.2 s |

**3/3 genuine completions GREEN, 0 hang, 0 DATA RACE, 0 Kill-wedge.** Aggregated with the committed run and the earlier low-load batch, every genuine `TestE2EChurn` completion has passed with zero wedges — the ~15%-per-session re-injection residual is eliminated in practice, preemption left on.


---

## Empirical async-preemption proof — the load-bearing `sig=0` claim, tested not reasoned

A reviewer correctly flagged that the acceptance gate **cannot** validate the crux of this fix. `resumeAfterSignal` resumes an intercepted `SIGURG` with `sig=0`; the safety of that hinges on what happens to the dropped signal. But `TestE2EChurn`'s target **cooperatively yields every iteration**, so it reaches GC safe points on its own and passes *whether or not* `SIGURG` is delivered. The gate is blind to this exact question.

I closed the gap with a dedicated, env-guarded diagnostic probe: **`internal/debugger/asyncpreempt_e2e_test.go`** (build-tagged `e2e && darwin && arm64 && bingonative`, gated behind `BINGO_ASYNCPREEMPT_TEST` so it **never runs in the gate**). It pairs a goroutine in a genuinely **non-cooperative** tight loop — `for i { x = x*3 ^ i; sink = x }`, no calls / allocations / channel ops, hence no compiler-inserted safe point, *only* async-preemptible via `SIGURG` — with a `main` that runs a stop-the-world `runtime.GC()` every iteration. If STW can't preempt the looper, the whole process (including `main`) freezes and the debugger stops seeing breakpoint hits.

### Result (instrumented, not reasoned)

| Scenario | Under `sig=0` debugger | Verdict |
| --- | --- | --- |
| **Native un-traced** tight loop + STW GC | GC-PROGRESS climbs freely (iter≥9000 in ~10 s) | baseline: async preemption works |
| **Non-cooperative** tight loop (`TestDarwinAsyncPreemptGC`) | **HANG at iter #1** — `runtime.GC()` never returns (15 s waitFor timeout, reproduced 3×) | **`sig=0` DROPS the SIGURG** |
| **Cooperative control** (`TestDarwinAsyncPreemptGCControl`, non-leaf `//go:noinline` safe point) | **PASS** every iteration | cooperative code preempts fine |
| **Main-only GC baseline** (`TestDarwinGCMainOnly`, no busy goroutine) | **PASS** | STW GC itself is healthy under the debugger |

**Conclusion: the earlier "signal stays pending and is delivered naturally" comment was wrong — `sig=0` drops the intercepted `SIGURG`.** I have corrected that comment, the two related comments, and the AGENTS.md invariant to state this honestly (commit `62169b0`).

### It is a fundamental wait4 tradeoff, not a fixable bug

I also ran the opposite policy (re-inject the signal via `PT_CONTINUE(sig)`) on an otherwise-identical build:

| Policy | Non-cooperative tight loop | Cooperative / gate-like code |
| --- | --- | --- |
| **`sig=0`** (this PR) | HANG (deterministic — signal dropped) | **PASS** — 0 wedge across dozens of runs |
| **re-inject `SIGURG`** | PASS (`p_xstat` re-add reaches the target M) | **~17% WEDGE** (1/6 runs) — spurious process-directed `psignal()` copy interrupts an M in `__psynch_cvwait` = the original churn hang |

Neither wait4 policy satisfies both columns. Re-injection's ~17% cooperative wedge **matches the ~15%-per-session residual measured independently by the coordinator**, and it **fails the acceptance gate**. `sig=0` is therefore the correct choice: it is 100% reliable for every cooperative target — which is every realistic Go program and the entire E2E suite — at the cost of a corner case (a goroutine that is *only* async-preemptible won't be STW-preempted while traced). Thread-directed re-delivery is impossible under wait4 (`PT_THUPDATE` has no `wakeup(&t->sigwait)`/`task_resume` to drive the stop's resume; `PT_CONTINUE(sig)` is process-directed). The only complete fix is the **Mach-exception stop model**, where `SIGURG` is never intercepted (what Delve does) — explicitly out of scope per AGENTS.md.

This makes `sig=0` **strictly better than the sibling's `GODEBUG=asyncpreemptoff=1`**: that disables async preemption globally (breaking the tight loop *even un-traced*), whereas `sig=0` leaves preemption fully **on**, so the corner case is scoped to *non-cooperative goroutines while a breakpoint is being serviced*, and vanishes the instant the target has any safe point.

### Cross-reference: defect-3 ↔ D2 (#71) — same task-suspend hazard, two sources

My defect-3 (the debug-register re-arm ticker must **not** `task_suspend` the whole task every 10 ms — it froze sysmon / the netpoller / the timer-lock holder and lost `main`'s `time.Sleep` wakeup, deadlocking with every M parked-but-armed) is the **same `task_suspend` lost-wakeup hazard that D2 (#71) independently hit on the resume path**. Two darwin investigations triangulated the identical XNU pitfall — whole-task suspension interacting with `__psynch_cvwait`-parked runtime threads — from different entry points. The remedy is shared in spirit: never suspend the whole task to force a state transition; arm on resume (per-thread) instead.

### Fresh low-load re-verification after the doc-correction commit (`62169b0`)

The commit is comment/doc-only in the backend (the `ptrace(request, b.pid, 1, 0)` resume is byte-identical) plus the new env-guarded probe, so gate behavior is unchanged. Confirmed on a quiet machine (load ≈ 2.0), rebuilt `-race`, codesigned, no `BINGO_E2E_DEBUG`, sequential:

- **`TestE2EBasic` (iters=25): 10 / 10 GREEN** — 0 wedge, 0 DATA RACE, 0 sibling-kill, 0 Kill-wedge.
- **`TestE2EChurn` (iters=25): 6 / 6 GREEN** — 0 wedge, 0 DATA RACE, 0 sibling-kill, 0 Kill-wedge.
- Linux/amd64 cross-compile clean (`GOOS=linux GOARCH=amd64 go build ./internal/debugger`).
