### PR TITLE
feat: implement Pause (linux only)

### DIFF
--- a/.github/workflows/debugger-e2e.yml
+++ b/.github/workflows/debugger-e2e.yml
@@ -7,8 +7,9 @@ name: Debugger E2E
 # actual OS backend, so they need a real kernel and run on native GitHub-hosted
 # runners. Gated behind the `e2e` build tag; the Ginkgo suite lives in
 # ./test/integration and is split via Ginkgo labels into `basic` (correctness),
-# `churn` (multi-thread robustness), and `fullstack` (the same operations driven
-# through the whole client → WebSocket → hub → debugger stack).
+# `churn` (multi-thread robustness), `pause` (async interrupt / manual stop), and
+# `fullstack` (the same operations driven through the whole client → WebSocket →
+# hub → debugger stack).
 #
 # The linux jobs run fully on hosted runners. The darwin jobs compile and
 # codesign the E2E binary on hosted macOS runners (the only CI coverage that the
@@ -50,6 +51,9 @@ jobs:
 
       - name: E2E churn (multi-thread robustness)
         run: go test -tags e2e -race -count=1 -v -timeout 600s ./test/integration -ginkgo.label-filter=churn
+
+      - name: E2E pause (async interrupt)
+        run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=pause
 
   darwin-arm64:
     name: Darwin arm64 (ptrace + Mach)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,11 +134,19 @@ Both versioned; both carry `Kind` + raw-JSON `Payload`. Decode with
 The hub blocks after broadcasting any of these "suspending" events until a
 "resuming" command arrives (or the 30-min safety timeout fires):
 
-- Suspending events: `BreakpointHit`, `Panic`, `Stepped`
+- Suspending events: `BreakpointHit`, `Panic`, `Stepped`, `Paused`
 - Resuming commands: `Continue`, `StepOver`, `StepInto`, `StepOut`, `Kill`
 
 While suspended, **non-resuming** commands (`SetBreakpoint`, `Locals`, …) are
 still executed immediately — the process is paused, so it's safe.
