### PR TITLE
feat(hub): implement Restart operation, harden StopProcess for Pause

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,6 +367,83 @@ confirmations like `BreakpointSet`). If clients saw both streams interleaved,
 they'd see two overlapping monotonic sequences and couldn't detect drops.
 **Always go through `h.seq.Add(1)` before broadcasting.**
 
+## Restart — hub-level, not engine-level
+
+`CmdRestart` (`internal/hub/hub.go` → `handleRestart`) kills the current
+process and relaunches it, reinstalling previously-set breakpoints. It is
+implemented entirely in the hub, **not** as a new `Debugger`/engine method,
+because of the engine's one-way shutdown invariant (see
+[Engine concurrency model](#engine-concurrency-model--non-obvious-invariants)):
+once `stateExited` is reached, `loop()` permanently closes `done` and
+`events`. Reviving a dead engine in place would need an epoch/generation
+counter on `stopResult` to stop a stale `waitLoop` result from the killed
+process being misread as belonging to the new one — too risky in the most
+fragile package in the repo. Instead, Restart calls `Kill()` on the old
+`Debugger`, discards it, and creates a fresh one via the hub's existing
+`newDebugger` factory (the same one `Launch`/`Attach` already use for managed
+sessions), then relaunches and re-sets breakpoints on the new instance. This
+mirrors Delve's `Debugger.Restart` (`service/debugger/debugger.go`): kill/
+detach, relaunch, reinstall logical breakpoints, collect `DiscardedBreakpoint`
+for ones that fail to resolve (bingo: `protocol.DiscardedBreakpoint`).
+
+Bookkeeping needed across the kill+relaunch, since the old engine's state is
+gone once killed:
+
+- `h.lastLaunch *protocol.LaunchPayload` — the program/args/env from the most
+  recent successful `Launch`. Restart refuses to run if this is nil (no prior
+  Launch, or the session was started via `Attach` — mirrors Delve's
+  `canRestart`: there's no "same binary" to relaunch for an attached process).
+  Set on `CmdLaunch` success, cleared on `CmdAttach` success.
+- `h.restartBreakpoints map[int]protocol.Location` — id → location for every
+  breakpoint currently believed installed. Updated on `CmdSetBreakpoint` /
+  `CmdClearBreakpoint` success, reset on `CmdLaunch`/`CmdAttach`. Restart
+  reinstalls these (sorted by id for determinism) via `SetBreakpoint` on the
+  new `Debugger`, which re-resolves each `file:line` through DWARF against the
+  new process image — addresses aren't reused directly since a relaunch can
+  shift the load address.
+
+**Routing quirk**: `CmdRestart` intentionally does **not** go through
+`resumeCh` like `CmdContinue`/`CmdKill`/etc. `resumeCh` is only ever drained
+inside `handleEvent`'s suspend-wait loop — Run's outer `select` never reads
+it — so a resuming command sent while the hub *isn't* currently suspended
+(the common case: restarting a running or idle session) would sit unread in
+the buffered channel indefinitely. This is a real pre-existing gap affecting
+`CmdKill` today too; it wasn't fixed for the general case, but Restart can't
+tolerate it because "restart while running" is the primary use case, not an
+edge case. Instead `CmdRestart` is routed through the ordinary `cmdCh` (like
+`SetBreakpoint`), which both Run's outer loop and the suspend-wait loop's
+`case cc := <-h.cmdCh:` branch drain. The one special case: that branch
+normally loops back to keep waiting for a resume after executing a
+non-resuming command, but for `CmdRestart` it `return`s instead — the
+suspended process it was waiting on no longer exists, so there's nothing left
+to resume, and returning lets Run's outer loop naturally pick up the new
+debugger's events channel (`h.dbg` is reassigned inside `handleRestart`
+before the confirmation event is broadcast).
+
+`EventRestarted` is a confirmation event (like `BreakpointSet`), not a
+suspending one — the new process's suspended state (if any, e.g. break-on-
+entry) is reported the normal way via `EventStepped`/`EventBreakpointHit` once
+the relaunched process actually reaches that point.
+
+## StopProcess — Pause groundwork only
+
+`Backend.StopProcess()` (both `backend_linux_amd64.go` and
+`backend_darwin_arm64.go`) sends a whole-process `SIGSTOP`, hardened as the
+one primitive a future `Pause` command would need — **no `Pause` command is
+wired up yet**, and this is not the whole story: Delve's actual manual-stop
+implementations are far more involved (Linux: `sys.Kill(pid, SIGTRAP)` plus a
+`trapWaitInternal` halt-flag state machine in
+`pkg/proc/native/proc_linux.go`; Darwin: Mach `thread_suspend` on every thread
+plus an atomic halt flag in `pkg/proc/native/proc_darwin.go`) to correctly
+distinguish a manual halt from a spontaneous trap and to safely land every
+thread at a consistent stop point. Implementing that state machine is out of
+scope until `Pause` is actually built. The hardening done now: direct
+`syscall.Kill(pid, SIGSTOP)` instead of `os.FindProcess(pid).Signal(...)`
+(the latter never actually distinguishes "no such process" on Unix — `
+os.FindProcess` can't fail there), a `pid == 0` guard, and treating `ESRCH`
+(process already gone) as an idempotent no-op success rather than an error,
+consistent with `engine.Kill()`'s idempotency elsewhere in this package.
+
 ## Error handling
 
 Conventions for wrapping, logging, and propagating errors live in

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -129,6 +129,20 @@ func main() {
 				printErr(err)
 			}
 
+		case "restart":
+			p, err := c.Restart(nil, nil)
+			if err != nil {
+				printErr(err)
+				continue
+			}
+			fmt.Printf("  restarted %s\n", p.Program)
+			for _, bp := range p.Breakpoints {
+				fmt.Printf("  breakpoint %d reinstalled at %s:%d\n", bp.ID, bp.Location.File, bp.Location.Line)
+			}
+			for _, d := range p.Discarded {
+				fmt.Printf("  breakpoint at %s:%d discarded: %s\n", d.Location.File, d.Location.Line, d.Reason)
+			}
+
 		case "c", "continue":
 			if err := c.Continue(); err != nil {
 				printErr(err)
@@ -291,6 +305,13 @@ func eventPrinter(events <-chan protocol.Event) {
 				fmt.Printf("\n  [error] %s: %s\nbingo> ", p.Command, p.Message)
 			}
 
+		case protocol.EventRestarted:
+			var p protocol.RestartedPayload
+			if protocol.DecodeEventPayload(evt, &p) == nil {
+				fmt.Printf("\n  [restarted] %s (%d breakpoint(s), %d discarded)\nbingo> ",
+					p.Program, len(p.Breakpoints), len(p.Discarded))
+			}
+
 		default:
 			fmt.Printf("\n  [%s] seq=%d\nbingo> ", evt.Kind, evt.Seq)
 		}
@@ -321,6 +342,7 @@ func printHelp() {
   launch <binary> [args...]  start a process under the debugger
   attach <pid> [binary]      attach to a running process  (find pid: pgrep <name>)
   kill                       terminate the debuggee
+  restart                    kill and relaunch, reinstalling breakpoints
 
   c / continue               resume execution
   n / next                   step over

--- a/internal/debugger/backend_darwin_arm64.go
+++ b/internal/debugger/backend_darwin_arm64.go
@@ -573,22 +573,11 @@ func (b *darwinBackend) setSingleStep(tid int, on bool) error {
 // requestManualStop, which suspends via Mach thread_suspend on every thread
 // plus an atomic halt flag (pkg/proc/native/proc_darwin.go). This is Pause
 // groundwork only: it does not implement that halt-flag state machine, so no
-// Pause command is wired to it yet — see AGENTS.md.
-//
-// syscall.Kill is used directly instead of os.FindProcess(pid).Signal:
-// os.FindProcess never fails to find a process on Unix (it just wraps the
-// pid), so the previous os.FindProcess/Signal pair was never distinguishing
-// "no such process" from any other error. ESRCH (process already gone) is
-// treated as an idempotent no-op, matching engine.Kill's idempotency
-// convention elsewhere in this package.
+// Pause command is wired to it yet — see AGENTS.md. The signal mechanics
+// (syscall.Kill, ESRCH-as-idempotent) are shared with the linux backend via
+// stopProcessSignal in process.go.
 func (b *darwinBackend) StopProcess() error {
-	if b.pid == 0 {
-		return fmt.Errorf("StopProcess: no process")
-	}
-	if err := syscall.Kill(b.pid, syscall.SIGSTOP); err != nil && err != syscall.ESRCH {
-		return fmt.Errorf("StopProcess: %w", err)
-	}
-	return nil
+	return stopProcessSignal(b.pid)
 }
 
 func (b *darwinBackend) GetRegisters(tid int) (Registers, error) {

--- a/internal/debugger/backend_darwin_arm64.go
+++ b/internal/debugger/backend_darwin_arm64.go
@@ -568,12 +568,27 @@ func (b *darwinBackend) setSingleStep(tid int, on bool) error {
 	return nil
 }
 
+// StopProcess sends a whole-thread-group SIGSTOP as a stand-in halt
+// primitive, mirroring the intent (not the mechanism) of Delve's Darwin
+// requestManualStop, which suspends via Mach thread_suspend on every thread
+// plus an atomic halt flag (pkg/proc/native/proc_darwin.go). This is Pause
+// groundwork only: it does not implement that halt-flag state machine, so no
+// Pause command is wired to it yet — see AGENTS.md.
+//
+// syscall.Kill is used directly instead of os.FindProcess(pid).Signal:
+// os.FindProcess never fails to find a process on Unix (it just wraps the
+// pid), so the previous os.FindProcess/Signal pair was never distinguishing
+// "no such process" from any other error. ESRCH (process already gone) is
+// treated as an idempotent no-op, matching engine.Kill's idempotency
+// convention elsewhere in this package.
 func (b *darwinBackend) StopProcess() error {
-	p, err := os.FindProcess(b.pid)
-	if err != nil {
-		return err
+	if b.pid == 0 {
+		return fmt.Errorf("StopProcess: no process")
 	}
-	return p.Signal(syscall.SIGSTOP)
+	if err := syscall.Kill(b.pid, syscall.SIGSTOP); err != nil && err != syscall.ESRCH {
+		return fmt.Errorf("StopProcess: %w", err)
+	}
+	return nil
 }
 
 func (b *darwinBackend) GetRegisters(tid int) (Registers, error) {

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -227,12 +227,28 @@ func (b *linuxBackend) SingleStep(tid int) error {
 	return nil
 }
 
+// StopProcess sends a whole-thread-group SIGSTOP, mirroring Delve's
+// requestManualStop-adjacent halt primitive (pkg/proc/native/proc_linux.go
+// sends a process-wide signal rather than per-thread, since a ptrace-stopped
+// tracee still delivers signals to the group). This is Pause groundwork
+// only: it does not implement Delve's trapWaitInternal halt-flag state
+// machine that distinguishes a manual stop from a spontaneous trap, so no
+// Pause command is wired to it yet — see AGENTS.md.
+//
+// syscall.Kill is used directly instead of os.FindProcess(pid).Signal:
+// os.FindProcess never fails to find a process on Unix (it just wraps the
+// pid), so the previous os.FindProcess/Signal pair was never distinguishing
+// "no such process" from any other error. ESRCH (process already gone) is
+// treated as an idempotent no-op, matching engine.Kill's idempotency
+// convention elsewhere in this package.
 func (b *linuxBackend) StopProcess() error {
-	p, err := os.FindProcess(b.pid)
-	if err != nil {
-		return err
+	if b.pid == 0 {
+		return fmt.Errorf("StopProcess: no process")
 	}
-	return p.Signal(syscall.SIGSTOP)
+	if err := syscall.Kill(b.pid, syscall.SIGSTOP); err != nil && err != syscall.ESRCH {
+		return fmt.Errorf("StopProcess: %w", err)
+	}
+	return nil
 }
 
 func (b *linuxBackend) ReadMemory(addr uint64, dst []byte) error {

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -233,22 +233,11 @@ func (b *linuxBackend) SingleStep(tid int) error {
 // tracee still delivers signals to the group). This is Pause groundwork
 // only: it does not implement Delve's trapWaitInternal halt-flag state
 // machine that distinguishes a manual stop from a spontaneous trap, so no
-// Pause command is wired to it yet — see AGENTS.md.
-//
-// syscall.Kill is used directly instead of os.FindProcess(pid).Signal:
-// os.FindProcess never fails to find a process on Unix (it just wraps the
-// pid), so the previous os.FindProcess/Signal pair was never distinguishing
-// "no such process" from any other error. ESRCH (process already gone) is
-// treated as an idempotent no-op, matching engine.Kill's idempotency
-// convention elsewhere in this package.
+// Pause command is wired to it yet — see AGENTS.md. The signal mechanics
+// (syscall.Kill, ESRCH-as-idempotent) are shared with the darwin backend via
+// stopProcessSignal in process.go.
 func (b *linuxBackend) StopProcess() error {
-	if b.pid == 0 {
-		return fmt.Errorf("StopProcess: no process")
-	}
-	if err := syscall.Kill(b.pid, syscall.SIGSTOP); err != nil && err != syscall.ESRCH {
-		return fmt.Errorf("StopProcess: %w", err)
-	}
-	return nil
+	return stopProcessSignal(b.pid)
 }
 
 func (b *linuxBackend) ReadMemory(addr uint64, dst []byte) error {

--- a/internal/debugger/process.go
+++ b/internal/debugger/process.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"syscall"
 )
 
 // process tracks the OS handle for the tracee, with platform-specific hooks
@@ -60,6 +61,24 @@ func (p *process) kill(b Backend) error {
 	p.live = false
 	if err := killProcess(b, p.pid, p.cmd); err != nil {
 		return fmt.Errorf("kill: %w", err)
+	}
+	return nil
+}
+
+// stopProcessSignal sends a whole-thread-group SIGSTOP to pid, the shared
+// mechanism behind both backends' StopProcess(). syscall.Kill is used
+// directly instead of os.FindProcess(pid).Signal: os.FindProcess never fails
+// to find a process on Unix (it just wraps the pid), so that pairing never
+// actually distinguished "no such process" from any other error. ESRCH
+// (process already gone) is treated as an idempotent no-op, matching
+// process.kill's idempotency above. See AGENTS.md → StopProcess for why this
+// exists (Pause groundwork) and what it deliberately doesn't do.
+func stopProcessSignal(pid int) error {
+	if pid == 0 {
+		return fmt.Errorf("StopProcess: no process")
+	}
+	if err := syscall.Kill(pid, syscall.SIGSTOP); err != nil && err != syscall.ESRCH {
+		return fmt.Errorf("StopProcess: %w", err)
 	}
 	return nil
 }

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -68,6 +69,20 @@ type Hub struct {
 
 	shutdownCh chan struct{}
 	done       chan struct{}
+
+	// lastLaunch remembers the most recently successful Launch payload so
+	// Restart can relaunch the same binary with the same args/env. nil for
+	// Attach-based sessions and before any successful Launch — Restart
+	// refuses those, mirroring Delve's canRestart check (Restart only makes
+	// sense for a process bingo itself started).
+	lastLaunch *protocol.LaunchPayload
+
+	// restartBreakpoints mirrors the breakpoints installed on the current
+	// debugger (id -> location), purely so Restart can reinstall them on the
+	// relaunched process. The engine's breakpointTable remains the sole
+	// source of truth for the live process; this is bookkeeping the hub
+	// needs across a Kill+relaunch, when the old breakpointTable is gone.
+	restartBreakpoints map[int]protocol.Location
 }
 
 type clientCommand struct {
@@ -79,12 +94,13 @@ func newHub(log *slog.Logger) *Hub {
 		log = slog.Default()
 	}
 	return &Hub{
-		registry:   newRegistry(),
-		cmdCh:      make(chan clientCommand, 32),
-		resumeCh:   make(chan protocol.Command, 1),
-		shutdownCh: make(chan struct{}),
-		done:       make(chan struct{}),
-		log:        log,
+		registry:           newRegistry(),
+		cmdCh:              make(chan clientCommand, 32),
+		resumeCh:           make(chan protocol.Command, 1),
+		shutdownCh:         make(chan struct{}),
+		done:               make(chan struct{}),
+		log:                log,
+		restartBreakpoints: make(map[int]protocol.Location),
 	}
 }
 
@@ -252,7 +268,14 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 		case cc := <-h.cmdCh:
 			// Non-resuming command (SetBreakpoint, Locals, …) while suspended.
 			// Execute immediately — process is paused — and keep waiting.
+			// Restart is the one exception: it tears down and replaces the
+			// suspended process entirely, so there's nothing left to wait a
+			// resume on — return and let Run's outer loop pick up the new
+			// debugger's events channel (assigned inside handleRestart).
 			h.executeCommand(cc.cmd)
+			if cc.cmd.Kind == protocol.CmdRestart {
+				return
+			}
 
 		case <-timeout.C:
 			h.log.Warn("30-minute suspend timeout — auto-continuing")
@@ -278,6 +301,14 @@ func (h *Hub) handleDebuggerClosed() {
 }
 
 func (h *Hub) executeCommand(cmd protocol.Command) {
+	// Restart doesn't fit the generic dispatch(dbg, cmd) shape below: it
+	// tears down h.dbg and replaces it with a brand new instance, which only
+	// the hub (holder of newDebugger) can do. See handleRestart.
+	if cmd.Kind == protocol.CmdRestart {
+		h.handleRestart(cmd)
+		return
+	}
+
 	if h.sessionID != "" && (cmd.Kind == protocol.CmdLaunch || cmd.Kind == protocol.CmdAttach) {
 		if h.dbg != nil {
 			h.broadcastError(cmd.Kind, fmt.Errorf("debugger already active (state: %s)", h.State()))
@@ -306,10 +337,22 @@ func (h *Hub) executeCommand(cmd protocol.Command) {
 	}
 
 	switch cmd.Kind {
-	case protocol.CmdLaunch, protocol.CmdAttach:
+	case protocol.CmdLaunch:
 		h.transitionState(protocol.StateRunning)
+		h.rememberLaunch(cmd)
+		h.restartBreakpoints = make(map[int]protocol.Location)
+	case protocol.CmdAttach:
+		h.transitionState(protocol.StateRunning)
+		// Restart only makes sense for a process bingo itself launched —
+		// mirrors Delve's canRestart check.
+		h.lastLaunch = nil
+		h.restartBreakpoints = make(map[int]protocol.Location)
 	case protocol.CmdContinue, protocol.CmdStepOver, protocol.CmdStepInto, protocol.CmdStepOut:
 		h.transitionState(protocol.StateRunning)
+	case protocol.CmdSetBreakpoint:
+		h.rememberBreakpoint(result)
+	case protocol.CmdClearBreakpoint:
+		h.forgetBreakpoint(cmd)
 	}
 
 	if result.event != nil {
@@ -327,6 +370,141 @@ func (h *Hub) teardownFailedStart() {
 	if h.State() != protocol.StateIdle {
 		h.transitionState(protocol.StateIdle)
 	}
+}
+
+// rememberLaunch decodes cmd's LaunchPayload and stores a copy for a future
+// Restart. Decode failures are ignored — Launch has already succeeded by the
+// time this is called, so at worst Restart later reports "nothing to
+// restart" rather than corrupting an active session.
+func (h *Hub) rememberLaunch(cmd protocol.Command) {
+	var p protocol.LaunchPayload
+	if err := protocol.DecodeCommandPayload(cmd, &p); err != nil {
+		return
+	}
+	h.lastLaunch = &p
+}
+
+// rememberBreakpoint records a successfully-set breakpoint's id -> location
+// so Restart can reinstall it later.
+func (h *Hub) rememberBreakpoint(result dispatchResult) {
+	if result.event == nil {
+		return
+	}
+	var p protocol.BreakpointSetPayload
+	if err := protocol.DecodeEventPayload(*result.event, &p); err != nil {
+		return
+	}
+	h.restartBreakpoints[p.Breakpoint.ID] = p.Breakpoint.Location
+}
+
+// forgetBreakpoint removes a cleared breakpoint from the Restart bookkeeping.
+func (h *Hub) forgetBreakpoint(cmd protocol.Command) {
+	var p protocol.ClearBreakpointPayload
+	if err := protocol.DecodeCommandPayload(cmd, &p); err != nil {
+		return
+	}
+	delete(h.restartBreakpoints, p.ID)
+}
+
+// sortedRestartLocations returns the tracked breakpoint locations in
+// ascending ID order, so Restart reinstalls them in a deterministic sequence
+// (and thus assigns deterministic new IDs) across runs.
+func (h *Hub) sortedRestartLocations() []protocol.Location {
+	ids := make([]int, 0, len(h.restartBreakpoints))
+	for id := range h.restartBreakpoints {
+		ids = append(ids, id)
+	}
+	sort.Ints(ids)
+	locs := make([]protocol.Location, 0, len(ids))
+	for _, id := range ids {
+		locs = append(locs, h.restartBreakpoints[id])
+	}
+	return locs
+}
+
+// handleRestart kills the current process (if any), relaunches the last
+// Launch'd binary, and reinstalls previously-set breakpoints at their
+// original file:line locations — addresses are re-resolved via DWARF since a
+// relaunch can change the load address. Breakpoints that fail to resolve are
+// reported as discarded, mirroring Delve's Restart (pkg/proc/target_group.go).
+// Only supported for managed, Launch-based sessions: Attach-based sessions
+// have no "same binary" to relaunch, matching Delve's canRestart check.
+//
+// The old debugger's remaining events (e.g. a final ProcessExited from the
+// Kill below) are deliberately not forwarded to clients: from the client's
+// perspective Restart is one atomic operation, not a Kill followed by a
+// fresh Launch. Once Kill returns, the old debugger is abandoned — its
+// internal goroutines still tear down on their own (see AGENTS.md → shutdown
+// sequence), they're just no longer observed by the hub.
+func (h *Hub) handleRestart(cmd protocol.Command) {
+	if h.sessionID == "" || h.newDebugger == nil {
+		h.broadcastError(cmd.Kind, fmt.Errorf("restart requires a managed session"))
+		return
+	}
+	if h.lastLaunch == nil {
+		h.broadcastError(cmd.Kind, fmt.Errorf("no launched process to restart — use Launch first"))
+		return
+	}
+
+	var override protocol.RestartPayload
+	if len(cmd.Payload) > 0 {
+		if err := protocol.DecodeCommandPayload(cmd, &override); err != nil {
+			h.broadcastError(cmd.Kind, err)
+			return
+		}
+	}
+
+	program := h.lastLaunch.Program
+	args := h.lastLaunch.Args
+	if override.Args != nil {
+		args = override.Args
+	}
+	env := h.lastLaunch.Env
+	if override.Env != nil {
+		env = override.Env
+	}
+
+	saved := h.sortedRestartLocations()
+
+	if h.dbg != nil {
+		_ = h.dbg.Kill()
+		h.dbg = nil
+	}
+
+	newDbg := h.newDebugger()
+	if err := newDbg.Launch(program, args, env); err != nil {
+		h.broadcastError(cmd.Kind, fmt.Errorf("restart: relaunch failed: %w", err))
+		h.transitionState(protocol.StateIdle)
+		return
+	}
+	h.dbg = newDbg
+	h.lastLaunch = &protocol.LaunchPayload{Program: program, Args: args, Env: env}
+	h.transitionState(protocol.StateRunning)
+
+	installed := make([]protocol.Breakpoint, 0, len(saved))
+	discarded := make([]protocol.DiscardedBreakpoint, 0)
+	newBreakpoints := make(map[int]protocol.Location, len(saved))
+	for _, loc := range saved {
+		bp, err := newDbg.SetBreakpoint(loc.File, loc.Line)
+		if err != nil {
+			discarded = append(discarded, protocol.DiscardedBreakpoint{Location: loc, Reason: err.Error()})
+			continue
+		}
+		installed = append(installed, bp)
+		newBreakpoints[bp.ID] = bp.Location
+	}
+	h.restartBreakpoints = newBreakpoints
+
+	evt, err := protocol.NewEvent(protocol.EventRestarted, h.seq.Add(1), protocol.RestartedPayload{
+		Program:     program,
+		Breakpoints: installed,
+		Discarded:   discarded,
+	})
+	if err != nil {
+		h.log.Error("failed to create Restarted event", "err", err)
+		return
+	}
+	h.broadcast(evt)
 }
 
 // injectCommand is called by client read-pumps. Resuming commands go to

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -656,4 +656,180 @@ var _ = Describe("Hub", func() {
 			}, "500ms", "10ms").Should(Equal(protocol.EventError))
 		})
 	})
+
+	Describe("Restart", func() {
+		It("rejects Restart on a raw (non-managed) hub", func() {
+			conn := newFakeWSConn()
+			h.AddClient(conn, nil)
+
+			conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+
+			e, ok := recvEvent(conn)
+			Expect(ok).To(BeTrue())
+			Expect(e.Kind).To(Equal(protocol.EventError))
+		})
+
+		It("rejects Restart before any successful Launch", func() {
+			managed := hub.NewSession("session", func() debugger.Debugger { return newFakeDebugger() }, nil)
+			cancelManaged := runHub(managed)
+			defer cancelManaged()
+
+			conn := newFakeWSConn()
+			managed.AddClient(conn, nil)
+			_, _ = recvEvent(conn) // welcome/state event
+
+			conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+
+			e, ok := recvEvent(conn)
+			Expect(ok).To(BeTrue())
+			Expect(e.Kind).To(Equal(protocol.EventError))
+		})
+
+		It("rejects Restart after Attach (no relaunchable binary)", func() {
+			managed := hub.NewSession("session", func() debugger.Debugger { return fd }, nil)
+			cancelManaged := runHub(managed)
+			defer cancelManaged()
+
+			conn := newFakeWSConn()
+			managed.AddClient(conn, nil)
+			_, _ = recvEvent(conn)
+
+			conn.inject(mustCommand(protocol.CmdAttach, protocol.AttachPayload{PID: 123}))
+			Eventually(fd.recordedCalls, "500ms", "10ms").Should(ContainElement("Attach"))
+
+			conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+
+			Eventually(func() protocol.EventKind {
+				e, ok := recvEvent(conn)
+				if !ok {
+					return ""
+				}
+				return e.Kind
+			}, "500ms", "10ms").Should(Equal(protocol.EventError))
+		})
+
+		It("kills the old debugger, relaunches, and reinstalls breakpoints", func() {
+			managed := hub.NewSession("session", func() debugger.Debugger { return fd }, nil)
+			cancelManaged := runHub(managed)
+			defer cancelManaged()
+
+			conn := newFakeWSConn()
+			managed.AddClient(conn, nil)
+			_, _ = recvEvent(conn)
+
+			conn.inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "myapp", Args: []string{"-x"}}))
+			Eventually(fd.recordedCalls, "500ms", "10ms").Should(ContainElement("Launch"))
+			_, _ = recvEvent(conn) // state -> running
+
+			fd.setBPResult = protocol.Breakpoint{ID: 1, Location: protocol.Location{File: "main.go", Line: 10}}
+			conn.inject(mustCommand(protocol.CmdSetBreakpoint, protocol.SetBreakpointPayload{File: "main.go", Line: 10}))
+			Eventually(func() protocol.EventKind {
+				e, ok := recvEvent(conn)
+				if !ok {
+					return ""
+				}
+				return e.Kind
+			}, "500ms", "10ms").Should(Equal(protocol.EventBreakpointSet))
+
+			conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+
+			var restarted protocol.RestartedPayload
+			Eventually(func() bool {
+				e, ok := recvEvent(conn)
+				if !ok || e.Kind != protocol.EventRestarted {
+					return false
+				}
+				Expect(protocol.DecodeEventPayload(e, &restarted)).To(Succeed())
+				return true
+			}, "500ms", "10ms").Should(BeTrue())
+
+			Expect(restarted.Program).To(Equal("myapp"))
+			Expect(restarted.Breakpoints).To(HaveLen(1))
+			Expect(restarted.Discarded).To(BeEmpty())
+
+			calls := fd.recordedCalls()
+			Expect(calls).To(ContainElement("Kill"))
+			launchCount := 0
+			bpCount := 0
+			for _, c := range calls {
+				if c == "Launch" {
+					launchCount++
+				}
+				if c == "SetBreakpoint" {
+					bpCount++
+				}
+			}
+			Expect(launchCount).To(Equal(2), "expected a Launch for the original start plus one for restart")
+			Expect(bpCount).To(Equal(2), "expected the original SetBreakpoint plus a reinstall on restart")
+		})
+
+		It("reports discarded breakpoints that fail to reinstall", func() {
+			managed := hub.NewSession("session", func() debugger.Debugger { return fd }, nil)
+			cancelManaged := runHub(managed)
+			defer cancelManaged()
+
+			conn := newFakeWSConn()
+			managed.AddClient(conn, nil)
+			_, _ = recvEvent(conn)
+
+			conn.inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "myapp"}))
+			Eventually(fd.recordedCalls, "500ms", "10ms").Should(ContainElement("Launch"))
+			_, _ = recvEvent(conn)
+
+			fd.setBPResult = protocol.Breakpoint{ID: 1, Location: protocol.Location{File: "main.go", Line: 10}}
+			conn.inject(mustCommand(protocol.CmdSetBreakpoint, protocol.SetBreakpointPayload{File: "main.go", Line: 10}))
+			Eventually(func() protocol.EventKind {
+				e, ok := recvEvent(conn)
+				if !ok {
+					return ""
+				}
+				return e.Kind
+			}, "500ms", "10ms").Should(Equal(protocol.EventBreakpointSet))
+
+			fd.setBPErr = fmt.Errorf("no such line")
+			conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+
+			var restarted protocol.RestartedPayload
+			Eventually(func() bool {
+				e, ok := recvEvent(conn)
+				if !ok || e.Kind != protocol.EventRestarted {
+					return false
+				}
+				Expect(protocol.DecodeEventPayload(e, &restarted)).To(Succeed())
+				return true
+			}, "500ms", "10ms").Should(BeTrue())
+
+			Expect(restarted.Breakpoints).To(BeEmpty())
+			Expect(restarted.Discarded).To(HaveLen(1))
+			Expect(restarted.Discarded[0].Reason).To(Equal("no such line"))
+		})
+
+		It("unblocks a suspended hub, same as Kill", func() {
+			managed := hub.NewSession("session", func() debugger.Debugger { return fd }, nil)
+			cancelManaged := runHub(managed)
+			defer cancelManaged()
+
+			conn := newFakeWSConn()
+			managed.AddClient(conn, nil)
+			_, _ = recvEvent(conn)
+
+			conn.inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "myapp"}))
+			Eventually(fd.recordedCalls, "500ms", "10ms").Should(ContainElement("Launch"))
+			_, _ = recvEvent(conn)
+
+			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+			_, _ = recvEvent(conn)
+
+			conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+
+			Eventually(func() protocol.EventKind {
+				e, ok := recvEvent(conn)
+				if !ok {
+					return ""
+				}
+				return e.Kind
+			}, "500ms", "10ms").Should(Equal(protocol.EventRestarted))
+		})
+	})
 })

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -656,180 +656,146 @@ var _ = Describe("Hub", func() {
 			}, "500ms", "10ms").Should(Equal(protocol.EventError))
 		})
 	})
