### PR TITLE
feat: implement Pause (darwin)

### DIFF
--- a/.github/workflows/debugger-e2e.yml
+++ b/.github/workflows/debugger-e2e.yml
@@ -86,11 +86,12 @@ jobs:
       # in the kernel, so the Mach backend can never run here. Execution is gated
       # to self-hosted runners; hosted runners stop after the compile+codesign
       # above. Delve hits the identical wall. Run locally via `just e2e-darwin`.
-      - name: E2E basic + churn (self-hosted runners only)
+      - name: E2E basic + churn + pause (self-hosted runners only)
         if: runner.environment == 'self-hosted'
         run: |
           ./e2e.test -test.v -test.timeout 300s -ginkgo.label-filter=basic
           ./e2e.test -test.v -test.timeout 600s -ginkgo.label-filter=churn
+          ./e2e.test -test.v -test.timeout 300s -ginkgo.label-filter=pause
 
       - name: Skip execution on hosted runners (task_for_pid unavailable)
         if: runner.environment != 'self-hosted'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -440,9 +440,9 @@ breakpoint. It's the one suspend that is *asynchronous*: breakpoints and steps
 are self-stops (the tracee runs into a trap it was set up to hit), whereas Pause
 interrupts from the outside at an arbitrary instruction.
 
-Flow (detection is platform-agnostic, in the shared engine — no backend changes
-were needed for it on the platform where it works, linux; see the darwin caveat
-at the end):
+Flow (detection is platform-agnostic, in the shared engine — the only
+per-platform piece is *which* signal `StopProcess()` sends, abstracted behind
+`Backend.PauseSignal()`):
 
 1. Client sends `CmdPause` while running. The hub routes it via `cmdCh`
    (**not** `resumeCh` — Pause is not a resuming command; see
@@ -453,17 +453,17 @@ at the end):
    returns immediately. It does **not** change state — the suspend happens when
    the stop surfaces. Fire-and-forget from the client's view; `EventPaused`
    arrives asynchronously.
-3. `StopProcess()` sends `SIGSTOP`. On **linux**, a deliberate SIGSTOP surfaces
-   from `Backend.Wait()` as `StopEvent{Reason: StopSignal, Signal: SIGSTOP}`
-   (a ptrace signal-delivery-stop), so detection lives entirely in the engine's
-   `handleStop` `StopSignal` branch. (Darwin does **not** surface it — see the
-   caveat below.)
+3. `StopProcess()` sends the backend's interrupt signal (`PauseSignal()`:
+   `SIGSTOP` on linux, `SIGUSR2` on darwin). A deliberate signal surfaces from
+   `Backend.Wait()` as `StopEvent{Reason: StopSignal, Signal: PauseSignal()}`
+   (a ptrace signal-delivery-stop) on **both** backends, so detection lives
+   entirely in the engine's `handleStop` `StopSignal` branch.
 4. `handleStop` `StopSignal` branch: if `manualStopPending` (and
-   `stop.Signal == SIGSTOP`), it clears the flag, defensively reinstalls any
-   in-flight step-over BP (mirrors the existing StopSignal reinstall),
-   `populateStopPC`s, `setState(stateSuspended)`, and `emitPaused(stop)` —
-   returning **without** continuing. Genuine other signals keep the original
-   emit-output-then-auto-resume behavior.
+   `stop.Signal == e.backend.PauseSignal()`), it clears the flag, defensively
+   reinstalls any in-flight step-over BP (mirrors the existing StopSignal
+   reinstall), `populateStopPC`s, `setState(stateSuspended)`, and
+   `emitPaused(stop)` — returning **without** continuing. Genuine other signals
+   keep the original emit-output-then-auto-resume behavior.
 
 **Loop-thread-only flag, no sync.** `manualStopPending` is a plain `bool` with
 no mutex because both writers/readers — `Pause()`'s dispatched closure and
