### PR TITLE
fix(debugger): report real tracee exit code at PTRACE_EVENT_EXIT (linux)

### DIFF
--- a/.github/workflows/debugger-e2e.yml
+++ b/.github/workflows/debugger-e2e.yml
@@ -10,8 +10,8 @@ name: Debugger E2E
 # (correctness), `churn` (multi-thread robustness), `pause` (async interrupt /
 # manual stop), `stepping` (StepInto/StepOut), `inspect`
 # (StackFrames/Locals/Goroutines), `breakpoints` (ClearBreakpoint), `kill`
-# (kill-while-running), `restart`, and `fullstack` (operations driven through the
-# whole client → WebSocket → hub → debugger stack).
+# (kill-while-running), `exit` (process exit status), `restart`, and `fullstack`
+# (operations driven through the whole client → WebSocket → hub → debugger stack).
 #
 # Both linux and darwin run the full set. The step-off-an-armed-trap specs
 # (basic, stepping, breakpoints, churn) and kill (kill-while-running) used to be
@@ -76,6 +76,9 @@ jobs:
       - name: E2E kill (kill-while-running)
         run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=kill
 
+      - name: E2E exit (process exit status)
+        run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=exit
+
   darwin-arm64:
     name: Darwin arm64 (Mach exceptions)
     runs-on: macos-14
@@ -137,6 +140,10 @@ jobs:
       - name: E2E kill (kill-while-running)
         if: runner.environment == 'self-hosted'
         run: ./e2e.test -test.v -test.timeout 300s -ginkgo.label-filter=kill
+
+      - name: E2E exit (process exit status)
+        if: runner.environment == 'self-hosted'
+        run: ./e2e.test -test.v -test.timeout 300s -ginkgo.label-filter=exit
 
       - name: E2E hygiene (Mach port-right leak regression)
         if: runner.environment == 'self-hosted'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -421,7 +421,13 @@ are detected by a `mach_msg` receive loop.
   away (the "parking the thread group" hazard).
 - `Wait` uses `Wait4(-1, …, WALL)` to receive events for any thread.
   `PTRACE_EVENT_*` stops are absorbed (resumed and looped) and never surface
-  to the engine.
+  to the engine — except the **main thread's** `PTRACE_EVENT_EXIT`, which is the
+  one exit the engine needs. Because `PTRACE_O_TRACEEXIT` stops the leader
+  *before* it dies and the engine tears down on the resulting `StopExited`, the
+  real status never resurfaces as a later `wait4` `Exited()`; so `Wait` reads it
+  at that stop via `PTRACE_GETEVENTMSG` (a `wait(2)`-encoded status) and reports
+  the true `ExitCode`, or `StopKilled` on signal death. Returning a hardcoded 0
+  here dropped every tracee's exit code (#94).
 - ptrace stops are per-thread. The backend records the last stopped TID and
   targets `ContinueProcess` / memory reads / memory writes at that TID, not
   blindly at the process PID. Non-main thread exits are absorbed inside `Wait`.
@@ -674,7 +680,8 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   (StepInto crosses into a callee, StepOut returns to the caller), `inspect`
   (StackFrames chain + Locals + Goroutines at a breakpoint), `breakpoints`
   (a cleared breakpoint stops firing), `kill` (Kill terminates a
-  freely-running tracee), and `restart` (hub-level kill+relaunch reinstalls
+  freely-running tracee), `exit` (EventProcessExited reports the tracee's real
+  exit code), and `restart` (hub-level kill+relaunch reinstalls
   breakpoints and reruns from the top), all driving `debugger.Debugger`
   in-process (except `restart`/`fullstack`, which go through the stack); plus
   `fullstack`, which drives operations through the ENTIRE stack (pkg/client →
@@ -692,8 +699,9 @@ side `chan error` — every debugger outcome, failures included, rides the singl
 
   **Platform scoping — both containers run the full set.** The darwin container
   wires the same specs as linux: `basic`, `stepping`, `breakpoints`, `churn`,
-  `kill`, `pause`, `inspect`, `restart`, and `fullstack`, plus the darwin-only
-  `hygiene` (Mach exception port-right leak regression). This was NOT always so:
+  `kill`, `exit`, `pause`, `inspect`, `restart`, and `fullstack`, plus the
+  darwin-only `hygiene` (Mach exception port-right leak regression). This was NOT
+  always so:
   under the old darwin wait4/ptrace model the step-off-an-armed-trap specs
   (`basic`, `stepping`, `breakpoints`, `churn`) and `kill` (kill-while-running)
   were LINUX-ONLY, because single-stepping off a software breakpoint could be

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -407,11 +407,31 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 					}
 					continue
 				}