+})
 
-	Describe("Restart", func() {
-		It("rejects Restart on a raw (non-managed) hub", func() {
-			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+// newManagedRestartHub starts a managed session backed by fd, connects one
+// client, and drains the initial welcome/state event. The returned cancel
+// must be deferred by the caller.
+func newManagedRestartHub(fd *fakeDebugger) (*hub.Hub, *fakeWSConn, context.CancelFunc) {
+	managed := hub.NewSession("session", func() debugger.Debugger { return fd }, nil)
+	cancel := runHub(managed)
+	conn := newFakeWSConn()
+	managed.AddClient(conn, nil)
+	_, _ = recvEvent(conn) // welcome/state event
+	return managed, conn, cancel
+}
 
-			conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+// launchManaged injects a Launch and waits for it to reach the fake debugger
+// and the resulting running-state event to drain.
+func launchManaged(conn *fakeWSConn, fd *fakeDebugger, program string) {
+	conn.inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: program}))
+	Eventually(fd.recordedCalls, "500ms", "10ms").Should(ContainElement("Launch"))
+	_, _ = recvEvent(conn) // state -> running
+}
 
-			e, ok := recvEvent(conn)
-			Expect(ok).To(BeTrue())
-			Expect(e.Kind).To(Equal(protocol.EventError))
-		})
+// waitForEventKind polls conn until an event of the given kind arrives,
+// decoding it into out (if non-nil) before returning.
+func waitForEventKind(conn *fakeWSConn, kind protocol.EventKind, out any) {
+	Eventually(func() bool {
+		e, ok := recvEvent(conn)
+		if !ok || e.Kind != kind {
+			return false
+		}
+		if out != nil {
+			ExpectWithOffset(1, protocol.DecodeEventPayload(e, out)).To(Succeed())
+		}
+		return true
+	}, "500ms", "10ms").Should(BeTrue())
+}
 