@@ -471,60 +471,62 @@ no mutex because both writers/readers — `Pause()`'s dispatched closure and
 [Engine concurrency model](#engine-concurrency-model--non-obvious-invariants)).
 Don't add locking; don't touch it from another goroutine.
 
-**Pending-SIGSTOP race.** If a real breakpoint/step stop wins the race after
-`Pause()` set the flag but before the SIGSTOP is dequeued, the process suspends
-for *that* self-stop and the SIGSTOP stays queued in the tracee. To stop it
-being misread as a bogus Pause on the next resume, `manualStopPending` is
+**Pending-interrupt race.** If a real breakpoint/step stop wins the race after
+`Pause()` set the flag but before the interrupt signal is dequeued, the process
+suspends for *that* self-stop and the signal stays queued in the tracee. To stop
+it being misread as a bogus Pause on the next resume, `manualStopPending` is
 cleared on **every** self-stop suspend (`emitBreakpointHit` / `emitStepped`).
-Then when the leftover SIGSTOP later surfaces with the flag clear, the
+Then when the leftover signal later surfaces with the flag clear, the
 `StopSignal` branch silently suppresses it (continue, no `EventPaused`, no
-spurious "signal 19" output). A focused engine unit test pins this ordering.
+spurious signal output). A focused engine unit test pins this ordering.
 
 **Linux: SIGSTOP is directed at the main thread.** `StopProcess()` on
 [backend_linux_amd64.go](internal/debugger/backend_linux_amd64.go) uses
-`tgkill(pid, pid, SIGSTOP)` rather than the process-directed
-`stopProcessSignal` (`kill`) the darwin backend shares. A process-directed
-SIGSTOP can be dequeued by any thread, and linux `Wait()` deliberately
-**swallows** a non-main-thread SIGSTOP as a clone group-stop
+`tgkill(pid, pid, SIGSTOP)` rather than a process-directed `kill`. A
+process-directed SIGSTOP can be dequeued by any thread, and linux `Wait()`
+deliberately **swallows** a non-main-thread SIGSTOP as a clone group-stop
 (`sig == SIGSTOP && tid != b.pid` → continue), so a multithreaded Pause could
 be lost. Targeting the main thread (`tid == pid`) makes it fall through to the
-`StopSignal` return every time.
+`StopSignal` return every time. `PauseSignal()` returns `SIGSTOP`.
 
-**Resume-after-pause is a plain Continue.** bingo never *injects* the SIGSTOP
-(`Continue` does `PtraceCont(tid, 0)`, which suppresses the pending signal), so
-only the reporting thread entered signal-delivery-stop and no whole-group stop
-was created. Resuming is therefore identical to resuming from a breakpoint —
-no special handling. The linux `pause`-labelled E2E spec
-(`declarePauseSpec`, [debugger_e2e_common_test.go](test/integration/debugger_e2e_common_test.go),
-wired into the linux container only) runs the Continue→Pause→Paused round-trip
-several times; if the first resume hung, the second Pause's signal would never
-surface and the spec would time out.
+**Darwin: a *catchable* signal (SIGUSR2), not SIGSTOP.** darwin `StopProcess()`
+([backend_darwin_arm64.go](internal/debugger/backend_darwin_arm64.go)) sends
+`kill(pid, SIGUSR2)` and `PauseSignal()` returns `SIGUSR2`. SIGSTOP does **not**
+work on darwin: XNU delivers a SIGSTOP to a ptraced tracee as a *job-control*
+stop that Go's `syscall.WaitStatus` classifies as neither `Stopped()` nor
+`Exited()` (`StopSignal() == -1`), so `Wait()`'s `if !ws.Stopped() { continue }`
+skips it and re-blocks in `wait4` forever — verified empirically on real Apple
+Silicon. A **catchable** signal instead produces an ordinary ptrace
+signal-delivery stop that `wait4` *does* report, so it falls through darwin
+`Wait()` to `StopEvent{StopSignal, sig}` (SIGTRAP is breakpoint/step and
+SIGURG/SIGWINCH are re-delivered, so those are special-cased; SIGUSR2 is not).
+SIGUSR2 is chosen because it is catchable, never terminal-generated, and unused
+by the Go runtime. Bingo never re-injects it (`Continue` resumes with signal 0),
+so the tracee never actually receives it — resume is a plain Continue, and the
+async-preempt SIGURG hazard doesn't apply (the darwin backend also forces
+`GODEBUG=asyncpreemptoff=1`, so the tracee has no SIGURG anyway). This mirrors
+Delve's *intent* (an on-demand halt surfaced to the wait loop) while fitting
+bingo's `wait4` architecture — it does **not** use Mach `thread_suspend` (Delve
+needs that only because it detects stops via a Mach exception port, not `wait4`).
 
