### PR TITLE
fix(hub): keep the suspend loop alive when a resume is rejected

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,15 @@ delivered over the wire yet.
 When multiple clients race resume commands: **first writer wins**, the rest
 are dropped (`resumeCh` has capacity 1; see [hub.go injectCommand](internal/hub/hub.go)).
 
+Rejected resumes: a resuming command only ends the suspend if the debugger
+actually resumes the process. If the resume is **rejected** — e.g. a transient
+backend error while reinstalling a software breakpoint leaves the engine
+`stateSuspended` — the hub broadcasts the `EventError` but **stays in the wait
+loop** (it checks that the session left `suspended` before returning). Bailing
+out on a failed resume would strand the client: the process is still suspended,
+but a retry resume lands in `resumeCh`, which only the wait loop drains, so the
+session could never be resumed again.
+
 ### Session state machine
 
 `SessionState` ∈ {`idle`, `running`, `suspended`, `exited`}.

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -298,8 +298,20 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 
 		case cmd := <-h.resumeCh:
 			h.log.Info("resuming", "command", cmd.Kind)
+			// A resume ends the suspend only if it actually took effect. When
+			// the debugger rejects it — e.g. a transient backend error while
+			// reinstalling a software breakpoint (AGENTS.md → step-over flow),
+			// leaving the engine stateSuspended — executeCommand broadcasts an
+			// EventError but performs no → running transition. Returning here
+			// would strand the client: a retry resume lands in resumeCh, which
+			// only this wait loop drains (Run's outer loop never selects on it),
+			// so the process could never be resumed again. Keep waiting unless
+			// the resume advanced the session out of suspended (running on
+			// success, or exited if the process died mid-resume).
 			h.executeCommand(cmd)
-			return
+			if h.State() != protocol.StateSuspended {
+				return
+			}
 
 		case cc := <-h.cmdCh:
 			// Non-resuming command (SetBreakpoint, Locals, …) while suspended.

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -561,6 +561,76 @@ var _ = Describe("Hub", func() {
 		})
 	})
 
+	Describe("failed resume keeps the hub suspended", func() {
+		// A resuming command can be rejected by the debugger while the process
+		// stays suspended (e.g. a transient backend error reinstalling a
+		// software breakpoint — see AGENTS.md → step-over flow). The hub must
+		// NOT abandon the suspend on that failure: a retry resume lands in
+		// resumeCh, which only the suspend-wait loop drains (Run's outer loop
+		// never selects on it), so leaving the loop would strand the client and
+		// wedge the session with no way to resume.
+		It("lets a retry Continue reach the debugger after the first fails", func() {
+			conn := newFakeWSConn()
+			h.AddClient(conn, nil)
+			fd.continueErr = errors.New("reinstall failed")
+
+			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+			waitForEventKind(conn, protocol.EventBreakpointHit, nil)
+
+			conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
+			// The rejected resume surfaces as an EventError; it also serves as a
+			// happens-before barrier before we clear the transient error below.
+			waitForEventKind(conn, protocol.EventError, nil)
+			Expect(countCalls(fd.recordedCalls(), "Continue")).To(Equal(1))
+
+			fd.continueErr = nil
+			conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
+			Eventually(func() int {
+				return countCalls(fd.recordedCalls(), "Continue")
+			}, "500ms", "10ms").Should(Equal(2),
+				"retry resume must reach the debugger after a failed resume")
+		})
+
+		It("still resumes via Continue after a failed StepOver", func() {
+			conn := newFakeWSConn()
+			h.AddClient(conn, nil)
+			fd.stepOverErr = errors.New("step failed")
+
+			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+			waitForEventKind(conn, protocol.EventBreakpointHit, nil)
+
+			conn.inject(mustCommand(protocol.CmdStepOver, struct{}{}))
+			waitForEventKind(conn, protocol.EventError, nil)
+			Expect(fd.recordedCalls()).NotTo(ContainElement("Continue"))
+
+			conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
+			Eventually(fd.recordedCalls, "500ms", "10ms").
+				Should(ContainElement("Continue"))
+		})
+
+		It("still services non-resuming commands after a failed resume", func() {
+			conn := newFakeWSConn()
+			h.AddClient(conn, nil)
+			fd.setBPResult = protocol.Breakpoint{ID: 9}
+			fd.continueErr = errors.New("boom")
+
+			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+			waitForEventKind(conn, protocol.EventBreakpointHit, nil)
+
+			conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
+			waitForEventKind(conn, protocol.EventError, nil)
+
+			// The hub is still parked in the suspend-wait loop, so a SetBreakpoint
+			// (non-resuming) is executed immediately while suspended.
+			conn.inject(mustCommand(protocol.CmdSetBreakpoint,
+				protocol.SetBreakpointPayload{File: "main.go", Line: 5}))
+			waitForEventKind(conn, protocol.EventBreakpointSet, nil)
+		})
+	})
+
 	Describe("Pause", func() {
 		It("routes CmdPause to the debugger while the process runs", func() {
 			conn := newFakeWSConn()


### PR DESCRIPTION
## Summary

The hub's suspend-wait loop in `handleEvent` abandoned the suspend as soon as it *dequeued* a resuming command from `resumeCh`, even when the debugger **rejected** that resume:

```go
case cmd := <-h.resumeCh:
    h.executeCommand(cmd)
    return   // returns even if the resume failed and we're still suspended
```

`executeCommand` only transitions the session to `running` on a *successful* dispatch. `engine.Continue()`/`StepOver()`/`StepInto()`/`StepOut()` can return an error while the engine stays `stateSuspended` — e.g. the documented "reinstall failure → suspend instead of resume" path (AGENTS.md → *Software-breakpoint step-over flow*) or a transient `WriteMemory`/ptrace/Mach error. On that path the hub broadcast an `EventError` and returned with the **process still suspended**. `Run`'s outer `select` never drains `resumeCh`, so any retry resume was stranded there forever and the session could never be resumed again.

This is the same "stranded resume in `resumeCh`" failure mode as #78 (finding 1), reached via a *failed* resume rather than a resume sent while running.

## Fix

Only leave the wait loop when the resume actually took effect — i.e. when the session is no longer `suspended` (`running` on success, or `exited` if the process died mid-resume). A rejected resume now keeps the hub in the wait loop so the client can retry.

```go
h.executeCommand(cmd)
if h.State() != protocol.StateSuspended {
    return
}
```

State transitions happen only on the `Run` goroutine, so reading `h.State()` immediately after the synchronous `executeCommand` is a reliable success signal.

## Tests

New coverage in `internal/hub/hub_test.go` (all under `-race`):

- **a failed `Continue` keeps the hub suspended so a retry `Continue` still reaches the debugger** — fails on `main` (retry stranded in `resumeCh`), passes with the fix.
- **a failed `StepOver` keeps the hub suspended so a later `Continue` resumes** — fails on `main`, passes with the fix.
- **non-resuming commands (`SetBreakpoint`) are still serviced after a failed resume** — adjacent coverage of the wait-loop `cmdCh` path.

AGENTS.md's suspend/resume section documents the rejected-resume invariant.

## Verification

- `go test -tags bingonative -race ./internal/hub/ ./internal/server/` — pass
- `go vet` + `golangci-lint run --build-tags bingonative` — clean
- `goimports`/`gofmt` — clean; cross-compiles for `linux/amd64`

Closes #95