-		It("rejects Restart before any successful Launch", func() {
-			managed := hub.NewSession("session", func() debugger.Debugger { return newFakeDebugger() }, nil)
-			cancelManaged := runHub(managed)
-			defer cancelManaged()
+// countCalls returns how many times name appears in calls.
+func countCalls(calls []string, name string) int {
+	n := 0
+	for _, c := range calls {
+		if c == name {
+			n++
+		}
+	}
+	return n
+}
 
-			conn := newFakeWSConn()
-			managed.AddClient(conn, nil)
-			_, _ = recvEvent(conn) // welcome/state event
+var _ = Describe("Restart", func() {
+	var fd *fakeDebugger
 
-			conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+	BeforeEach(func() {
+		fd = newFakeDebugger()
+	})
 
-			e, ok := recvEvent(conn)
-			Expect(ok).To(BeTrue())
-			Expect(e.Kind).To(Equal(protocol.EventError))
-		})
+	It("rejects Restart on a raw (non-managed) hub", func() {
+		h := hub.New(fd, nil)
+		cancel := runHub(h)
+		defer cancel()
 
-		It("rejects Restart after Attach (no relaunchable binary)", func() {
-			managed := hub.NewSession("session", func() debugger.Debugger { return fd }, nil)
-			cancelManaged := runHub(managed)
-			defer cancelManaged()
+		conn := newFakeWSConn()
+		h.AddClient(conn, nil)
 
-			conn := newFakeWSConn()
-			managed.AddClient(conn, nil)
-			_, _ = recvEvent(conn)
+		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		waitForEventKind(conn, protocol.EventError, nil)
+	})
 
-			conn.inject(mustCommand(protocol.CmdAttach, protocol.AttachPayload{PID: 123}))
-			Eventually(fd.recordedCalls, "500ms", "10ms").Should(ContainElement("Attach"))
+	It("rejects Restart before any successful Launch", func() {
+		_, conn, cancel := newManagedRestartHub(fd)
+		defer cancel()
 
-			conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		waitForEventKind(conn, protocol.EventError, nil)
+	})
 
-			Eventually(func() protocol.EventKind {
-				e, ok := recvEvent(conn)
-				if !ok {
-					return ""
-				}
-				return e.Kind
-			}, "500ms", "10ms").Should(Equal(protocol.EventError))
-		})
+	It("rejects Restart after Attach (no relaunchable binary)", func() {
+		_, conn, cancel := newManagedRestartHub(fd)
+		defer cancel()
 
-		It("kills the old debugger, relaunches, and reinstalls breakpoints", func() {
-			managed := hub.NewSession("session", func() debugger.Debugger { return fd }, nil)
-			cancelManaged := runHub(managed)
-			defer cancelManaged()
+		conn.inject(mustCommand(protocol.CmdAttach, protocol.AttachPayload{PID: 123}))
+		Eventually(fd.recordedCalls, "500ms", "10ms").Should(ContainElement("Attach"))
 
-			conn := newFakeWSConn()
-			managed.AddClient(conn, nil)
-			_, _ = recvEvent(conn)
+		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		waitForEventKind(conn, protocol.EventError, nil)
+	})
 
-			conn.inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "myapp", Args: []string{"-x"}}))
-			Eventually(fd.recordedCalls, "500ms", "10ms").Should(ContainElement("Launch"))
-			_, _ = recvEvent(conn) // state -> running
+	It("kills the old debugger, relaunches, and reinstalls breakpoints", func() {
+		_, conn, cancel := newManagedRestartHub(fd)
+		defer cancel()
+		launchManaged(conn, fd, "myapp")
 
-			fd.setBPResult = protocol.Breakpoint{ID: 1, Location: protocol.Location{File: "main.go", Line: 10}}
-			conn.inject(mustCommand(protocol.CmdSetBreakpoint, protocol.SetBreakpointPayload{File: "main.go", Line: 10}))
-			Eventually(func() protocol.EventKind {
-				e, ok := recvEvent(conn)
-				if !ok {
-					return ""
-				}
-				return e.Kind
-			}, "500ms", "10ms").Should(Equal(protocol.EventBreakpointSet))
+		fd.setBPResult = protocol.Breakpoint{ID: 1, Location: protocol.Location{File: "main.go", Line: 10}}
+		conn.inject(mustCommand(protocol.CmdSetBreakpoint, protocol.SetBreakpointPayload{File: "main.go", Line: 10}))
+		waitForEventKind(conn, protocol.EventBreakpointSet, nil)
 
-			conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		var restarted protocol.RestartedPayload
+		waitForEventKind(conn, protocol.EventRestarted, &restarted)
 
-			var restarted protocol.RestartedPayload
-			Eventually(func() bool {
-				e, ok := recvEvent(conn)
-				if !ok || e.Kind != protocol.EventRestarted {
-					return false
-				}
-				Expect(protocol.DecodeEventPayload(e, &restarted)).To(Succeed())
-				return true
-			}, "500ms", "10ms").Should(BeTrue())
+		Expect(restarted.Program).To(Equal("myapp"))
+		Expect(restarted.Breakpoints).To(HaveLen(1))
+		Expect(restarted.Discarded).To(BeEmpty())
 
-			Expect(restarted.Program).To(Equal("myapp"))
-			Expect(restarted.Breakpoints).To(HaveLen(1))
-			Expect(restarted.Discarded).To(BeEmpty())
+		calls := fd.recordedCalls()
+		Expect(calls).To(ContainElement("Kill"))
+		Expect(countCalls(calls, "Launch")).To(Equal(2),
+			"expected a Launch for the original start plus one for restart")
+		Expect(countCalls(calls, "SetBreakpoint")).To(Equal(2),
+			"expected the original SetBreakpoint plus a reinstall on restart")
+	})
 
-			calls := fd.recordedCalls()
-			Expect(calls).To(ContainElement("Kill"))
-			launchCount := 0
-			bpCount := 0
-			for _, c := range calls {
-				if c == "Launch" {
-					launchCount++
-				}
-				if c == "SetBreakpoint" {
-					bpCount++
-				}
-			}
-			Expect(launchCount).To(Equal(2), "expected a Launch for the original start plus one for restart")
-			Expect(bpCount).To(Equal(2), "expected the original SetBreakpoint plus a reinstall on restart")
-		})
+	It("reports discarded breakpoints that fail to reinstall", func() {
+		_, conn, cancel := newManagedRestartHub(fd)
+		defer cancel()
+		launchManaged(conn, fd, "myapp")
 
-		It("reports discarded breakpoints that fail to reinstall", func() {
-			managed := hub.NewSession("session", func() debugger.Debugger { return fd }, nil)
-			cancelManaged := runHub(managed)
-			defer cancelManaged()
+		fd.setBPResult = protocol.Breakpoint{ID: 1, Location: protocol.Location{File: "main.go", Line: 10}}
+		conn.inject(mustCommand(protocol.CmdSetBreakpoint, protocol.SetBreakpointPayload{File: "main.go", Line: 10}))
+		waitForEventKind(conn, protocol.EventBreakpointSet, nil)
 
-			conn := newFakeWSConn()
-			managed.AddClient(conn, nil)
-			_, _ = recvEvent(conn)
+		fd.setBPErr = fmt.Errorf("no such line")
+		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		var restarted protocol.RestartedPayload
+		waitForEventKind(conn, protocol.EventRestarted, &restarted)
 
-			conn.inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "myapp"}))
-			Eventually(fd.recordedCalls, "500ms", "10ms").Should(ContainElement("Launch"))
-			_, _ = recvEvent(conn)
+		Expect(restarted.Breakpoints).To(BeEmpty())
+		Expect(restarted.Discarded).To(HaveLen(1))
+		Expect(restarted.Discarded[0].Reason).To(Equal("no such line"))
+	})
 
