### PR TITLE
fix(debugger): inspect the stopped thread, not threads[0]

### DIFF
--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -357,11 +357,15 @@ func (e *engine) Locals(frameIndex int) ([]protocol.Variable, error) {
 		if e.dw == nil {
 			return fmt.Errorf("Locals: no DWARF info")
 		}
-		threads, err := e.backend.Threads()
-		if err != nil || len(threads) == 0 {
-			return fmt.Errorf("Locals: no threads")
+		// Inspect the thread the user is stopped on (curTID via activeTID), not
+		// threads[0]: on Darwin threads[0] is frequently an idle runtime M, so a
+		// breakpoint that fires on another thread would otherwise report an
+		// unrelated frame's locals. See the activeTID/collectFrames invariant.
+		tid, err := e.activeTID()
+		if err != nil {
+			return fmt.Errorf("Locals: %w", err)
 		}
-		regs, err := e.backend.GetRegisters(threads[0])
+		regs, err := e.backend.GetRegisters(tid)
 		if err != nil {
 			return fmt.Errorf("Locals: get registers: %w", err)
 		}
@@ -396,7 +400,10 @@ func (e *engine) StackFrames() ([]protocol.Frame, error) {
 			return err
 		}
 		var err error
-		frames, err = e.collectFrames(e.lastBPTID)
+		// Walk the currently-stopped thread. lastBPTID is only valid immediately
+		// after a breakpoint hit and is cleared once we single-step off it, so it
+		// goes stale after a step; curTID always tracks the active stop.
+		frames, err = e.collectFrames(e.curTID)
 		return err
 	})
 	return frames, err
