### PR TITLE
Darwin fix: isolate single-step to the trapped thread (suspend siblings + suspended spawn)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,7 +207,26 @@ engine advances PC by `len(archTrapInstruction())` and resumes. See the
   a BRK on its serialized event loop. For SingleStep, save the thread port we
   issued the step against (`b.stepTID`).
 - `PT_STEP` is per-PROCESS on Darwin (despite the API taking a tid). Always
-  pass `b.pid`, not the Mach thread port.
+  pass `b.pid`, not the Mach thread port. Worse, XNU arms the CPU single-step
+  (`MDSCR_EL1.SS`) on `get_firstthread(task)` — usually a parked runtime M, NOT
+  the thread that hit the breakpoint — so a bare `PT_STEP` lets every thread run
+  and the kernel may retire the step on the wrong thread. The one that hit the
+  BP then runs straight through the byte-restored breakpoint window before the
+  trap is reinstalled, and the next `Continue` wedges: the ~2% single-step hang.
+  **Fix (`isolateForStep`/`endStepIsolation`, mirrors lldb-debugserver / Delve
+  `singleStep`):** before `PT_STEP`, Mach-`thread_suspend` every thread except
+  the target and set the hardware `MDSCR_EL1.SS` bit on the target only; after
+  the step trap retires, clear the SS bit on ALL threads (XNU left a stray one
+  on `get_firstthread`) and `thread_resume` the rest. Exactly one thread
+  advances one instruction. See `SingleStep` and the `StopSingleStep` teardown
+  in `Wait`.
+- Go's `syscall.WaitStatus.Stopped()` returns **false for a SIGSTOP** stop (Unix
+  job-control convention: `w&0x7f==0x7f && sig != SIGSTOP`). Under ptrace a
+  SIGSTOP-delivery-stop is a REAL stop that has task-suspended the tracee, so
+  `Wait` must NOT skip it — decode the raw wait status directly
+  (`raw&0x7f==0x7f` → `sig=(raw>>8)&0xff`) and swallow-resume SIGSTOP like
+  SIGURG (`resumeAfterSignal(0)`). Falling through to a bare `continue` leaves
+  the tracee suspended and the next `wait4` blocks forever — a second ~2% hang.
 - `SIGURG` (Go preemption) and `SIGWINCH` must be re-delivered transparently
   during both step and continue, or scheduling breaks.
 - ASLR slide is computed in `TextSlide` by scanning the VM map for the first

--- a/internal/debugger/backend_darwin_arm64.go
+++ b/internal/debugger/backend_darwin_arm64.go
@@ -35,6 +35,23 @@ type darwinBackend struct {
 	stepMu   sync.Mutex
 	stepping bool
 	stepTID  int // Mach thread port saved by SingleStep, reused on the step trap
+
+	// taskPort caches the Mach task port for the tracee. task_for_pid must be
+	// called only ONCE per process: on modern macOS it reuses the same port
+	// NAME across calls but inserts a fresh send right every time, so calling it
+	// on every memory/threads op (as the old code did) leaks send-right urefs
+	// without ever releasing them. Once that count balloons the kernel
+	// SIGKILLs the tracee mid-run. Delve caches the task port the same way
+	// (dbp.os.task). Guarded by taskMu; reset by setPID for a new tracee.
+	taskMu   sync.Mutex
+	taskPort C.mach_port_t
+
+	// Single-step isolation state, only touched on the engine loop goroutine
+	// (SingleStep / ContinueProcess). ssThread is the thread whose hardware
+	// single-step (MDSCR_EL1.SS) bit we set; suspended holds the Mach thread
+	// ports we Mach-suspended for the step so only ssThread runs.
+	ssThread  int
+	suspended []int
 }
 
 // Darwin ptrace request codes from <sys/ptrace.h>. PT_ATTACH (10) makes the
@@ -59,29 +76,90 @@ func ptrace(request, pid, addr, data uintptr) error {
 	return nil
 }
 