-				// Main thread is about to call exit_group — let it actually exit.
+				// Main thread is about to exit. PTRACE_O_TRACEEXIT stops it here
+				// BEFORE it dies, and the engine tears down on this StopExited, so
+				// the real status never resurfaces as a later wait4 Exited()/
+				// Signaled(). Read it now via PTRACE_GETEVENTMSG (a wait(2)-encoded
+				// status) so a non-zero exit or a fatal signal isn't misreported as
+				// a clean exit 0. GETEVENTMSG must run before we resume the thread —
+				// once continued it is gone and the message is unreadable.
+				var msg uint
+				var msgErr error
+				b.execPtrace(func() { msg, msgErr = syscall.PtraceGetEventMsg(tid) })
 				if err := b.continueIfTraceeExists(tid, 0); err != nil {
 					return StopEvent{}, fmt.Errorf("PTRACE_CONT exiting process tid %d: %w", tid, err)
 				}
 				b.recordStop(tid)
+				if msgErr == nil {
+					status := syscall.WaitStatus(msg)
+					switch {
+					case status.Signaled():
+						return StopEvent{Reason: StopKilled, TID: tid}, nil
+					case status.Exited():
+						return StopEvent{Reason: StopExited, TID: tid, ExitCode: status.ExitStatus()}, nil
+					}
+				}
+				// Status unreadable (e.g. ESRCH racing a Kill) or unexpected shape:
+				// fall back to a clean exit rather than inventing a code.
 				return StopEvent{Reason: StopExited, TID: tid, ExitCode: 0}, nil
 
 			case syscall.PTRACE_EVENT_EXEC:

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -199,6 +199,22 @@ func main() {
 }
 `
 
+// exitCodeTargetSrc exits with a fixed, distinctive non-zero status the instant
+// it is resumed — no breakpoints, no threads to manage. It pins the exit-status
+// reporting path: EventProcessExited must carry the tracee's real code, not a
+// hardcoded 0. Regression guard for the linux backend dropping the
+// PTRACE_EVENT_EXIT status (issue #94); darwin already reported ws.ExitStatus().
+const exitCodeTargetExpected = 42
+
+const exitCodeTargetSrc = `package main
+
+import "os"
+
+func main() {
+	os.Exit(42)
+}
+`
+
 // declareBasicStepOverSpec adds the continue+step-over acceptance spec to the
 // enclosing Ginkgo container. It is the correctness gate: set a breakpoint on a
 // line that calls a function, repeatedly Continue to it and StepOver the call,
@@ -561,6 +577,29 @@ func assertTerminated(ch <-chan protocol.Event, timeout time.Duration) {
 			Fail(fmt.Sprintf("TIMEOUT after %s: Kill did not terminate the running tracee", timeout))
 		}
 	}
+}
+
+// declareExitCodeSpec adds the process-exit-status spec. It launches a target
+// that exits with a fixed non-zero code the moment it is resumed and asserts the
+// EventProcessExited payload carries that exact code. On linux this is the
+// regression guard for the backend dropping the PTRACE_EVENT_EXIT status and
+// reporting a hardcoded 0 (issue #94); on darwin it pins the ws.ExitStatus()
+// path. Runs on both containers so the two backends stay in agreement.
+func declareExitCodeSpec() {
+	It("reports the tracee's real exit code", Label("exit"), func() {
+		bin := buildTarget("exit_target", exitCodeTargetSrc)
+
+		h := newE2EHarness(bin)
+		h.waitFor(15*time.Second, protocol.EventStepped) // initial launch stop
+
+		Expect(h.d.Continue()).To(Succeed(), "Continue so the tracee runs to os.Exit")
+
+		evt := h.waitFor(15*time.Second, protocol.EventProcessExited)
+		var payload protocol.ProcessExitedPayload
+		Expect(json.Unmarshal(evt.Payload, &payload)).To(Succeed(), "decode ProcessExited")
+		Expect(payload.ExitCode).To(Equal(exitCodeTargetExpected),
+			"EventProcessExited must carry the tracee's real exit code, not a hardcoded 0")
+	})
 }
 
 // bpLine decodes a BreakpointHit event and returns its resolved line.

--- a/test/integration/debugger_e2e_darwin_arm64_test.go
+++ b/test/integration/debugger_e2e_darwin_arm64_test.go
@@ -34,6 +34,7 @@ import (
 //   - breakpoints: a cleared breakpoint stops firing.
 //   - churn: hundreds of step-overs under continuous thread creation.
 //   - kill: Kill terminates a freely-running tracee.
+//   - exit: EventProcessExited reports the tracee's real exit code.
 //   - pause: Continue -> Pause -> Paused round-trips (async interrupt).
 //   - inspect: continue into a breakpoint, then StackFrames/Locals/Goroutines.
 //   - restart: hub kill + relaunch + reinstall, reaching the breakpoint again.
@@ -49,6 +50,7 @@ var _ = Describe("Darwin arm64 debugger backend (Mach exceptions) E2E", Label("d
 	declareInspectSpec()
 	declareClearBreakpointSpec()
 	declareKillRunningSpec()
+	declareExitCodeSpec()
 	declareFullStackSpec()
 	declareRestartSpec()
 	declarePortHygieneSpec()

--- a/test/integration/debugger_e2e_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_linux_amd64_test.go
@@ -16,6 +16,7 @@ var _ = Describe("Linux amd64 debugger backend (ptrace) E2E", Label("linux"), fu
 	declareInspectSpec()
 	declareClearBreakpointSpec()
 	declareKillRunningSpec()
+	declareExitCodeSpec()
 	declareFullStackSpec()
 	declareRestartSpec()
 })


### PR DESCRIPTION
## Summary

On the **linux/amd64** ptrace backend, `EventProcessExited` always carried `ExitCode: 0`, regardless of the tracee's real exit status. A traced Go program that exits non-zero (e.g. `os.Exit(3)`) was reported to clients as a clean exit-0, and a process that died from a fatal signal was mislabeled as a normal exit-0. The **darwin/arm64** backend already returns the true code (`ws.ExitStatus()`), so this was a genuine linux-only defect and a cross-platform inconsistency.

Closes #94

## Root cause

`internal/debugger/backend_linux_amd64.go`, `Wait()`, the `PTRACE_EVENT_EXIT` main-thread branch hardcoded the exit code:

```go
// Main thread is about to call exit_group — let it actually exit.
if err := b.continueIfTraceeExists(tid, 0); err != nil { ... }
b.recordStop(tid)
return StopEvent{Reason: StopExited, TID: tid, ExitCode: 0}, nil
```

`startTracedProcess` sets `PTRACE_O_TRACEEXIT`, so the kernel stops the group leader at `PTRACE_EVENT_EXIT` **before** it dies, and the engine tears down on the resulting `StopExited`. The real status therefore never resurfaces via a later `wait4` `Exited()`/`Signaled()`. Because `PTRACE_O_TRACEEXIT` is inherited by every clone, the leader deterministically hits this branch first, so the reported code was effectively always `0`.

## Fix

Read the status at the EVENT_EXIT stop via `PTRACE_GETEVENTMSG` (a `wait(2)`-encoded value) on the tracer thread, **before** resuming the thread (once continued it is gone and the message is unreadable). Decode it as a `syscall.WaitStatus` and return the real `ExitCode` — or `StopKilled` on signal death — matching the darwin backend. Falls back to a clean exit-0 if the message is unreadable (e.g. `ESRCH` racing a `Kill`) rather than inventing a code.

## Test / coverage

- New `exit`-labelled e2e spec (`declareExitCodeSpec`) that launches a target which `os.Exit(42)` and asserts `EventProcessExited.ExitCode == 42`.
- Wired into **both** the linux and darwin containers, plus a CI step in each `debugger-e2e.yml` job (darwin execution self-hosted-gated, as with the other specs).
- On `main` this spec fails on linux (asserts 42, gets 0) and passes after the fix; it passes on darwin either way (darwin was never buggy), pinning the two backends in agreement.
- AGENTS.md kept in sync (Linux backend quirks + Test layering label list) in the same commit.

## Validation

- `GOOS=linux GOARCH=amd64 go vet ./...` and `golangci-lint run` (linux target): clean.
- Linux + darwin e2e test binaries cross-compile.
- Ran the darwin suite locally on Apple Silicon (`exit`, `kill`, `basic`, `restart`, `fullstack`): all pass, including the new `exit` spec.
- Default unit tests pass.
- The linux `exit` spec runs for real in the `Debugger E2E` → `Linux amd64 (ptrace)` CI job (the definitive linux validation, since the maintainer host here is darwin/arm64).