-**Darwin caveat — Pause is not functional on darwin yet (linux-only).** The
-platform-agnostic detection above works on linux but **not** on darwin/arm64.
-macOS applies a `kill(pid, SIGSTOP)` to a ptraced tracee as a *job-control*
-stop, which is **not** reported through our ptrace `wait4` loop as a
-signal-delivery-stop — so `Backend.Wait()` never returns, no `StopSignal`
-surfaces, and no `EventPaused` is emitted (a Pause on darwin currently hangs the
-suspend). This was verified empirically on real Apple Silicon. The darwin
-`StopProcess()` groundwork comment already flags this: a correct darwin Pause
-needs Mach `thread_suspend` on every thread plus an atomic halt flag, exactly
-like Delve's `requestManualStop` (`pkg/proc/native/proc_darwin.go`) — **not**
-SIGSTOP. That is a darwin-native change to
-[backend_darwin_arm64.go](internal/debugger/backend_darwin_arm64.go), which is
-deliberately **out of scope** here to stay clear of the
-[darwin verification gate](#test-layering); it is left as a follow-up. Nothing
-in the shared engine, hub, protocol, client, or CLI is darwin-specific — the
-moment darwin's backend surfaces the stop, `EventPaused` will flow with no
-further engine changes.
+**Resume-after-pause is a plain Continue.** bingo never *injects* the interrupt
+signal (`Continue` does `PtraceCont(tid, 0)` / `PT_CONTINUE` with signal 0,
+which suppresses the pending signal), so only the reporting thread entered
+signal-delivery-stop and no whole-group stop was created. Resuming is therefore
+identical to resuming from a breakpoint — no special handling. The
+`pause`-labelled E2E spec (`declarePauseSpec`,
+[debugger_e2e_common_test.go](test/integration/debugger_e2e_common_test.go),
+wired into **both** the linux and darwin containers) runs the
+Continue→Pause→Paused round-trip several times; if the first resume hung, the
+second Pause's signal would never surface and the spec would time out.
 
-`StopProcess()` itself is still the hardened idempotent primitive from the
-Restart groundwork: a `pid == 0` guard and `ESRCH` (process already gone)
-treated as a no-op success. Delve's manual-stop is heavier (Linux:
-`sys.Kill(pid, SIGTRAP)` + a `trapWaitInternal` halt-flag state machine; Darwin:
-Mach `thread_suspend` on every thread + an atomic halt flag) because it lands
-*every* thread at a consistent stop point; bingo's partial-stop model only needs
-the one reporting thread suspended, so on linux the SIGSTOP approach suffices.
+`StopProcess()` itself is the hardened idempotent primitive from the Restart
+groundwork: a `pid == 0` guard and `ESRCH` (process already gone) treated as a
+no-op success. Delve's manual-stop is heavier (Linux: `sys.Kill(pid, SIGTRAP)` +
+a `trapWaitInternal` halt-flag state machine; Darwin: Mach `thread_suspend` on
+every thread + an atomic halt flag) because it lands *every* thread at a
+consistent stop point; bingo's partial-stop model only needs the one reporting
+thread suspended, so a single interrupt signal suffices on both platforms.
 
 ## Error handling
 
@@ -566,10 +568,10 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   internal/server → internal/hub → debugger → tracee) to catch transport/hub
   wiring regressions the backend-only specs can't (seq re-stamping of real
   events, the suspend/resume gate on a genuine BreakpointHit, synchronous
