### PR TITLE
fix(hub): terminate Kill while running and prevent stale resume; guard darwin suspend list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,16 @@ engine advances PC by `len(archTrapInstruction())` and resumes. See the
 - ASLR slide is computed in `TextSlide` by scanning the VM map for the first
   exec region with the 64-bit Mach-O magic. Do NOT use `TASK_DYLD_INFO` — its
   image array is unpopulated at the very first ptrace stop.
+- The step-over suspend list (`b.suspended`) is **stepMu-guarded**, not
+  engine-loop-confined. `endThreadStep` → `resumeSuspended` runs on the engine
+  loop for a `Kill`, but the waitLoop also calls `endThreadStep` when an
+  in-flight `PT_STEP` fails, so the two can race. `suspendOthers`/
+  `resumeSuspended` therefore take `stepMu` around every read/write of
+  `b.suspended`; emptying the slice under the lock makes a second concurrent
+  teardown a no-op instead of a double `thread_resume`. `suspendOthers` calls
+  `Threads()` *before* taking `stepMu` to avoid nesting the thread/task locks
+  under it, and `stepMu` is non-reentrant so no locked path calls back into
+  these helpers.
 
 ### Linux / amd64 ([backend_linux_amd64.go](internal/debugger/backend_linux_amd64.go))
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,18 +135,32 @@ The hub blocks after broadcasting any of these "suspending" events until a
 "resuming" command arrives (or the 30-min safety timeout fires):
 
 - Suspending events: `BreakpointHit`, `Panic`, `Stepped`, `Paused`
-- Resuming commands: `Continue`, `StepOver`, `StepInto`, `StepOut`, `Kill`
+- Resuming commands: `Continue`, `StepOver`, `StepInto`, `StepOut`
 
 While suspended, **non-resuming** commands (`SetBreakpoint`, `Locals`, …) are
 still executed immediately — the process is paused, so it's safe.
 