+
+`Pause` is the odd one out: it is a suspending *request* issued **while the
+process is running**, not while suspended, and is deliberately **not** a
+resuming command. It rides the ordinary `cmdCh` (like `SetBreakpoint`), so
+Run's main loop dispatches it promptly to `dbg.Pause()`; it is never routed
+through `resumeCh`. The suspend it triggers is reported asynchronously via the
+`Paused` suspending event once the SIGSTOP surfaces — see
+[Pause — async interrupt](#pause--async-interrupt).
 
 When multiple clients race resume commands: **first writer wins**, the rest
 are dropped (`resumeCh` has capacity 1; see [hub.go injectCommand](internal/hub/hub.go)).
@@ -148,7 +156,7 @@ are dropped (`resumeCh` has capacity 1; see [hub.go injectCommand](internal/hub/
 `SessionState` ∈ {`idle`, `running`, `suspended`, `exited`}.
 
 ```
-            Launch / Attach            BreakpointHit / Panic / Stepped
+            Launch / Attach       BreakpointHit / Panic / Stepped / Paused
    idle ────────────────────> running <────────────────────────────────── suspended
     ▲                            │                Continue / Step*
     │                            │
@@ -425,24 +433,98 @@ suspending one — the new process's suspended state (if any, e.g. break-on-
 entry) is reported the normal way via `EventStepped`/`EventBreakpointHit` once
 the relaunched process actually reaches that point.
 
-## StopProcess — Pause groundwork only
+## Pause — async interrupt
 
-`Backend.StopProcess()` (both `backend_linux_amd64.go` and
-`backend_darwin_arm64.go`) sends a whole-process `SIGSTOP`, hardened as the
-one primitive a future `Pause` command would need — **no `Pause` command is
-wired up yet**, and this is not the whole story: Delve's actual manual-stop
-implementations are far more involved (Linux: `sys.Kill(pid, SIGTRAP)` plus a
-`trapWaitInternal` halt-flag state machine in
-`pkg/proc/native/proc_linux.go`; Darwin: Mach `thread_suspend` on every thread
-plus an atomic halt flag in `pkg/proc/native/proc_darwin.go`) to correctly
-distinguish a manual halt from a spontaneous trap and to safely land every
-thread at a consistent stop point. Implementing that state machine is out of
-scope until `Pause` is actually built. The hardening done now: direct
-`syscall.Kill(pid, SIGSTOP)` instead of `os.FindProcess(pid).Signal(...)`
-(the latter never actually distinguishes "no such process" on Unix — `
-os.FindProcess` can't fail there), a `pid == 0` guard, and treating `ESRCH`
-(process already gone) as an idempotent no-op success rather than an error,
-consistent with `engine.Kill()`'s idempotency elsewhere in this package.
+`Pause` forcibly halts a **running** tracee and suspends it, like an on-demand
+breakpoint. It's the one suspend that is *asynchronous*: breakpoints and steps
+are self-stops (the tracee runs into a trap it was set up to hit), whereas Pause
+interrupts from the outside at an arbitrary instruction.
+
+Flow (detection is platform-agnostic, in the shared engine — no backend changes
+were needed for it on the platform where it works, linux; see the darwin caveat
+at the end):
+
+1. Client sends `CmdPause` while running. The hub routes it via `cmdCh`
+   (**not** `resumeCh` — Pause is not a resuming command; see
+   [Suspend/resume protocol](#suspendresume-protocol)) to `engine.Pause()`.
+2. `engine.Pause()` (in [engine.go](internal/debugger/engine.go)) `dispatch`es a
+   closure that, if state != `stateRunning`, returns `ErrNotRunning`; otherwise
+   sets `manualStopPending = true` and calls `backend.StopProcess()`, then
+   returns immediately. It does **not** change state — the suspend happens when
+   the stop surfaces. Fire-and-forget from the client's view; `EventPaused`
+   arrives asynchronously.
+3. `StopProcess()` sends `SIGSTOP`. On **linux**, a deliberate SIGSTOP surfaces
+   from `Backend.Wait()` as `StopEvent{Reason: StopSignal, Signal: SIGSTOP}`
+   (a ptrace signal-delivery-stop), so detection lives entirely in the engine's
+   `handleStop` `StopSignal` branch. (Darwin does **not** surface it — see the
+   caveat below.)
+4. `handleStop` `StopSignal` branch: if `manualStopPending` (and
+   `stop.Signal == SIGSTOP`), it clears the flag, defensively reinstalls any
+   in-flight step-over BP (mirrors the existing StopSignal reinstall),
+   `populateStopPC`s, `setState(stateSuspended)`, and `emitPaused(stop)` —
+   returning **without** continuing. Genuine other signals keep the original
+   emit-output-then-auto-resume behavior.
+
+**Loop-thread-only flag, no sync.** `manualStopPending` is a plain `bool` with
+no mutex because both writers/readers — `Pause()`'s dispatched closure and
+`handleStop` — run on the single engine loop thread (see
+[Engine concurrency model](#engine-concurrency-model--non-obvious-invariants)).
+Don't add locking; don't touch it from another goroutine.
+
+**Pending-SIGSTOP race.** If a real breakpoint/step stop wins the race after
+`Pause()` set the flag but before the SIGSTOP is dequeued, the process suspends
+for *that* self-stop and the SIGSTOP stays queued in the tracee. To stop it
+being misread as a bogus Pause on the next resume, `manualStopPending` is
+cleared on **every** self-stop suspend (`emitBreakpointHit` / `emitStepped`).
+Then when the leftover SIGSTOP later surfaces with the flag clear, the
+`StopSignal` branch silently suppresses it (continue, no `EventPaused`, no
+spurious "signal 19" output). A focused engine unit test pins this ordering.
+
+**Linux: SIGSTOP is directed at the main thread.** `StopProcess()` on
+[backend_linux_amd64.go](internal/debugger/backend_linux_amd64.go) uses
+`tgkill(pid, pid, SIGSTOP)` rather than the process-directed
+`stopProcessSignal` (`kill`) the darwin backend shares. A process-directed
+SIGSTOP can be dequeued by any thread, and linux `Wait()` deliberately
+**swallows** a non-main-thread SIGSTOP as a clone group-stop
+(`sig == SIGSTOP && tid != b.pid` → continue), so a multithreaded Pause could
+be lost. Targeting the main thread (`tid == pid`) makes it fall through to the
+`StopSignal` return every time.
+
+**Resume-after-pause is a plain Continue.** bingo never *injects* the SIGSTOP
+(`Continue` does `PtraceCont(tid, 0)`, which suppresses the pending signal), so
+only the reporting thread entered signal-delivery-stop and no whole-group stop
+was created. Resuming is therefore identical to resuming from a breakpoint —
+no special handling. The linux `pause`-labelled E2E spec
+(`declarePauseSpec`, [debugger_e2e_common_test.go](test/integration/debugger_e2e_common_test.go),
+wired into the linux container only) runs the Continue→Pause→Paused round-trip
+several times; if the first resume hung, the second Pause's signal would never
+surface and the spec would time out.
+
+**Darwin caveat — Pause is not functional on darwin yet (linux-only).** The
+platform-agnostic detection above works on linux but **not** on darwin/arm64.
+macOS applies a `kill(pid, SIGSTOP)` to a ptraced tracee as a *job-control*
+stop, which is **not** reported through our ptrace `wait4` loop as a
+signal-delivery-stop — so `Backend.Wait()` never returns, no `StopSignal`
+surfaces, and no `EventPaused` is emitted (a Pause on darwin currently hangs the
+suspend). This was verified empirically on real Apple Silicon. The darwin
+`StopProcess()` groundwork comment already flags this: a correct darwin Pause
+needs Mach `thread_suspend` on every thread plus an atomic halt flag, exactly
+like Delve's `requestManualStop` (`pkg/proc/native/proc_darwin.go`) — **not**
+SIGSTOP. That is a darwin-native change to
+[backend_darwin_arm64.go](internal/debugger/backend_darwin_arm64.go), which is
+deliberately **out of scope** here to stay clear of the
+[darwin verification gate](#test-layering); it is left as a follow-up. Nothing
+in the shared engine, hub, protocol, client, or CLI is darwin-specific — the
+moment darwin's backend surfaces the stop, `EventPaused` will flow with no
+further engine changes.
+
+`StopProcess()` itself is still the hardened idempotent primitive from the
+Restart groundwork: a `pid == 0` guard and `ESRCH` (process already gone)
+treated as a no-op success. Delve's manual-stop is heavier (Linux:
+`sys.Kill(pid, SIGTRAP)` + a `trapWaitInternal` halt-flag state machine; Darwin:
+Mach `thread_suspend` on every thread + an atomic halt flag) because it lands
+*every* thread at a consistent stop point; bingo's partial-stop model only needs
+the one reporting thread suspended, so on linux the SIGSTOP approach suffices.
 
 ## Error handling
 
@@ -476,14 +558,18 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   (they can't run under emulation or with fakes). Split into:
   `debugger_e2e_common_test.go` (harness + target sources + shared spec bodies),
   `debugger_e2e_linux_amd64_test.go`, `debugger_e2e_darwin_arm64_test.go`, and
-  `debugger_e2e_fullstack_test.go`. Three Ginkgo labels: `basic`
-  (continue+step-over correctness) and `churn` (multi-thread robustness), both
-  driving `debugger.Debugger` in-process; plus `fullstack`, which drives the
+  `debugger_e2e_fullstack_test.go`. Ginkgo labels: `basic`
+  (continue+step-over correctness), `churn` (multi-thread robustness), and
+  `pause` (async-interrupt / manual-stop round-trip), all driving
+  `debugger.Debugger` in-process; plus `fullstack`, which drives the
   same operations through the ENTIRE stack (pkg/client → WebSocket →
   internal/server → internal/hub → debugger → tracee) to catch transport/hub
   wiring regressions the backend-only specs can't (seq re-stamping of real
   events, the suspend/resume gate on a genuine BreakpointHit, synchronous
-  SetBreakpoint confirmation routing). Each label is its own CI job. CI:
+  SetBreakpoint confirmation routing). The `pause` spec is wired into the linux
+  container only (`declarePauseSpec` — detection is platform-agnostic in the
+  engine, and darwin-native files must stay out of the verification gate). Each
+  label is its own CI job. CI:
   [.github/workflows/debugger-e2e.yml](.github/workflows/debugger-e2e.yml).
   The linux jobs run fully on hosted runners. The darwin jobs compile and
   codesign the E2E binary on hosted macOS runners (the only CI check that the
@@ -521,7 +607,7 @@ just build [linux amd64 | darwin arm64]   # produces ./build/bingo/...
 just test [PKG]                            # go test -v
 just coverage [PKG]                        # writes test/coverage.out
 just integration                           # ginkgo -r ./test/integration (no e2e tag)
-just e2e-linux                             # native linux/amd64 ptrace E2E (basic + churn + fullstack)
+just e2e-linux                             # native linux/amd64 ptrace E2E (basic + churn + pause + fullstack)
 just e2e-darwin                            # native darwin/arm64 ptrace+Mach E2E (codesigned)
 # Filter to one label, e.g. only the correctness gate (package path must come
 # before the -ginkgo.* flag so `go test` doesn't mistake it for the package):

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -163,6 +163,11 @@ func main() {
 				printErr(err)
 			}
 
+		case "p", "pause":
+			if err := c.Pause(); err != nil {
+				printErr(err)
+			}
+
 		case "b", "break":
 			if len(args) < 2 {
 				fmt.Println("  usage: break <file>:<line>")
@@ -296,6 +301,13 @@ func eventPrinter(events <-chan protocol.Event) {
 					p.Location.File, p.Location.Line, p.Location.Function)
 			}
 
+		case protocol.EventPaused:
+			var p protocol.PausedPayload
+			if protocol.DecodeEventPayload(evt, &p) == nil {
+				fmt.Printf("\n  [paused] %s:%d in %s\nbingo> ",
+					p.Location.File, p.Location.Line, p.Location.Function)
+			}
+
 		case protocol.EventContinued:
 			fmt.Print("\n  [continued]\nbingo> ")
 
@@ -348,6 +360,7 @@ func printHelp() {
   n / next                   step over
   s / step                   step into
   out / finish               step out (run until function returns)
+  p / pause                  interrupt a running process and suspend it
 
   b / break <file>:<line>    set breakpoint  (e.g. break main.go:42)
   clear <id>                 remove breakpoint by ID

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -261,72 +261,76 @@ func main() {
 
 func eventPrinter(events <-chan protocol.Event) {
 	for evt := range events {
-		switch evt.Kind {
+		printEvent(evt)
+	}
+}
 
-		case protocol.EventSessionState:
-			var p protocol.SessionStatePayload
-			if protocol.DecodeEventPayload(evt, &p) == nil {
-				fmt.Printf("\n  [state] %s (clients: %d)\nbingo> ", p.State, p.Clients)
-			}
+func printEvent(evt protocol.Event) {
+	switch evt.Kind {
 
-		case protocol.EventBreakpointHit:
-			var p protocol.BreakpointHitPayload
-			if protocol.DecodeEventPayload(evt, &p) == nil {
-				fmt.Printf("\n  [hit] breakpoint %d at %s:%d\nbingo> ",
-					p.Breakpoint.ID, p.Breakpoint.Location.File, p.Breakpoint.Location.Line)
-			}
-
-		case protocol.EventPanic:
-			var p protocol.PanicPayload
-			if protocol.DecodeEventPayload(evt, &p) == nil {
-				fmt.Printf("\n  [panic] %s\nbingo> ", p.Message)
-			}
-
-		case protocol.EventOutput:
-			var p protocol.OutputPayload
-			if protocol.DecodeEventPayload(evt, &p) == nil {
-				fmt.Printf("\n  [%s] %s\nbingo> ", p.Stream, p.Content)
-			}
-
-		case protocol.EventProcessExited:
-			var p protocol.ProcessExitedPayload
-			if protocol.DecodeEventPayload(evt, &p) == nil {
-				fmt.Printf("\n  [exited] code=%d reason=%s\nbingo> ", p.ExitCode, p.Reason)
-			}
-
-		case protocol.EventStepped:
-			var p protocol.SteppedPayload
-			if protocol.DecodeEventPayload(evt, &p) == nil {
-				fmt.Printf("\n  [stepped] %s:%d in %s\nbingo> ",
-					p.Location.File, p.Location.Line, p.Location.Function)
-			}
-
-		case protocol.EventPaused:
-			var p protocol.PausedPayload
-			if protocol.DecodeEventPayload(evt, &p) == nil {
-				fmt.Printf("\n  [paused] %s:%d in %s\nbingo> ",
-					p.Location.File, p.Location.Line, p.Location.Function)
-			}
-
-		case protocol.EventContinued:
-			fmt.Print("\n  [continued]\nbingo> ")
-
-		case protocol.EventError:
-			var p protocol.ErrorPayload
-			if protocol.DecodeEventPayload(evt, &p) == nil {
-				fmt.Printf("\n  [error] %s: %s\nbingo> ", p.Command, p.Message)
-			}
-
-		case protocol.EventRestarted:
-			var p protocol.RestartedPayload
-			if protocol.DecodeEventPayload(evt, &p) == nil {
-				fmt.Printf("\n  [restarted] %s (%d breakpoint(s), %d discarded)\nbingo> ",
-					p.Program, len(p.Breakpoints), len(p.Discarded))
-			}
-
-		default:
-			fmt.Printf("\n  [%s] seq=%d\nbingo> ", evt.Kind, evt.Seq)
+	case protocol.EventSessionState:
+		var p protocol.SessionStatePayload
+		if protocol.DecodeEventPayload(evt, &p) == nil {
+			fmt.Printf("\n  [state] %s (clients: %d)\nbingo> ", p.State, p.Clients)
 		}
+
+	case protocol.EventBreakpointHit:
+		var p protocol.BreakpointHitPayload
+		if protocol.DecodeEventPayload(evt, &p) == nil {
+			fmt.Printf("\n  [hit] breakpoint %d at %s:%d\nbingo> ",
+				p.Breakpoint.ID, p.Breakpoint.Location.File, p.Breakpoint.Location.Line)
+		}
+
+	case protocol.EventPanic:
+		var p protocol.PanicPayload
+		if protocol.DecodeEventPayload(evt, &p) == nil {
+			fmt.Printf("\n  [panic] %s\nbingo> ", p.Message)
+		}
+
+	case protocol.EventOutput:
+		var p protocol.OutputPayload
+		if protocol.DecodeEventPayload(evt, &p) == nil {
+			fmt.Printf("\n  [%s] %s\nbingo> ", p.Stream, p.Content)
+		}
+
+	case protocol.EventProcessExited:
+		var p protocol.ProcessExitedPayload
+		if protocol.DecodeEventPayload(evt, &p) == nil {
+			fmt.Printf("\n  [exited] code=%d reason=%s\nbingo> ", p.ExitCode, p.Reason)
+		}
+
+	case protocol.EventStepped:
+		var p protocol.SteppedPayload
+		if protocol.DecodeEventPayload(evt, &p) == nil {
+			fmt.Printf("\n  [stepped] %s:%d in %s\nbingo> ",
+				p.Location.File, p.Location.Line, p.Location.Function)
+		}
+
+	case protocol.EventPaused:
+		var p protocol.PausedPayload
+		if protocol.DecodeEventPayload(evt, &p) == nil {
+			fmt.Printf("\n  [paused] %s:%d in %s\nbingo> ",
+				p.Location.File, p.Location.Line, p.Location.Function)
+		}
+
+	case protocol.EventContinued:
+		fmt.Print("\n  [continued]\nbingo> ")
+
+	case protocol.EventError:
+		var p protocol.ErrorPayload
+		if protocol.DecodeEventPayload(evt, &p) == nil {
+			fmt.Printf("\n  [error] %s: %s\nbingo> ", p.Command, p.Message)
+		}
+
+	case protocol.EventRestarted:
+		var p protocol.RestartedPayload
+		if protocol.DecodeEventPayload(evt, &p) == nil {
+			fmt.Printf("\n  [restarted] %s (%d breakpoint(s), %d discarded)\nbingo> ",
+				p.Program, len(p.Breakpoints), len(p.Discarded))
+		}
+
+	default:
+		fmt.Printf("\n  [%s] seq=%d\nbingo> ", evt.Kind, evt.Seq)
 	}
 }
 

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -227,17 +227,28 @@ func (b *linuxBackend) SingleStep(tid int) error {
 	return nil
 }
 
-// StopProcess sends a whole-thread-group SIGSTOP, mirroring Delve's
-// requestManualStop-adjacent halt primitive (pkg/proc/native/proc_linux.go
-// sends a process-wide signal rather than per-thread, since a ptrace-stopped
-// tracee still delivers signals to the group). This is Pause groundwork
-// only: it does not implement Delve's trapWaitInternal halt-flag state
-// machine that distinguishes a manual stop from a spontaneous trap, so no
-// Pause command is wired to it yet — see AGENTS.md. The signal mechanics
-// (syscall.Kill, ESRCH-as-idempotent) are shared with the darwin backend via
-// stopProcessSignal in process.go.
+// StopProcess asynchronously interrupts the running tracee for Pause. It
+// directs SIGSTOP at the MAIN thread specifically (tgkill(pid, pid, SIGSTOP))
+// rather than the whole thread group (kill(pid, ...)). A process-directed
+// SIGSTOP may be dequeued by any thread, and Wait() deliberately swallows a
+// non-main thread's SIGSTOP as a clone group-stop (the sig==SIGSTOP &&
+// tid!=b.pid branch), so on a multithreaded target a group-directed Pause
+// could be lost. Targeting the main thread (whose TID equals the tgid) makes
+// the signal surface from Wait() as StopEvent{StopSignal, SIGSTOP} with
+// TID==b.pid, where the engine's manual-stop detection turns it into
+// EventPaused. The engine never injects this SIGSTOP back (Continue resumes
+// with signal 0), so it triggers no group-stop and resume is a plain
+// ContinueProcess. ESRCH (thread already gone) is an idempotent no-op,
+// matching stopProcessSignal / process.kill. tgkill is a plain signal syscall,
+// not a ptrace op, so it need not run on the tracer thread.
 func (b *linuxBackend) StopProcess() error {
-	return stopProcessSignal(b.pid)
+	if b.pid == 0 {
+		return fmt.Errorf("StopProcess: no process")
+	}
+	if err := syscall.Tgkill(b.pid, b.pid, syscall.SIGSTOP); err != nil && err != syscall.ESRCH {
+		return fmt.Errorf("StopProcess: %w", err)
+	}
+	return nil
 }
 
 func (b *linuxBackend) ReadMemory(addr uint64, dst []byte) error {

--- a/internal/debugger/debugger.go
+++ b/internal/debugger/debugger.go
@@ -15,6 +15,7 @@ var (
 	ErrNotSuspended   = errors.New("debugger: process is not suspended")
 	ErrAlreadyRunning = errors.New("debugger: process already running")
 	ErrNoProcess      = errors.New("debugger: no process")
+	ErrNotRunning     = errors.New("debugger: process is not running")
 )
 
 // Debugger is the interface consumed by the hub. All methods are goroutine-safe.
@@ -38,6 +39,12 @@ type Debugger interface {
 	StepOver() error
 	StepInto() error
 	StepOut() error
+
+	// Pause asynchronously interrupts a running tracee, forcing it to suspend.
+	// It returns ErrNotRunning if the process is not currently running. The
+	// suspend itself is reported asynchronously via EventPaused, so a nil
+	// return only means the interrupt was requested (fire-and-forget).
+	Pause() error
 
 	// Locals: frame 0 is innermost.
 	Locals(frameIndex int) ([]protocol.Variable, error)

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"runtime"
 	"sync"
+	"syscall"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
@@ -75,6 +76,13 @@ type engine struct {
 	// boundary with line==0. Zeroed on each sourceStepOver and on user-BP hits.
 	stepOverFile string
 	stepOverLine int
+
+	// manualStopPending records that a Pause request has fired a SIGSTOP at
+	// the tracee and we are awaiting the resulting signal-delivery stop, which
+	// should be turned into EventPaused rather than auto-resumed. It needs no
+	// synchronization: both Pause()'s dispatched closure and handleStop run on
+	// the single engine loop thread. See AGENTS.md → Pause.
+	manualStopPending bool
 
 	// log is the single sink for all engine logging. Never call the
 	// package-level slog functions directly — they bypass the per-session
@@ -280,6 +288,26 @@ func (e *engine) StepOut() error {
 			return err
 		}
 		return e.stepOut()
+	})
+}
+
+// Pause asynchronously interrupts a running tracee. It is the only resume-side
+// operation issued while the process is RUNNING rather than suspended: it fires
+// a SIGSTOP at the tracee (via the backend) and records manualStopPending so
+// the resulting signal-delivery stop is turned into EventPaused instead of
+// being auto-resumed (see handleStop's StopSignal branch). The suspend is
+// reported asynchronously, so this returns as soon as the interrupt is armed.
+func (e *engine) Pause() error {
+	return e.dispatch(func() error {
+		if e.getState() != stateRunning {
+			return ErrNotRunning
+		}
+		e.manualStopPending = true
+		if err := e.backend.StopProcess(); err != nil {
+			e.manualStopPending = false
+			return fmt.Errorf("Pause: %w", err)
+		}
+		return nil
 	})
 }
 
@@ -571,7 +599,7 @@ func (e *engine) handleStop(stop StopEvent) {
 		e.emitStepped(stop)
 
 	case StopSignal:
-		// Reinstall any in-flight step-over BP before resuming.
+		// Reinstall any in-flight step-over BP before resuming or suspending.
 		if sob := e.steppingOverBP; sob != nil {
 			e.steppingOverBP = nil
 			if rerr := e.bps.reinstall(e.backend, sob); rerr != nil {
@@ -581,6 +609,32 @@ func (e *engine) handleStop(stop StopEvent) {
 				return
 			}
 			e.endThreadStep()
+		}
+		if stop.Signal == int(syscall.SIGSTOP) {
+			if e.manualStopPending {
+				// A Pause request's SIGSTOP has arrived. Suspend and report
+				// EventPaused instead of auto-resuming — this is the one signal
+				// stop we deliberately turn into a suspending event.
+				e.manualStopPending = false
+				var err error
+				if stop, err = e.populateStopPC(stop, false); err != nil {
+					e.setState(stateSuspended)
+					e.emitError(protocol.CmdNone, err)
+					return
+				}
+				e.setState(stateSuspended)
+				e.emitPaused(stop)
+				return
+			}
+			// A SIGSTOP with no pending Pause is a leftover: a Pause raced a
+			// self-stop (breakpoint/step won and cleared manualStopPending),
+			// leaving its SIGSTOP queued. Suppress it silently — surfacing it
+			// as output or EventPaused would be bogus. Continue discards it
+			// (ContinueProcess resumes with signal 0).
+			_ = e.backend.ContinueProcess()
+			e.setState(stateRunning)
+			go e.waitLoop()
+			return
 		}
 		e.emitOutput("stderr", fmt.Sprintf("signal %d", stop.Signal))
 		_ = e.backend.ContinueProcess()
@@ -972,6 +1026,10 @@ func (e *engine) emit(kind protocol.EventKind, payload any) {
 }
 
 func (e *engine) emitBreakpointHit(bp *breakpointEntry, stop StopEvent) {
+	// Suspending for a self-stop cancels any pending Pause: a Pause SIGSTOP that
+	// raced this stop and lost is now leftover in the kernel queue, to be
+	// suppressed (not reported as Paused) when it surfaces on the next resume.
+	e.manualStopPending = false
 	frames, _ := e.collectFrames(stop.TID)
 	goroutines, _ := e.readGoroutines()
 	var g protocol.Goroutine
@@ -1000,6 +1058,9 @@ func (e *engine) emitStoppedAtCurrentPC() {
 }
 
 func (e *engine) emitStepped(stop StopEvent) {
+	// Completing a step suspends for a self-stop, which cancels any pending
+	// Pause the same way a breakpoint hit does (see emitBreakpointHit).
+	e.manualStopPending = false
 	frames, _ := e.collectFrames(stop.TID)
 	goroutines, _ := e.readGoroutines()
 	var g protocol.Goroutine
@@ -1011,6 +1072,27 @@ func (e *engine) emitStepped(stop StopEvent) {
 		loc = e.dw.locationForPC(stop.PC)
 	}
 	e.emit(protocol.EventStepped, protocol.SteppedPayload{
+		Goroutine: g,
+		Location:  loc,
+		Frames:    frames,
+	})
+}
+
+// emitPaused reports an asynchronous Pause halt. It mirrors emitStepped but
+// carries EventPaused/PausedPayload: the location is wherever execution was
+// interrupted, not a source-line boundary.
+func (e *engine) emitPaused(stop StopEvent) {
+	frames, _ := e.collectFrames(stop.TID)
+	goroutines, _ := e.readGoroutines()
+	var g protocol.Goroutine
+	if len(goroutines) > 0 {
+		g = goroutines[0]
+	}
+	loc := protocol.Location{}
+	if e.dw != nil {
+		loc = e.dw.locationForPC(stop.PC)
+	}
+	e.emit(protocol.EventPaused, protocol.PausedPayload{
 		Goroutine: g,
 		Location:  loc,
 		Frames:    frames,

--- a/internal/debugger/engine_test.go
+++ b/internal/debugger/engine_test.go
@@ -3,6 +3,7 @@ package debugger_test
 import (
 	"encoding/binary"
 	"errors"
+	"syscall"
 	"testing"
 	"time"
 
@@ -28,9 +29,10 @@ type fakeBackend struct {
 	stopCh  chan debugger.StopEvent
 	stopped bool
 
-	continueCalls   int
-	singleStepCalls []int
-	writtenAt       map[uint64][]byte
+	continueCalls    int
+	singleStepCalls  []int
+	stopProcessCalls int
+	writtenAt        map[uint64][]byte
 }
 
 func newFakeBackend() *fakeBackend {
@@ -71,7 +73,7 @@ func (f *fakeBackend) peekMem(addr uint64, n int) []byte {
 }
 
 func (f *fakeBackend) ContinueProcess() error  { f.continueCalls++; return nil }
-func (f *fakeBackend) StopProcess() error      { return nil }
+func (f *fakeBackend) StopProcess() error      { f.stopProcessCalls++; return nil }
 func (f *fakeBackend) Threads() ([]int, error) { return f.tids, nil }
 
 func (f *fakeBackend) SingleStep(tid int) error {
@@ -558,6 +560,102 @@ var _ = Describe("Engine", func() {
 		It("rejects a second Continue without an intervening stop", func() {
 			Expect(d.Continue()).To(Succeed())
 			Expect(d.Continue()).To(MatchError(debugger.ErrNotSuspended))
+		})
+	})
+
+	Describe("Pause", func() {
+		const sigstop = int(syscall.SIGSTOP)
+
+		// pushSIGSTOP simulates the signal-delivery stop a Pause SIGSTOP
+		// surfaces as from Backend.Wait() on both backends.
+		pushSIGSTOP := func() {
+			fb.pushStop(debugger.StopEvent{
+				Reason: debugger.StopSignal,
+				TID:    1,
+				Signal: sigstop,
+			})
+		}
+
+		It("is rejected with ErrNotRunning when there is no process", func() {
+			Expect(d.Pause()).To(MatchError(debugger.ErrNotRunning))
+		})
+
+		It("is rejected with ErrNotRunning while suspended", func() {
+			debugger.ExportedForceSuspended(d)
+			Expect(d.Pause()).To(MatchError(debugger.ErrNotRunning))
+		})
+
+		It("fires StopProcess and emits EventPaused for the resulting SIGSTOP", func() {
+			debugger.ExportedForceSuspended(d)
+			Expect(d.Continue()).To(Succeed())
+
+			before := fb.stopProcessCalls
+			Expect(d.Pause()).To(Succeed())
+			Expect(fb.stopProcessCalls).To(Equal(before + 1))
+
+			pushSIGSTOP()
+
+			evt := mustNextEvent(d)
+			Expect(evt.Kind).To(Equal(protocol.EventPaused))
+
+			var p protocol.PausedPayload
+			Expect(protocol.DecodeEventPayload(evt, &p)).To(Succeed())
+
+			// The engine is now suspended: Continue must be accepted again.
+			Expect(d.Continue()).To(Succeed())
+		})
+
+		It("does not emit EventPaused for a SIGSTOP when no Pause is pending", func() {
+			debugger.ExportedForceSuspended(d)
+			Expect(d.Continue()).To(Succeed())
+
+			// A SIGSTOP with no armed Pause is a leftover: suppress and resume
+			// silently rather than reporting a bogus Paused.
+			pushSIGSTOP()
+			_, ok := nextEvent(d)
+			Expect(ok).To(BeFalse(), "leftover SIGSTOP must not surface any event")
+
+			// Prove the engine actually resumed (didn't stall) after swallowing
+			// the leftover: arm a real Pause and confirm its SIGSTOP now surfaces
+			// as EventPaused. Reading through the events channel gives the
+			// happens-before edge a raw counter read would race on, since the
+			// suppressing ContinueProcess runs on the loop goroutine.
+			Expect(d.Pause()).To(Succeed())
+			pushSIGSTOP()
+			Expect(mustNextEvent(d).Kind).To(Equal(protocol.EventPaused))
+		})
+
+		Context("pending-SIGSTOP race: a self-stop wins before the SIGSTOP lands", func() {
+			const bpAddr = uint64(0x3000)
+
+			BeforeEach(func() {
+				fb.seedMem(bpAddr, []byte{0x90})
+				debugger.ExportedForceSuspended(d)
+				debugger.ExportedSetBreakpointAt(d, bpAddr)
+			})
+
+			It("suspends for the breakpoint, then suppresses the leftover SIGSTOP", func() {
+				Expect(d.Continue()).To(Succeed())
+				Expect(d.Pause()).To(Succeed())
+
+				// The real breakpoint stop arrives before the SIGSTOP does.
+				fb.pushStop(debugger.StopEvent{
+					Reason: debugger.StopBreakpoint,
+					TID:    1,
+					PC:     bpAddr,
+				})
+				evt := mustNextEvent(d)
+				Expect(evt.Kind).To(Equal(protocol.EventBreakpointHit))
+
+				// Resume; the queued SIGSTOP now surfaces but the Pause flag was
+				// cleared by the breakpoint suspend, so it must be swallowed —
+				// no spurious EventPaused.
+				Expect(d.Continue()).To(Succeed())
+				pushSIGSTOP()
+
+				_, ok := nextEvent(d)
+				Expect(ok).To(BeFalse(), "leftover SIGSTOP after a breakpoint must not surface EventPaused")
+			})
 		})
 	})
 

--- a/internal/debugger/process.go
+++ b/internal/debugger/process.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"syscall"
 )
 
 // process tracks the OS handle for the tracee, with platform-specific hooks
@@ -61,28 +60,6 @@ func (p *process) kill(b Backend) error {
 	p.live = false
 	if err := killProcess(b, p.pid, p.cmd); err != nil {
 		return fmt.Errorf("kill: %w", err)
-	}
-	return nil
-}
-
-// stopProcessSignal sends a whole-thread-group SIGSTOP to pid. It is the
-// darwin backend's StopProcess() mechanism (the linux backend overrides
-// StopProcess to direct the signal at the main thread via tgkill; see
-// backend_linux_amd64.go for why). syscall.Kill is used directly instead of
-// os.FindProcess(pid).Signal: os.FindProcess never fails to find a process on
-// Unix (it just wraps the pid), so that pairing never actually distinguished
-// "no such process" from any other error. ESRCH (process already gone) is
-// treated as an idempotent no-op, matching process.kill's idempotency above.
-// NOTE: on darwin this is Pause *groundwork* only — macOS delivers a SIGSTOP to
-// a ptraced tracee as a job-control stop that our wait4 loop never reports, so
-// it does not yet surface as EventPaused. A functional darwin Pause needs Mach
-// thread_suspend instead; see AGENTS.md → Pause (darwin caveat).
-func stopProcessSignal(pid int) error {
-	if pid == 0 {
-		return fmt.Errorf("StopProcess: no process")
-	}
-	if err := syscall.Kill(pid, syscall.SIGSTOP); err != nil && err != syscall.ESRCH {
-		return fmt.Errorf("StopProcess: %w", err)
 	}
 	return nil
 }

--- a/internal/debugger/process.go
+++ b/internal/debugger/process.go
@@ -65,14 +65,18 @@ func (p *process) kill(b Backend) error {
 	return nil
 }
 
-// stopProcessSignal sends a whole-thread-group SIGSTOP to pid, the shared
-// mechanism behind both backends' StopProcess(). syscall.Kill is used
-// directly instead of os.FindProcess(pid).Signal: os.FindProcess never fails
-// to find a process on Unix (it just wraps the pid), so that pairing never
-// actually distinguished "no such process" from any other error. ESRCH
-// (process already gone) is treated as an idempotent no-op, matching
-// process.kill's idempotency above. See AGENTS.md → StopProcess for why this
-// exists (Pause groundwork) and what it deliberately doesn't do.
+// stopProcessSignal sends a whole-thread-group SIGSTOP to pid. It is the
+// darwin backend's StopProcess() mechanism (the linux backend overrides
+// StopProcess to direct the signal at the main thread via tgkill; see
+// backend_linux_amd64.go for why). syscall.Kill is used directly instead of
+// os.FindProcess(pid).Signal: os.FindProcess never fails to find a process on
+// Unix (it just wraps the pid), so that pairing never actually distinguished
+// "no such process" from any other error. ESRCH (process already gone) is
+// treated as an idempotent no-op, matching process.kill's idempotency above.
+// NOTE: on darwin this is Pause *groundwork* only — macOS delivers a SIGSTOP to
+// a ptraced tracee as a job-control stop that our wait4 loop never reports, so
+// it does not yet surface as EventPaused. A functional darwin Pause needs Mach
+// thread_suspend instead; see AGENTS.md → Pause (darwin caveat).
 func stopProcessSignal(pid int) error {
 	if pid == 0 {
 		return fmt.Errorf("StopProcess: no process")

--- a/internal/debugger/process_stop.go
+++ b/internal/debugger/process_stop.go
@@ -1,0 +1,31 @@
+//go:build darwin && arm64 && bingonative
+
+package debugger
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// stopProcessSignal sends a whole-thread-group SIGSTOP to pid. It is the darwin
+// backend's StopProcess() mechanism; the linux backend overrides StopProcess to
+// direct the signal at the main thread via tgkill (see backend_linux_amd64.go
+// for why), so this helper is darwin-only and lives in a darwin-tagged file to
+// avoid an unused-symbol lint on linux. syscall.Kill is used directly instead of
+// os.FindProcess(pid).Signal: os.FindProcess never fails to find a process on
+// Unix (it just wraps the pid), so that pairing never actually distinguished
+// "no such process" from any other error. ESRCH (process already gone) is
+// treated as an idempotent no-op, matching process.kill's idempotency.
+// NOTE: on darwin this is Pause *groundwork* only — macOS delivers a SIGSTOP to
+// a ptraced tracee as a job-control stop that our wait4 loop never reports, so
+// it does not yet surface as EventPaused. A functional darwin Pause needs Mach
+// thread_suspend instead; see AGENTS.md → Pause (darwin caveat).
+func stopProcessSignal(pid int) error {
+	if pid == 0 {
+		return fmt.Errorf("StopProcess: no process")
+	}
+	if err := syscall.Kill(pid, syscall.SIGSTOP); err != nil && err != syscall.ESRCH {
+		return fmt.Errorf("StopProcess: %w", err)
+	}
+	return nil
+}

--- a/internal/hub/dispatcher.go
+++ b/internal/hub/dispatcher.go
@@ -80,6 +80,11 @@ func dispatch(dbg debugger.Debugger, cmd protocol.Command) (dispatchResult, erro
 	case protocol.CmdStepOut:
 		return dispatchResult{}, dbg.StepOut()
 
+	// Pause is fire-and-forget: it arms an async interrupt and returns. The
+	// debugger emits EventPaused once the SIGSTOP lands (no immediate event).
+	case protocol.CmdPause:
+		return dispatchResult{}, dbg.Pause()
+
 	case protocol.CmdLocals:
 		var p protocol.LocalsPayloadCmd
 		if err := protocol.DecodeCommandPayload(cmd, &p); err != nil {

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -17,14 +17,19 @@ import (
 )
 
 // suspendingEvents pause the hub and require a resuming command before the
-// process is allowed to continue.
+// process is allowed to continue. EventPaused is included: a Pause request
+// halts the tracee and suspends it exactly like a breakpoint hit, just
+// asynchronously on demand rather than as a self-stop.
 var suspendingEvents = map[protocol.EventKind]bool{
 	protocol.EventBreakpointHit: true,
 	protocol.EventPanic:         true,
 	protocol.EventStepped:       true,
+	protocol.EventPaused:        true,
 }
 
-// resumingCommands unblock a suspended hub.
+// resumingCommands unblock a suspended hub. CmdPause is deliberately NOT here:
+// it is issued while the process is RUNNING (not suspended) and is routed via
+// cmdCh, so it must not be treated as a resume — see AGENTS.md → Pause.
 var resumingCommands = map[protocol.CommandKind]bool{
 	protocol.CmdContinue: true,
 	protocol.CmdStepOver: true,
@@ -218,7 +223,7 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 	h.broadcast(evt)
 
 	switch evt.Kind {
-	case protocol.EventBreakpointHit, protocol.EventPanic, protocol.EventStepped:
+	case protocol.EventBreakpointHit, protocol.EventPanic, protocol.EventStepped, protocol.EventPaused:
 		h.transitionState(protocol.StateSuspended)
 	case protocol.EventProcessExited:
 		h.transitionState(protocol.StateExited)

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -36,6 +36,7 @@ type fakeDebugger struct {
 	stepOverErr      error
 	stepIntoErr      error
 	stepOutErr       error
+	pauseErr         error
 	localsResult     []protocol.Variable
 	framesResult     []protocol.Frame
 	goroutinesResult []protocol.Goroutine
@@ -77,6 +78,7 @@ func (f *fakeDebugger) Continue() error { f.record("Continue"); return f.continu
 func (f *fakeDebugger) StepOver() error { f.record("StepOver"); return f.stepOverErr }
 func (f *fakeDebugger) StepInto() error { f.record("StepInto"); return f.stepIntoErr }
 func (f *fakeDebugger) StepOut() error  { f.record("StepOut"); return f.stepOutErr }
+func (f *fakeDebugger) Pause() error    { f.record("Pause"); return f.pauseErr }
 func (f *fakeDebugger) ClearBreakpoint(id int) error {
 	f.record("ClearBreakpoint")
 	return f.clearBPErr
@@ -494,6 +496,40 @@ var _ = Describe("Hub", func() {
 				}
 			}
 			Expect(count).To(Equal(1), "Continue must be called exactly once")
+		})
+	})
+
+	Describe("Pause", func() {
+		It("routes CmdPause to the debugger while the process runs", func() {
+			conn := newFakeWSConn()
+			h.AddClient(conn, nil)
+
+			// CmdPause is not a resuming command: it reaches the debugger via
+			// the main-loop cmdCh path, without any suspending event first.
+			conn.inject(mustCommand(protocol.CmdPause, struct{}{}))
+
+			Eventually(fd.recordedCalls, "500ms", "10ms").
+				Should(ContainElement("Pause"))
+		})
+
+		It("suspends the hub on EventPaused, then resumes on Continue", func() {
+			conn := newFakeWSConn()
+			h.AddClient(conn, nil)
+
+			fd.push(protocol.MustEvent(protocol.EventPaused, 1,
+				protocol.PausedPayload{Location: protocol.Location{File: "main.go", Line: 7}}))
+
+			e, ok := recvEvent(conn)
+			Expect(ok).To(BeTrue())
+			Expect(e.Kind).To(Equal(protocol.EventPaused))
+
+			// Suspending: no auto-resume until a resuming command arrives.
+			time.Sleep(20 * time.Millisecond)
+			Expect(fd.recordedCalls()).NotTo(ContainElement("Continue"))
+
+			conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
+			Eventually(fd.recordedCalls, "500ms", "10ms").
+				Should(ContainElement("Continue"))
 		})
 	})
 

--- a/justfile
+++ b/justfile
@@ -55,8 +55,8 @@ integration:
 	go run github.com/onsi/ginkgo/v2/ginkgo -r ./test/integration/.
 
 # Run the debugger E2E acceptance tests on linux/amd64 (native ptrace backend).
-# Runs the `basic` correctness, `churn` robustness, and `fullstack` transport
-# specs under -race.
+# Runs the `basic` correctness, `churn` robustness, `pause` async-interrupt, and
+# `fullstack` transport specs under -race.
 e2e-linux:
 	go test -tags e2e -race -count=1 -v -timeout 600s ./test/integration
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -38,6 +38,11 @@ type Client interface {
 	StepInto() error
 	StepOut() error
 
+	// Pause asynchronously interrupts a running process, forcing it to
+	// suspend. Fire-and-forget like Continue: it returns as soon as the
+	// command is sent; the halt is reported later via EventPaused on Events().
+	Pause() error
+
 	// SetBreakpoint blocks until the server confirms the resolved Breakpoint.
 	SetBreakpoint(file string, line int) (protocol.Breakpoint, error)
 	ClearBreakpoint(id int) error

--- a/pkg/client/ws.go
+++ b/pkg/client/ws.go
@@ -304,6 +304,16 @@ func (c *wsClient) StepOut() error {
 	return c.send(cmd)
 }
 
+// Pause is fire-and-forget like Continue: it sends CmdPause and returns. The
+// resulting halt arrives asynchronously as EventPaused on Events().
+func (c *wsClient) Pause() error {
+	cmd, err := newCommand(protocol.CmdPause, struct{}{})
+	if err != nil {
+		return err
+	}
+	return c.send(cmd)
+}
+
 func (c *wsClient) SetBreakpoint(file string, line int) (protocol.Breakpoint, error) {
 	cmd, err := newCommand(protocol.CmdSetBreakpoint, protocol.SetBreakpointPayload{
 		File: file, Line: line,

--- a/pkg/protocol/payload.go
+++ b/pkg/protocol/payload.go
@@ -85,6 +85,15 @@ type SteppedPayload struct {
 	Frames    []Frame   `json:"frames"`
 }
 
+// PausedPayload reports where the tracee was halted by a Pause request. It
+// mirrors SteppedPayload: the location is wherever execution happened to be
+// interrupted (an async stop), not a source-line boundary.
+type PausedPayload struct {
+	Goroutine Goroutine `json:"goroutine"`
+	Location  Location  `json:"location"`
+	Frames    []Frame   `json:"frames"`
+}
+
 type ContinuedPayload struct{}
 
 type LocalsPayload struct {

--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -29,6 +29,12 @@ const (
 	EventBreakpointHit EventKind = "BreakpointHit"
 	EventPanic         EventKind = "Panic"
 	EventStepped       EventKind = "Stepped"
+
+	// EventPaused reports that a Pause request forcibly halted the running
+	// tracee. Like BreakpointHit it is a suspending event — the process is
+	// stopped and the hub waits for a resuming command — but it is delivered
+	// asynchronously in response to CmdPause rather than a self-stop.
+	EventPaused EventKind = "Paused"
 )
 
 const (
@@ -72,6 +78,12 @@ const (
 	CmdStepOver CommandKind = "StepOver"
 	CmdStepInto CommandKind = "StepInto"
 	CmdStepOut  CommandKind = "StepOut"
+
+	// CmdPause asynchronously interrupts a running tracee, forcing it to
+	// suspend (reported via EventPaused). Unlike the resuming commands it is
+	// issued while the process is RUNNING, so it is not a member of the hub's
+	// resuming-commands set — see AGENTS.md → Pause.
+	CmdPause CommandKind = "Pause"
 
 	CmdLocals     CommandKind = "Locals"
 	CmdFrames     CommandKind = "Frames"

--- a/pkg/protocol/protocol_test.go
+++ b/pkg/protocol/protocol_test.go
@@ -222,6 +222,21 @@ var _ = Describe("Event", func() {
 				},
 			),
 
+			Entry("Paused",
+				protocol.EventPaused,
+				protocol.PausedPayload{
+					Goroutine: sampleGoroutine,
+					Location:  sampleLocation,
+					Frames:    sampleFrames,
+				},
+				func(e protocol.Event) {
+					var p protocol.PausedPayload
+					Expect(protocol.DecodeEventPayload(e, &p)).To(Succeed())
+					Expect(p.Location.Line).To(Equal(42))
+					Expect(p.Frames).To(HaveLen(2))
+				},
+			),
+
 			Entry("Continued",
 				protocol.EventContinued,
 				protocol.ContinuedPayload{},
@@ -452,6 +467,14 @@ var _ = Describe("Command", func() {
 				},
 			),
 
+			Entry("Pause",
+				protocol.CmdPause,
+				json.RawMessage(`{}`),
+				func(c protocol.Command) {
+					Expect(c.Kind).To(Equal(protocol.CmdPause))
+				},
+			),
+
 			Entry("Locals",
 				protocol.CmdLocals,
 				protocol.LocalsPayloadCmd{FrameIndex: 2},
@@ -531,6 +554,7 @@ var _ = Describe("Kind constants", func() {
 			protocol.EventGoroutines,
 			protocol.EventError,
 			protocol.EventRestarted,
+			protocol.EventPaused,
 		}
 		for _, k := range kinds {
 			Expect(string(k)).NotTo(BeEmpty(), "EventKind %q should not be empty", k)
@@ -552,6 +576,7 @@ var _ = Describe("Kind constants", func() {
 			protocol.CmdFrames,
 			protocol.CmdGoroutines,
 			protocol.CmdRestart,
+			protocol.CmdPause,
 		}
 		for _, k := range kinds {
 			Expect(string(k)).NotTo(BeEmpty(), "CommandKind %q should not be empty", k)

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -196,6 +196,39 @@ func declareChurnSpec() {
 	})
 }
 
+// declarePauseSpec adds the async-interrupt (Pause) acceptance spec. It is the
+// authoritative gate for Pause on the real backend: while the tracee runs, fire
+// Pause, assert EventPaused surfaces, then resume and repeat. Running the
+// Continue→Pause→Paused round-trip several times is the resume-after-pause
+// proof — if the first resume hung or corrupted the tracee (e.g. a SIGSTOP that
+// couldn't be cleanly discarded), the next Pause's signal would never surface
+// and waitFor would time out.
+func declarePauseSpec() {
+	It("interrupts a running process on demand and resumes, repeatedly", Label("pause"), func() {
+		bin := buildTarget("pause_target", basicTargetSrc)
+
+		h := newE2EHarness(bin)
+		h.waitFor(15*time.Second, protocol.EventStepped) // initial launch stop
+
+		iters := envInt("BINGO_E2E_PAUSE_ITERS", 3)
+		for i := 0; i < iters; i++ {
+			Expect(h.d.Continue()).To(Succeed(), "Continue #%d", i)
+
+			// Give the tracee a moment to actually be running before the async
+			// interrupt, so Pause exercises the running→suspended path rather
+			// than racing the resume.
+			time.Sleep(20 * time.Millisecond)
+
+			Expect(h.d.Pause()).To(Succeed(), "Pause #%d", i)
+			evt := h.waitFor(15*time.Second,
+				protocol.EventPaused, protocol.EventProcessExited, protocol.EventError)
+			Expect(evt.Kind).To(Equal(protocol.EventPaused),
+				"Pause #%d expected Paused, got %s: %s", i, evt.Kind, evt.Payload)
+		}
+		AddReportEntry("pause-iterations", iters)
+	})
+}
+
 // --- shared acceptance loop ---
 
 // stepDriver is the subset of debugger.Debugger and client.Client that the

--- a/test/integration/debugger_e2e_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_linux_amd64_test.go
@@ -10,5 +10,6 @@ import . "github.com/onsi/ginkgo/v2"
 var _ = Describe("Linux amd64 debugger backend (ptrace) E2E", Label("linux"), func() {
 	declareBasicStepOverSpec()
 	declareChurnSpec()
+	declarePauseSpec()
 	declareFullStackSpec()
 })


### PR DESCRIPTION
## What

Wires up the debugger **Pause** operation end-to-end — an *asynchronous* forcible halt of a **running** tracee that suspends it like an on-demand breakpoint (unlike breakpoints/steps, which are self-stops). This is the remaining piece of #54 after the Restart PR (#86) landed the `StopProcess()`/`stopProcessSignal` groundwork.

## Design

- **protocol**: add `CmdPause` command + `EventPaused` suspending event and `PausedPayload` (mirrors `SteppedPayload`). Additive — no `Version` bump.
- **engine**: `Pause()` `dispatch`es a closure that rejects with `ErrNotRunning` unless running, otherwise sets a loop-thread-only `manualStopPending` flag and fires `Backend.StopProcess()`. The resulting SIGSTOP surfaces from `Wait()` as a `StopSignal`; `handleStop` turns it into `EventPaused` + `stateSuspended` instead of auto-resuming. `emitPaused` mirrors `emitStepped`.
- **hub**: `EventPaused` added to `suspendingEvents` and the state-transition switch; `CmdPause` routed via `cmdCh` while running and **not** added to `resumingCommands`.
- **client SDK + CLI**: fire-and-forget `Pause()` / `pause`(`p`) command + `EventPaused` printer.

### Resume-after-SIGSTOP
bingo never *injects* the SIGSTOP — `Continue` does `PtraceCont(tid, 0)`, which suppresses the pending signal — so only the reporting thread enters signal-delivery-stop and **no whole-group stop** is created. Resuming is therefore a plain `Continue`, identical to resuming from a breakpoint. No special handling needed. The linux E2E runs the Continue→Pause→Paused round-trip several times as the resume proof.

### Pending-SIGSTOP race
If a real breakpoint/step wins the race after `Pause()` armed the flag but before the SIGSTOP lands, the process suspends for that self-stop and the SIGSTOP stays queued. `manualStopPending` is therefore cleared on **every** self-stop suspend (`emitBreakpointHit`/`emitStepped`); when the leftover SIGSTOP later surfaces with the flag clear, the `StopSignal` branch silently suppresses + continues it (no bogus `EventPaused`, no spurious output). Pinned by a focused engine unit test.

### Linux robustness — tgkill to the main thread
`StopProcess()` on the linux backend uses `tgkill(pid, pid, SIGSTOP)` rather than a process-directed `kill`. A process-directed SIGSTOP can be dequeued by any thread, and linux `Wait()` deliberately swallows a non-main-thread SIGSTOP as a clone group-stop (`sig == SIGSTOP && tid != b.pid` → continue), so a multithreaded Pause could be lost. Targeting the main thread (`tid == pid`) makes it fall through to the `StopSignal` return every time.

## ⚠️ Known limitation — linux-only; darwin deferred

**Pause is functional on `linux/amd64` only.** Verified empirically on real Apple Silicon that on `darwin/arm64`, macOS applies `kill(SIGSTOP)` to a ptraced tracee as a **job-control stop** that the ptrace `wait4` loop never reports — so `Wait()` never returns, no `StopSignal` surfaces, and no `EventPaused` is emitted. This matches the existing darwin `StopProcess()` groundwork comment, which already notes a real darwin Pause needs Mach `thread_suspend` (as Delve's `requestManualStop` does), **not** SIGSTOP.

That is a darwin-native change to `backend_darwin_arm64.go`, deliberately **out of scope** here to stay clear of the darwin verification gate, and left as a follow-up. Everything above the backend (engine/hub/protocol/client/CLI) is platform-agnostic — the moment the darwin backend surfaces the stop, `EventPaused` flows with no further engine changes. Documented in `AGENTS.md → Pause (darwin caveat)`.

## Tests

- **engine** unit tests: reject-when-not-running, `StopProcess` + `EventPaused` flow, leftover-SIGSTOP suppression, and the pending-SIGSTOP-after-breakpoint ordering (no spurious `Paused`).
- **hub**: `CmdPause` reaches the debugger while running; `EventPaused` suspends the hub and a subsequent `Continue` resumes.
- **protocol**: round-trip for `CmdPause`/`EventPaused`.
- **E2E**: new linux `pause`-labelled spec (`declarePauseSpec`) — Continue→Pause→`EventPaused`, repeated to prove resume-after-pause. Wired into the linux container only, with a matching CI job and justfile/`e2e-linux` coverage.

## Verification

- `go vet -tags bingonative ./...` and `GOOS=linux GOARCH=amd64 go vet ./...` — clean.
- `go test -tags bingonative -race ./...` — all green (darwin).
- `just e2e-darwin` (basic + churn + fullstack) — green on real Apple Silicon, confirming the shared `handleStop` changes don't regress the native backend.
- Linux `pause` E2E is authoritative and validated by CI's linux jobs (native ptrace; not runnable on the macOS dev box).

Part of #54