### PR TITLE
Darwin fix: stable Mach-port lifecycle + trapped-thread single-step

### DIFF
--- a/internal/debugger/backend_darwin_arm64.go
+++ b/internal/debugger/backend_darwin_arm64.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"unsafe"
 )
@@ -30,11 +31,46 @@ func newBackend() Backend {
 	return &darwinBackend{}
 }
 
+
 type darwinBackend struct {
-	pid      int
-	stepMu   sync.Mutex
-	stepping bool
-	stepTID  int // Mach thread port saved by SingleStep, reused on the step trap
+	pid int
+
+	// task_for_pid is expensive and leaks a task send-right on every call, so
+	// acquire the tracee task port once and reuse it. Stable for the process
+	// lifetime (we never follow exec).
+	taskMu   sync.Mutex
+	taskPort C.mach_port_t
+
+	// One retained send-right per live tracee thread, keyed by Mach port name.
+	// task_threads hands out a fresh send-right per thread on every call; we
+	// keep exactly one and deallocate the rest (and the rights of threads that
+	// have exited) so the debugger doesn't leak ports under thread churn and so
+	// a given thread keeps a stable port name across enumerations.
+	threadMu    sync.Mutex
+	threadPorts map[C.mach_port_t]struct{}
+
+	// Single-step state. armedTID is the thread whose MDSCR_EL1.SS bit we set
+	// (0 = none); it outlives `stepping` because the hardware bit persists until
+	// we explicitly clear it (disarmStep). armedIsFirst records whether armedTID
+	// is the task's first thread, which selects the resume verb (see SingleStep).
+	// suspended lists the Mach thread ports we thread_suspend'd for the duration
+	// of a single-step so only the target thread runs; disarmStep resumes them.
+	stepMu       sync.Mutex
+	stepping     bool
+	stepTID      int
+	armedTID     int
+	armedIsFirst bool
+	suspended    []int
+
+	// pendingSig holds a process-level asynchronous signal (SIGWINCH) that
+	// arrived while a single-step was armed. Delivering a signal to a thread
+	// mid-single-step redirects it into Go's signal trampoline instead of
+	// retiring the stepped instruction, which corrupts a breakpoint step-off. We
+	// suppress the signal for the step and stash it here so the next full
+	// (non-stepping) resume re-delivers it. SIGURG (Go async preemption) is NOT
+	// stashed — re-injecting it via ptrace targets the wrong thread and wedges
+	// the Go scheduler (see deferSignal). 0 means none.
+	pendingSig atomic.Int32
 }
 
 // Darwin ptrace request codes from <sys/ptrace.h>. PT_ATTACH (10) makes the
@@ -100,6 +136,12 @@ func killProcess(pid int, cmd *exec.Cmd) error {
 		if err := cmd.Process.Kill(); err != nil && !isAlreadyExited(err) {
 			return err
 		}
+		// A ptrace-stopped tracee stays frozen in its trace-stop and never
+		// processes the pending SIGKILL, so cmd.Wait() would block indefinitely
+		// (the "Kill doesn't reap" wedge). Resume it while injecting SIGKILL so
+		// the uncatchable signal is delivered and the process exits, then reap.
+		// If the tracee isn't currently stopped this ptrace fails harmlessly.
+		_ = ptrace(ptDarwinContinue, uintptr(pid), 1, uintptr(syscall.SIGKILL))
 		_ = cmd.Wait()
 		return nil
 	}