-`Pause` is the odd one out: it is a suspending *request* issued **while the
-process is running**, not while suspended, and is deliberately **not** a
-resuming command. It rides the ordinary `cmdCh` (like `SetBreakpoint`), so
-Run's main loop dispatches it promptly to `dbg.Pause()`; it is never routed
-through `resumeCh`. The suspend it triggers is reported asynchronously via the
-`Paused` suspending event once the SIGSTOP surfaces — see
-[Pause — async interrupt](#pause--async-interrupt).
+`Pause` and `Kill` are the odd ones out: both must act **while the process is
+running**, not only while suspended, so neither is a resuming command. They ride
+the ordinary `cmdCh` (like `SetBreakpoint`), which both Run's main loop and the
+suspended wait loop drain. `Pause` is a suspending *request* whose suspend is
+reported asynchronously via the `Paused` event once the interrupt surfaces (see
+[Pause — async interrupt](#pause--async-interrupt)). `Kill` was previously
+misrouted through `resumeCh`, which is only drained while suspended — so a `Kill`
+against a runaway target (tight loop, no breakpoints) could never terminate it
+through the protocol. Routing `Kill` via `cmdCh` fixes that; the suspended wait
+loop `return`s after executing a `Kill` (like `Restart`), since the process it
+was waiting to resume no longer exists. `Kill` with no active debugger is a
+benign no-op success (nothing to terminate).
+
+Stale resumes: a resuming command sent **while the process is still running**
+(an erroneous or racing client) lands in `resumeCh` but is not drained by Run's
+main loop. To stop it from satisfying a *future* suspend — auto-continuing past
+a fresh `BreakpointHit`/`Stepped` before the client can inspect — the wait loop
+**drains `resumeCh` on entry**, immediately after broadcasting the suspending
+event. Any resume buffered at that instant is necessarily stale: a legitimate
+resume can only follow the client observing the suspend, which hasn't been
+delivered over the wire yet.
 
 When multiple clients race resume commands: **first writer wins**, the rest
 are dropped (`resumeCh` has capacity 1; see [hub.go injectCommand](internal/hub/hub.go)).
@@ -411,22 +425,22 @@ gone once killed:
   shift the load address.
 
 **Routing quirk**: `CmdRestart` intentionally does **not** go through
-`resumeCh` like `CmdContinue`/`CmdKill`/etc. `resumeCh` is only ever drained
+`resumeCh` like `CmdContinue`/`CmdStep*`. `resumeCh` is only ever drained
 inside `handleEvent`'s suspend-wait loop — Run's outer `select` never reads
 it — so a resuming command sent while the hub *isn't* currently suspended
 (the common case: restarting a running or idle session) would sit unread in
-the buffered channel indefinitely. This is a real pre-existing gap affecting
-`CmdKill` today too; it wasn't fixed for the general case, but Restart can't
-tolerate it because "restart while running" is the primary use case, not an
-edge case. Instead `CmdRestart` is routed through the ordinary `cmdCh` (like
-`SetBreakpoint`), which both Run's outer loop and the suspend-wait loop's
-`case cc := <-h.cmdCh:` branch drain. The one special case: that branch
-normally loops back to keep waiting for a resume after executing a
-non-resuming command, but for `CmdRestart` it `return`s instead — the
-suspended process it was waiting on no longer exists, so there's nothing left
-to resume, and returning lets Run's outer loop naturally pick up the new
-debugger's events channel (`h.dbg` is reassigned inside `handleRestart`
-before the confirmation event is broadcast).
+the buffered channel indefinitely. `CmdKill` used to share this hazard (it was
+a resuming command); it is now routed via `cmdCh` for exactly this reason — see
+[Suspend/resume protocol](#suspendresume-protocol). `CmdRestart` is likewise
+routed through the ordinary `cmdCh` (like `SetBreakpoint`), which both Run's
+outer loop and the suspend-wait loop's `case cc := <-h.cmdCh:` branch drain.
+The one special case: that branch normally loops back to keep waiting for a
+resume after executing a non-resuming command, but for `CmdRestart` **and**
+`CmdKill` it `return`s instead — the suspended process it was waiting on no
+longer exists (replaced or terminated), so there's nothing left to resume, and
+returning lets Run's outer loop naturally pick up the new/closed debugger's
+events channel (`h.dbg` is reassigned inside `handleRestart` before the
+confirmation event is broadcast).
 
 `EventRestarted` is a confirmation event (like `BreakpointSet`), not a
 suspending one — the new process's suspended state (if any, e.g. break-on-

--- a/internal/debugger/backend_darwin_arm64.go
+++ b/internal/debugger/backend_darwin_arm64.go
@@ -61,19 +61,21 @@ type darwinBackend struct {
 
 	// Atomic step-over-breakpoint bookkeeping.
 	//
-	// suspended and the suspend/resume of held threads are touched ONLY from the
-	// engine loop goroutine (singleStepThread before waitLoop starts, and
-	// endThreadStep after the stopCh hand-back), so they need no lock.
-	//
-	// The remaining fields are shared: advanceStepOver drives the step on the
-	// waitLoop goroutine while endThreadStep may run concurrently on the engine
-	// loop goroutine if a Kill lands mid-step. They are guarded by stepMu.
+	// All of these are shared between two goroutines: advanceStepOver drives
+	// the step on the waitLoop goroutine, while endThreadStep may run
+	// concurrently on the engine loop goroutine if a Kill lands mid-step (and
+	// endThreadStep is itself also called from the waitLoop on a PT_STEP
+	// failure). They are guarded by stepMu. That includes `suspended`: it is
+	// truncated by resumeSuspended, which endThreadStep calls from EITHER
+	// goroutine, so an unguarded slice would race (and double-resume the same
+	// Mach ports) when a Kill races a waitLoop teardown.
 	// sobActive gates the step-over path in Wait; sobAddr is the disarmed
 	// breakpoint address the stepped thread must retire past; sobBranch records
 	// whether the instruction there alters control flow (so we can't assume it
 	// retires to sobAddr+4); sobSteps bounds the retry loop that steps through
 	// signal-handler excursions; stepThreadPort is the thread armed with
-	// hardware single-step that must be disarmed afterwards.
+	// hardware single-step that must be disarmed afterwards; suspended lists the
+	// exact Mach ports held so endThreadStep resumes precisely those.
 	suspended      []int
 	stepThreadPort int
 	sobActive      bool
@@ -527,8 +529,10 @@ func (b *darwinBackend) advanceStepOver() (StopEvent, bool) {
 // disarm hardware single-step on the stepped thread and resume every thread we
 // suspended. Idempotent and safe to call when no atomic step is in flight. May
 // run on the engine loop goroutine (Kill) while advanceStepOver runs on the
-// waitLoop goroutine, so the shared fields are touched under stepMu; the
-// suspend list itself is engine-loop-only.
+// waitLoop goroutine — and is itself also called from the waitLoop on a PT_STEP
+// failure — so every shared field it touches, `suspended` included, is accessed
+// under stepMu. Because resumeSuspended empties `suspended` under the lock, a
+// second concurrent teardown finds it empty and cannot double-resume a port.
 func (b *darwinBackend) endThreadStep() {
 	b.stepMu.Lock()
 	b.sobActive = false
@@ -544,12 +548,17 @@ func (b *darwinBackend) endThreadStep() {
 
 // suspendOthers Mach-suspends every task thread except keep, recording the
 // exact ports suspended so endThreadStep resumes precisely those (threads that
-// spawn during the window are left alone; threads that exit are ignored).
+// spawn during the window are left alone; threads that exit are ignored). The
+// `suspended` slice is written under stepMu since endThreadStep/resumeSuspended
+// may read and truncate it from another goroutine. Threads() is enumerated
+// before taking stepMu to avoid nesting the thread/task locks under it.
 func (b *darwinBackend) suspendOthers(keep int) error {
 	tids, err := b.Threads()
 	if err != nil {
 		return err
 	}
+	b.stepMu.Lock()
+	defer b.stepMu.Unlock()
 	b.suspended = b.suspended[:0]
 	for _, tid := range tids {
 		if tid == keep {
@@ -562,7 +571,13 @@ func (b *darwinBackend) suspendOthers(keep int) error {
 	return nil
 }
 
+// resumeSuspended resumes and clears every Mach port held by suspendOthers.
+// Guarded by stepMu because endThreadStep can call it from either the engine
+// loop (Kill) or the waitLoop (PT_STEP failure); emptying the slice under the
+// lock makes a racing second call a no-op instead of a double resume.
 func (b *darwinBackend) resumeSuspended() {
+	b.stepMu.Lock()
+	defer b.stepMu.Unlock()
 	for _, tid := range b.suspended {
 		C.bingo_thread_resume(C.mach_port_t(tid))
 	}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -27,15 +27,19 @@ var suspendingEvents = map[protocol.EventKind]bool{
 	protocol.EventPaused:        true,
 }
 
-// resumingCommands unblock a suspended hub. CmdPause is deliberately NOT here:
-// it is issued while the process is RUNNING (not suspended) and is routed via
-// cmdCh, so it must not be treated as a resume — see AGENTS.md → Pause.
+// resumingCommands unblock a suspended hub via resumeCh (first-writer-wins).
+// They are only meaningful while the process is suspended.
+//
+// CmdKill and CmdPause are deliberately NOT here: both must act while the
+// process is RUNNING, not only while suspended, so they ride the ordinary
+// cmdCh that Run's main loop drains. Kill routed through resumeCh could not
+// terminate a runaway target (tight loop, no breakpoints) because resumeCh is
+// only drained inside the suspended wait — see AGENTS.md → Suspend/resume.
 var resumingCommands = map[protocol.CommandKind]bool{
 	protocol.CmdContinue: true,
 	protocol.CmdStepOver: true,
 	protocol.CmdStepInto: true,
 	protocol.CmdStepOut:  true,
-	protocol.CmdKill:     true,
 }
 
 // Hub owns one debug session. It bridges the Debugger with all connected
@@ -48,6 +52,16 @@ type Hub struct {
 	newDebugger func() debugger.Debugger
 
 	// dbg is the active debugger. nil while idle (no process launched).
+	//
+	// All writes happen on the Run goroutine (executeCommand, handleRestart,
+	// handleDebuggerClosed, teardownFailedStart). shutdown() may read it from a
+	// DIFFERENT goroutine (removeClient spawns `go h.shutdown()` when the last
+	// client leaves), so writes go through setDbg and shutdown's read takes
+	// dbgMu — otherwise a mid-flight Launch/Restart racing the last disconnect
+	// is an unsynchronized interface read. Run-goroutine reads need no lock:
+	// they only ever contend with same-goroutine writes (sequential) or with
+	// shutdown's read (read-read).
+	dbgMu    sync.Mutex
 	dbg      debugger.Debugger
 	registry *registry
 	log      *slog.Logger
@@ -184,6 +198,15 @@ func (h *Hub) eventsCh() <-chan protocol.Event {
 	return h.dbg.Events()
 }
 
+// setDbg replaces the active debugger. Called only on the Run goroutine, but
+// takes dbgMu so a concurrent shutdown() on another goroutine reads a
+// consistent value (see the dbg field comment).
+func (h *Hub) setDbg(d debugger.Debugger) {
+	h.dbgMu.Lock()
+	h.dbg = d
+	h.dbgMu.Unlock()
+}
+
 // AddClient registers conn as a new client. Safe from any goroutine.
 func (h *Hub) AddClient(conn WSConn, log *slog.Logger) *Client {
 	c := newClient(conn, h, log)
@@ -235,6 +258,14 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 
 	h.log.Info("suspended — waiting for resuming command", "event", evt.Kind)
 
+	// Discard any resuming command that was buffered while the process was
+	// still running. Such a command is necessarily stale: a legitimate resume
+	// can only be sent after the client observes this suspending event, which
+	// hasn't been delivered over the network yet. Without this drain, that
+	// stale resume would be consumed immediately below and auto-continue past
+	// the suspend, robbing the client of its chance to inspect.
+	h.drainResumeCh()
+
 	timeout := time.NewTimer(30 * time.Minute)
 	defer timeout.Stop()
 
@@ -273,12 +304,13 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 		case cc := <-h.cmdCh:
 			// Non-resuming command (SetBreakpoint, Locals, …) while suspended.
 			// Execute immediately — process is paused — and keep waiting.
-			// Restart is the one exception: it tears down and replaces the
-			// suspended process entirely, so there's nothing left to wait a
-			// resume on — return and let Run's outer loop pick up the new
-			// debugger's events channel (assigned inside handleRestart).
+			// Restart and Kill are the exceptions: Restart tears down and
+			// replaces the suspended process, and Kill terminates it, so in
+			// both cases the process we were waiting to resume no longer
+			// exists — return and let Run's outer loop pick up the new or
+			// closed debugger's events channel.
 			h.executeCommand(cc.cmd)
-			if cc.cmd.Kind == protocol.CmdRestart {
+			if cc.cmd.Kind == protocol.CmdRestart || cc.cmd.Kind == protocol.CmdKill {
 				return
 			}
 
@@ -300,7 +332,7 @@ func (h *Hub) handleDebuggerClosed() {
 	if h.State() != protocol.StateExited {
 		h.transitionState(protocol.StateExited)
 	}
-	h.dbg = nil
+	h.setDbg(nil)
 	h.transitionState(protocol.StateIdle)
 	h.log.Info("debugger closed — session idle, ready for re-launch")
 }
@@ -323,10 +355,17 @@ func (h *Hub) executeCommand(cmd protocol.Command) {
 			h.broadcastError(cmd.Kind, fmt.Errorf("no debugger factory configured"))
 			return
 		}
-		h.dbg = h.newDebugger()
+		h.setDbg(h.newDebugger())
 	}
 
 	if h.dbg == nil {
+		// Kill with no active debugger is a benign no-op: there is nothing to
+		// terminate, so report success rather than an error. This keeps Kill
+		// idempotent across the running/idle/exited states now that it is
+		// routed through cmdCh and can reach an already-torn-down session.
+		if cmd.Kind == protocol.CmdKill {
+			return
+		}
 		h.broadcastError(cmd.Kind, fmt.Errorf("no active debugger — send Launch or Attach first"))
 		return
 	}
@@ -368,7 +407,7 @@ func (h *Hub) executeCommand(cmd protocol.Command) {
 
 func (h *Hub) teardownFailedStart() {
 	dbg := h.dbg
-	h.dbg = nil
+	h.setDbg(nil)
 	if dbg != nil {
 		_ = dbg.Kill()
 	}
@@ -473,7 +512,7 @@ func (h *Hub) handleRestart(cmd protocol.Command) {
 
 	if h.dbg != nil {
 		_ = h.dbg.Kill()
-		h.dbg = nil
+		h.setDbg(nil)
 	}
 
 	newDbg := h.newDebugger()
@@ -482,7 +521,7 @@ func (h *Hub) handleRestart(cmd protocol.Command) {
 		h.transitionState(protocol.StateIdle)
 		return
 	}
-	h.dbg = newDbg
+	h.setDbg(newDbg)
 	h.lastLaunch = &protocol.LaunchPayload{Program: program, Args: args, Env: env}
 	h.transitionState(protocol.StateRunning)
 
@@ -512,8 +551,10 @@ func (h *Hub) handleRestart(cmd protocol.Command) {
 	h.broadcast(evt)
 }
 
-// injectCommand is called by client read-pumps. Resuming commands go to
-// resumeCh to directly unblock a suspended hub; everything else to cmdCh.
+// injectCommand is called by client read-pumps. Resuming commands (Continue,
+// Step*) go to resumeCh to directly unblock a suspended hub; everything else —
+// including Kill and Pause, which must act while the process is running — goes
+// to cmdCh, drained by Run's main loop and the suspended wait loop alike.
 func (h *Hub) injectCommand(_ *Client, cmd protocol.Command) {
 	if resumingCommands[cmd.Kind] {
 		select {
@@ -527,6 +568,15 @@ func (h *Hub) injectCommand(_ *Client, cmd protocol.Command) {
 	case h.cmdCh <- clientCommand{cmd: cmd}:
 	default:
 		h.log.Warn("command queue full — dropping", "kind", cmd.Kind)
+	}
+}
+
+// drainResumeCh removes any single buffered resuming command without blocking.
+// resumeCh has capacity 1, so one non-blocking receive empties it.
+func (h *Hub) drainResumeCh() {
+	select {
+	case <-h.resumeCh:
+	default:
 	}
 }
 
@@ -622,8 +672,14 @@ func (h *Hub) shutdown() {
 		h.log.Info("hub shutting down")
 		close(h.shutdownCh)
 		h.registry.closeAll()
-		if h.dbg != nil {
-			_ = h.dbg.Kill()
+		// shutdown may run on a non-Run goroutine (go h.shutdown() from
+		// removeClient), so snapshot dbg under dbgMu to avoid racing a
+		// mid-flight Launch/Restart on the Run goroutine.
+		h.dbgMu.Lock()
+		dbg := h.dbg
+		h.dbgMu.Unlock()
+		if dbg != nil {
+			_ = dbg.Kill()
 		}
 	})
 }

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -499,6 +499,68 @@ var _ = Describe("Hub", func() {
 		})
 	})
 
+	Describe("Kill while running", func() {
+		It("terminates the process even with no breakpoint set (no suspend first)", func() {
+			conn := newFakeWSConn()
+			h.AddClient(conn, nil)
+
+			// A runaway target with no breakpoints never suspends. Kill must
+			// still reach the debugger: it rides cmdCh (main loop), not
+			// resumeCh (drained only while suspended).
+			conn.inject(mustCommand(protocol.CmdKill, struct{}{}))
+
+			Eventually(fd.recordedCalls, "500ms", "10ms").
+				Should(ContainElement("Kill"))
+		})
+
+		It("still terminates the process while suspended", func() {
+			conn := newFakeWSConn()
+			h.AddClient(conn, nil)
+
+			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+			_, _ = recvEvent(conn)
+
+			conn.inject(mustCommand(protocol.CmdKill, struct{}{}))
+			Eventually(fd.recordedCalls, "500ms", "10ms").
+				Should(ContainElement("Kill"))
+		})
+	})
+
+	Describe("stale resume handling", func() {
+		It("discards a resume buffered while running so it can't auto-continue a later suspend", func() {
+			conn := newFakeWSConn()
+			h.AddClient(conn, nil)
+			fd.setBPResult = protocol.Breakpoint{ID: 7}
+
+			// Erroneously send Continue while the process is still running: it
+			// lands in resumeCh. The SetBreakpoint that follows rides cmdCh from
+			// the SAME read-pump, so once its confirmation arrives the stale
+			// Continue is guaranteed to already be buffered in resumeCh.
+			conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
+			conn.inject(mustCommand(protocol.CmdSetBreakpoint,
+				protocol.SetBreakpointPayload{File: "main.go", Line: 3}))
+			waitForEventKind(conn, protocol.EventBreakpointSet, nil)
+
+			// Now the process suspends. The stale Continue must be dropped, not
+			// consumed to auto-resume.
+			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+			_, _ = recvEvent(conn) // BreakpointHit
+
+			time.Sleep(50 * time.Millisecond)
+			Expect(fd.recordedCalls()).NotTo(ContainElement("Continue"),
+				"stale resume must not auto-continue past the fresh suspend")
+
+			// A fresh Continue (sent after the suspend) resumes normally.
+			conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
+			Eventually(fd.recordedCalls, "500ms", "10ms").
+				Should(ContainElement("Continue"))
+			Expect(countCalls(fd.recordedCalls(), "Continue")).To(Equal(1),
+				"exactly one (fresh) Continue should have run")
+		})
+	})
+
 	Describe("Pause", func() {
 		It("routes CmdPause to the debugger while the process runs", func() {
 			conn := newFakeWSConn()
@@ -833,5 +895,30 @@ var _ = Describe("Restart", func() {
 
 		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
 		waitForEventKind(conn, protocol.EventRestarted, nil)
+	})
+})
+
+// This suite guards Finding 3 of #78: h.dbg is written on the Run goroutine
+// (Launch/Restart) but read by shutdown(), which runs on a separate goroutine
+// when the last client disconnects. Run under -race, the loop exercises that
+// write/read overlap; the dbgMu guard keeps it clean.
+var _ = Describe("dbg access during shutdown", func() {
+	It("has no data race between a mid-flight Launch and last-client shutdown", func() {
+		for i := 0; i < 100; i++ {
+			fd := newFakeDebugger()
+			managed := hub.NewSession("session", func() debugger.Debugger { return fd }, nil)
+			cancel := runHub(managed)
+
+			conn := newFakeWSConn()
+			managed.AddClient(conn, nil)
+
+			// Launch writes h.dbg on the Run goroutine; closing the only client
+			// spawns `go h.shutdown()`, which reads h.dbg concurrently.
+			conn.inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "x"}))
+			closeFakeWS(conn)
+
+			Eventually(managed.Done(), "1s", "10ms").Should(BeClosed())
+			cancel()
+		}
 	})
 })


### PR DESCRIPTION
## Summary

Addresses all three findings in #78 (concurrency follow-ups from the PR #58 review). Each was **confirmed still present on current `main`** before fixing.

`Closes #78`

---

### Finding 1 — Medium (hub): stranded Kill-while-running + stale resume

**Confirmed present.** Resuming commands (incl. `Kill`) were routed to `resumeCh` (cap 1) in `injectCommand`, but `resumeCh` is only drained inside the suspended wait loop. So a `Kill` against a runaway target with no breakpoints could never terminate it through the protocol, and any resume buffered while running became **stale** — the next suspend consumed it immediately and auto-resumed without the client acting.

**Fix:**
- Removed `CmdKill` from `resumingCommands`. `Kill` (like `Pause`) now rides the ordinary `cmdCh`, which **both** Run's main loop and the suspended wait loop drain — so it terminates the process whether running or suspended.
- The suspended wait loop now `return`s after executing `CmdKill` (as it already did for `CmdRestart`): the process it was waiting to resume no longer exists.
- Added `drainResumeCh()`, called at suspend entry in `handleEvent`, to discard any resume buffered while running. Such a command is necessarily stale (a legitimate resume can only be sent *after* the client observes the suspending event over the wire).
- `Kill` with no active debugger is now a benign no-op success (idempotent across running/idle/exited), instead of a spurious "no active debugger" error.
- Preserved the documented **first-writer-wins** resume semantics for `Continue`/`StepOver`/`StepInto`/`StepOut`.

**Tests** (`internal/hub/hub_test.go`): Kill-while-running actually kills (no suspend first); Kill-while-suspended still kills; a stale resume does **not** auto-continue past a fresh suspend (and a fresh Continue afterward resumes exactly once). Verified these fail against the old implementation.

### Finding 3 — Low (hub): unsynchronized `h.dbg` read in `shutdown()`

**Confirmed present.** `h.dbg` is written on the Run goroutine but `shutdown()` can run on another goroutine (`go h.shutdown()` from `removeClient`), an unsynchronized interface read racing a mid-flight Launch/Restart.

**Fix:** Added `dbgMu` guarding `dbg`; all Run-goroutine writes go through a `setDbg` helper and `shutdown()` snapshots under the lock. Run-goroutine reads stay lock-free (they only contend with same-goroutine writes or shutdown's read-read). Added a 100-iteration `-race` smoke test racing Launch against last-client shutdown.

### Finding 2 — Low/Medium (darwin): data race on `b.suspended`

**Confirmed present.** The Mach step-over suspend list was read/truncated by `resumeSuspended` with no synchronization. `endThreadStep → resumeSuspended` runs on the engine loop for a `Kill`, but the waitLoop **also** calls `endThreadStep` on an in-flight `PT_STEP` failure — so the two goroutines could race on `b.suspended` and double-`thread_resume` the same port.

**Fix:** Guarded every read/write of `b.suspended` with the existing `stepMu`. `suspendOthers` enumerates `Threads()` *before* taking the lock (avoids nesting the thread/task locks under `stepMu`); `resumeSuspended` empties the slice under the lock, so a racing second teardown is a no-op. `stepMu` is non-reentrant and no locked path re-enters these helpers.

---

## Verification

- `go vet -tags bingonative ./...` — clean
- `go test -tags bingonative ./...` — all green
- `go test -tags bingonative -race ./internal/hub/... ./internal/debugger/... ./internal/server/...` — clean
- **`just e2e-darwin` — 6/6 green** (`basic`, `churn`, `pause`, `fullstack`) under `-race` on Apple Silicon

## ⚠️ Darwin verification gate

This PR touches `internal/debugger/backend_darwin_arm64.go`, so the **"Darwin E2E verified"** check will be **red** until a maintainer adds the `darwin-e2e-verified` label. I ran `just e2e-darwin` locally (6/6 green, `-race`) as required — please add the label to satisfy the gate.

## Coordination

A sibling agent is investigating a flaky darwin `fullstack` e2e test (#89) and may also touch `backend_darwin_arm64.go`. My darwin change is minimal and self-contained (only the `stepMu` guard on the suspend list). The Finding 2 race is between `Kill`/step-over teardown on `b.suspended`; if the #89 flake reproduces as a `-race` failure or double-resume on that list, it may share this root cause — worth linking. My local runs were stable (6/6).

## Docs

`AGENTS.md` updated in the same commits: suspend/resume routing (Kill no longer a resuming command + stale-resume drain), the Restart routing-quirk note (Kill gap now closed), and a darwin backend-quirks bullet on the `stepMu`-guarded suspend list.