### PR TITLE
fix(ci): auto-remove darwin-e2e-verified label on new commits

### DIFF
--- a/.github/workflows/darwin-verification-gate.yml
+++ b/.github/workflows/darwin-verification-gate.yml
@@ -12,9 +12,15 @@ name: Darwin verification gate
 # passes, and add the `darwin-e2e-verified` label to the PR. The gate is a
 # no-op (green) for PRs that don't touch that code.
 #
-# It re-runs on `labeled`/`unlabeled` so adding the label flips the check to
-# green without needing a new push. To actually block merges, mark
-# "Darwin E2E verified" as a required status check in branch protection.
+# On every `synchronize` (new commits pushed) the `darwin-e2e-verified` label is
+# automatically removed: a prior verification only covers the commits it was
+# run against, so it must not silently carry forward onto unverified code. The
+# gate then re-evaluates the (now-current) label state in the same run, rather
+# than trusting the stale `github.event.pull_request.labels` payload, since that
+# payload predates the removal step. It also re-runs on `labeled`/`unlabeled` so
+# adding the label back flips the check to green without needing a new push.
+# To actually block merges, mark "Darwin E2E verified" as a required status
+# check in branch protection.
 
 on:
   pull_request:
@@ -22,7 +28,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   darwin-e2e-verified:
@@ -32,12 +38,22 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       VERIFIED_LABEL: darwin-e2e-verified
-      HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'darwin-e2e-verified') }}
       # Paths whose runtime behaviour only runs on real darwin/arm64 hardware and
       # therefore can't be exercised by any CI job. Keep in sync with the darwin
       # files under internal/debugger, the darwin E2E spec, and entitlements.
       DARWIN_NATIVE_REGEX: '^(internal/debugger/.*_darwin_.*|internal/debugger/trap_arm64\.go|test/integration/.*_darwin_.*_test\.go|entitlements\.plist)$'
     steps:
+      - name: Remove stale verification label on new commits
+        if: github.event.action == 'synchronize'
+        run: |
+          set -euo pipefail
+          pr='${{ github.event.pull_request.number }}'
+          if gh pr edit "$pr" --repo "${{ github.repository }}" --remove-label "$VERIFIED_LABEL" 2>/dev/null; then
+            echo "Removed '$VERIFIED_LABEL' label — new commits require re-verification."
+          else
+            echo "'$VERIFIED_LABEL' label was not present — nothing to remove."
+          fi
+
       - name: Require local darwin E2E verification when darwin-native code changes
         run: |
           set -euo pipefail
@@ -61,7 +77,13 @@ jobs:
             exit 0
           fi
 
-          if [ "$HAS_LABEL" = "true" ]; then
+          # Re-fetch the current label state live rather than trusting
+          # github.event.pull_request.labels, which is a snapshot from before
+          # this run (and predates the removal step above on `synchronize`).
+          has_label=$(gh pr view "$pr" --repo "${{ github.repository }}" --json labels \
+            -q "[.labels[].name] | any(. == \"$VERIFIED_LABEL\")")
+
+          if [ "$has_label" = "true" ]; then
             echo "'$VERIFIED_LABEL' label present — darwin backend verified locally. ✅"
             exit 0
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,8 +337,15 @@ they'd see two overlapping monotonic sequences and couldn't detect drops.
   `test/integration/*_darwin_*_test.go`, and `entitlements.plist`. The "Darwin
   E2E verified" check fails until the label is present; it re-runs on
   `labeled`/`unlabeled` so adding the label flips it green without a new push,
-  and is a green no-op for PRs that don't touch those paths. Mark it a required
-  status check in branch protection to actually block merges.
+  and is a green no-op for PRs that don't touch those paths. On `synchronize`
+  (new commits pushed) the workflow removes the `darwin-e2e-verified` label
+  itself before evaluating the gate — a verification only covers the commits
+  it was run against, so it must not silently carry forward onto new,
+  unverified commits — then re-checks the label live via `gh pr view` rather
+  than the stale `github.event.pull_request.labels` payload, since that
+  payload predates the removal. This needs `pull-requests: write` permission
+  (not just `read`). Mark it a required status check in branch protection to
+  actually block merges.
 
 Build/test commands:
 


### PR DESCRIPTION
## Summary

The Darwin verification gate previously kept the `darwin-e2e-verified` label on a PR across new pushes, so unverified darwin-native commits could silently ride along on a stale approval.

## Changes

- On `synchronize` (new commits pushed), the workflow now removes the `darwin-e2e-verified` label before evaluating the gate.
- The gate re-checks the label state live via `gh pr view` instead of trusting the (now potentially stale) `github.event.pull_request.labels` payload.
- Bumped `permissions.pull-requests` from `read` to `write` so the workflow can remove the label.
- Updated the workflow's comment block and `AGENTS.md` to describe the new auto-removal behavior.

Closes #79