-  SetBreakpoint confirmation routing). The `pause` spec is wired into the linux
-  container only (`declarePauseSpec` — detection is platform-agnostic in the
-  engine, and darwin-native files must stay out of the verification gate). Each
-  label is its own CI job. CI:
+  SetBreakpoint confirmation routing). The `pause` spec (`declarePauseSpec`) is
+  wired into **both** the linux and darwin containers — detection is
+  platform-agnostic in the engine and each backend's `PauseSignal()` surfaces
+  the interrupt through `wait4`. Each label is its own CI job. CI:
   [.github/workflows/debugger-e2e.yml](.github/workflows/debugger-e2e.yml).
   The linux jobs run fully on hosted runners. The darwin jobs compile and
   codesign the E2E binary on hosted macOS runners (the only CI check that the

--- a/internal/debugger/backend.go
+++ b/internal/debugger/backend.go
@@ -11,6 +11,13 @@ type Backend interface {
 	SingleStep(tid int) error
 	StopProcess() error
 
+	// PauseSignal reports the signal number StopProcess delivers to interrupt a
+	// running tracee. The engine matches a StopSignal stop against it to tell an
+	// operator Pause apart from a genuine program signal (linux: SIGSTOP via
+	// tgkill; darwin: a catchable signal that surfaces through its wait4 loop —
+	// SIGSTOP cannot, see backend_darwin_arm64.go).
+	PauseSignal() int
+
 	ReadMemory(addr uint64, dst []byte) error
 	WriteMemory(addr uint64, src []byte) error
 

--- a/internal/debugger/backend_darwin_arm64.go
+++ b/internal/debugger/backend_darwin_arm64.go
@@ -101,6 +101,18 @@ const (
 	ptDarwinDetach   = uintptr(11)
 )
 
+// darwinPauseSignal is the signal StopProcess sends to interrupt a running
+// tracee for Pause. It must be a CATCHABLE signal (so it surfaces through the
+// wait4 loop as a signal-delivery stop; SIGSTOP does not — see StopProcess) and
+// one Wait does not special-case (SIGTRAP is breakpoint/step; SIGURG/SIGWINCH
+// are re-delivered), leaving the StopSignal fall-through. SIGUSR2 fits: it is
+// never terminal-generated (unlike SIGINT/SIGTSTP), the Go runtime does not use
+// it for itself, and the engine suppresses it on resume so the tracee never
+// actually receives it. A genuine SIGUSR2 sent to the tracee while no Pause is
+// pending is silently discarded (like a stray SIGSTOP on linux); the tradeoff
+// is documented in AGENTS.md → Pause.
+const darwinPauseSignal = syscall.SIGUSR2
+
 // The two darwin/arm64 step-over correctness fixes are independently toggleable
 // so an operator can run the behavior-preserving atomic step-over (#1) without
 // the async-preemption workaround (#2), which alters the tracee's goroutine
@@ -568,17 +580,27 @@ func (b *darwinBackend) setSingleStep(tid int, on bool) error {
 	return nil
 }
 
-// StopProcess sends a whole-thread-group SIGSTOP as a stand-in halt
-// primitive, mirroring the intent (not the mechanism) of Delve's Darwin
-// requestManualStop, which suspends via Mach thread_suspend on every thread
-// plus an atomic halt flag (pkg/proc/native/proc_darwin.go). This is Pause
-// groundwork only: it does not implement that halt-flag state machine, so no
-// Pause command is wired to it yet — see AGENTS.md. The signal mechanics
-// (syscall.Kill, ESRCH-as-idempotent) are shared with the linux backend via
-// stopProcessSignal in process.go.
+// StopProcess asynchronously interrupts the running tracee for Pause by sending
+// it darwinPauseSignal. Unlike Delve's Darwin backend — which halts via Mach
+// thread_suspend on every thread because it detects stops through a Mach
+// exception port — bingo detects stops through wait4, so Pause must produce a
+// wait4-visible stop. SIGSTOP cannot: XNU delivers it to a ptraced tracee as a
+// job-control stop that Go's syscall.WaitStatus reports as neither Stopped nor
+// Exited (StopSignal()==-1), so Wait's `if !ws.Stopped()` skips it and re-blocks
+// forever. A catchable signal instead surfaces as an ordinary ptrace
+// signal-delivery stop — Wait returns it as StopEvent{StopSignal, sig} and the
+// engine's manual-stop detection turns it into EventPaused. The engine never
+// re-injects it (Continue resumes with signal 0), so the tracee never actually
+// receives the signal and resume is a plain ContinueProcess. ESRCH (process
+// already gone) is an idempotent no-op, matching process.kill.
 func (b *darwinBackend) StopProcess() error {
-	return stopProcessSignal(b.pid)
+	return stopProcessSignal(b.pid, darwinPauseSignal)
 }
+
+// PauseSignal is the catchable signal StopProcess delivers and that the engine
+// turns into EventPaused. See Backend.PauseSignal and StopProcess for why a
+// catchable signal (not SIGSTOP) is required on darwin.
+func (b *darwinBackend) PauseSignal() int { return int(darwinPauseSignal) }
 
 func (b *darwinBackend) GetRegisters(tid int) (Registers, error) {
 	thread := C.mach_port_t(tid)

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -251,6 +251,10 @@ func (b *linuxBackend) StopProcess() error {
 	return nil
 }
 
+// PauseSignal is SIGSTOP: the signal StopProcess directs at the main thread and
+// that the engine turns into EventPaused. See Backend.PauseSignal.
+func (b *linuxBackend) PauseSignal() int { return int(syscall.SIGSTOP) }
+
 func (b *linuxBackend) ReadMemory(addr uint64, dst []byte) error {
 	tid := b.traceTID()
 	var n int

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"runtime"
 	"sync"
-	"syscall"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
@@ -77,7 +76,8 @@ type engine struct {
 	stepOverFile string
 	stepOverLine int
 
-	// manualStopPending records that a Pause request has fired a SIGSTOP at
+	// manualStopPending records that a Pause request has fired the backend's
+	// interrupt signal (PauseSignal — SIGSTOP on linux, SIGUSR2 on darwin) at
 	// the tracee and we are awaiting the resulting signal-delivery stop, which
 	// should be turned into EventPaused rather than auto-resumed. It needs no
 	// synchronization: both Pause()'s dispatched closure and handleStop run on
@@ -293,10 +293,11 @@ func (e *engine) StepOut() error {
 
 // Pause asynchronously interrupts a running tracee. It is the only resume-side
 // operation issued while the process is RUNNING rather than suspended: it fires
-// a SIGSTOP at the tracee (via the backend) and records manualStopPending so
-// the resulting signal-delivery stop is turned into EventPaused instead of
-// being auto-resumed (see handleStop's StopSignal branch). The suspend is
-// reported asynchronously, so this returns as soon as the interrupt is armed.
+// the backend's interrupt signal (PauseSignal) at the tracee via
+// StopProcess and records manualStopPending so the resulting signal-delivery
+// stop is turned into EventPaused instead of being auto-resumed (see
+// handleStop's StopSignal branch). The suspend is reported asynchronously, so
+// this returns as soon as the interrupt is armed.
 func (e *engine) Pause() error {
 	return e.dispatch(func() error {
 		if e.getState() != stateRunning {
@@ -610,11 +611,11 @@ func (e *engine) handleStop(stop StopEvent) {
 			}
 			e.endThreadStep()
 		}
-		if stop.Signal == int(syscall.SIGSTOP) {
+		if stop.Signal == e.backend.PauseSignal() {
 			if e.manualStopPending {
-				// A Pause request's SIGSTOP has arrived. Suspend and report
-				// EventPaused instead of auto-resuming — this is the one signal
-				// stop we deliberately turn into a suspending event.
+				// A Pause request's interrupt signal has arrived. Suspend and
+				// report EventPaused instead of auto-resuming — this is the one
+				// signal stop we deliberately turn into a suspending event.
 				e.manualStopPending = false
 				var err error
 				if stop, err = e.populateStopPC(stop, false); err != nil {
@@ -626,11 +627,11 @@ func (e *engine) handleStop(stop StopEvent) {
 				e.emitPaused(stop)
 				return
 			}
-			// A SIGSTOP with no pending Pause is a leftover: a Pause raced a
-			// self-stop (breakpoint/step won and cleared manualStopPending),
-			// leaving its SIGSTOP queued. Suppress it silently — surfacing it
-			// as output or EventPaused would be bogus. Continue discards it
-			// (ContinueProcess resumes with signal 0).
+			// The interrupt signal with no pending Pause is a leftover: a Pause
+			// raced a self-stop (breakpoint/step won and cleared
+			// manualStopPending), leaving the signal queued. Suppress it
+			// silently — surfacing it as output or EventPaused would be bogus.
+			// Continue discards it (ContinueProcess resumes with signal 0).
 			_ = e.backend.ContinueProcess()
 			e.setState(stateRunning)
 			go e.waitLoop()
@@ -1026,9 +1027,10 @@ func (e *engine) emit(kind protocol.EventKind, payload any) {
 }
 
 func (e *engine) emitBreakpointHit(bp *breakpointEntry, stop StopEvent) {
-	// Suspending for a self-stop cancels any pending Pause: a Pause SIGSTOP that
-	// raced this stop and lost is now leftover in the kernel queue, to be
-	// suppressed (not reported as Paused) when it surfaces on the next resume.
+	// Suspending for a self-stop cancels any pending Pause: a Pause interrupt
+	// signal that raced this stop and lost is now leftover in the kernel queue,
+	// to be suppressed (not reported as Paused) when it surfaces on the next
+	// resume.
 	e.manualStopPending = false
 	frames, _ := e.collectFrames(stop.TID)
 	goroutines, _ := e.readGoroutines()

--- a/internal/debugger/engine_test.go
+++ b/internal/debugger/engine_test.go
@@ -74,6 +74,7 @@ func (f *fakeBackend) peekMem(addr uint64, n int) []byte {
 
 func (f *fakeBackend) ContinueProcess() error  { f.continueCalls++; return nil }
 func (f *fakeBackend) StopProcess() error      { f.stopProcessCalls++; return nil }
+func (f *fakeBackend) PauseSignal() int        { return int(syscall.SIGSTOP) }
 func (f *fakeBackend) Threads() ([]int, error) { return f.tids, nil }
 
 func (f *fakeBackend) SingleStep(tid int) error {

--- a/internal/debugger/process_stop.go
+++ b/internal/debugger/process_stop.go
@@ -7,24 +7,20 @@ import (
 	"syscall"
 )
 
-// stopProcessSignal sends a whole-thread-group SIGSTOP to pid. It is the darwin
-// backend's StopProcess() mechanism; the linux backend overrides StopProcess to
-// direct the signal at the main thread via tgkill (see backend_linux_amd64.go
-// for why), so this helper is darwin-only and lives in a darwin-tagged file to
-// avoid an unused-symbol lint on linux. syscall.Kill is used directly instead of
+// stopProcessSignal sends sig to pid. It is the darwin backend's Pause
+// interrupt primitive (StopProcess passes darwinPauseSignal); the linux backend
+// directs its own SIGSTOP at the main thread via tgkill and never calls this, so
+// the helper is darwin-only and lives in a darwin-tagged file to avoid an
+// unused-symbol lint on linux. syscall.Kill is used directly instead of
 // os.FindProcess(pid).Signal: os.FindProcess never fails to find a process on
 // Unix (it just wraps the pid), so that pairing never actually distinguished
 // "no such process" from any other error. ESRCH (process already gone) is
 // treated as an idempotent no-op, matching process.kill's idempotency.
-// NOTE: on darwin this is Pause *groundwork* only — macOS delivers a SIGSTOP to
-// a ptraced tracee as a job-control stop that our wait4 loop never reports, so
-// it does not yet surface as EventPaused. A functional darwin Pause needs Mach
-// thread_suspend instead; see AGENTS.md → Pause (darwin caveat).
-func stopProcessSignal(pid int) error {
+func stopProcessSignal(pid int, sig syscall.Signal) error {
 	if pid == 0 {
 		return fmt.Errorf("StopProcess: no process")
 	}
-	if err := syscall.Kill(pid, syscall.SIGSTOP); err != nil && err != syscall.ESRCH {
+	if err := syscall.Kill(pid, sig); err != nil && err != syscall.ESRCH {
 		return fmt.Errorf("StopProcess: %w", err)
 	}
 	return nil

--- a/justfile
+++ b/justfile
@@ -61,8 +61,9 @@ e2e-linux:
 	go test -tags e2e -race -count=1 -v -timeout 600s ./test/integration
 
 # Run the debugger E2E acceptance tests on darwin/arm64 (native ptrace+Mach
-# backend). task_for_pid needs the debugger entitlement, so the test binary is
-# codesigned before it runs.
+# backend). Runs the `basic` correctness, `churn` robustness, `pause`
+# async-interrupt, and `fullstack` transport specs. task_for_pid needs the
+# debugger entitlement, so the test binary is codesigned before it runs.
 e2e-darwin:
 	mkdir -p ./build
 	env CGO_ENABLED=1 go test -tags 'e2e bingonative' -race -c -o ./build/bingo-e2e.test ./test/integration

--- a/test/integration/debugger_e2e_darwin_arm64_test.go
+++ b/test/integration/debugger_e2e_darwin_arm64_test.go
@@ -11,5 +11,6 @@ import . "github.com/onsi/ginkgo/v2"
 var _ = Describe("Darwin arm64 debugger backend (ptrace+Mach) E2E", Label("darwin"), func() {
 	declareBasicStepOverSpec()
 	declareChurnSpec()
+	declarePauseSpec()
 	declareFullStackSpec()
 })


### PR DESCRIPTION
## What

Makes the **Pause** operation actually work on **darwin/arm64**. The linux Pause (PR #87) shipped detection entirely in the shared engine, but the darwin path hung. This PR fixes darwin without touching any of the platform-agnostic engine/hub/protocol/client/CLI plumbing — the only per-platform piece is *which signal* the interrupt uses.

## Why darwin hung (root cause, corrected)

The earlier conclusion was "darwin Pause is impossible without Mach `thread_suspend`." That turned out to be wrong. Investigated on real Apple Silicon:

- A deliberate `SIGSTOP` to a **ptraced** tracee is delivered by XNU as a **job-control stop**. `wait4` *does* return for it (`ws=0x117f`), but Go's `syscall.WaitStatus` classifies it as **neither `Stopped()` nor `Exited()`** (`StopSignal() == -1`).
- bingo's darwin `Wait()` has `if !ws.Stopped() { continue }`, so it **skips the SIGSTOP and re-blocks in `wait4` forever** → the hang. This is subtler than "SIGSTOP is never reported."

## The fix

Darwin `StopProcess()` sends a **catchable** signal (**SIGUSR2**) instead of SIGSTOP. A catchable signal produces an ordinary ptrace **signal-delivery stop** that `wait4` reports, so it falls through the existing `Wait()` to `StopEvent{StopSignal, sig}` and the engine's manual-stop detection turns it into `EventPaused` — exactly mirroring the linux mechanism. This fits bingo's `wait4` architecture and does **not** need Mach `thread_suspend` (Delve needs that only because it detects stops via a Mach exception port, not `wait4`).

**Signal choice — SIGUSR2:** catchable (surfaces via `wait4`), never terminal-generated (unlike SIGINT/SIGTSTP), unused by the Go runtime (unlike SIGURG), and not special-cased by `Wait()` (SIGTRAP is breakpoint/step; SIGURG/SIGWINCH are re-delivered). The engine suppresses it on resume (`Continue` → `PT_CONTINUE` with signal 0), so the tracee never actually receives it.

**Platform-agnostic detection:** added `Backend.PauseSignal() int` reporting the signal `StopProcess()` delivers (linux `SIGSTOP`, darwin `SIGUSR2`). The engine now matches the `StopSignal` stop against `e.backend.PauseSignal()` instead of a hard-coded `SIGSTOP`, keeping the manual-stop detection **and** the leftover-suppression race handling consistent across both platforms. (This also drops engine.go's last `syscall` import.)

**Resume-after-pause** is unchanged — a plain `Continue`. bingo never injects the interrupt signal, so only the reporting thread entered signal-delivery-stop; no group-stop is created.

## Validation (real Apple Silicon)

- `just e2e-darwin` — full suite **6/6 pass** (basic, churn, **pause**, fullstack), no regressions.
- Pause spec stressed **5 runs × 10 iterations** of Continue→Pause→`EventPaused`→resume — **no flakiness**.
- `go vet -tags bingonative ./...`, `go test -tags bingonative -race ./...` (all green), cross-compiled linux vet/build/e2e, `golangci-lint` linux clean. (Pre-existing `Wait` gocyclo warning is untouched darwin code and only surfaces under `-tags bingonative`, which CI doesn't lint.)

## Files

- `internal/debugger/backend.go` — `PauseSignal()` added to the `Backend` interface.
- `internal/debugger/backend_darwin_arm64.go` — `darwinPauseSignal = SIGUSR2`; `StopProcess()` sends it; `PauseSignal()`; rewritten doc.
- `internal/debugger/backend_linux_amd64.go` — `PauseSignal()` returns `SIGSTOP`.
- `internal/debugger/process_stop.go` — `stopProcessSignal(pid, sig)` parametrized.
- `internal/debugger/engine.go` — key on `PauseSignal()`; drop `syscall` import; platform-neutral docs.
- `internal/debugger/engine_test.go` — `fakeBackend.PauseSignal()`.
- `test/integration/debugger_e2e_darwin_arm64_test.go` — wire `declarePauseSpec()`.
- `justfile`, `.github/workflows/debugger-e2e.yml` — darwin `pause` label run + comments.
- `AGENTS.md` — rewrite the Pause section: darwin now functional, `PauseSignal()` abstraction, why SIGSTOP fails on darwin, signal-choice rationale.

## ⚠️ Darwin verification gate

This intentionally trips the [darwin verification gate](.github/workflows/darwin-verification-gate.yml) (touches `backend_darwin_arm64.go` + `*_darwin_*_test.go`). I ran `just e2e-darwin` locally (results above) — a maintainer needs to add the **`darwin-e2e-verified`** label to turn the gate green.

Part of #54