-			fd.setBPResult = protocol.Breakpoint{ID: 1, Location: protocol.Location{File: "main.go", Line: 10}}
-			conn.inject(mustCommand(protocol.CmdSetBreakpoint, protocol.SetBreakpointPayload{File: "main.go", Line: 10}))
-			Eventually(func() protocol.EventKind {
-				e, ok := recvEvent(conn)
-				if !ok {
-					return ""
-				}
-				return e.Kind
-			}, "500ms", "10ms").Should(Equal(protocol.EventBreakpointSet))
+	It("unblocks a suspended hub, same as Kill", func() {
+		_, conn, cancel := newManagedRestartHub(fd)
+		defer cancel()
+		launchManaged(conn, fd, "myapp")
 
-			fd.setBPErr = fmt.Errorf("no such line")
-			conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+		_, _ = recvEvent(conn)
 
-			var restarted protocol.RestartedPayload
-			Eventually(func() bool {
-				e, ok := recvEvent(conn)
-				if !ok || e.Kind != protocol.EventRestarted {
-					return false
-				}
-				Expect(protocol.DecodeEventPayload(e, &restarted)).To(Succeed())
-				return true
-			}, "500ms", "10ms").Should(BeTrue())
-
-			Expect(restarted.Breakpoints).To(BeEmpty())
-			Expect(restarted.Discarded).To(HaveLen(1))
-			Expect(restarted.Discarded[0].Reason).To(Equal("no such line"))
-		})
-
-		It("unblocks a suspended hub, same as Kill", func() {
-			managed := hub.NewSession("session", func() debugger.Debugger { return fd }, nil)
-			cancelManaged := runHub(managed)
-			defer cancelManaged()
-
-			conn := newFakeWSConn()
-			managed.AddClient(conn, nil)
-			_, _ = recvEvent(conn)
-
-			conn.inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "myapp"}))
-			Eventually(fd.recordedCalls, "500ms", "10ms").Should(ContainElement("Launch"))
-			_, _ = recvEvent(conn)
-
-			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
-				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
-			_, _ = recvEvent(conn)
-
-			conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
-
-			Eventually(func() protocol.EventKind {
-				e, ok := recvEvent(conn)
-				if !ok {
-					return ""
-				}
-				return e.Kind
-			}, "500ms", "10ms").Should(Equal(protocol.EventRestarted))
-		})
+		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		waitForEventKind(conn, protocol.EventRestarted, nil)
 	})
 })

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -27,6 +27,12 @@ type Client interface {
 	Attach(pid int, binaryPath string) error
 	Kill() error
 
+	// Restart kills the current process (if any launched via Launch) and
+	// relaunches it, reinstalling previously-set breakpoints. Pass nil for
+	// args/env to reuse the values from the original Launch. Blocks until
+	// the server confirms via EventRestarted.
+	Restart(args, env []string) (protocol.RestartedPayload, error)
+
 	Continue() error
 	StepOver() error
 	StepInto() error

--- a/pkg/client/ws.go
+++ b/pkg/client/ws.go
@@ -256,6 +256,22 @@ func (c *wsClient) Kill() error {
 	return c.send(cmd)
 }
 
+func (c *wsClient) Restart(args, env []string) (protocol.RestartedPayload, error) {
+	cmd, err := newCommand(protocol.CmdRestart, protocol.RestartPayload{Args: args, Env: env})
+	if err != nil {
+		return protocol.RestartedPayload{}, err
+	}
+	evt, err := c.sendAndWait(cmd, protocol.EventRestarted)
+	if err != nil {
+		return protocol.RestartedPayload{}, err
+	}
+	var p protocol.RestartedPayload
+	if err := protocol.DecodeEventPayload(evt, &p); err != nil {
+		return protocol.RestartedPayload{}, fmt.Errorf("decode Restarted: %w", err)
+	}
+	return p, nil
+}
+
 func (c *wsClient) Continue() error {
 	cmd, err := newCommand(protocol.CmdContinue, struct{}{})
 	if err != nil {

--- a/pkg/protocol/payload.go
+++ b/pkg/protocol/payload.go
@@ -139,3 +139,24 @@ type ClearBreakpointPayload struct {
 type LocalsPayloadCmd struct {
 	FrameIndex int `json:"frameIndex"`
 }
+
+// RestartPayload optionally overrides the args/env used for the relaunch.
+// Leave both nil to reuse the values from the original Launch.
+type RestartPayload struct {
+	Args []string `json:"args,omitempty"`
+	Env  []string `json:"env,omitempty"`
+}
+
+// DiscardedBreakpoint reports a previously-set breakpoint that could not be
+// reinstalled after a Restart (e.g. the file:line no longer resolves).
+type DiscardedBreakpoint struct {
+	Location Location `json:"location"`
+	Reason   string   `json:"reason"`
+}
+
+// RestartedPayload confirms a completed Restart.
+type RestartedPayload struct {
+	Program     string                `json:"program"`
+	Breakpoints []Breakpoint          `json:"breakpoints,omitempty"`
+	Discarded   []DiscardedBreakpoint `json:"discarded,omitempty"`
+}

--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -46,6 +46,13 @@ const (
 	EventSessionState EventKind = "SessionState"
 
 	EventError EventKind = "Error"
+
+	// EventRestarted confirms a completed Restart: the process was
+	// relaunched and previously-set breakpoints were reinstalled where
+	// possible. It is a confirmation, not a suspending event — the process's
+	// own suspend state is reported separately via the Stepped event emitted
+	// at the new process's entry point (same as after Launch).
+	EventRestarted EventKind = "Restarted"
 )
 
 type CommandKind string
@@ -69,4 +76,10 @@ const (
 	CmdLocals     CommandKind = "Locals"
 	CmdFrames     CommandKind = "Frames"
 	CmdGoroutines CommandKind = "Goroutines"
+
+	// CmdRestart kills the current process (if any) and relaunches the last
+	// Launch'd binary, reinstalling previously-set breakpoints. Only
+	// supported for managed sessions started via Launch — see AGENTS.md →
+	// Restart.
+	CmdRestart CommandKind = "Restart"
 )

--- a/pkg/protocol/protocol_test.go
+++ b/pkg/protocol/protocol_test.go
@@ -291,6 +291,25 @@ var _ = Describe("Event", func() {
 					Expect(hasCmd).To(BeFalse(), "command field should be omitted for CmdNone")
 				},
 			),
+
+			Entry("Restarted",
+				protocol.EventRestarted,
+				protocol.RestartedPayload{
+					Program:     "/tmp/myapp",
+					Breakpoints: []protocol.Breakpoint{sampleBreakpoint},
+					Discarded: []protocol.DiscardedBreakpoint{
+						{Location: protocol.Location{File: "gone.go", Line: 5}, Reason: "no such file"},
+					},
+				},
+				func(e protocol.Event) {
+					var p protocol.RestartedPayload
+					Expect(protocol.DecodeEventPayload(e, &p)).To(Succeed())
+					Expect(p.Program).To(Equal("/tmp/myapp"))
+					Expect(p.Breakpoints).To(HaveLen(1))
+					Expect(p.Discarded).To(HaveLen(1))
+					Expect(p.Discarded[0].Reason).To(Equal("no such file"))
+				},
+			),
 		)
 	})
 
@@ -458,6 +477,16 @@ var _ = Describe("Command", func() {
 					Expect(c.Kind).To(Equal(protocol.CmdGoroutines))
 				},
 			),
+
+			Entry("Restart",
+				protocol.CmdRestart,
+				protocol.RestartPayload{Args: []string{"--verbose"}},
+				func(c protocol.Command) {
+					var p protocol.RestartPayload
+					Expect(protocol.DecodeCommandPayload(c, &p)).To(Succeed())
+					Expect(p.Args).To(ConsistOf("--verbose"))
+				},
+			),
 		)
 	})
 