@@ -844,9 +851,8 @@ func (e *engine) sourceStepOver() error {
 		e.stepOverLine = 0
 
 		if file == "" || line == 0 {
-			threads, err := e.backend.Threads()
-			if err == nil && len(threads) > 0 {
-				if regs, err := e.backend.GetRegisters(threads[0]); err == nil {
+			if tid, err := e.activeTID(); err == nil {
+				if regs, err := e.backend.GetRegisters(tid); err == nil {
 					loc := e.dw.locationForPC(regs.PC)
 					file = loc.File
 					line = loc.Line
@@ -1020,11 +1026,13 @@ func (e *engine) walkStack(regs Registers) []uint64 {
 }
 
 func (e *engine) readGoroutines() ([]protocol.Goroutine, error) {
-	threads, err := e.backend.Threads()
-	if err != nil || len(threads) == 0 {
+	// Report the stopped thread's location (curTID via activeTID); threads[0] may
+	// be an idle runtime M and would misreport where execution is paused.
+	tid, err := e.activeTID()
+	if err != nil {
 		return nil, nil
 	}
-	regs, err := e.backend.GetRegisters(threads[0])
+	regs, err := e.backend.GetRegisters(tid)
 	if err != nil {
 		return nil, fmt.Errorf("Goroutines: %w", err)
 	}

--- a/internal/debugger/engine_curtid_test.go
+++ b/internal/debugger/engine_curtid_test.go
@@ -1,0 +1,189 @@
+package debugger_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/bingosuite/bingo/internal/debugger"
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+// inspectFixtureSrc has two functions with distinctly-named locals so a
+// misdirected inspection (reading the wrong thread's frame) is detectable by
+// the variable/function names it returns. Built with -N -l so the locals are
+// present in DWARF and not optimized away.
+const inspectFixtureSrc = `package main
+
+func alpha(x int) int {
+	a := x * 2 // alpha-marker
+	return a
+}
+
+func beta(y int) int {
+	b := y + 3 // beta-marker
+	return b
+}
+
+func main() {
+	println(alpha(1) + beta(2))
+}
+`
+
+var (
+	inspectFixtureOnce sync.Once
+	inspectFixtureBin  string
+	inspectFixtureErr  error
+)
+
+// inspectFixture builds the fixture once per test binary and returns its path.
+func inspectFixture() (string, error) {
+	inspectFixtureOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "bingo-inspect-fixture")
+		if err != nil {
+			inspectFixtureErr = err
+			return
+		}
+		src := filepath.Join(dir, "fix.go")
+		if err := os.WriteFile(src, []byte(inspectFixtureSrc), 0o600); err != nil {
+			inspectFixtureErr = err
+			return
+		}
+		bin := filepath.Join(dir, "fix")
+		cmd := exec.Command("go", "build", "-gcflags=all=-N -l", "-o", bin, src)
+		cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+		if out, buildErr := cmd.CombinedOutput(); buildErr != nil {
+			inspectFixtureErr = fmt.Errorf("build inspect fixture: %v\n%s", buildErr, out)
+			return
+		}
+		inspectFixtureBin = bin
+	})
+	return inspectFixtureBin, inspectFixtureErr
+}
+
+func inspectMarkerLine(marker string) int {
+	for i, line := range strings.Split(inspectFixtureSrc, "\n") {
+		if strings.Contains(line, marker) {
+			return i + 1
+		}
+	}
+	return 0
+}
+
+func varNames(vars []protocol.Variable) []string {
+	names := make([]string, 0, len(vars))
+	for _, v := range vars {
+		names = append(names, v.Name)
+	}
+	return names
+}
+
+// Regression coverage for the "inspect the thread the user is stopped on"
+// invariant (see engine.activeTID / curTID). Before the fix, Locals and
+// Goroutines read threads[0] and StackFrames read the stale lastBPTID, so a
+// breakpoint that fired on any thread other than threads[0] — the common case
+// on darwin, where threads[0] is frequently an idle runtime M — returned frames
+// and variables from an unrelated thread.
+var _ = Describe("current-thread inspection", func() {
+	var (
+		fb       *fakeBackend
+		d        debugger.Debugger
+		pcAlpha  uint64
+		pcBeta   uint64
+		fileName = "fix.go"
+	)
+
+	BeforeEach(func() {
+		bin, err := inspectFixture()
+		Expect(err).NotTo(HaveOccurred())
+
+		fb = newFakeBackend()
+		d = debugger.NewWithBackend(fb, nil)
+		debugger.ExportedLoadDWARF(d, bin)
+
+		pcAlpha, err = debugger.ExportedPCForFileLine(d, fileName, inspectMarkerLine("alpha-marker"))
+		Expect(err).NotTo(HaveOccurred())
+		pcBeta, err = debugger.ExportedPCForFileLine(d, fileName, inspectMarkerLine("beta-marker"))
+		Expect(err).NotTo(HaveOccurred())
+
+		// threads[0]==1 is parked in alpha (stands in for an idle runtime M);
+		// the user thread 2 is the one that stops in beta.
+		fb.tids = []int{1, 2}
+		fb.regs[1] = debugger.Registers{PC: pcAlpha}
+		fb.regs[2] = debugger.Registers{PC: pcBeta}
+	})
+
+	AfterEach(func() {
+		_ = d.Kill()
+		if !fb.stopped {
+			close(fb.stopCh)
+			fb.stopped = true
+		}
+	})
+
+	// stopOnThread2 drives a breakpoint stop on TID 2, leaving the engine
+	// suspended with curTID==2 (thread 2 in beta) while threads[0]==1 is alpha.
+	stopOnThread2 := func() {
+		debugger.ExportedForceSuspended(d)
+		debugger.ExportedSetBreakpointAt(d, pcBeta)
+		Expect(d.Continue()).To(Succeed())
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopBreakpoint, TID: 2, PC: pcBeta})
+		Expect(mustNextEvent(d).Kind).To(Equal(protocol.EventBreakpointHit))
+	}
+
+	It("Locals reads the stopped thread's frame, not threads[0]", func() {
+		stopOnThread2()
+
+		vars, err := d.Locals(0)
+		Expect(err).NotTo(HaveOccurred())
+
+		names := varNames(vars)
+		Expect(names).To(ContainElement("b"),
+			"Locals must return beta's local from the stopped thread (2), got %v", names)
+		Expect(names).NotTo(ContainElement("a"),
+			"Locals must not return alpha's local from threads[0], got %v", names)
+	})
+
+	It("StackFrames walks the stopped thread, not threads[0]", func() {
+		stopOnThread2()
+
+		frames, err := d.StackFrames()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(frames).NotTo(BeEmpty())
+		Expect(frames[0].Location.Function).To(ContainSubstring("beta"),
+			"innermost frame should be beta (thread 2), got %q", frames[0].Location.Function)
+	})
+
+	It("Goroutines report the stopped thread's location", func() {
+		stopOnThread2()
+
+		gs, err := d.Goroutines()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(gs).To(HaveLen(1))
+		Expect(gs[0].CurrentLoc.Function).To(ContainSubstring("beta"),
+			"goroutine location should track the stopped thread (2), got %q", gs[0].CurrentLoc.Function)
+	})
+
+	It("StackFrames tracks curTID after a step clears lastBPTID", func() {
+		stopOnThread2()
+
+		// StepInto over the breakpoint completes on thread 2. resumeFromBreakpoint
+		// zeroes lastBPTID, so a StackFrames that keyed off lastBPTID would fall
+		// back to threads[0] (alpha). curTID stays 2 (beta).
+		Expect(d.StepInto()).To(Succeed())
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSingleStep, TID: 2, PC: pcBeta})
+		Expect(mustNextEvent(d).Kind).To(Equal(protocol.EventStepped))
+
+		frames, err := d.StackFrames()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(frames).NotTo(BeEmpty())
+		Expect(frames[0].Location.Function).To(ContainSubstring("beta"),
+			"after a step, StackFrames should follow curTID (2), got %q", frames[0].Location.Function)
+	})
+})

--- a/internal/debugger/export_test.go
+++ b/internal/debugger/export_test.go
@@ -1,8 +1,41 @@
 // Exposes internal symbols to debugger_test. Compiled only during `go test`.
 package debugger
 
+import "fmt"
+
 func ExportedTrapInstruction() []byte {
 	return archTrapInstruction()
+}
+
+// ExportedLoadDWARF loads DWARF from binaryPath into the engine, bypassing a
+// real Launch/Attach so DWARF-dependent inspection paths (Locals, StackFrames,
+// Goroutines) can be exercised against the fakeBackend. Panics on failure.
+func ExportedLoadDWARF(d Debugger, binaryPath string) {
+	e := d.(*engine)
+	if err := e.dispatch(func() error {
+		e.loadDWARF(binaryPath)
+		if e.dw == nil {
+			return fmt.Errorf("no DWARF for %s", binaryPath)
+		}
+		return nil
+	}); err != nil {
+		panic("ExportedLoadDWARF: " + err.Error())
+	}
+}
+
+// ExportedPCForFileLine resolves file:line to a runtime PC via the loaded DWARF.
+func ExportedPCForFileLine(d Debugger, file string, line int) (uint64, error) {
+	e := d.(*engine)
+	var pc uint64
+	err := e.dispatch(func() error {
+		if e.dw == nil {
+			return fmt.Errorf("no DWARF loaded")
+		}
+		var lookupErr error
+		pc, lookupErr = e.dw.PCForFileLine(file, line)
+		return lookupErr
+	})
+	return pc, err
 }
 
 func ExportedFileMatches(candidate, target string) bool {


### PR DESCRIPTION
Closes #98

## What

On-demand inspection APIs read the wrong thread when a breakpoint fires on a thread other than `threads[0]`:

- `Locals` and `readGoroutines` read `threads[0]` directly.
- `StackFrames` called `collectFrames(e.lastBPTID)`, and `lastBPTID` is zeroed by `resumeFromBreakpoint` after a single step — so post-step it fell back to `threads[0]`.

On darwin `threads[0]` is frequently an idle runtime M, so these paths returned variables/frames/goroutine location from an unrelated thread whenever execution stopped elsewhere — the common case for a concurrency debugger. The event-embedded frames already did the right thing via `collectFrames(stop.TID)`; this brings the on-demand paths in line with the `curTID`/`activeTID` invariant (#92).

## Fix

Route `Locals`, `StackFrames`, `readGoroutines`, and the `sourceStepOver` line fallback through `activeTID()`/`curTID`.

## Tests

New DWARF-backed regression spec `current-thread inspection` (`engine_curtid_test.go`) drives a breakpoint on a non-`threads[0]` thread and asserts `Locals`, `StackFrames`, and `Goroutines` follow the stopped thread, including after a step clears `lastBPTID`. **3 of its 4 specs fail on `main` and pass with this fix.** Added test-only `ExportedLoadDWARF` / `ExportedPCForFileLine` helpers to exercise DWARF paths against the fakeBackend.

`go vet -tags bingonative ./internal/debugger/` clean; full package suite green (75 specs).

## Notes

No darwin-native files touched (engine.go + test files only), so the Darwin E2E gate is not affected.