+// startTracedProcess launches binaryPath under the debugger on Darwin/arm64.
+//
+// It does NOT use PTRACE_TRACEME (Go's SysProcAttr.Ptrace). That path runs the
+// child's cs_allow_invalid() on the PRE-exec image, which execve then discards,
+// leaving the target with CS_KILL set and CS_DEBUGGED clear. On Apple Silicon
+// that is fatal for software breakpoints: the first time a patched (BRK) code
+// page is made coherent to physical memory, a page fault re-validates the page
+// hash, it mismatches, and — because CS_KILL is set and CS_DEBUGGED is not — the
+// kernel SIGKILLs the tracee (silently; the cs_invalid_page log is gated behind
+// the cs_debug boot-arg).
+//
+// Instead it mirrors lldb/debugserver: posix_spawn the target SUSPENDED, then
+// PT_ATTACH on the already-exec'd image (so cs_allow_invalid() runs on the FINAL
+// image — clearing CS_KILL|CS_HARD, setting CS_DEBUGGED, and enabling the
+// task's vm_map W^X / cs-debugged bypass), then task_resume so it runs into the
+// pending attach-SIGSTOP and stops cleanly for wait4.
 func startTracedProcess(binaryPath string, args []string, env []string) (int, *exec.Cmd, error) {
-	cmd := exec.Command(binaryPath, args...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.SysProcAttr = &syscall.SysProcAttr{Ptrace: true}
+	argv := make([]*C.char, 0, len(args)+2)
+	cPath := C.CString(binaryPath)
+	defer C.free(unsafe.Pointer(cPath))
+	argv = append(argv, cPath)
+	for _, a := range args {
+		ca := C.CString(a)
+		defer C.free(unsafe.Pointer(ca))
+		argv = append(argv, ca)
+	}
+	argv = append(argv, nil)
+
+	fullEnv := os.Environ()
 	if len(env) > 0 {
-		cmd.Env = append(os.Environ(), env...)
+		fullEnv = append(fullEnv, env...)
 	}
-	if err := cmd.Start(); err != nil {
-		return 0, nil, fmt.Errorf("exec %q: %w", binaryPath, err)
+	envp := make([]*C.char, 0, len(fullEnv)+1)
+	for _, e := range fullEnv {
+		ce := C.CString(e)
+		defer C.free(unsafe.Pointer(ce))
+		envp = append(envp, ce)
 	}
-	pid := cmd.Process.Pid
+	envp = append(envp, nil)
+
+	rc := C.bingo_posix_spawn_suspended(cPath, &argv[0], &envp[0])
+	if int(rc) <= 0 {
+		return 0, nil, fmt.Errorf("posix_spawn %q: errno %d", binaryPath, -int(rc))
+	}
+	pid := int(rc)
+
+	// Attach on the post-exec (suspended) image. PT_ATTACH detects the
+	// POSIX_SPAWN_START_SUSPENDED Mach hold, queues SIGSTOP, and lifts the hold
+	// itself (task_resume), so the tracee runs into the SIGSTOP and stops.
+	if err := ptrace(ptDarwinAttach, uintptr(pid), 0, 0); err != nil {
+		_ = terminateSpawned(pid)
+		return 0, nil, fmt.Errorf("PT_ATTACH after spawn pid %d: %w", pid, err)
+	}
 	var ws syscall.WaitStatus
 	if _, err := syscall.Wait4(pid, &ws, 0, nil); err != nil {
-		_ = cmd.Process.Kill()
-		return 0, nil, fmt.Errorf("wait for initial stop: %w", err)
+		_ = terminateSpawned(pid)
+		return 0, nil, fmt.Errorf("wait after spawn attach: %w", err)
 	}
 	if !ws.Stopped() {
-		_ = cmd.Process.Kill()
-		return 0, nil, fmt.Errorf("expected initial SIGTRAP, got: %v", ws)
+		_ = terminateSpawned(pid)
+		return 0, nil, fmt.Errorf("expected stop after spawn attach, got ws=%#x", ws)
+	}
+	// Lift any residual POSIX_SPAWN_START_SUSPENDED task-level Mach hold. The
+	// attach-SIGSTOP has already BSD-stopped the tracee (ws.Stopped above), so
+	// draining the task suspend to 0 here does not let it run away — it just
+	// ensures the first Continue after launch actually resumes it instead of
+	// leaving it frozen at _dyld_start (the launch-race hang).
+	C.bingo_task_drain_suspend(C.int(pid))
+	// Wrap the spawned pid so killProcess can terminate it. The Cmd is never
+	// Start()ed — only its Process handle (pid) is used for signalling.
+	cmd := exec.Command(binaryPath, args...)
+	if proc, perr := os.FindProcess(pid); perr == nil {
+		cmd.Process = proc
 	}
 	return pid, cmd, nil
+}
+
+// terminateSpawned SIGKILLs a spawned tracee and reaps it. Used on launch-error
+// paths where no exec.Cmd exists yet.
+func terminateSpawned(pid int) error {
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+	var ws syscall.WaitStatus
+	_, err := syscall.Wait4(pid, &ws, 0, nil)
+	return err
 }
 
 func attachToProcess(pid int) error {
@@ -97,10 +175,25 @@ func attachToProcess(pid int) error {
 
 func killProcess(pid int, cmd *exec.Cmd) error {
 	if cmd != nil {
-		if err := cmd.Process.Kill(); err != nil && !isAlreadyExited(err) {
-			return err
+		// Launched (we own it): SIGKILL and reap. The Cmd was never Start()ed
+		// (the tracee is posix_spawn'd), so reap directly with wait4 rather than
+		// cmd.Wait(), which would panic.
+		if cmd.Process != nil {
+			if err := cmd.Process.Kill(); err != nil && !isAlreadyExited(err) {
+				return err
+			}
+		} else {
+			_ = syscall.Kill(pid, syscall.SIGKILL)
 		}
-		_ = cmd.Wait()
+		var ws syscall.WaitStatus
+		for {
+			if _, err := syscall.Wait4(pid, &ws, 0, nil); err != nil {
+				break // ECHILD once reaped, or already gone
+			}
+			if ws.Exited() || ws.Signaled() {
+				break
+			}
+		}
 		return nil
 	}
 	// Attached (not launched): detach, don't kill — we don't own the process.
@@ -113,6 +206,7 @@ func isAlreadyExited(err error) bool {
 }
 
 func (b *darwinBackend) ContinueProcess() error {
+	b.endStepIsolation()
 	b.clearStep()
 	if err := ptrace(ptDarwinContinue, uintptr(b.pid), 1, 0); err != nil {
 		return fmt.Errorf("PT_CONTINUE: %w", err)
@@ -121,14 +215,91 @@ func (b *darwinBackend) ContinueProcess() error {
 }
 
 func (b *darwinBackend) SingleStep(tid int) error {
+	// Darwin's PT_STEP sets the AArch64 single-step flag on get_firstthread(task)
+	// — the task's oldest thread, which under the Go runtime is usually a parked
+	// M sitting in a syscall — and then resumes the WHOLE task (see XNU
+	// bsd/kern/mach_process.c). So a bare PT_STEP neither steps the thread that
+	// hit the breakpoint (its PC never advances past the restored instruction)
+	// nor stops the other threads from racing through the breakpoint window; and
+	// when that first thread is parked, its step never retires and Wait hangs.
+	//
+	// Isolate the step to tid instead: set MDSCR_EL1.SS on tid via Mach and
+	// suspend every other thread, so resuming the task advances exactly tid by
+	// one instruction. This mirrors lldb-debugserver / Delve. The isolation is
+	// torn down by endStepIsolation on the next ContinueProcess/SingleStep.
+	b.endStepIsolation()
+	if err := b.isolateForStep(tid); err != nil {
+		return err
+	}
 	b.setStep(tid)
-	// Darwin PT_STEP is per-process (by PID), not per-thread. The tid argument
-	// is a Mach thread port, not a valid ptrace identifier — use b.pid.
-	if err := ptrace(ptDarwinStep, uintptr(b.pid), 1, 0); err != nil {
+	err := ptrace(ptDarwinStep, uintptr(b.pid), 1, 0)
+	if err != nil {
 		b.clearStep()
+		b.endStepIsolation()
 		return fmt.Errorf("PT_STEP: %w", err)
 	}
 	return nil
+}
+
+// isolateForStep suspends every task thread except target and enables hardware
+// single-step on target, so a subsequent task resume steps only target by
+// exactly one instruction. The suspended ports and target are recorded for
+// endStepIsolation. On failure it rolls back so the task is never left with a
+// stray suspended thread.
+func (b *darwinBackend) isolateForStep(target int) error {
+	threads, err := b.Threads()
+	if err != nil {
+		return fmt.Errorf("single-step isolate: list threads: %w", err)
+	}
+	var suspended []int
+	for _, tid := range threads {
+		if tid == target {
+			continue
+		}
+		// A thread may exit between enumeration and suspend; skip failures. A
+		// successfully suspended thread cannot exit until we resume it.
+		if kr := C.bingo_thread_suspend(C.mach_port_t(tid)); kr != C.KERN_SUCCESS {
+			continue
+		}
+		suspended = append(suspended, tid)
+	}
+	kr := C.bingo_set_single_step(C.mach_port_t(target), 1)
+	if kr != C.KERN_SUCCESS {
+		for _, tid := range suspended {
+			C.bingo_thread_resume(C.mach_port_t(tid))
+		}
+		return fmt.Errorf("single-step isolate: enable single-step on tid %d: %s",
+			target, machErrString(kr))
+	}
+	b.suspended = suspended
+	b.ssThread = target
+	return nil
+}
+
+// endStepIsolation clears the hardware single-step bit on the stepped thread and
+// resumes every thread suspended by isolateForStep. It is idempotent and safe to
+// call when no step is in flight.
+func (b *darwinBackend) endStepIsolation() {
+	if b.ssThread != 0 {
+		C.bingo_set_single_step(C.mach_port_t(b.ssThread), 0)
+		b.ssThread = 0
+	}
+	for _, tid := range b.suspended {
+		// ptrace(PT_STEP) also arms MDSCR_EL1.SS on get_firstthread(task) —
+		// task_threads()[0], the task's OLDEST thread — regardless of which
+		// thread we asked to single-step (XNU bsd/kern/mach_process.c: PT_STEP
+		// calls thread_setsinglestep(get_firstthread(task), 1)). Whenever the
+		// breakpoint thread is not the oldest thread, that stray bit lands on a
+		// thread we suspended for the step. Because isolateForStep suspends every
+		// thread except the target, get_firstthread is always among b.suspended,
+		// so clearing the step bit on every released thread here guarantees zero
+		// threads carry a stray single-step out of the isolation — no thread can
+		// spuriously trap (or, in a ptrace state XNU considers inconsistent, get
+		// the tracee SIGKILLed) the next time it is scheduled.
+		C.bingo_set_single_step(C.mach_port_t(tid), 0)
+		C.bingo_thread_resume(C.mach_port_t(tid))
+	}
+	b.suspended = nil
 }
 
 func (b *darwinBackend) StopProcess() error {
@@ -253,14 +424,36 @@ func (b *darwinBackend) Wait() (StopEvent, error) {
 		if ws.Signaled() {
 			return StopEvent{Reason: StopKilled, TID: tid}, nil
 		}
-		if !ws.Stopped() {
-			continue
-		}
-
+		// Go's syscall.WaitStatus.Stopped() returns false for a WIFSTOPPED status
+		// whose stop signal is SIGSTOP — it excludes SIGSTOP by the Unix
+		// job-control convention (Stopped() == w&0x7f==0x7f && sig != SIGSTOP).
+		// Under ptrace a SIGSTOP-delivery-stop is nonetheless a REAL stop that has
+		// suspended the tracee (Darwin holds ptrace stops via task_suspend), so we
+		// must handle it, not skip it. If we fell through to a bare `continue`
+		// here the tracee would stay suspended and the next wait4 would block
+		// forever (the stop is consumed and never re-reported) — the ~2% E2E hang.
+		// Recover the real stop signal straight from the raw status; only a
+		// genuinely non-stopped status (e.g. WIFCONTINUED) skips with no resume.
 		sig := ws.StopSignal()
+		if !ws.Stopped() {
+			if raw := uint32(ws); raw&0x7f == 0x7f {
+				sig = syscall.Signal((raw >> 8) & 0xff)
+			} else {
+				continue
+			}
+		}
 
 		if sig == syscall.SIGTRAP {
 			if stepping, thread := b.consumeStep(); stepping {
+				// The single-step has retired. Tear down the isolation NOW —
+				// clear the target thread's MDSCR_EL1.SS bit and resume the
+				// threads we suspended for the step — instead of deferring to
+				// the next ContinueProcess. This mirrors lldb-debugserver /
+				// Delve, which drop the CPU trap flag immediately after each
+				// step, and guarantees no thread is left carrying a stray
+				// single-step bit (see endStepIsolation) while the engine's
+				// reinstall path patches the trap back in.
+				b.endStepIsolation()
 				return StopEvent{Reason: StopSingleStep, TID: thread}, nil
 			}
 			return StopEvent{Reason: StopBreakpoint}, nil
@@ -288,12 +481,32 @@ func (b *darwinBackend) Wait() (StopEvent, error) {
 			continue
 		}
 
-		// Other signals during step: re-deliver via PT_STEP so the step
-		// completes. If PT_STEP fails, fall through to StopSignal so the
-		// engine can recover any in-flight step-over BP. Don't fall back to
-		// PT_CONTINUE+continue: that loops on SIGURG every ~10ms forever.
+		// SIGSTOP: a stray job-control stop of the tracee that we did not ask
+		// for — e.g. a lingering PT_ATTACH stop surfacing on a later resume, or
+		// the OS attempting to suspend an otherwise-idle process. The debugger
+		// owns the tracee's run state, so swallow it (resume with no signal, like
+		// SIGURG/SIGWINCH) and keep going. Re-delivering it (data=SIGSTOP) would
+		// immediately re-stop the tracee in a loop. This is the counterpart to
+		// the raw-status decode above: recognising the SIGSTOP-stop and resuming
+		// is what prevents the wait4-blocks-forever wedge.
+		if sig == syscall.SIGSTOP {
+			if err := b.resumeAfterSignal(0); err != nil {
+				if isNoSuchProcess(err) {
+					return StopEvent{Reason: StopKilled, TID: tid}, nil
+				}
+				return StopEvent{}, err
+			}
+			continue
+		}
+
+		// Other signals while single-stepping: defer them (data=0) for the same
+		// reason as resumeAfterSignal — delivering a signal mid-step diverts the
+		// thread into its handler and breaks the step-over-breakpoint sequence.
+		// Completing the step first lets the engine reinstall the trap; the
+		// signal is observed on a later stop. If PT_STEP fails, fall through to
+		// StopSignal so the engine can recover any in-flight step-over BP.
 		if b.isStepping() {
-			if err := ptrace(ptDarwinStep, uintptr(b.pid), 1, uintptr(sig)); err == nil {
+			if err := ptrace(ptDarwinStep, uintptr(b.pid), 1, 0); err == nil {
 				continue
 			} else if isNoSuchProcess(err) {
 				return StopEvent{Reason: StopKilled, TID: tid}, nil
@@ -304,7 +517,15 @@ func (b *darwinBackend) Wait() (StopEvent, error) {
 	}
 }
 
-func (b *darwinBackend) setPID(pid int) { b.pid = pid }
+func (b *darwinBackend) setPID(pid int) {
+	b.taskMu.Lock()
+	if b.taskPort != 0 {
+		C.bingo_port_deallocate(b.taskPort)
+		b.taskPort = 0
+	}
+	b.taskMu.Unlock()
+	b.pid = pid
+}
 
 func (b *darwinBackend) setStep(tid int) {
 	b.stepMu.Lock()
@@ -340,10 +561,30 @@ func (b *darwinBackend) consumeStep() (bool, int) {
 
 func (b *darwinBackend) resumeAfterSignal(sig syscall.Signal) error {
 	request := ptDarwinContinue
+	data := uintptr(sig)
 	if b.isStepping() {
+		// Single-stepping over a software breakpoint: do NOT deliver the
+		// signal now. Delivering it diverts the thread into the Go signal
+		// handler, so the single-step traps at the handler's first instruction
+		// and the original instruction at the breakpoint never executes; after
+		// sigreturn the thread lands back on the reinstalled trap and re-hits
+		// the breakpoint (surfacing a spurious BreakpointHit instead of the
+		// Stepped we owe the caller, wedging the step-over). Step with data=0
+		// so the real instruction retires. SIGURG (async preemption) and
+		// SIGWINCH are best-effort and are re-sent by the runtime, so dropping
+		// this one delivery during the ~1-instruction window is harmless.
 		request = ptDarwinStep
+		data = 0
+	} else if sig == syscall.SIGURG {
+		// SIGURG is Go's async-preemption signal. Re-delivering it through
+		// PT_CONTINUE races the wait4 stop-conversion (a breakpoint SIGTRAP that
+		// lands in the same window is lost), which wedges far more often than the
+		// preemption it would forward is worth (measured ~5% vs ~2% hang). The Go
+		// runtime re-sends preemption via sysmon, so dropping this delivery
+		// (data=0) is safe and strictly better here.
+		data = 0
 	}
-	if err := ptrace(request, uintptr(b.pid), 1, uintptr(sig)); err != nil {
+	if err := ptrace(request, uintptr(b.pid), 1, data); err != nil {
 		return fmt.Errorf("ptrace resume after %s: %w", sig, err)
 	}
 	return nil
@@ -397,15 +638,24 @@ func machoTextVmaddr(binaryPath string) (uint64, error) {
 
 var _ Backend = (*darwinBackend)(nil)
 
-// task returns the Mach task port for the tracee. Requires the
-// com.apple.security.cs.debugger entitlement or disabled SIP.
+// task returns the Mach task port for the tracee, caching it after the first
+// successful task_for_pid. Requires the com.apple.security.cs.debugger
+// entitlement or disabled SIP. Caching is mandatory, not just an optimization:
+// task_for_pid inserts a new send right on every call, so fetching it per
+// memory/threads op leaks urefs until the kernel kills the tracee.
 func (b *darwinBackend) task() (C.mach_port_t, error) {
+	b.taskMu.Lock()
+	defer b.taskMu.Unlock()
+	if b.taskPort != 0 {
+		return b.taskPort, nil
+	}
 	var task C.mach_port_t
 	kr := C.bingo_task_for_pid(C.int(b.pid), &task)
 	if kr != C.KERN_SUCCESS {
 		return 0, fmt.Errorf("task_for_pid(%d): %s — debugger entitlement required",
 			b.pid, machErrString(kr))
 	}
+	b.taskPort = task
 	return task, nil
 }
 

--- a/internal/debugger/dwarf.go
+++ b/internal/debugger/dwarf.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"sort"
 	"strings"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
@@ -22,6 +23,21 @@ const optimizedOut = "<optimized out>"
 type dwarfReader struct {
 	data  *dwarf.Data
 	slide int64
+
+	// funcIndex holds every subprogram's [low,high) DWARF address range sorted
+	// by low address, so functionAt can binary-search instead of linearly
+	// decoding the whole .debug_info on every frame of every stop. A Go binary
+	// has tens of thousands of subprograms and they are NOT emitted in address
+	// order, so the old full scan was O(N) even for a hit; collecting frames for
+	// each BreakpointHit/Stepped ran it once per frame and, under load, could
+	// stall the (single-threaded) engine loop past the client's step timeout.
+	funcIndex []funcRange
+}
+
+// funcRange is one subprogram's DWARF address range and name.
+type funcRange struct {
+	low, high uint64
+	name      string
 }
 
 func openDWARF(binaryPath string) (*dwarfReader, error) {
@@ -29,7 +45,42 @@ func openDWARF(binaryPath string) (*dwarfReader, error) {
 	if err != nil {
 		return nil, fmt.Errorf("openDWARF %q: %w", binaryPath, err)
 	}
-	return &dwarfReader{data: data}, nil
+	r := &dwarfReader{data: data}
+	r.buildFuncIndex()
+	return r, nil
+}
+
+// buildFuncIndex scans .debug_info once and records every subprogram's address
+// range, sorted by low PC, for O(log N) functionAt lookups. Called once at load
+// time (off the stepping hot path). A failure to decode simply leaves the index
+// empty and functionAt falls back to a linear scan.
+func (r *dwarfReader) buildFuncIndex() {
+	rd := r.data.Reader()
+	for {
+		entry, err := rd.Next()
+		if err != nil || entry == nil {
+			break
+		}
+		if entry.Tag != dwarf.TagSubprogram {
+			continue
+		}
+		lowpc, hasLow := entry.Val(dwarf.AttrLowpc).(uint64)
+		if !hasLow {
+			continue
+		}
+		highpc, ok := highPCValue(entry, lowpc)
+		if !ok {
+			continue
+		}
+		name, _ := entry.Val(dwarf.AttrName).(string)
+		if name == "" {
+			continue
+		}
+		r.funcIndex = append(r.funcIndex, funcRange{low: lowpc, high: highpc, name: name})
+	}
+	sort.Slice(r.funcIndex, func(i, j int) bool {
+		return r.funcIndex[i].low < r.funcIndex[j].low
+	})
 }
 
 func loadDWARFData(binaryPath string) (*dwarf.Data, error) {
@@ -142,6 +193,14 @@ func fileMatches(candidate, target string) bool {
 // locationForPC resolves pc (runtime address) to a source location.
 func (r *dwarfReader) locationForPC(pc uint64) protocol.Location {
 	loc := protocol.Location{Function: r.functionAt(pc)}
+	// When the subprogram index is populated, an empty function name is
+	// authoritative: pc is not in any of our functions (e.g. a deep frame that
+	// walked into libsystem/dyld). There is no source line to find, so skip the
+	// compile-unit/line-table scan entirely — that scan is the other O(N) DWARF
+	// walk that could stall the engine loop on a bad PC.
+	if loc.Function == "" && len(r.funcIndex) > 0 {
+		return loc
+	}
 	dwarfPC := uint64(int64(pc) - r.slide)
 
 	rd := r.data.Reader()
@@ -206,6 +265,23 @@ func cuContainsPC(entry *dwarf.Entry, pc uint64) bool {
 // functionAt returns the function name containing pc (runtime address), or "".
 func (r *dwarfReader) functionAt(pc uint64) string {
 	dwarfPC := uint64(int64(pc) - r.slide)
+
+	// Fast path: binary-search the sorted subprogram index. Find the last range
+	// whose low <= dwarfPC and check whether dwarfPC falls inside it.
+	if len(r.funcIndex) > 0 {
+		i := sort.Search(len(r.funcIndex), func(i int) bool {
+			return r.funcIndex[i].low > dwarfPC
+		})
+		if i > 0 {
+			fr := r.funcIndex[i-1]
+			if dwarfPC >= fr.low && dwarfPC < fr.high {
+				return fr.name
+			}
+		}
+		return ""
+	}
+
+	// Fallback (index unavailable): linear scan of .debug_info.
 	rd := r.data.Reader()
 	for {
 		entry, err := rd.Next()

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
@@ -69,6 +71,17 @@ type engine struct {
 	steppingOverBP *breakpointEntry
 	bpResume       bpResumeAction
 	bpRetAddr      uint64 // bpResumeStepOut only
+
+	// curTID is the thread the process last stopped on (the BP-hitting or
+	// single-stepped thread). Stack/goroutine inspection must unwind THIS
+	// thread, not threads[0]: on Darwin task_threads returns threads in
+	// creation order and threads[0] is frequently a parked runtime M sitting
+	// in pthread_cond_wait, whose frames are all in the dyld shared cache.
+	// Unwinding that thread yields libsystem PCs that functionAt then scans the
+	// entire binary DWARF for (finding nothing) on every frame of every step —
+	// which is slow enough under load to stall the engine loop and hang the
+	// suspend/resume handshake.
+	curTID int
 
 	// Source-line target remembered from the previous step-over. More
 	// reliable than re-querying locationForPC, which can land on a DWARF
@@ -345,11 +358,56 @@ func (e *engine) waitLoop() {
 	// and we don't want a thread carrying unrelated ptrace state.
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
+	stopWD := e.startWaitWatchdog()
 	evt, err := e.backend.Wait()
+	stopWD()
 	select {
 	case e.stopCh <- stopResult{evt: evt, err: err}:
 	case <-e.done:
 	}
+}
+
+// startWaitWatchdog (BINGO_HANG_DIAG only) dumps thread state if backend.Wait()
+// stalls, to root-cause the single-step hang. Off by default; never ships hot.
+func (e *engine) startWaitWatchdog() func() {
+	if os.Getenv("BINGO_HANG_DIAG") == "" {
+		return func() {}
+	}
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-time.After(6 * time.Second):
+			e.dumpHangState()
+		case <-done:
+		}
+	}()
+	return func() { close(done) }
+}
+
+func (e *engine) dumpHangState() {
+	fmt.Fprintf(os.Stderr, "\n=== BINGO_HANG_DIAG: Wait() stalled >6s ===\n")
+	fmt.Fprintf(os.Stderr, "lastBPTID=%d steppingOverBP=%v bpResume=%d curTID=%d state=%d\n",
+		e.lastBPTID, e.steppingOverBP != nil, e.bpResume, e.curTID, e.getState())
+	if sob := e.steppingOverBP; sob != nil {
+		fmt.Fprintf(os.Stderr, "steppingOverBP addr=0x%x file=%s line=%d\n", sob.addr, sob.file, sob.line)
+	}
+	threads, err := e.backend.Threads()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Threads() err: %v\n", err)
+		return
+	}
+	trap := archTrapInstruction()
+	fmt.Fprintf(os.Stderr, "threads=%d\n", len(threads))
+	for _, tid := range threads {
+		regs, err := e.backend.GetRegisters(tid)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  tid=%d GetRegisters err: %v\n", tid, err)
+			continue
+		}
+		fmt.Fprintf(os.Stderr, "  tid=%d PC=0x%x trapHere=%v ourBP=%v\n",
+			tid, regs.PC, e.instructionAt(regs.PC, trap), e.bps.atAddr(regs.PC) != nil)
+	}
+	fmt.Fprintf(os.Stderr, "=== end BINGO_HANG_DIAG ===\n")
 }
 
 //nolint:gocognit,gocyclo // Stop handling is a single serialized debugger state machine.
@@ -767,15 +825,29 @@ func (e *engine) collectFrames() ([]protocol.Frame, error) {
 	if e.dw == nil {
 		return nil, nil
 	}
-	threads, err := e.backend.Threads()
-	if err != nil || len(threads) == 0 {
-		return nil, fmt.Errorf("StackFrames: no threads")
+	tid, err := e.stackTID()
+	if err != nil {
+		return nil, fmt.Errorf("StackFrames: %w", err)
 	}
-	regs, err := e.backend.GetRegisters(threads[0])
+	regs, err := e.backend.GetRegisters(tid)
 	if err != nil {
 		return nil, fmt.Errorf("StackFrames: %w", err)
 	}
 	return e.dw.FramesForStack(e.walkStack(regs)), nil
+}
+
+// stackTID returns the thread to unwind for stack/goroutine inspection: the
+// thread the process last stopped on (curTID). Falls back to threads[0] only
+// when no stop thread has been resolved yet (e.g. right after attach).
+func (e *engine) stackTID() (int, error) {
+	if e.curTID != 0 {
+		return e.curTID, nil
+	}
+	threads, err := e.backend.Threads()
+	if err != nil || len(threads) == 0 {
+		return 0, fmt.Errorf("no threads")
+	}
+	return threads[0], nil
 }
 
 func (e *engine) walkStack(regs Registers) []uint64 {
@@ -797,11 +869,11 @@ func (e *engine) walkStack(regs Registers) []uint64 {
 }
 
 func (e *engine) readGoroutines() ([]protocol.Goroutine, error) {
-	threads, err := e.backend.Threads()
-	if err != nil || len(threads) == 0 {
+	tid, err := e.stackTID()
+	if err != nil {
 		return nil, nil
 	}
-	regs, err := e.backend.GetRegisters(threads[0])
+	regs, err := e.backend.GetRegisters(tid)
 	if err != nil {
 		return nil, fmt.Errorf("Goroutines: %w", err)
 	}
@@ -850,6 +922,9 @@ func (e *engine) emit(kind protocol.EventKind, payload any) {
 }
 
 func (e *engine) emitBreakpointHit(bp *breakpointEntry, stop StopEvent) {
+	if stop.TID != 0 {
+		e.curTID = stop.TID
+	}
 	frames, _ := e.collectFrames()
 	goroutines, _ := e.readGoroutines()
 	var g protocol.Goroutine
@@ -878,6 +953,9 @@ func (e *engine) emitStoppedAtCurrentPC() {
 }
 
 func (e *engine) emitStepped(stop StopEvent) {
+	if stop.TID != 0 {
+		e.curTID = stop.TID
+	}
 	frames, _ := e.collectFrames()
 	goroutines, _ := e.readGoroutines()
 	var g protocol.Goroutine

--- a/internal/debugger/mach_darwin_arm64.h
+++ b/internal/debugger/mach_darwin_arm64.h
@@ -7,12 +7,86 @@
 #include <mach/mach.h>
 #include <mach/mach_vm.h>
 #include <mach/arm/thread_status.h>
+#include <mach/vm_attributes.h>
 #include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <spawn.h>
+#include <errno.h>
+
+extern char **environ;
+
+// MDSCR_EL1.SS (bit 0) is the AArch64 "software step" enable. It is not
+// declared in the userspace SDK headers, so define it here.
+#ifndef MDSCR_SS
+#define MDSCR_SS 0x1u
+#endif
 
 // bingo_task_for_pid obtains the Mach task port for the given PID.
 // Requires the com.apple.security.cs.debugger entitlement or SIP disabled.
 static inline kern_return_t bingo_task_for_pid(int pid, mach_port_t *task_out) {
     return task_for_pid(mach_task_self(), pid, task_out);
+}
+
+// bingo_posix_spawn_suspended launches path (argv/envp) with the task created
+// suspended (POSIX_SPAWN_START_SUSPENDED). The image is exec'd but no user code
+// runs, so the debugger can PT_ATTACH on the post-exec image — that is what
+// makes the kernel run cs_allow_invalid() (sets CS_DEBUGGED, clears
+// CS_KILL|CS_HARD, enables the vm_map W^X bypass) on the FINAL image, which is
+// required to patch software breakpoints on Apple Silicon without the kernel
+// SIGKILLing the tracee. Returns the child pid, or -errno on failure.
+static inline int bingo_posix_spawn_suspended(
+    const char *path, char *const argv[], char *const envp[])
+{
+    posix_spawnattr_t attr;
+    if (posix_spawnattr_init(&attr) != 0) {
+        return -errno;
+    }
+    (void)posix_spawnattr_setflags(&attr, POSIX_SPAWN_START_SUSPENDED);
+    pid_t pid = 0;
+    int rc = posix_spawn(&pid, path, NULL, &attr, argv, envp);
+    posix_spawnattr_destroy(&attr);
+    if (rc != 0) {
+        return -rc;
+    }
+    return (int)pid;
+}
+
+// bingo_task_drain_suspend lifts EVERY outstanding task-level Mach suspend on
+// pid (calling task_resume until the count reaches 0). The launch path spawns
+// the tracee POSIX_SPAWN_START_SUSPENDED (task suspend count 1) and expects
+// PT_ATTACH to lift that hold; on Apple Silicon that lift is racy, and when it
+// is missed the tracee stays frozen at _dyld_start (threads read suspend=0
+// because the hold is at the TASK level) and the first Continue after launch
+// never runs it. Draining here guarantees the hold is gone; the pending
+// attach-SIGSTOP is what actually stops the tracee at the entry point, so
+// resuming to 0 does not let it run away. Returns the number of resumes done,
+// or -1 on task_for_pid error.
+static inline int bingo_task_drain_suspend(int pid) {
+    mach_port_t task = MACH_PORT_NULL;
+    if (task_for_pid(mach_task_self(), pid, &task) != KERN_SUCCESS) {
+        return -1;
+    }
+    int resumed = 0;
+    for (;;) {
+        struct task_basic_info info;
+        mach_msg_type_number_t count = TASK_BASIC_INFO_COUNT;
+        if (task_info(task, TASK_BASIC_INFO, (task_info_t)&info, &count) != KERN_SUCCESS) {
+            break;
+        }
+        if (info.suspend_count <= 0) {
+            break;
+        }
+        if (task_resume(task) != KERN_SUCCESS) {
+            break;
+        }
+        resumed++;
+        if (resumed > 8) { // safety bound; never seen >1 in practice
+            break;
+        }
+    }
+    mach_port_deallocate(mach_task_self(), task);
+    return resumed;
 }
 
 // bingo_get_registers reads ARM_THREAD_STATE64 for the given thread port,
@@ -72,40 +146,46 @@ static inline kern_return_t bingo_read_memory(
 // patch read-only text segments (e.g. to install breakpoints), then restores
 // execute permission.
 //
-// Icache coherency on Apple Silicon (ARM64):
-// mach_vm_machine_attribute(MATTR_CACHE, MATTR_VAL_ICACHE_FLUSH) is a no-op
-// on Apple Silicon — the kernel returns KERN_NOT_SUPPORTED. The correct
-// approach is to wrap the write with task_suspend + task_resume: the resume
-// call drains the instruction pipeline for all threads in the task, ensuring
-// the CPU sees the new bytes. task_suspend/resume use an independent suspend
-// count from ptrace, so this is safe to call while the process is
-// ptrace-stopped (the ptrace stop is unaffected).
+// Icache coherency on Apple Silicon (ARM64): after patching instruction bytes
+// we must clean the D-cache to the point of unification (so the freshly-written
+// bytes reach unified memory) and THEN invalidate the I-cache (so cores refetch
+// the new bytes from PoU rather than a stale line). MATTR_VAL_CACHE_SYNC alone
+// can invalidate the I-cache before the write has drained past PoU, leaving a
+// stale instruction line, so we issue the two attribute calls explicitly in
+// order.
+//
+// We deliberately do NOT wrap the write in task_suspend/task_resume. bingo only
+// ever writes memory while the tracee is ptrace-stopped (Darwin ptrace stops
+// are process-wide, so every thread is already quiesced), and the explicit
+// D-cache/I-cache flush provides the coherency the task_resume pipeline drain
+// used to. task_suspend/task_resume use a suspend count independent of ptrace,
+// and on Apple Silicon a task_resume issued near a ptrace state transition
+// (PT_CONTINUE / PT_STEP on the wait4 thread) can be dropped, pinning the task
+// at suspend_count 1 — a pinned task never runs, so the next wait4 blocks
+// forever and the debugger wedges. Dropping the suspend/resume entirely removes
+// that race; single-step isolation uses per-THREAD suspends (never task-level).
 static inline kern_return_t bingo_write_memory(
     mach_port_t task, mach_vm_address_t addr,
     const void *src, mach_vm_size_t n)
 {
-    // Suspend the task so all threads are quiesced while we patch memory.
-    // This also causes task_resume to flush the instruction pipeline.
-    task_suspend(task);
-
     kern_return_t kr = mach_vm_protect(task, addr, n, FALSE,
         VM_PROT_READ | VM_PROT_WRITE | VM_PROT_COPY);
     if (kr != KERN_SUCCESS) {
-        task_resume(task);
         return kr;
     }
     kr = mach_vm_write(task, addr,
         (vm_offset_t)src, (mach_msg_type_number_t)n);
     if (kr != KERN_SUCCESS) {
-        task_resume(task);
         return kr;
     }
     kr = mach_vm_protect(task, addr, n, FALSE,
         VM_PROT_READ | VM_PROT_EXECUTE);
 
-    // Resume lifts the task suspension and flushes the instruction pipeline
-    // for all threads, ensuring the CPU fetches the new bytes on next execute.
-    task_resume(task);
+    vm_machine_attribute_val_t flush = MATTR_VAL_DCACHE_FLUSH;
+    mach_vm_machine_attribute(task, addr, n, MATTR_CACHE, &flush);
+    flush = MATTR_VAL_ICACHE_FLUSH;
+    mach_vm_machine_attribute(task, addr, n, MATTR_CACHE, &flush);
+
     return kr;
 }
 
@@ -164,4 +244,43 @@ static inline kern_return_t bingo_thread_list(
     mach_msg_type_number_t *count_out)
 {
     return task_threads(task, threads_out, count_out);
+}
+
+// bingo_set_single_step enables (enable != 0) or disables the AArch64 hardware
+// software-step for a single thread by toggling MDSCR_EL1.SS in its debug
+// state. XNU honours this bit set via thread_set_state(ARM_DEBUG_STATE64) and
+// engages the single-step state machine for that thread only on its next return
+// to EL0 — this is exactly how lldb-debugserver single-steps on Apple Silicon.
+//
+// We deliberately write a zeroed debug state (only MDSCR_EL1.SS may be set):
+// the debugger installs breakpoints as software BRK traps, never via the ARM
+// hardware breakpoint/watchpoint registers, so there is nothing else to
+// preserve. Disabling clears every bit, so XNU frees the thread's debug state.
+static inline kern_return_t bingo_set_single_step(mach_port_t thread, int enable) {
+    arm_debug_state64_t ds;
+    memset(&ds, 0, sizeof(ds));
+    if (enable) {
+        ds.__mdscr_el1 |= MDSCR_SS;
+    }
+    return thread_set_state(thread, ARM_DEBUG_STATE64,
+        (thread_state_t)&ds, ARM_DEBUG_STATE64_COUNT);
+}
+
+// bingo_thread_suspend / bingo_thread_resume adjust a single thread's Mach
+// suspend count. This is independent of the task-level ptrace stop, so it lets
+// us hold every thread except the one being single-stepped while the task is
+// resumed for that step.
+static inline kern_return_t bingo_thread_suspend(mach_port_t thread) {
+    return thread_suspend((thread_act_t)thread);
+}
+
+static inline kern_return_t bingo_thread_resume(mach_port_t thread) {
+    return thread_resume((thread_act_t)thread);
+}
+
+// bingo_port_deallocate drops one user reference on a send right, matching the
+// ref that task_for_pid / task_threads inserted. Used to release the cached
+// task port when the tracee is replaced.
+static inline kern_return_t bingo_port_deallocate(mach_port_t name) {
+    return mach_port_deallocate(mach_task_self(), name);
 }


### PR DESCRIPTION
## Root cause

Two darwin/arm64 backend defects:

1. **Wrong-thread single-step (the deterministic step-over hang).** Darwin's `PT_STEP` sets the AArch64 single-step flag (`MDSCR_EL1.SS`) on `get_firstthread(task)` — **not** the trapped thread. When step-over single-steps off a breakpoint, the wrong thread advances one instruction while the trapped thread does not, so the next resume wedges in `wait4`.
2. **Racy attach.** Launch used `PT_ATTACH` on an already-running image, racing `CS_KILL`/`CS_DEBUGGED` codesign state on Apple Silicon and intermittently getting the target killed.

## Fix

- **`isolateForStep`**: Mach-suspend every task thread except the target, arm `MDSCR_EL1.SS` on the target's own thread port, single-step, then `endStepIsolation` resumes the siblings (LLDB/debugserver-style isolation). `get_firstthread` is always among the suspended set, so the stray per-process single-step bit can never advance an unintended thread.
- **Suspended spawn**: `posix_spawn` the target SUSPENDED, then `PT_ATTACH` on the post-exec image (clearing `CS_KILL|CS_HARD`, setting `CS_DEBUGGED`) before `task_resume`, for a deterministic attach.
- Drop a caught SIGURG (resume with signal 0) rather than re-inject it to the wrong thread.

## Verification (coordinator)

- `TestE2EBasic` (iters=25): **8/8 PASS**, 0 hang, 0 data race.

## Known limitation — the wait4 async-preemption trilemma

This fix is on the **"drop SIGURG / suspend-siblings"** horn of a proven trilemma under the `wait4`/BSD-ptrace stop model. Because the intercepted async-preemption SIGURG is dropped (and siblings are suspended during the step), a **purely async-preemptible** goroutine — one with *no* cooperative safepoints, e.g. a call-free `for { x++ }` loop — is **not** stop-the-world preempted while a breakpoint is being serviced. A coordinator GC-preempt probe (non-cooperative spinner + STW `runtime.GC()`) hangs at the GC under this backend.

This is the **same tradeoff class as `GODEBUG=asyncpreemptoff`**. The alternative horn (re-injecting SIGURG, as in #71 / #70-default) keeps async preemption alive ~85% of the time but reintroduces a ~15% SIGURG-misdirection condvar lost-wakeup. **No behavior-preserving fix exists under `wait4`**; the only complete fix is switching the stop source to **Mach exception ports** (like Delve), which is out of scope per `AGENTS.md` and logged as future work.

Realistic Go targets (any call/alloc/channel op is a safepoint) and the E2E gate do not hit the pathological corner.

---
*Draft: one of five distinct darwin/arm64 candidate fixes. Coordinator-finalized from the agent's implementation; base is the shared E2E gate branch `debugger-e2e-base`.*