@@ -501,6 +530,7 @@ var _ = Describe("Kind constants", func() {
 			protocol.EventFrames,
 			protocol.EventGoroutines,
 			protocol.EventError,
+			protocol.EventRestarted,
 		}
 		for _, k := range kinds {
 			Expect(string(k)).NotTo(BeEmpty(), "EventKind %q should not be empty", k)
@@ -521,6 +551,7 @@ var _ = Describe("Kind constants", func() {
 			protocol.CmdLocals,
 			protocol.CmdFrames,
 			protocol.CmdGoroutines,
+			protocol.CmdRestart,
 		}
 		for _, k := range kinds {
 			Expect(string(k)).NotTo(BeEmpty(), "CommandKind %q should not be empty", k)


### PR DESCRIPTION
## Summary

Implements the missing `Restart` debugger operation end-to-end (protocol → hub → client SDK → CLI), and hardens `Backend.StopProcess()` as groundwork for a future `Pause` command, per Delve's native backend halt primitives.

Part of #54

## Restart

- **Protocol**: `CmdRestart`, `EventRestarted`, `RestartPayload{Args, Env}` (optional overrides), `RestartedPayload{Program, Breakpoints, Discarded}`, `DiscardedBreakpoint{Location, Reason}`.
- **Hub** (`internal/hub/hub.go`): implemented entirely at the hub level, *not* as a new `Debugger`/engine method. The engine's shutdown is a one-way door — once `stateExited` is reached, `loop()` permanently closes `done`/`events` — so reviving a dead engine in place would need an epoch counter to guard against stale `waitLoop` results. Instead, Restart kills the old `Debugger`, creates a fresh one via the existing `newDebugger` factory (same one `Launch`/`Attach` use), relaunches, and reinstalls previously-tracked breakpoints (re-resolved via DWARF against the new process image). This mirrors Delve's `Debugger.Restart`.
- The hub tracks `lastLaunch` (program/args/env from the last successful `Launch`) and `restartBreakpoints` (id → location) to survive the kill+relaunch. Restart is refused if there's no prior `Launch`, or after `Attach` (no "same binary" to relaunch — mirrors Delve's `canRestart`).
- **Routing note**: `CmdRestart` goes through the ordinary `cmdCh`, not `resumeCh`. `resumeCh` is only drained inside the suspend-wait loop, so a resuming command sent while the hub *isn't* suspended (the common Restart case) would sit unread indefinitely — a real pre-existing gap for `CmdKill` too, but one Restart can't tolerate since "restart while running" is the primary use case.
- **Client SDK / CLI**: `Client.Restart(args, env)` (synchronous, via `sendAndWait` on `EventRestarted`), plus a `restart` CLI command and `EventRestarted` printer case.

## StopProcess hardening (Pause groundwork)

`StopProcess()` (linux + darwin backends) now uses `syscall.Kill(pid, SIGSTOP)` directly instead of `os.FindProcess(pid).Signal(...)` (which never actually distinguishes "no such process" on Unix), guards `pid == 0`, and treats `ESRCH` as an idempotent no-op — consistent with `engine.Kill()`'s idempotency elsewhere. No `Pause` command is wired up yet; Delve's full halt-flag state machine (`trapWaitInternal` on Linux, Mach `thread_suspend` + atomic flag on Darwin) is out of scope until `Pause` is actually built.

## Testing

- New hub tests covering: reject on raw/non-managed hub, reject before any Launch, reject after Attach, full kill+relaunch+breakpoint-reinstall flow, discarded-breakpoint reporting, and unblocking a suspended hub.
- New protocol round-trip tests for `CmdRestart`/`EventRestarted`.
- `go vet` + `go test -tags bingonative ./...` all green.
- Verified `just e2e-darwin` — confirmed the one failing spec (`fullstack`, WebSocket transport) and intermittent `basic` timeouts are pre-existing flakiness in this environment: reproduced identically on `main` before this PR's changes (stashed and reran). No new failures introduced.

## Docs

`AGENTS.md` updated with new "Restart — hub-level, not engine-level" and "StopProcess — Pause groundwork only" sections documenting these decisions.