### PR TITLE
fix(debugger): route engine logging through the session logger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,21 @@ engine advances PC by `len(archTrapInstruction())` and resumes. See the
   Register-allocated variables come back as `<optimized out>`. Values are
   read as 8 bytes and returned hex; type-aware formatting is a TODO.
 
+## Logging — one injected logger per component
+
+`server`, `hub`, `client`, and the debugger `engine` each hold a `*slog.Logger`
+field (`s.log`, `h.log`, `c.log`, `e.log`), threaded down from
+[cmd/bingo/main.go](cmd/bingo/main.go) through `server.New` → `sessionStore` →
+`hub.NewSession` → `debugger.New`/`NewWithBackend`. `sessionStore.create` scopes
+it with `.With("session", id)` before handing it to both the hub and the
+debugger, so every log line for a session — regardless of which layer emitted
+it — is correlated by that field. **Never call the package-level `slog.Debug`
+/ `slog.Info` / `slog.Warn` / `slog.Error` from inside these components** —
+that bypasses the configured level/handler and the session correlation,
+producing duplicate-looking, uncorrelated log lines (this was the root cause
+of issue #32). Constructors accept a nil logger and fall back to
+`slog.Default()` (tests rely on this).
+
 ## Hub seq stream — why one counter
 
 The hub re-stamps every outbound event with its own atomic `seq` counter. The

--- a/internal/debugger/debugger.go
+++ b/internal/debugger/debugger.go
@@ -5,6 +5,7 @@ package debugger
 
 import (
 	"errors"
+	"log/slog"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
@@ -47,12 +48,14 @@ type Debugger interface {
 	Events() <-chan protocol.Event
 }
 
-// New returns a Debugger backed by the platform-native OS backend.
-func New() Debugger {
-	return newEngine(newBackend())
+// New returns a Debugger backed by the platform-native OS backend. log is the
+// single sink for all debugger logging; pass nil to fall back to
+// slog.Default().
+func New(log *slog.Logger) Debugger {
+	return newEngine(newBackend(), log)
 }
 
 // NewWithBackend returns a Debugger using the supplied Backend. Tests only.
-func NewWithBackend(b Backend) Debugger {
-	return newEngine(b)
+func NewWithBackend(b Backend, log *slog.Logger) Debugger {
+	return newEngine(b, log)
 }

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -75,6 +75,12 @@ type engine struct {
 	// boundary with line==0. Zeroed on each sourceStepOver and on user-BP hits.
 	stepOverFile string
 	stepOverLine int
+
+	// log is the single sink for all engine logging. Never call the
+	// package-level slog functions directly — they bypass the per-session
+	// logger the hub/server configure, producing duplicate, uncorrelated
+	// log lines. See AGENTS.md.
+	log *slog.Logger
 }
 
 type engineCmd struct {
@@ -117,7 +123,10 @@ type stopResult struct {
 	err error
 }
 
-func newEngine(b Backend) *engine {
+func newEngine(b Backend, log *slog.Logger) *engine {
+	if log == nil {
+		log = slog.Default()
+	}
 	e := &engine{
 		backend: b,
 		bps:     newBreakpointTable(),
@@ -126,6 +135,7 @@ func newEngine(b Backend) *engine {
 		stopCh:  make(chan stopResult, 1),
 		done:    make(chan struct{}),
 		state:   stateNoProcess,
+		log:     log,
 	}
 	go e.loop()
 	return e
@@ -429,7 +439,7 @@ func (e *engine) handleStop(stop StopEvent) {
 			return
 		}
 		bp := e.bps.atAddr(stop.PC)
-		slog.Debug("StopBreakpoint", "pc", fmt.Sprintf("0x%x", stop.PC),
+		e.log.Debug("StopBreakpoint", "pc", fmt.Sprintf("0x%x", stop.PC),
 			"found", bp != nil,
 			"steppingOverBP", e.steppingOverBP != nil)
 		if bp == nil {
@@ -437,7 +447,7 @@ func (e *engine) handleStop(stop StopEvent) {
 			// internal trap or libc assertion). On ARM64 PC points AT the
 			// BRK; ContinueProcess with signal=0 leaves PC unchanged and
 			// re-executes the trap forever. Advance PC past the 4-byte BRK.
-			slog.Warn("spurious SIGTRAP — advancing PC past BRK and resuming",
+			e.log.Warn("spurious SIGTRAP — advancing PC past BRK and resuming",
 				"pc", fmt.Sprintf("0x%x", stop.PC))
 			if regs, err := e.backend.GetRegisters(stop.TID); err == nil {
 				regs.PC = stop.PC + uint64(len(archTrapInstruction()))
@@ -448,7 +458,7 @@ func (e *engine) handleStop(stop StopEvent) {
 			go e.waitLoop()
 			return
 		}
-		slog.Debug("StopBreakpoint matched", "file", bp.file, "line", bp.line,
+		e.log.Debug("StopBreakpoint matched", "file", bp.file, "line", bp.line,
 			"addr", fmt.Sprintf("0x%x", bp.addr))
 		e.rewindToBreakpoint(stop)
 		if bp.file == stepOverNextFile {
@@ -484,7 +494,7 @@ func (e *engine) handleStop(stop StopEvent) {
 			e.emitError(protocol.CmdNone, err)
 			return
 		}
-		slog.Debug("StopSingleStep", "pc", fmt.Sprintf("0x%x", stop.PC),
+		e.log.Debug("StopSingleStep", "pc", fmt.Sprintf("0x%x", stop.PC),
 			"steppingOverBP", e.steppingOverBP != nil)
 		if sob := e.steppingOverBP; sob != nil {
 			e.steppingOverBP = nil
@@ -492,7 +502,7 @@ func (e *engine) handleStop(stop StopEvent) {
 				// Reinstall failed. Suspend instead of resuming — running
 				// without the trap would let the process loose.
 				e.endThreadStep()
-				slog.Error("breakpoint reinstall failed — suspending to prevent runaway process",
+				e.log.Error("breakpoint reinstall failed — suspending to prevent runaway process",
 					"addr", fmt.Sprintf("0x%x", sob.addr), "err", rerr)
 				e.setState(stateSuspended)
 				e.emitError(protocol.CmdNone, fmt.Errorf("reinstall breakpoint 0x%x: %w", sob.addr, rerr))
@@ -501,7 +511,7 @@ func (e *engine) handleStop(stop StopEvent) {
 			// The trap byte is back in place; only now is it safe to release
 			// the threads we held for the atomic step-over.
 			e.endThreadStep()
-			slog.Debug("breakpoint reinstalled", "addr", fmt.Sprintf("0x%x", sob.addr))
+			e.log.Debug("breakpoint reinstalled", "addr", fmt.Sprintf("0x%x", sob.addr))
 			switch e.bpResume {
 			case bpResumeContinue:
 				_ = e.backend.ContinueProcess()
@@ -516,7 +526,7 @@ func (e *engine) handleStop(stop StopEvent) {
 				// the BP and can land on a DWARF entry with line==0.
 				if e.dw != nil && sob.file != "" && sob.line > 0 {
 					if nextPC, nextLine, ok := e.dw.NextLinePC(sob.file, sob.line); ok {
-						slog.Debug("sourceStepOver: setting "+stepOverNextFile,
+						e.log.Debug("sourceStepOver: setting "+stepOverNextFile,
 							"from", fmt.Sprintf("%s:%d", sob.file, sob.line),
 							"nextPC", fmt.Sprintf("0x%x", nextPC), "nextLine", nextLine)
 						entry, setErr := e.bps.set(e.backend, stepOverNextFile, 0, nextPC)
@@ -533,15 +543,15 @@ func (e *engine) handleStop(stop StopEvent) {
 								e.stepOverLine = 0
 							}
 						} else {
-							slog.Warn("sourceStepOver: set "+stepOverNextFile+" failed",
+							e.log.Warn("sourceStepOver: set "+stepOverNextFile+" failed",
 								"addr", fmt.Sprintf("0x%x", nextPC), "err", setErr)
 						}
 					} else {
-						slog.Warn("sourceStepOver: NextLinePC found no next line",
+						e.log.Warn("sourceStepOver: NextLinePC found no next line",
 							"file", sob.file, "line", sob.line)
 					}
 				}
-				slog.Debug("sourceStepOver fallback: emitting Stepped")
+				e.log.Debug("sourceStepOver fallback: emitting Stepped")
 				e.setState(stateSuspended)
 				e.emitStepped(stop)
 			case bpResumeStepOut:
@@ -622,7 +632,7 @@ func (e *engine) rewindToBreakpoint(stop StopEvent) {
 	}
 	regs, err := e.backend.GetRegisters(stop.TID)
 	if err != nil {
-		slog.Warn("rewindToBreakpoint: get registers failed",
+		e.log.Warn("rewindToBreakpoint: get registers failed",
 			"tid", stop.TID, "err", err)
 		return
 	}
@@ -631,7 +641,7 @@ func (e *engine) rewindToBreakpoint(stop StopEvent) {
 	}
 	regs.PC = stop.PC
 	if err := e.backend.SetRegisters(stop.TID, regs); err != nil {
-		slog.Warn("rewindToBreakpoint: set registers failed",
+		e.log.Warn("rewindToBreakpoint: set registers failed",
 			"tid", stop.TID, "pc", fmt.Sprintf("0x%x", stop.PC), "err", err)
 	}
 }

--- a/internal/debugger/engine_test.go
+++ b/internal/debugger/engine_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Engine", func() {
 
 	BeforeEach(func() {
 		fb = newFakeBackend()
-		d = debugger.NewWithBackend(fb)
+		d = debugger.NewWithBackend(fb, nil)
 	})
 
 	AfterEach(func() {
@@ -390,7 +390,7 @@ var _ = Describe("Engine", func() {
 	Describe("process exit", func() {
 		It("emits EventProcessExited with exit code when StopExited arrives", func() {
 			fb2 := newFakeBackend()
-			d2 := debugger.NewWithBackend(fb2)
+			d2 := debugger.NewWithBackend(fb2, nil)
 			defer func() {
 				if !fb2.stopped {
 					close(fb2.stopCh)
@@ -418,7 +418,7 @@ var _ = Describe("Engine", func() {
 
 		It("closes the Events channel after process exits", func() {
 			fb2 := newFakeBackend()
-			d2 := debugger.NewWithBackend(fb2)
+			d2 := debugger.NewWithBackend(fb2, nil)
 			defer func() { _ = d2.Kill() }()
 
 			debugger.ExportedForceSuspended(d2)

--- a/internal/server/session.go
+++ b/internal/server/session.go
@@ -55,12 +55,15 @@ func newSessionStore(log *slog.Logger) *sessionStore {
 func (ss *sessionStore) create(ctx context.Context) *session {
 	id := uuid.New().String()
 
-	// Each launch/re-launch gets a fresh debugger.
+	log := ss.log.With("session", id)
+
+	// Each launch/re-launch gets a fresh debugger, sharing the session's
+	// scoped logger so debugger logs are correlated with the rest of the
+	// session's log lines instead of going to the package-level default.
 	factory := func() debugger.Debugger {
-		return debugger.New()
+		return debugger.New(log)
 	}
 
-	log := ss.log.With("session", id)
 	h := hub.NewSession(id, factory, log)
 
 	s := &session{

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -249,7 +249,7 @@ type e2eHarness struct {
 // failure mode instead of wedging the whole suite.
 func newE2EHarness(bin string) *e2eHarness {
 	GinkgoHelper()
-	d := debugger.New()
+	d := debugger.New(nil)
 	Expect(d.Launch(bin, nil, nil)).To(Succeed(), "Launch target")
 	DeferCleanup(func() {
 		done := make(chan struct{})


### PR DESCRIPTION
Closes #32

## Problem

`internal/debugger/engine.go` was the only component logging via the
package-level `slog.Debug` / `slog.Warn` / `slog.Error` functions. Every
other component (`server`, `hub`, `client`) uses an injected
`*slog.Logger` threaded down from `cmd/bingo`'s `-v` flag and scoped
per-session with `.With("session", id)`.

Because the engine bypassed that logger, its debug/warn/error lines:
- ignored the level configured by `-v` (so `slog.Debug` calls never
  respected the flag, and could still surface at the wrong verbosity
  depending on the process-wide default),
- weren't correlated with the session ID like every other log line,
- effectively formed a second, inconsistent logging stream layered on
  top of the hub's — the "too much logging... not coming from one
  place" behavior described in #32.

## Fix

- Added a `log *slog.Logger` field to `engine`, threaded through
  `newEngine`.
- `debugger.New` / `debugger.NewWithBackend` now take a `*slog.Logger`
  (nil falls back to `slog.Default()`, same convention as `hub`/`client`).
- Replaced every `slog.X(...)` call in `engine.go` with `e.log.X(...)`.
- `sessionStore.create` now passes the same session-scoped logger it
  gives the hub down into `debugger.New`, so debugger and hub log lines
  for a session share the same `session=<id>` attribute.
- Updated the (few) call sites — `engine_test.go` and the E2E harness —
  to pass `nil` for the new logger parameter.
- Documented the single-logger-per-component pattern in `AGENTS.md` so
  future debugger code doesn't reintroduce a global-`slog` call site.

No log statements were removed; this is a routing fix so debug output is
unified and properly gated by `-v`, not a change in what gets logged.

## Testing

```
go build -tags bingonative ./...
go vet -tags bingonative ./...
go test -tags bingonative ./...   # all packages pass
```

Note: `just test` (no `-tags bingonative`) fails to build on macOS with
`undefined: newBackend` — this is pre-existing and documented in
`AGENTS.md` ("On macOS, `go test ./...` without `-tags bingonative` will
fail..."), unrelated to this change.