### PR TITLE
fix(debugger): add fallback backend for unsupported platforms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,11 @@ Built and tested only on:
   `com.apple.security.cs.debugger` entitlement (or SIP off)
 - `linux/amd64`
 
-Other GOOS/GOARCH combos fail with `undefined: newBackend`.
+Other GOOS/GOARCH combos (and darwin/arm64 without `-tags bingonative`) build
+fine via the fallback backend in
+[backend_unsupported.go](internal/debugger/backend_unsupported.go), but panic
+with a clear "unsupported platform" message the moment `debugger.New()` is
+called.
 
 ## Layout
 
@@ -356,9 +360,10 @@ go test -tags e2e -race ./test/integration -ginkgo.label-filter=basic
 go test -tags e2e -race ./test/integration -ginkgo.label-filter=fullstack
 ```
 
-On macOS, `go test ./...` without `-tags bingonative` will fail with
-`undefined: newBackend`. Always use `go test -tags bingonative ./...` or run
-through the justfile.
+On macOS, `go test ./...` without `-tags bingonative` now compiles and passes
+(unit tests use `fakeBackend`, not the real Mach backend), but to exercise the
+actual darwin backend — and for the E2E suite — always use
+`go test -tags bingonative ./...` or run through the justfile.
 
 ## Things that look weird but are intentional
 
@@ -382,8 +387,10 @@ through the justfile.
   `resumingCommands` in [hub.go](internal/hub/hub.go), and the matching
   hub_test cases.
 - **New OS or arch**: add a new `backend_<goos>_<goarch>.go` and a matching
-  `trap_<goarch>.go` if the trap differs. Update [README.md](README.md) and
-  the build matrix in [.github/workflows/](.github/workflows/) and
-  [justfile](justfile).
+  `trap_<goarch>.go` if the trap differs. Update
+  [backend_unsupported.go](internal/debugger/backend_unsupported.go)'s
+  `//go:build` constraint to exclude the newly-supported combo. Update
+  [README.md](README.md) and the build matrix in
+  [.github/workflows/](.github/workflows/) and [justfile](justfile).
 - **AGENTS.md drift**: if you introduce a new invariant or change one of the
   ones documented above, update this file in the same commit.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ BinGo is currently built and tested on:
 - `darwin/arm64` (Apple Silicon) — build with `-tags bingonative`
 - `linux/amd64`
 
-Builds on other GOOS/GOARCH combinations will fail with `undefined: newBackend` and similar errors from the [internal/debugger](internal/debugger/) package.
+Other GOOS/GOARCH combinations (and darwin/arm64 built without `-tags bingonative`) build successfully but panic with a clear "unsupported platform" message from [internal/debugger](internal/debugger/) as soon as a debug session is started.
 
 ## Documentation
 

--- a/internal/debugger/backend_unsupported.go
+++ b/internal/debugger/backend_unsupported.go
@@ -1,0 +1,43 @@
+//go:build !(linux && amd64) && !(darwin && arm64 && bingonative)
+
+package debugger
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// This file is the fallback for every GOOS/GOARCH combination bingo does not
+// ship a native backend for (see backend_linux_amd64.go and
+// backend_darwin_arm64.go). Without it, unsupported platforms fail the build
+// with a cryptic "undefined: newBackend" from the compiler. Instead we build
+// cleanly everywhere and fail loudly, with an actionable message, the moment
+// New() actually tries to construct a backend.
+//
+// Note this also catches darwin/arm64 built without the required
+// "bingonative" tag (and entitlement) — that combination has no working
+// Mach-based backend either.
+
+func unsupportedPlatformError() error {
+	return fmt.Errorf(
+		"bingo: unsupported platform %s/%s (only linux/amd64 and darwin/arm64 with -tags bingonative are supported)",
+		runtime.GOOS, runtime.GOARCH,
+	)
+}
+
+func newBackend() Backend {
+	panic(unsupportedPlatformError())
+}
+
+func startTracedProcess(_ Backend, _ string, _ []string, _ []string) (int, *exec.Cmd, error) {
+	return 0, nil, unsupportedPlatformError()
+}
+
+func attachToProcess(_ Backend, _ int) error {
+	return unsupportedPlatformError()
+}
+
+func killProcess(_ Backend, _ int, _ *exec.Cmd) error {
+	return unsupportedPlatformError()
+}


### PR DESCRIPTION
## Summary

Closes #61

Building bingo for any GOOS/GOARCH other than `linux/amd64` or
`darwin/arm64` (with `-tags bingonative`) previously failed with a cryptic
`undefined: newBackend` compiler error, since no `backend_*.go` file
provided the platform-specific hooks (`newBackend`, `startTracedProcess`,
`attachToProcess`, `killProcess`).

## Changes

- Added `internal/debugger/backend_unsupported.go`, guarded by a
  `//go:build` constraint matching every unsupported combination
  (including `darwin/arm64` built *without* the `bingonative` tag). It
  builds cleanly everywhere and instead panics with a clear,
  actionable "unsupported platform" message — naming the actual
  supported platforms — as soon as `debugger.New()` is called.
- Updated `README.md` and `AGENTS.md` to document the new fallback
  behavior.

## Verification

- `just build linux amd64` — succeeds
- `just build darwin arm64` — succeeds (codesigned)
- `GOOS=windows GOARCH=amd64 go build ./cmd/bingo` — now compiles
  successfully (previously failed with `undefined: newBackend`);
  confirmed the runtime panic message is clear via a temporary test
  invoking `debugger.New()` under an unsupported build tag combo
- `go test -tags bingonative ./...` — all packages pass
- `go test ./...` (no bingonative tag, darwin) — now also compiles and
  passes, using `fakeBackend` in unit tests as before