### PR TITLE
docs: define agent conventions and add CLAUDE/Copilot pointers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,18 @@
+# Copilot instructions
+
+The full guidance for AI agents working on **bingo** lives in
+[`AGENTS.md`](../AGENTS.md) at the repo root — read it first. It's the single
+source of truth; this file only exists so GitHub Copilot picks up the pointer.
+
+Non-negotiables (see `AGENTS.md` for the rest and the *why*):
+
+- **Comments explain why, not what.** No decorative or code-restating
+  one-liners.
+- **Conventional Commits are enforced** (`feat|fix|docs|style|refactor|perf|test|chore|wip`)
+  by the commit-msg hook.
+- **Return errors, don't `panic`** in server/hub/debugger control paths.
+- **Supported platforms are linux/amd64 and darwin/arm64 only.** On macOS,
+  build and test with `-tags bingonative` (or use the `just` recipes).
+- **`internal/debugger/` is the most fragile code** — read the concurrency and
+  breakpoint sections of `AGENTS.md` before touching it.
+- **Keep `AGENTS.md` in sync** in the same commit when you change an invariant.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,12 @@ for agents — terse, link-heavy, biased toward "what you must know to not break
 things." Keep this file up to date when touching architecture; it's the index
 that replaces inline narrative comments.
 
+**This file is the single source of truth for agent guidance.** Tool-specific
+entry points ([CLAUDE.md](CLAUDE.md),
+[.github/copilot-instructions.md](.github/copilot-instructions.md)) are thin
+pointers back here — put new guidance in this file, not in them, so nothing
+drifts.
+
 ## What bingo is
 
 A standalone visual concurrency debugger for Go. Server (`cmd/bingo`) launches
@@ -19,6 +25,64 @@ Built and tested only on:
 - `linux/amd64`
 
 Other GOOS/GOARCH combos fail with `undefined: newBackend`.
+
+## Conventions for AI agents
+
+Rules for making changes. These encode decisions already litigated in the repo;
+follow them so reviews stay about substance, not style.
+
+### Comments
+
+- Explain **why**, not **what**. A comment must add context the code can't:
+  an invariant, a non-obvious constraint, a hazard, a reference. Never restate
+  what the next line literally does.
+- Do **not** add decorative or narrating one-liners (the
+  `// arbitrary instruction byte` / `// loop over items` style). They were
+  deliberately purged from this codebase; don't reintroduce them.
+- Prefer a short doc comment on the function/type over inline noise. If a block
+  genuinely needs explaining, one paragraph above it beats five scattered tags.
+- When you remove or move non-obvious logic, move its *why*-comment with it.
+
+### Code style
+
+- `gofmt` / `goimports` are mandatory — the lefthook pre-commit hook runs
+  `goimports -w` on staged `*.go` files. Match the surrounding style otherwise.
+- Make surgical, focused changes. Don't opportunistically reformat or refactor
+  unrelated code in the same commit.
+- Return errors; don't `panic` in server/hub/debugger control paths. Panics
+  crash the whole server (see issues #29, #60). `panic` is acceptable only in
+  clearly test-only or truly-unreachable-by-construction spots.
+
+### Commits
+
+- Conventional Commits are **enforced** by the commit-msg hook
+  ([cmd/githook](cmd/githook/), wired via [lefthook.yml](lefthook.yml)).
+  Format: `<type>(<scope>): <description>`.
+- Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
+  `chore`, `wip`. Non-conforming messages are rejected.
+
+### Build, test, verify
+
+- Always verify before declaring done: `go vet` + the relevant tests.
+- On macOS the darwin backend needs `-tags bingonative`; plain
+  `go test ./...` fails with `undefined: newBackend`. Use the justfile
+  (`just build`, `just test`) or pass the tag explicitly. Full command list is
+  in the build/test commands block near the end of this file.
+- Only run linters/builds/tests that already exist; don't introduce new
+  tooling for a change unless the task is specifically about that.
+
+### Platform scope
+
+- Supported platforms are **linux/amd64** and **darwin/arm64** only. Do not add
+  backends, build tags, or CI matrix entries for other GOOS/GOARCH (see #61).
+
+### Keep docs in sync
+
+- If you change an architectural invariant documented here, update AGENTS.md in
+  the **same commit** (see [When you change something](#when-you-change-something)).
+- Keep the tool pointer files ([CLAUDE.md](CLAUDE.md),
+  [.github/copilot-instructions.md](.github/copilot-instructions.md)) as thin
+  redirects — never fork guidance into them.
 
 ## Layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+Guidance for Claude Code lives in [AGENTS.md](AGENTS.md) — the single source of
+truth for agents working on this repo. The import below pulls it in; don't
+duplicate guidance here, edit `AGENTS.md` instead.
+
+@AGENTS.md


### PR DESCRIPTION
## What

Resolves #64 — defines explicit rules for AI agents making code changes, and answers the "should we have CLAUDE.md?" question by pointing every tool at a single source of truth.

### AGENTS.md — new "Conventions for AI agents" section
Codifies decisions already litigated in the repo so reviews stay about substance:
- **Comments** — explain *why*, not *what*; no decorative/code-restating one-liners (the `// arbitrary instruction byte` style stays purged).
- **Code style** — `gofmt`/`goimports` (pre-commit hook), surgical changes only.
- **Error handling** — return errors, don't `panic` in server/hub/debugger control paths (issues #29, #60).
- **Commits** — enforced Conventional Commits (`feat|fix|docs|style|refactor|perf|test|chore|wip`) via the commit-msg hook.
- **Build/test** — darwin needs `-tags bingonative`; use the justfile.
- **Platform scope** — linux/amd64 and darwin/arm64 only (#61).
- **Docs-in-sync** — update AGENTS.md in the same commit as invariant changes.

### Pointer files (no content duplication)
- `CLAUDE.md` — imports AGENTS.md via `@AGENTS.md` so Claude Code picks it up.
- `.github/copilot-instructions.md` — short redirect + the non-negotiables for GitHub Copilot.

AGENTS.md remains the **single source of truth**; the pointers are thin redirects so guidance can't drift across tools.

## Why this approach
Rather than maintaining parallel CLAUDE.md / Copilot / etc. files that inevitably diverge, all agent tooling now funnels to AGENTS.md.

Closes #64