@@ -113,22 +155,158 @@ func isAlreadyExited(err error) bool {
 }
 
 func (b *darwinBackend) ContinueProcess() error {
-	b.clearStep()
-	if err := ptrace(ptDarwinContinue, uintptr(b.pid), 1, 0); err != nil {
+	// Clear any lingering single-step arming so the task runs free.
+	b.disarmStep()
+	// Re-deliver any process-level signal (SIGWINCH) that was deferred while a
+	// single-step was armed. SIGURG is never stashed here (see deferSignal): it
+	// is Go's per-thread async-preemption signal and must not be re-injected via
+	// ptrace, which would target the wrong thread.
+	sig := b.takePendingSig()
+	if err := ptrace(ptDarwinContinue, uintptr(b.pid), 1, uintptr(sig)); err != nil {
 		return fmt.Errorf("PT_CONTINUE: %w", err)
 	}
 	return nil
 }
 
+// deferSignal remembers a process-level asynchronous signal that arrived during
+// a single-step so ContinueProcess can re-deliver it once the process resumes
+// freely.
+//
+// SIGURG is deliberately NOT stashed. It is Go's async-preemption signal, which
+// the runtime delivers to a SPECIFIC M with pthread_kill. Darwin ptrace, however,
+// re-injects a caught signal to get_firstthread(task) (XNU bsd/kern/mach_process.c)
+// — not the M the runtime targeted. Re-injecting SIGURG therefore preempts the
+// wrong thread and corrupts the scheduler's stopTheWorld bookkeeping, which can
+// wedge the whole tracee (all Ms park with a runnable G that never gets scheduled).
+// Dropping SIGURG is safe: it is a best-effort hint (the runtime re-issues it) and
+// Go's cooperative preemption (g.stackguard0 = stackPreempt, checked at call
+// prologues) still preempts the goroutine at the next function call. Only SIGWINCH,
+// which is process-level and thread-agnostic, is deferred for re-delivery.
+func (b *darwinBackend) deferSignal(sig syscall.Signal) {
+	if sig == syscall.SIGWINCH {
+		b.pendingSig.Store(int32(sig))
+	}
+}
+
+// takePendingSig atomically returns and clears any deferred signal (0 if none).
+func (b *darwinBackend) takePendingSig() syscall.Signal {
+	return syscall.Signal(b.pendingSig.Swap(0))
+}
+
+// SingleStep advances exactly one instruction on the thread identified by tid
+// (a Mach thread port), which must be the thread that is actually stopped where
+// we want to step (e.g. the thread that hit a breakpoint).
+//
+// It does NOT use ptrace(PT_STEP): on Darwin PT_STEP arms single-step on
+// get_firstthread(task) only (XNU bsd/kern/mach_process.c), which in a
+// multithreaded Go process is almost always an idle runtime M parked in a
+// syscall — it never retires an instruction, so no SIGTRAP ever arrives and
+// wait4 hangs. Instead we arm hardware single-step (MDSCR_EL1.SS) on tid's own
+// debug state and resume the whole task. PT_STEP/PT_CONTINUE only touch
+// get_firstthread's single-step bit, so we pick the resume verb to leave
+// exactly tid armed:
+//   - tid is NOT the first thread -> PT_CONTINUE (clears first thread's bit,
+//     leaves tid's bit set: only tid steps)
+//   - tid IS  the first thread    -> PT_STEP    (arms the first thread == tid)
 func (b *darwinBackend) SingleStep(tid int) error {
-	b.setStep(tid)
-	// Darwin PT_STEP is per-process (by PID), not per-thread. The tid argument
-	// is a Mach thread port, not a valid ptrace identifier — use b.pid.
-	if err := ptrace(ptDarwinStep, uintptr(b.pid), 1, 0); err != nil {
-		b.clearStep()
-		return fmt.Errorf("PT_STEP: %w", err)
+	// Drop any previous arming before arming a new thread.
+	b.disarmStep()
+
+	thread := C.mach_port_t(tid)
+	if thread == 0 {
+		return fmt.Errorf("SingleStep: invalid tid 0")
+	}
+	if kr := C.bingo_set_thread_single_step(thread, 1); kr != C.KERN_SUCCESS {
+		return fmt.Errorf("arm single-step tid %d: %s", tid, machErrString(kr))
+	}
+
+	isFirst := b.isFirstThread(tid)
+	b.armStep(tid, isFirst)
+
+	// Suspend every other thread so the task resume runs only tid. This gives
+	// single-thread-step semantics (as LLDB's debugserver does): no sibling can
+	// hit a breakpoint or take a signal during the one-instruction step window
+	// and perturb the ARM software-step state machine.
+	b.suspendOthers(tid)
+
+	req := ptDarwinContinue
+	if isFirst {
+		req = ptDarwinStep
+	}
+	if err := ptrace(req, uintptr(b.pid), 1, 0); err != nil {
+		b.disarmStep()
+		return fmt.Errorf("resume for single-step tid %d: %w", tid, err)
 	}
 	return nil
+}
+
+// StepOffBreakpoint advances tid exactly one instruction and consumes the
+// resulting trap internally, without surfacing a StopEvent to the engine's wait
+// loop.
+//
+// On Darwin/arm64 a thread that is parked on the PC where a software breakpoint
+// (BRK) just fired cannot be reliably resumed by a plain task PT_CONTINUE: the
+// thread stays wedged at that PC and the next wait4 blocks forever. Arming a
+// hardware single-step (MDSCR_EL1.SS) first forces the thread through the
+// exception-return path so it retires one instruction and moves to a clean PC,
+// after which an ordinary continue resumes it normally.
+//
+// The engine calls this (via an optional interface) after clearing a one-shot
+// internal sentinel breakpoint (<stepover-next> / <stepout-return>), so the
+// following Continue resumes cleanly. It mirrors the user-breakpoint path, which
+// already single-steps off the trap inside resumeFromBreakpoint before resuming.
+//
+// It must be called ONLY while the process is stopped and no wait loop is active
+// (i.e. from the engine's serialized stop handler): it runs its own wait4 to
+// catch the step's SIGTRAP.
+func (b *darwinBackend) StepOffBreakpoint(tid int) error {
+	if tid == 0 {
+		return nil
+	}
+	if err := b.SingleStep(tid); err != nil {
+		return err
+	}
+	for {
+		var ws syscall.WaitStatus
+		_, err := syscall.Wait4(b.pid, &ws, 0, nil)
+		if err != nil {
+			b.disarmStep()
+			if isNoChildProcess(err) {
+				return nil
+			}
+			return fmt.Errorf("wait4 (step off bp): %w", err)
+		}
+		if ws.Exited() || ws.Signaled() {
+			b.disarmStep()
+			return nil
+		}
+		if !ws.Stopped() {
+			continue
+		}
+		sig := ws.StopSignal()
+		if sig == syscall.SIGTRAP {
+			// Step retired: clear MDSCR_EL1.SS so the next resume runs free.
+			b.disarmStep()
+			return nil
+		}
+		// A non-TRAP signal (SIGURG preemption, SIGWINCH, …) arrived before the
+		// single-step retired. Delivering it now would redirect this thread into
+		// Go's signal trampoline (_sigtramp) instead of executing the instruction
+		// at the breakpoint address — the step would "complete" in the handler,
+		// leaving the thread never actually stepped past the trap and wedging the
+		// following resume. Suppress it for the step (resume with signal 0 so the
+		// real instruction retires); deferSignal stashes SIGWINCH for re-delivery
+		// and drops SIGURG (re-injecting async preemption via ptrace wedges the
+		// scheduler — see deferSignal).
+		b.deferSignal(sig)
+		if err := ptrace(b.stepResumeVerb(), uintptr(b.pid), 1, 0); err != nil {
+			b.disarmStep()
+			if isNoSuchProcess(err) {
+				return nil
+			}
+			return fmt.Errorf("resume after signal (step off bp): %w", err)
+		}
+	}
 }
 
 func (b *darwinBackend) StopProcess() error {
@@ -223,17 +401,50 @@ func (b *darwinBackend) Threads() ([]int, error) {
 	if kr != C.KERN_SUCCESS {
 		return nil, fmt.Errorf("task_threads pid %d: %s", b.pid, machErrString(kr))
 	}
-	defer C.vm_deallocate(
+	ports := unsafe.Slice((*C.mach_port_t)(unsafe.Pointer(threads)), int(count))
+
+	// Retain exactly one send-right per live thread; drop the duplicate rights
+	// this call produced and the rights of threads that have since exited.
+	b.threadMu.Lock()
+	if b.threadPorts == nil {
+		b.threadPorts = make(map[C.mach_port_t]struct{})
+	}
+	seen := make(map[C.mach_port_t]struct{}, len(ports))
+	tids := make([]int, len(ports))
+	for i, p := range ports {
+		seen[p] = struct{}{}
+		if _, ok := b.threadPorts[p]; ok {
+			C.bingo_port_deallocate(p)
+		} else {
+			b.threadPorts[p] = struct{}{}
+		}
+		tids[i] = int(p)
+	}
+	for p := range b.threadPorts {
+		if _, ok := seen[p]; !ok {
+			C.bingo_port_deallocate(p)
+			delete(b.threadPorts, p)
+		}
+	}
+	b.threadMu.Unlock()
+
+	C.vm_deallocate(
 		C.mach_task_self_,
 		C.vm_address_t(uintptr(unsafe.Pointer(threads))),
 		C.vm_size_t(uintptr(count)*unsafe.Sizeof(C.mach_port_t(0))),
 	)
-	ports := unsafe.Slice((*C.mach_port_t)(unsafe.Pointer(threads)), int(count))
-	tids := make([]int, len(ports))
-	for i, p := range ports {
-		tids[i] = int(p)
-	}
 	return tids, nil
+}
+
+// isFirstThread reports whether tid is the task's first thread. task_threads
+// returns threads in creation order, so tids[0] is get_firstthread(task) — the
+// thread ptrace(PT_STEP/PT_CONTINUE) arms/clears single-step on.
+func (b *darwinBackend) isFirstThread(tid int) bool {
+	tids, err := b.Threads()
+	if err != nil || len(tids) == 0 {
+		return false
+	}
+	return tids[0] == tid
 }
 
 //nolint:gocognit // The wait loop is one serialized ptrace state machine.
@@ -266,9 +477,34 @@ func (b *darwinBackend) Wait() (StopEvent, error) {
 			return StopEvent{Reason: StopBreakpoint}, nil
 		}
 
-		// SIGURG is Go's goroutine-preemption signal. Re-deliver transparently.
+		// A non-TRAP signal arrived. If a single-step is armed on a thread,
+		// delivering the signal now would redirect that thread into Go's signal
+		// trampoline (_sigtramp) instead of retiring the stepped instruction,
+		// corrupting a breakpoint step-off and wedging the next resume. Suppress
+		// it for the step (resume with signal 0); deferSignal stashes SIGWINCH
+		// for re-delivery on the next full resume and drops SIGURG (see
+		// deferSignal for why re-injecting async preemption is unsafe here).
+		if b.isStepping() {
+			b.deferSignal(sig)
+			if err := ptrace(b.stepResumeVerb(), uintptr(b.pid), 1, 0); err != nil {
+				if isNoSuchProcess(err) {
+					return StopEvent{Reason: StopKilled, TID: tid}, nil
+				}
+				b.disarmStep()
+				return StopEvent{Reason: StopSignal, Signal: int(sig)}, nil
+			}
+			continue
+		}
+
+		// Not stepping: the process is running freely. SIGURG is Go's async-
+		// preemption signal, delivered per-M with pthread_kill. Darwin ptrace can
+		// only re-inject a signal to get_firstthread(task), NOT the M the runtime
+		// targeted, so re-injecting SIGURG preempts the wrong thread and corrupts
+		// the scheduler's stopTheWorld bookkeeping — occasionally deadlocking the
+		// whole tracee (all Ms park with a runnable goroutine). Drop it (resume
+		// with signal 0); Go's cooperative preemption keeps the tracee scheduling.
 		if sig == syscall.SIGURG {
-			if err := b.resumeAfterSignal(sig); err != nil {
+			if err := ptrace(ptDarwinContinue, uintptr(b.pid), 1, 0); err != nil {
 				if isNoSuchProcess(err) {
 					return StopEvent{Reason: StopKilled, TID: tid}, nil
 				}
@@ -276,8 +512,7 @@ func (b *darwinBackend) Wait() (StopEvent, error) {
 			}
 			continue
 		}
-
-		// SIGWINCH (terminal resize): handled by the Go runtime, re-deliver.
+		// SIGWINCH is process-level, so re-injecting it to any thread is correct.
 		if sig == syscall.SIGWINCH {
 			if err := b.resumeAfterSignal(sig); err != nil {
 				if isNoSuchProcess(err) {
@@ -288,35 +523,62 @@ func (b *darwinBackend) Wait() (StopEvent, error) {
 			continue
 		}
 
-		// Other signals during step: re-deliver via PT_STEP so the step
-		// completes. If PT_STEP fails, fall through to StopSignal so the
-		// engine can recover any in-flight step-over BP. Don't fall back to
-		// PT_CONTINUE+continue: that loops on SIGURG every ~10ms forever.
-		if b.isStepping() {
-			if err := ptrace(ptDarwinStep, uintptr(b.pid), 1, uintptr(sig)); err == nil {
-				continue
-			} else if isNoSuchProcess(err) {
-				return StopEvent{Reason: StopKilled, TID: tid}, nil
-			}
-			b.clearStep()
-		}
 		return StopEvent{Reason: StopSignal, Signal: int(sig)}, nil
 	}
 }
 
 func (b *darwinBackend) setPID(pid int) { b.pid = pid }
 
-func (b *darwinBackend) setStep(tid int) {
+// armStep records an in-flight single-step on tid whose MDSCR_EL1.SS bit is set.
+func (b *darwinBackend) armStep(tid int, isFirst bool) {
 	b.stepMu.Lock()
 	b.stepping = true
 	b.stepTID = tid
+	b.armedTID = tid
+	b.armedIsFirst = isFirst
 	b.stepMu.Unlock()
 }
 
-func (b *darwinBackend) clearStep() {
+// disarmStep clears the single-step arming: it drops the in-flight state,
+// clears MDSCR_EL1.SS on the armed thread, and resumes any sibling threads that
+// suspendOthers parked for the step, so the task can run freely again.
+func (b *darwinBackend) disarmStep() {
 	b.stepMu.Lock()
+	armed := b.armedTID
+	suspended := b.suspended
+	b.suspended = nil
 	b.stepping = false
 	b.stepTID = 0
+	b.armedTID = 0
+	b.armedIsFirst = false
+	b.stepMu.Unlock()
+	if armed != 0 {
+		_ = C.bingo_set_thread_single_step(C.mach_port_t(armed), 0)
+	}
+	for _, t := range suspended {
+		_ = C.bingo_thread_resume(C.mach_port_t(t))
+	}
+}
+
+// suspendOthers thread_suspends every current tracee thread except tid and
+// records them so disarmStep can resume them after the step. Ports for threads
+// that have already exited simply fail to suspend and are skipped.
+func (b *darwinBackend) suspendOthers(tid int) {
+	tids, err := b.Threads()
+	if err != nil {
+		return
+	}
+	suspended := make([]int, 0, len(tids))
+	for _, t := range tids {
+		if t == tid {
+			continue
+		}
+		if kr := C.bingo_thread_suspend(C.mach_port_t(t)); kr == C.KERN_SUCCESS {
+			suspended = append(suspended, t)
+		}
+	}
+	b.stepMu.Lock()
+	b.suspended = suspended
 	b.stepMu.Unlock()
 }
 
@@ -326,6 +588,23 @@ func (b *darwinBackend) isStepping() bool {
 	return b.stepping
 }
 
+// stepResumeVerb returns the ptrace request that resumes the task while keeping
+// the armed thread's single-step effective. PT_STEP/PT_CONTINUE only toggle
+// get_firstthread's single-step bit, so when the armed thread IS the first
+// thread we must resume with PT_STEP (which re-arms it); otherwise PT_CONTINUE
+// leaves the armed thread's bit intact.
+func (b *darwinBackend) stepResumeVerb() uintptr {
+	b.stepMu.Lock()
+	defer b.stepMu.Unlock()
+	if b.armedTID != 0 && b.armedIsFirst {
+		return ptDarwinStep
+	}
+	return ptDarwinContinue
+}
+
+// consumeStep reports whether a single-step was in flight and returns the
+// stepped thread's port. The MDSCR_EL1.SS bit stays set (disarmStep clears it
+// on the next resume) so we can still identify the armed thread.
 func (b *darwinBackend) consumeStep() (bool, int) {
 	b.stepMu.Lock()
 	defer b.stepMu.Unlock()
@@ -341,7 +620,7 @@ func (b *darwinBackend) consumeStep() (bool, int) {
 func (b *darwinBackend) resumeAfterSignal(sig syscall.Signal) error {
 	request := ptDarwinContinue
 	if b.isStepping() {
-		request = ptDarwinStep
+		request = b.stepResumeVerb()
 	}
 	if err := ptrace(request, uintptr(b.pid), 1, uintptr(sig)); err != nil {
 		return fmt.Errorf("ptrace resume after %s: %w", sig, err)
@@ -397,15 +676,21 @@ func machoTextVmaddr(binaryPath string) (uint64, error) {
 
 var _ Backend = (*darwinBackend)(nil)
 
-// task returns the Mach task port for the tracee. Requires the
-// com.apple.security.cs.debugger entitlement or disabled SIP.
+// task returns the Mach task port for the tracee, acquiring it once and caching
+// it. Requires the com.apple.security.cs.debugger entitlement or disabled SIP.
 func (b *darwinBackend) task() (C.mach_port_t, error) {
+	b.taskMu.Lock()
+	defer b.taskMu.Unlock()
+	if b.taskPort != 0 {
+		return b.taskPort, nil
+	}
 	var task C.mach_port_t
 	kr := C.bingo_task_for_pid(C.int(b.pid), &task)
 	if kr != C.KERN_SUCCESS {
 		return 0, fmt.Errorf("task_for_pid(%d): %s — debugger entitlement required",
 			b.pid, machErrString(kr))
 	}
+	b.taskPort = task
 	return task, nil
 }
 

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -75,6 +75,13 @@ type engine struct {
 	// boundary with line==0. Zeroed on each sourceStepOver and on user-BP hits.
 	stepOverFile string
 	stepOverLine int
+
+	// Destination address of an in-flight continue-based step-over/step-out.
+	// A one-shot sentinel trap is planted here and the origin trap removed, so
+	// the thread runs to the destination with a plain continue (no hardware
+	// single-step, which is unreliable on Darwin/arm64). Zero when no
+	// step-over is in flight. See resumeFromBreakpoint / finishStepOverContinue.
+	stepDestAddr uint64
 }
 
 type engineCmd struct {
@@ -249,11 +256,11 @@ func (e *engine) Locals(frameIndex int) ([]protocol.Variable, error) {
 		if e.dw == nil {
 			return fmt.Errorf("Locals: no DWARF info")
 		}
-		threads, err := e.backend.Threads()
-		if err != nil || len(threads) == 0 {
+		tid := e.inspectionTID(0)
+		if tid == 0 {
 			return fmt.Errorf("Locals: no threads")
 		}
-		regs, err := e.backend.GetRegisters(threads[0])
+		regs, err := e.backend.GetRegisters(tid)
 		if err != nil {
 			return fmt.Errorf("Locals: get registers: %w", err)
 		}
@@ -288,7 +295,7 @@ func (e *engine) StackFrames() ([]protocol.Frame, error) {
 			return err
 		}
 		var err error
-		frames, err = e.collectFrames()
+		frames, err = e.collectFrames(0)
 		return err
 	})
 	return frames, err
@@ -301,7 +308,7 @@ func (e *engine) Goroutines() ([]protocol.Goroutine, error) {
 			return err
 		}
 		var err error
-		goroutines, err = e.readGoroutines()
+		goroutines, err = e.readGoroutines(0)
 		return err
 	})
 	return goroutines, err
@@ -401,20 +408,21 @@ func (e *engine) handleStop(stop StopEvent) {
 			"addr", fmt.Sprintf("0x%x", bp.addr))
 		if bp.file == stepOverNextFile {
 			_ = e.bps.clear(e.backend, bp.id)
-			e.lastBP = nil
-			e.emitStepped(stop)
+			e.finishStepOverContinue(stop)
 			return
 		}
 		if bp.file == stepOutReturnFile {
 			_ = e.bps.clear(e.backend, bp.id)
-			e.lastBP = nil
-			e.emitStepped(stop)
+			e.finishStepOverContinue(stop)
 			return
 		}
 		e.lastBP = bp
 		e.lastBPTID = stop.TID
-		e.stepOverFile = ""
-		e.stepOverLine = 0
+		// A genuine user breakpoint. If a step-over/step-out was in flight
+		// (its origin trap removed, destination sentinel armed), tear that
+		// state down — reinstalling the origin and clearing the sentinel —
+		// before reporting the hit.
+		e.abandonStepOver()
 		e.emitBreakpointHit(bp, stop)
 
 	case StopSingleStep:
@@ -428,6 +436,9 @@ func (e *engine) handleStop(stop StopEvent) {
 		slog.Debug("StopSingleStep", "pc", fmt.Sprintf("0x%x", stop.PC),
 			"steppingOverBP", e.steppingOverBP != nil)
 		if sob := e.steppingOverBP; sob != nil {
+			// The single-step moved the thread off sob.addr (whose original
+			// bytes were restored for the step); reinstall the trap before
+			// resuming so the breakpoint stays active.
 			e.steppingOverBP = nil
 			if rerr := e.bps.reinstall(e.backend, sob); rerr != nil {
 				// Reinstall failed. Suspend instead of resuming — running
@@ -444,52 +455,15 @@ func (e *engine) handleStop(stop StopEvent) {
 				_ = e.backend.ContinueProcess()
 				e.setState(stateRunning)
 				go e.waitLoop()
-			case bpResumeStep:
+			default:
+				// bpResumeStep, and the rare bpResumeSourceStep/bpResumeStepOut
+				// fallback where no destination address was available (missing
+				// DWARF / return addr) so resumeFromBreakpoint single-stepped
+				// instead of continuing to a sentinel. We've advanced one
+				// instruction off the origin and reinstalled the trap; report
+				// that as the step result rather than risk a hang.
 				e.setState(stateSuspended)
 				e.emitStepped(stop)
-			case bpResumeSourceStep:
-				// Use sob.file/sob.line (the BP's known location) rather than
-				// a DWARF lookup from stop.PC: stop.PC is one instruction past
-				// the BP and can land on a DWARF entry with line==0.
-				if e.dw != nil && sob.file != "" && sob.line > 0 {
-					if nextPC, nextLine, ok := e.dw.NextLinePC(sob.file, sob.line); ok {
-						slog.Debug("sourceStepOver: setting "+stepOverNextFile,
-							"from", fmt.Sprintf("%s:%d", sob.file, sob.line),
-							"nextPC", fmt.Sprintf("0x%x", nextPC), "nextLine", nextLine)
-						entry, setErr := e.bps.set(e.backend, stepOverNextFile, 0, nextPC)
-						if setErr == nil || errors.Is(setErr, errBreakpointExists) {
-							e.stepOverFile = sob.file
-							e.stepOverLine = nextLine
-							if cerr := e.backend.ContinueProcess(); cerr == nil {
-								e.setState(stateRunning)
-								go e.waitLoop()
-								return
-							} else if entry != nil {
-								_ = e.bps.clear(e.backend, entry.id)
-								e.stepOverFile = ""
-								e.stepOverLine = 0
-							}
-						} else {
-							slog.Warn("sourceStepOver: set "+stepOverNextFile+" failed",
-								"addr", fmt.Sprintf("0x%x", nextPC), "err", setErr)
-						}
-					} else {
-						slog.Warn("sourceStepOver: NextLinePC found no next line",
-							"file", sob.file, "line", sob.line)
-					}
-				}
-				slog.Debug("sourceStepOver fallback: emitting Stepped")
-				e.setState(stateSuspended)
-				e.emitStepped(stop)
-			case bpResumeStepOut:
-				_, setErr := e.bps.set(e.backend, stepOutReturnFile, 0, e.bpRetAddr)
-				if setErr != nil && !errors.Is(setErr, errBreakpointExists) {
-					e.emitError(protocol.CmdStepOut, fmt.Errorf("StepOut: set return breakpoint: %w", setErr))
-					return
-				}
-				_ = e.backend.ContinueProcess()
-				e.setState(stateRunning)
-				go e.waitLoop()
 			}
 			return
 		}
@@ -721,23 +695,88 @@ func (e *engine) stepOut() error {
 	return nil
 }
 
-// resumeFromBreakpoint runs the step-over-software-BP sequence:
-// restore bytes → single-step → reinstall trap (in StopSingleStep handler)
-// → perform action.
+// resumeFromBreakpoint advances past the software breakpoint the process is
+// stopped on (e.lastBP) and then performs the requested action.
+//
+// For source-level step-over and step-out we know the destination address (the
+// next source line, or the return address), so we plant a one-shot sentinel trap
+// there, remove the origin trap, single-step the trapped thread one instruction
+// off the just-fired origin BRK PC (see stepOffClearedBP — a plain continue from
+// a just-fired-BRK PC intermittently wedges on Darwin/arm64), then let it run to
+// the sentinel with a plain continue. The destination trap is guaranteed to be on
+// the execution path. The origin trap is reinstalled when the sentinel is hit
+// (finishStepOverContinue), which also steps the thread off the sentinel PC.
+//
+// For plain continue and machine-instruction step we have no destination, so we
+// fall back to the classic restore → single-step → reinstall sequence (the
+// StopSingleStep handler reinstalls the trap and performs the action). That path
+// single-steps off the origin directly, so it also never plain-continues from a
+// just-fired-BRK PC.
 func (e *engine) resumeFromBreakpoint(action bpResumeAction, retAddr uint64) error {
 	bp := e.lastBP
 	e.lastBP = nil
+	originTID := e.lastBPTID
 	e.steppingOverBP = bp
 	e.bpResume = action
 	e.bpRetAddr = retAddr
 
+	// Determine a known destination for step-over / step-out and plant the
+	// sentinel there before touching the origin.
+	e.stepDestAddr = 0
+	dest, haveDest := uint64(0), false
+	switch action {
+	case bpResumeSourceStep:
+		if e.dw != nil && bp.file != "" && bp.line > 0 {
+			if nextPC, nextLine, ok := e.dw.NextLinePC(bp.file, bp.line); ok && nextPC != bp.addr {
+				if _, serr := e.bps.set(e.backend, stepOverNextFile, 0, nextPC); serr == nil || errors.Is(serr, errBreakpointExists) {
+					e.stepOverFile = bp.file
+					e.stepOverLine = nextLine
+					dest, haveDest = nextPC, true
+				}
+			}
+		}
+	case bpResumeStepOut:
+		if retAddr != 0 && retAddr != bp.addr {
+			if _, serr := e.bps.set(e.backend, stepOutReturnFile, 0, retAddr); serr == nil || errors.Is(serr, errBreakpointExists) {
+				dest, haveDest = retAddr, true
+			}
+		}
+	}
+
+	// Restore the original instruction at the origin so the thread can execute
+	// it. For the continue path the trap stays off until the sentinel is hit;
+	// for the single-step path it is reinstalled in the StopSingleStep handler.
 	e.bps.removeFromTable(bp)
 	if err := e.backend.WriteMemory(bp.addr, bp.originalBytes); err != nil {
 		e.bps.addToTable(bp)
 		e.steppingOverBP = nil
+		if haveDest {
+			if entry := e.bps.atAddr(dest); entry != nil {
+				_ = e.bps.clear(e.backend, entry.id)
+			}
+		}
 		return fmt.Errorf("resume BP: restore bytes: %w", err)
 	}
 
+	if haveDest {
+		e.stepDestAddr = dest
+		e.stepOffClearedBP(originTID)
+		if err := e.backend.ContinueProcess(); err != nil {
+			_ = e.backend.WriteMemory(bp.addr, archTrapInstruction())
+			e.bps.addToTable(bp)
+			e.steppingOverBP = nil
+			if entry := e.bps.atAddr(dest); entry != nil {
+				_ = e.bps.clear(e.backend, entry.id)
+			}
+			e.stepDestAddr = 0
+			return fmt.Errorf("resume BP: continue to destination: %w", err)
+		}
+		e.setState(stateRunning)
+		go e.waitLoop()
+		return nil
+	}
+
+	// Fallback single-step path (plain continue / instruction step).
 	// Use the TID that hit the breakpoint. On Darwin task_threads returns
 	// threads in creation order, so threads[0] is often an idle Go runtime M.
 	tid := e.lastBPTID
@@ -763,15 +802,123 @@ func (e *engine) resumeFromBreakpoint(action bpResumeAction, retAddr uint64) err
 	return nil
 }
 
-func (e *engine) collectFrames() ([]protocol.Frame, error) {
-	if e.dw == nil {
-		return nil, nil
+// finishStepOverContinue completes a continue-based step-over/step-out: the
+// origin trap was removed and a one-shot sentinel planted at the destination,
+// which has just been hit (and cleared by the caller, restoring the original
+// bytes there). It reinstalls the origin trap, steps the trapped thread off the
+// just-cleared destination PC, and emits Stepped.
+//
+// The step-off is essential: the thread is parked on the PC where the sentinel
+// BRK just fired, and on Darwin/arm64 a plain task continue from a just-fired-BRK
+// PC intermittently wedges (the thread stays in the kernel exception-return path
+// and the next wait4 blocks forever). Single-stepping one instruction off it now
+// — while the process is stopped and no wait loop is active — leaves the thread
+// on a clean PC so the following user Continue/Step resumes reliably. On backends
+// that resume an ex-breakpoint PC fine (Linux) the step-off is a no-op.
+//
+// stepOverFile/stepOverLine are left intact so the next step-over can reuse the
+// remembered destination line (the reported Stepped PC is still the destination;
+// the extra instruction retired by the step-off stays within that source line).
+func (e *engine) finishStepOverContinue(stop StopEvent) {
+	if sob := e.steppingOverBP; sob != nil {
+		e.steppingOverBP = nil
+		if rerr := e.bps.reinstall(e.backend, sob); rerr != nil {
+			// Reinstall failed. Suspend instead of resuming — running without
+			// the trap would let the process loose.
+			slog.Error("breakpoint reinstall failed — suspending to prevent runaway process",
+				"addr", fmt.Sprintf("0x%x", sob.addr), "err", rerr)
+			e.stepDestAddr = 0
+			e.lastBP = nil
+			e.setState(stateSuspended)
+			e.emitError(protocol.CmdNone, fmt.Errorf("reinstall breakpoint 0x%x: %w", sob.addr, rerr))
+			return
+		}
+	}
+	e.stepOffClearedBP(stop.TID)
+	e.stepDestAddr = 0
+	e.lastBP = nil
+	e.setState(stateSuspended)
+	e.emitStepped(stop)
+}
+
+// abandonStepOver tears down an in-flight continue-based step-over when a
+// *different* genuine breakpoint is hit before the destination sentinel. It
+// reinstalls the origin trap and clears the leftover sentinel so the reported
+// breakpoint hit leaves consistent state.
+func (e *engine) abandonStepOver() {
+	if sob := e.steppingOverBP; sob != nil {
+		e.steppingOverBP = nil
+		_ = e.bps.reinstall(e.backend, sob)
+	}
+	if e.stepDestAddr != 0 {
+		if entry := e.bps.atAddr(e.stepDestAddr); entry != nil &&
+			(entry.file == stepOverNextFile || entry.file == stepOutReturnFile) {
+			_ = e.bps.clear(e.backend, entry.id)
+		}
+		e.stepDestAddr = 0
+	}
+	e.stepOverFile = ""
+	e.stepOverLine = 0
+}
+
+// stepOffClearedBP advances tid one instruction off the PC where a software
+// breakpoint just fired, before the next resume. It is used both for the origin
+// user breakpoint (in resumeFromBreakpoint, before continuing to the destination
+// sentinel) and for a just-cleared internal sentinel (in finishStepOverContinue,
+// before handing control back for the next user resume). On Darwin/arm64 a thread
+// parked on a just-fired-BRK PC cannot be reliably resumed by a plain task
+// continue — it must be single-stepped off first. Backends that don't need it —
+// Linux, where PTRACE_CONT resumes an ex-breakpoint PC fine — don't implement
+// StepOffBreakpoint and this is a no-op. Runs synchronously while the process is
+// stopped and no wait loop is active.
+func (e *engine) stepOffClearedBP(tid int) {
+	if tid == 0 {
+		return
+	}
+	if so, ok := e.backend.(interface{ StepOffBreakpoint(tid int) error }); ok {
+		if err := so.StepOffBreakpoint(tid); err != nil {
+			slog.Warn("step off cleared breakpoint failed", "tid", tid, "err", err)
+		}
+	}
+}
+
+// inspectionTID resolves the thread whose state should be inspected while the
+// process is suspended. Prefer the explicitly-provided trapped thread (tid);
+// fall back to the last thread known to have stopped (lastBPTID), then to
+// threads[0].
+//
+// Using the trapped thread is essential on Darwin/arm64: task_threads returns
+// threads in creation order, so threads[0] is frequently an idle Go runtime M
+// (or, under churn, a thread mid-create/teardown) whose transient stack yields a
+// garbage frame-pointer chain. Walking that garbage produces dozens of bogus
+// return addresses, and resolving each one drives DWARF into a full linear scan
+// of .debug_info — up to maxStackDepth such scans back-to-back, which wedges the
+// engine loop for many seconds and makes the caller's waitFor time out. The
+// thread that actually hit the breakpoint/step has a valid chain that terminates
+// at the top of its goroutine stack, so its walk is short and every PC resolves.
+func (e *engine) inspectionTID(tid int) int {
+	if tid != 0 {
+		return tid
+	}
+	if e.lastBPTID != 0 {
+		return e.lastBPTID
 	}
 	threads, err := e.backend.Threads()
 	if err != nil || len(threads) == 0 {
+		return 0
+	}
+	return threads[0]
+}
+
+func (e *engine) collectFrames(tid int) ([]protocol.Frame, error) {
+	if e.dw == nil {
+		return nil, nil
+	}
+	tid = e.inspectionTID(tid)
+	if tid == 0 {
 		return nil, fmt.Errorf("StackFrames: no threads")
 	}
-	regs, err := e.backend.GetRegisters(threads[0])
+	regs, err := e.backend.GetRegisters(tid)
 	if err != nil {
 		return nil, fmt.Errorf("StackFrames: %w", err)
 	}
@@ -790,18 +937,27 @@ func (e *engine) walkStack(regs Registers) []uint64 {
 		if retAddr == 0 {
 			break
 		}
+		nextBP := binary.LittleEndian.Uint64(frame[:8])
 		pcs = append(pcs, retAddr)
-		bp = binary.LittleEndian.Uint64(frame[:8])
+		// Saved frame pointers must climb monotonically toward the top of the
+		// stack (higher addresses). If the chain stalls or moves backward we've
+		// wandered off real frames onto a transient/garbage stack — stop rather
+		// than emit up to maxStackDepth bogus PCs, each of which would trigger a
+		// full-DWARF scan and stall the engine loop.
+		if nextBP <= bp {
+			break
+		}
+		bp = nextBP
 	}
 	return pcs
 }
 
-func (e *engine) readGoroutines() ([]protocol.Goroutine, error) {
-	threads, err := e.backend.Threads()
-	if err != nil || len(threads) == 0 {
+func (e *engine) readGoroutines(tid int) ([]protocol.Goroutine, error) {
+	tid = e.inspectionTID(tid)
+	if tid == 0 {
 		return nil, nil
 	}
-	regs, err := e.backend.GetRegisters(threads[0])
+	regs, err := e.backend.GetRegisters(tid)
 	if err != nil {
 		return nil, fmt.Errorf("Goroutines: %w", err)
 	}
@@ -850,8 +1006,8 @@ func (e *engine) emit(kind protocol.EventKind, payload any) {
 }
 
 func (e *engine) emitBreakpointHit(bp *breakpointEntry, stop StopEvent) {
-	frames, _ := e.collectFrames()
-	goroutines, _ := e.readGoroutines()
+	frames, _ := e.collectFrames(stop.TID)
+	goroutines, _ := e.readGoroutines(stop.TID)
 	var g protocol.Goroutine
 	if len(goroutines) > 0 {
 		g = goroutines[0]
@@ -878,8 +1034,8 @@ func (e *engine) emitStoppedAtCurrentPC() {
 }
 
 func (e *engine) emitStepped(stop StopEvent) {
-	frames, _ := e.collectFrames()
-	goroutines, _ := e.readGoroutines()
+	frames, _ := e.collectFrames(stop.TID)
+	goroutines, _ := e.readGoroutines(stop.TID)
 	var g protocol.Goroutine
 	if len(goroutines) > 0 {
 		g = goroutines[0]

--- a/internal/debugger/mach_darwin_arm64.h
+++ b/internal/debugger/mach_darwin_arm64.h
@@ -6,6 +6,7 @@
 
 #include <mach/mach.h>
 #include <mach/mach_vm.h>
+#include <mach/vm_attributes.h>
 #include <mach/arm/thread_status.h>
 #include <stdint.h>
 
@@ -67,45 +68,81 @@ static inline kern_return_t bingo_read_memory(
         (mach_vm_address_t)dst, &out_size);
 }
 
-// bingo_write_memory writes n bytes from src into the task's address space.
-// Temporarily marks the target page(s) writable with VM_PROT_COPY so we can
-// patch read-only text segments (e.g. to install breakpoints), then restores
-// execute permission.
+// bingo_write_memory writes n bytes from src into the task's address space,
+// mirroring LLDB debugserver's MachVMMemory::WriteRegion and Delve's
+// write_memory (pkg/proc/native/threads_darwin.c) — the proven technique for
+// planting software breakpoints (BRK) on Apple Silicon.
 //
-// Icache coherency on Apple Silicon (ARM64):
-// mach_vm_machine_attribute(MATTR_CACHE, MATTR_VAL_ICACHE_FLUSH) is a no-op
-// on Apple Silicon — the kernel returns KERN_NOT_SUPPORTED. The correct
-// approach is to wrap the write with task_suspend + task_resume: the resume
-// call drains the instruction pipeline for all threads in the task, ensuring
-// the CPU sees the new bytes. task_suspend/resume use an independent suspend
-// count from ptrace, so this is safe to call while the process is
-// ptrace-stopped (the ptrace stop is unaffected).
+// Two details are load-bearing on Darwin/arm64:
+//
+//   - Instruction-cache flush. mach_vm_write updates memory through the DATA
+//     side, but the tracee's cores may still hold the ORIGINAL instruction in
+//     their L1 I-caches; without an explicit flush a freshly written BRK can be
+//     intermittently ineffective and the tracee executes straight through it.
+//     vm_machine_attribute(MATTR_CACHE, MATTR_VAL_CACHE_FLUSH) performs the
+//     cross-process DC-clean-to-PoU + IC-invalidate (broadcast to the inner-
+//     shareable domain, so every core sees it). Use vm_machine_attribute, NOT
+//     mach_vm_machine_attribute: only the former is wired to the arm64 pmap
+//     cache-flush path; the mach_vm_ variant returns KERN_SUCCESS but does not
+//     reliably invalidate the tracee's I-caches.
+//
+//   - VM_PROT_COPY when making the range writable. Text pages are file-backed
+//     and code-signed with max_protection R|X. Requesting VM_PROT_COPY forces a
+//     private, anonymous copy-on-write shadow of the page, so the patch lands in
+//     an unsigned private copy rather than the shared, signed file-backed page.
+//     This is exactly what Delve and debugserver do (both pass VM_PROT_WRITE|
+//     VM_PROT_COPY|VM_PROT_READ unconditionally). A CS_DEBUGGED (ptrace-traced)
+//     task is in fact permitted to patch its own text directly — the kernel logs
+//     "AMFI: code signature validation failed" for the modified page but does
+//     NOT kill the process (verified: runs complete cleanly while these logs
+//     fire continuously) — so COPY is not strictly required for correctness
+//     here. We use it because it is the reference-correct technique and keeps
+//     the write off the shared signed page entirely; we try COPY first and fall
+//     back to plain R|W only if COPY is rejected outright (for non-text pages).
+//
+// Do NOT task_suspend. The engine only writes memory while the tracee is fully
+// ptrace-stopped (no thread is running), exactly as debugserver writes to an
+// inferior stopped on a Mach exception. An extra task_suspend/resume is
+// redundant and perturbs the signal/scheduler state the step-off path depends on.
 static inline kern_return_t bingo_write_memory(
     mach_port_t task, mach_vm_address_t addr,
     const void *src, mach_vm_size_t n)
 {
-    // Suspend the task so all threads are quiesced while we patch memory.
-    // This also causes task_resume to flush the instruction pipeline.
-    task_suspend(task);
+    // Query the region so we can restore its exact original protection afterwards.
+    mach_vm_address_t region_addr = addr;
+    mach_vm_size_t region_size = n;
+    vm_region_basic_info_data_64_t info;
+    mach_msg_type_number_t info_count = VM_REGION_BASIC_INFO_COUNT_64;
+    mach_port_t object_name = MACH_PORT_NULL;
+    vm_prot_t orig_prot = VM_PROT_READ | VM_PROT_EXECUTE;
+    if (mach_vm_region(task, &region_addr, &region_size, VM_REGION_BASIC_INFO_64,
+                       (vm_region_info_t)&info, &info_count, &object_name)
+            == KERN_SUCCESS) {
+        orig_prot = info.protection;
+    }
 
+    // Make the range writable via a private copy-on-write shadow (VM_PROT_COPY).
+    // This is mandatory on Apple Silicon: it keeps the write off the shared,
+    // code-signed text page so AMFI can't kill the tracee for a hash mismatch.
+    // Fall back to plain R|W only if COPY is rejected outright.
     kern_return_t kr = mach_vm_protect(task, addr, n, FALSE,
         VM_PROT_READ | VM_PROT_WRITE | VM_PROT_COPY);
     if (kr != KERN_SUCCESS) {
-        task_resume(task);
-        return kr;
+        kr = mach_vm_protect(task, addr, n, FALSE,
+            VM_PROT_READ | VM_PROT_WRITE);
     }
-    kr = mach_vm_write(task, addr,
-        (vm_offset_t)src, (mach_msg_type_number_t)n);
     if (kr != KERN_SUCCESS) {
-        task_resume(task);
         return kr;
     }
-    kr = mach_vm_protect(task, addr, n, FALSE,
-        VM_PROT_READ | VM_PROT_EXECUTE);
 
-    // Resume lifts the task suspension and flushes the instruction pipeline
-    // for all threads, ensuring the CPU fetches the new bytes on next execute.
-    task_resume(task);
+    kr = mach_vm_write(task, addr, (vm_offset_t)src, (mach_msg_type_number_t)n);
+    if (kr == KERN_SUCCESS) {
+        // Flush I-cache for the range while it is still writable, then restore
+        // the original protection.
+        vm_machine_attribute_val_t flush = MATTR_VAL_CACHE_FLUSH;
+        vm_machine_attribute(task, addr, n, MATTR_CACHE, &flush);
+    }
+    mach_vm_protect(task, addr, n, FALSE, orig_prot);
     return kr;
 }
 
@@ -157,11 +194,95 @@ static inline kern_return_t bingo_find_macho_load_addr(
 }
 
 // bingo_thread_list enumerates all threads in task.
-// The caller must vm_deallocate the returned threads array.
+// The caller must vm_deallocate the returned threads array and
+// mach_port_deallocate every returned thread port (each is a send right).
 static inline kern_return_t bingo_thread_list(
     mach_port_t task,
     thread_act_port_array_t *threads_out,
     mach_msg_type_number_t *count_out)
 {
     return task_threads(task, threads_out, count_out);
+}
+
+// bingo_set_thread_single_step arms (on != 0) or disarms hardware single-step
+// on ONE specific thread by toggling MDSCR_EL1.SS (bit 0) in its
+// ARM_DEBUG_STATE64. This is the per-thread mechanism used by LLDB's
+// debugserver on Apple Silicon.
+//
+// It exists because ptrace(PT_STEP) is useless on multithreaded Darwin: XNU's
+// PT_STEP arms single-step on get_firstthread(task) only (bsd/kern/mach_process.c
+// -> thread_setsinglestep in osfmk/arm64/bsd_arm64.c), which is almost never the
+// thread that hit the breakpoint. thread_setsinglestep writes the same
+// per-thread mdscr_el1 debug state we set here, so arming it directly on the
+// trapped thread lets us single-step exactly that thread.
+//
+// Existing bcr/bvr/wcr/wvr (hardware breakpoints/watchpoints) are preserved by
+// reading the current state first; on read failure we start from a zeroed state.
+//
+// Reallocation on arm is REQUIRED for correctness, not an optimization. XNU's
+// return-to-user path (osfmk/arm64/locore.s) only reloads a thread's debug
+// registers when the live per-CPU debug pointer differs from the thread's:
+//
+//     ldr x1, [x4, CPU_USER_DEBUG]   // cpu_user_debug (live on this CPU)
+//     ldr x0, [x3, ACT_DEBUGDATA]    // thread->machine.DebugData
+//     cmp x0, x1
+//     beq L_skip_user_set_debug_state   // POINTER compare -> skip reload
+//     bl  EXT(arm_debug_set)            // else apply thread debug state
+//
+// arm_debug_set64 (osfmk/arm64/pcb.c) is what actually writes MDSCR_EL1.SS into
+// the hardware AND sets PSTATE.SS in the thread's saved CPSR (via
+// mask_user_saved_state_cpsr) — the two bits the ARM software-step state machine
+// needs. We set the SS bit out-of-band on an off-CPU thread, mutating the
+// CONTENTS of its debug struct while its POINTER stays the same across arm/disarm
+// (find_or_allocate_debug_state64 reuses an existing allocation). If that thread
+// is then scheduled onto a CPU whose cpu_user_debug already points at the very
+// same struct (with SS currently clear in hardware), the compare matches, the
+// reload is skipped, and our freshly-set SS bit never reaches the CPU: the thread
+// runs free, no step exception fires, and the next wait4 blocks forever. Whether
+// the target lands on such a CPU depends on the scheduler, which is why the hang
+// is intermittent (~50%).
+//
+// To defeat the skip we force the struct to be reallocated on every arm. Writing
+// an all-zero (disabled) debug state makes machine_thread_set_state call
+// free_debug_state(), which sets thread->machine.DebugData = NULL. The following
+// enabled write then goes through find_or_allocate_debug_state64 and zalloc's a
+// brand-new struct. A never-before-loaded pointer cannot equal any CPU's
+// cpu_user_debug (the live one is retained, so its storage can't be recycled),
+// so the return-to-user path always takes the reload branch and applies SS.
+static inline kern_return_t bingo_set_thread_single_step(mach_port_t thread, int on) {
+    arm_debug_state64_t ds = {0};
+    mach_msg_type_number_t count = ARM_DEBUG_STATE64_COUNT;
+    (void)thread_get_state(thread, ARM_DEBUG_STATE64, (thread_state_t)&ds, &count);
+    if (on) {
+        // Free the current debug state (DebugData -> NULL) so the enabled write
+        // below allocates a fresh struct with a new pointer, forcing a reload.
+        arm_debug_state64_t zero = {0};
+        (void)thread_set_state(thread, ARM_DEBUG_STATE64,
+            (thread_state_t)&zero, ARM_DEBUG_STATE64_COUNT);
+        ds.__mdscr_el1 |= 1ULL;      // MDSCR_EL1.SS
+    } else {
+        ds.__mdscr_el1 &= ~1ULL;
+    }
+    return thread_set_state(thread, ARM_DEBUG_STATE64,
+        (thread_state_t)&ds, ARM_DEBUG_STATE64_COUNT);
+}
+
+// bingo_port_deallocate releases one user reference to a Mach port name in our
+// own IPC space (used to release thread send-rights returned by task_threads).
+static inline kern_return_t bingo_port_deallocate(mach_port_t port) {
+    return mach_port_deallocate(mach_task_self(), port);
+}
+
+// bingo_thread_suspend / bingo_thread_resume adjust a Mach thread's suspend
+// count. During a single-step we suspend every thread except the one being
+// stepped so the whole task can be ptrace-resumed while only the target thread
+// actually runs — mirroring how debugserver isolates the stepping thread. This
+// keeps concurrent threads (and their SIGURG preemption signals) from perturbing
+// the ARM software-step state machine, which otherwise intermittently swallows
+// the step exception and hangs wait4.
+static inline kern_return_t bingo_thread_suspend(mach_port_t thread) {
+    return thread_suspend(thread);
+}
+static inline kern_return_t bingo_thread_resume(mach_port_t thread) {
+    return thread_resume(thread);
 }


### PR DESCRIPTION
## Root cause

Three darwin/arm64 backend defects:

1. **Mach-port leak / staleness.** `task_for_pid` leaks a task send-right on every call, and thread ports go stale under thread churn — unbounded Mach-port growth and operations issued against dead ports, causing instability.
2. **Wrong-thread single-step.** `PT_STEP` arms `MDSCR_EL1.SS` on `get_firstthread(task)`, not the trapped thread, so step-over from a breakpoint advances the wrong thread and the next resume wedges in `wait4`.
3. **SIGURG misdirection.** A caught SIGURG re-injected via ptrace is delivered to `get_firstthread(task)`, preempting the wrong M and corrupting the Go runtime's async preemption.

## Fix

- **Port lifecycle**: cache the single task port; track and deallocate thread ports so the backend stops leaking send-rights and never operates on a stale port.
- **Trapped-thread single-step**: arm `MDSCR_EL1.SS` on the trapped thread's own Mach port (LLDB/debugserver-style) instead of relying on per-process `PT_STEP`.
- Drop a caught SIGURG (resume with signal 0) rather than mis-target it; the Go runtime re-issues preemption hints.

## Verification (coordinator)

- `TestE2EBasic` (iters=25): **8/8 PASS**, 0 hang, 0 data race.
- `TestE2EChurn`: green.

## Known limitation — the wait4 async-preemption trilemma

This fix is on the **"drop SIGURG"** horn of a proven trilemma under the `wait4`/BSD-ptrace stop model. Because the intercepted async-preemption SIGURG is dropped, a **purely async-preemptible** goroutine (no cooperative safepoints, e.g. a call-free `for { x++ }` loop) is **not** stop-the-world preempted while a breakpoint is serviced. A coordinator GC-preempt probe (non-cooperative spinner + STW `runtime.GC()`) hangs at the GC under this backend — the **same tradeoff class as `GODEBUG=asyncpreemptoff`**.

The alternative horn (re-injecting SIGURG, as in #71 / #70-default) keeps async preemption alive ~85% of the time but reintroduces a ~15% SIGURG-misdirection condvar lost-wakeup. **No behavior-preserving fix exists under `wait4`**; the complete fix is switching the stop source to **Mach exception ports** (like Delve), out of scope per `AGENTS.md` (future work).

The **port-leak fix (defect 1) is independently valuable** and correct regardless of the SIGURG policy chosen.

---
*Draft: one of five distinct darwin/arm64 candidate fixes. Coordinator-finalized from the agent's implementation; base is the shared E2E gate branch `debugger-e2e-base`.*
