### PR TITLE
fix(debugger): release Mach send rights leaked by darwin exception messages

### DIFF
--- a/.github/workflows/debugger-e2e.yml
+++ b/.github/workflows/debugger-e2e.yml
@@ -138,6 +138,10 @@ jobs:
         if: runner.environment == 'self-hosted'
         run: ./e2e.test -test.v -test.timeout 300s -ginkgo.label-filter=kill
 
+      - name: E2E hygiene (Mach port-right leak regression)
+        if: runner.environment == 'self-hosted'
+        run: ./e2e.test -test.v -test.timeout 300s -ginkgo.label-filter=hygiene
+
       - name: Skip execution on hosted runners (task_for_pid unavailable)
         if: runner.environment != 'self-hosted'
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -335,6 +335,23 @@ are detected by a `mach_msg` receive loop.
   `ContinueProcess`/`killProcess` call `flushAllReplies`; `SingleStep` /
   `singleStepThread` / the `advanceStepOver` re-arm call `flushReply(tid)`. At
   most one pending reply per thread.
+- **Exception messages carry send rights that MUST be balanced.** Every
+  `exception_raise` (msgh_id 2401) the kernel delivers inserts a send right to
+  BOTH the faulting thread (`desc[0]`) and the task (`desc[1]`) into our IPC
+  space; Mach coalesces each onto our existing port name and bumps that name's
+  user-ref count. Left unbalanced this is a per-stop leak: the task is a single
+  cached name whose uref then grows without bound until `KERN_UREFS_OVERFLOW`,
+  after which the kernel can no longer copy out the exception and `Wait` wedges
+  (also one leaked dead name per exited thread under churn). So `bingo_mach_recv`
+  **deallocates the task right unconditionally** (we hold the cached `taskPort`,
+  so its uref stays ≥1) and hands the thread right back; the caller balances that:
+  the main `Wait` path folds it into the retained per-thread set
+  (`adoptExcThreadPort` — release if already tracked, else adopt, mirroring
+  `Threads()`), and the `bingo_stop_the_world` drain path deallocates each
+  absorbed straggler's thread right directly (it re-faults on the next resume).
+  Reconcile runs on EVERY received exception (including intermediate step-over
+  traps), not just returned stops, or the retire loop leaks. The regression gate
+  is the `hygiene`-labelled darwin E2E spec.
 - **Stop-the-world = individual thread suspends + drain.** On a real breakpoint,
   `stopTheWorld` (`bingo_stop_the_world`) suspends every running thread and
   **drains any already-queued exceptions** (reply to each). `thread_suspend` does
@@ -659,10 +676,15 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   wired into **both** the linux and darwin containers — detection is
   platform-agnostic in the engine and each backend's `StopProcess()` surfaces the
   interrupt to `Wait` (a real SIGSTOP on linux, a control-port wake on darwin).
+  The `hygiene` spec (`declarePortHygieneSpec`) is **darwin-only** — it asserts
+  the Mach exception path does not leak task/thread send rights across many
+  breakpoint stops (reads the `debugger.DarwinTaskPortSendRefs` hook), a check
+  meaningless on the ptrace backend.
 
   **Platform scoping — both containers run the full set.** The darwin container
   wires the same specs as linux: `basic`, `stepping`, `breakpoints`, `churn`,
-  `kill`, `pause`, `inspect`, `restart`, and `fullstack`. This was NOT always so:
+  `kill`, `pause`, `inspect`, `restart`, and `fullstack`, plus the darwin-only
+  `hygiene` (Mach exception port-right leak regression). This was NOT always so:
   under the old darwin wait4/ptrace model the step-off-an-armed-trap specs
   (`basic`, `stepping`, `breakpoints`, `churn`) and `kill` (kill-while-running)
   were LINUX-ONLY, because single-stepping off a software breakpoint could be

--- a/internal/debugger/backend_darwin_arm64.go
+++ b/internal/debugger/backend_darwin_arm64.go
@@ -742,6 +742,41 @@ func (b *darwinBackend) Threads() ([]int, error) {
 	return tids, nil
 }
 
+// adoptExcThreadPort reconciles the send right the kernel inserted for the
+// faulting thread of an exception message into the retained per-thread set,
+// keeping exactly one right per thread name. If we already track the thread the
+// message's extra right is released; otherwise it is adopted as the retained
+// one. This runs on the waitLoop goroutine and shares threadPorts with Threads()
+// (engine goroutine), so it takes threadMu. The name always ends with uref >= 1,
+// so the tid stays valid for the subsequent GetRegisters/suspend/step this stop
+// performs. Mirrors the adopt/dedup accounting in Threads().
+func (b *darwinBackend) adoptExcThreadPort(thread C.mach_port_t) {
+	b.threadMu.Lock()
+	defer b.threadMu.Unlock()
+	if b.threadPorts == nil {
+		b.threadPorts = make(map[C.mach_port_t]struct{})
+	}
+	if _, ok := b.threadPorts[thread]; ok {
+		C.bingo_port_deallocate(thread)
+	} else {
+		b.threadPorts[thread] = struct{}{}
+	}
+}
+
+// TaskPortSendRefs reports the Mach send-right user-reference count on the cached
+// tracee task port and whether the task port has been acquired yet. It exists
+// for the darwin port-hygiene regression test: the exception path must not leak
+// a task send right per stop (which would grow this count unboundedly toward
+// KERN_UREFS_OVERFLOW and wedge Wait). Returns (0, false) before launch/attach.
+func (b *darwinBackend) TaskPortSendRefs() (int, bool) {
+	b.taskMu.Lock()
+	defer b.taskMu.Unlock()
+	if !b.taskOK {
+		return 0, false
+	}
+	return int(C.bingo_port_send_refs(b.taskPort)), true
+}
+
 // Wait blocks on the Mach port set and turns each message into a StopEvent. It
 // is the pure-Mach replacement for the old wait4 loop: EXC_BREAKPOINT messages
 // (software BRK and hardware single-step) drive breakpoint/step detection, the
@@ -802,6 +837,13 @@ func (b *darwinBackend) Wait() (StopEvent, error) {
 
 		case C.BINGO_MSG_EXC:
 			tid := int(thread)
+			// The exception message carried a fresh send right to the faulting
+			// thread (see bingo_mach_recv). Fold it into the retained per-thread
+			// set: release the redundant right if we already track this thread,
+			// otherwise adopt it. Skipping this leaks one thread send right per
+			// stop (unbounded on a long-lived thread hitting a hot breakpoint,
+			// and one leaked dead name per exited thread under churn).
+			b.adoptExcThreadPort(thread)
 			// Defer the reply until this thread is resumed; see pendingReplies.
 			b.stashReply(tid, replyInfo{port: replyPort, bits: replyBits, id: replyID})
 			// Step-over in flight: ONLY the stepped thread's own single-step trap

--- a/internal/debugger/mach_darwin_arm64.h
+++ b/internal/debugger/mach_darwin_arm64.h
@@ -492,6 +492,16 @@ static inline int bingo_mach_recv(
         if (thread_out) *thread_out = thread;
         if (exc_out) *exc_out = (int)data[0];
         if (code0_out) *code0_out = (int64_t)data[2];
+        // The kernel inserts a send right to BOTH the faulting thread and the
+        // task into our IPC space for every exception message; Mach coalesces
+        // them to our existing names and bumps each name's user-ref count. We
+        // never use the task descriptor (we hold a cached task port), so release
+        // it here — otherwise a single name's uref grows by one per stop and
+        // eventually hits KERN_UREFS_OVERFLOW, after which the kernel can no
+        // longer copy out the exception and Wait wedges. The thread right IS
+        // handed back via thread_out; its accounting (adopt-or-release into the
+        // retained per-thread set) is the caller's responsibility.
+        mach_port_deallocate(mach_task_self(), desc[1].name);
         if (do_suspend) thread_suspend(thread);
         if (do_reply) {
             if (bingo__send_reply(&msg.hdr) != MACH_MSG_SUCCESS) return BINGO_MSG_ERROR;
@@ -537,7 +547,15 @@ static inline int bingo_stop_the_world(task_t task, mach_port_t port_set) {
             mach_port_t th = 0; int exc = 0, id = 0; int64_t c0 = 0;
             int cls = bingo_mach_recv(port_set, 0, &th, &exc, &c0, &id, 1, 1, 0, 0, 0);
             if (cls == BINGO_MSG_DEATH) return BINGO_MSG_DEATH;
-            if (cls == BINGO_MSG_EXC) continue; // absorbed a queued fault
+            if (cls == BINGO_MSG_EXC) {
+                // Absorbed a queued fault: it was replied immediately (do_reply=1)
+                // and its thread right is not handed to Go, so release it here.
+                // The thread stays suspended and re-faults on the next resume; the
+                // task right was already released inside bingo_mach_recv. Without
+                // this each drained straggler leaks one per-thread send right.
+                mach_port_deallocate(mach_task_self(), th);
+                continue;
+            }
             break; // none / pause / error
         }
         int running = bingo_num_running_threads(task);
@@ -604,4 +622,17 @@ static inline kern_return_t bingo_thread_probe(
         thread, ARM_THREAD_STATE64, (thread_state_t)&st, &tcount);
     *pc = (kr == KERN_SUCCESS) ? (uint64_t)st.__pc : 0;
     return KERN_SUCCESS;
+}
+// bingo_port_send_refs returns the number of send-right user references held on
+// a port NAME in our own IPC space, or -1 on error. Pure read (mach_port_get_refs
+// on mach_task_self). Used by the darwin port-hygiene regression test to assert
+// the exception-receive path does not leak a task/thread send right per stop — a
+// per-stop leak grows one name's uref unboundedly toward KERN_UREFS_OVERFLOW, at
+// which point the kernel can no longer copy out the exception message and Wait
+// wedges.
+static inline int bingo_port_send_refs(mach_port_t name) {
+    mach_port_urefs_t refs = 0;
+    if (mach_port_get_refs(mach_task_self(), name, MACH_PORT_RIGHT_SEND, &refs) != KERN_SUCCESS)
+        return -1;
+    return (int)refs;
 }

--- a/internal/debugger/port_diag_darwin_arm64.go
+++ b/internal/debugger/port_diag_darwin_arm64.go
@@ -1,0 +1,23 @@
+//go:build darwin && arm64 && bingonative
+
+package debugger
+
+// DarwinTaskPortSendRefs reports the Mach send-right user-reference count on the
+// tracee's cached task port (and whether it has been acquired yet). It is a
+// darwin-only test hook: the port-hygiene regression test in test/integration
+// runs against the public Debugger surface and cannot otherwise reach the
+// unexported backend. A count that grows once per stop signals the Mach
+// exception-receive path is leaking a task send right, which eventually hits
+// KERN_UREFS_OVERFLOW and wedges Wait (see backend_darwin_arm64.go). Returns
+// (0, false) for a non-engine Debugger or before the task port is acquired.
+func DarwinTaskPortSendRefs(d Debugger) (int, bool) {
+	e, ok := d.(*engine)
+	if !ok {
+		return 0, false
+	}
+	b, ok := e.backend.(*darwinBackend)
+	if !ok {
+		return 0, false
+	}
+	return b.TaskPortSendRefs()
+}

--- a/test/integration/debugger_e2e_darwin_arm64_test.go
+++ b/test/integration/debugger_e2e_darwin_arm64_test.go
@@ -2,7 +2,15 @@
 
 package integration
 
-import . "github.com/onsi/ginkgo/v2"
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/bingosuite/bingo/internal/debugger"
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
 
 // Darwin/arm64 debugger acceptance suite. Drives the real pure-Mach backend
 // (task-level EXC_MASK_BREAKPOINT exception port + mach_msg receive loop,
@@ -43,4 +51,64 @@ var _ = Describe("Darwin arm64 debugger backend (Mach exceptions) E2E", Label("d
 	declareKillRunningSpec()
 	declareFullStackSpec()
 	declareRestartSpec()
+	declarePortHygieneSpec()
 })
+
+// declarePortHygieneSpec is the regression gate for the Mach exception-message
+// port-right leak (issue: exception path leaked task/thread send rights). Every
+// exception_raise message the kernel delivers carries a send right to BOTH the
+// faulting thread and the task; Mach coalesces each onto our existing port name
+// and increments that name's user-reference count. The task name is a single
+// cached port, so a per-stop leak grows one name's uref without bound until it
+// hits KERN_UREFS_OVERFLOW — after which the kernel can no longer copy out the
+// exception message and Wait wedges (a hard hang reachable in any long session or
+// hot-loop breakpoint).
+//
+// The spec drives dozens of breakpoint stops and asserts the tracee task port's
+// send-ref count stays bounded. Before the fix the count grew ~linearly with the
+// number of stops (each stop's resume single-steps off the armed trap and then
+// re-hits it — two exceptions, two leaked task rights); after the fix each
+// exception's task right is released as it is received, so the count is flat.
+// Darwin-only: it reads a darwin backend introspection hook.
+func declarePortHygieneSpec() {
+	It("does not leak task send rights across many breakpoint stops", Label("hygiene"), func() {
+		line := markerLine(basicTargetSrc, "// BP")
+		bin := buildTarget("hygiene_target", basicTargetSrc)
+
+		h := newE2EHarness(bin)
+		h.waitFor(15*time.Second, protocol.EventStepped) // initial launch stop
+
+		_, err := h.d.SetBreakpoint("hygiene_target.go", line)
+		Expect(err).NotTo(HaveOccurred(), "SetBreakpoint")
+
+		// Reach the breakpoint once so the task port is acquired and the send-ref
+		// count is at steady state before the baseline reading.
+		Expect(h.d.Continue()).To(Succeed(), "initial Continue")
+		evt := h.waitFor(15*time.Second,
+			protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+		Expect(evt.Kind).To(Equal(protocol.EventBreakpointHit), "initial stop: %s", evt.Payload)
+
+		base, ok := debugger.DarwinTaskPortSendRefs(h.d)
+		Expect(ok).To(BeTrue(), "task port should be acquired after the first stop")
+
+		iters := envInt("BINGO_E2E_HYGIENE_ITERS", 40)
+		for i := 0; i < iters; i++ {
+			Expect(h.d.Continue()).To(Succeed(), "Continue #%d", i)
+			evt := h.waitFor(15*time.Second,
+				protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+			Expect(evt.Kind).To(Equal(protocol.EventBreakpointHit),
+				"Continue #%d expected BreakpointHit, got %s: %s", i, evt.Kind, evt.Payload)
+		}
+
+		after, ok := debugger.DarwinTaskPortSendRefs(h.d)
+		Expect(ok).To(BeTrue())
+		// Post-fix the count is flat; allow a tiny constant slack for any
+		// transient. Pre-fix it grew by ~2 per stop (dozens over the loop), so a
+		// small bound is a wide fail-before / pass-after margin.
+		Expect(after-base).To(BeNumerically("<=", 3),
+			"task port send-ref leak: base=%d after=%d over %d stops (grows ~linearly when the exception path leaks)",
+			base, after, iters)
+		AddReportEntry("hygiene-iterations", iters)
+		AddReportEntry("hygiene-task-send-refs", map[string]int{"base": base, "after": after})
+	})
+}


### PR DESCRIPTION
## What

Fixes a Mach **send-right leak** in the darwin/arm64 pure-Mach backend: every
`exception_raise` the kernel delivers carries a send right to both the faulting
thread and the task, and `bingo_mach_recv` never deallocated either. Mach
coalesces each right onto our existing port name and bumps its user-ref (uref)
count once per stop, so the **task** name — a single cached port — grows uref
without bound until `KERN_UREFS_OVERFLOW`, after which the kernel can no longer
copy the exception out and `Wait()` silently wedges. Thread names leak the same
way (unbounded on a hot-loop breakpoint; leaked dead names under thread churn).

`Closes #100`

## Root cause

`mach_darwin_arm64.h` `bingo_mach_recv` `case 2401` returns `desc[0].name`
(thread) but never releases the thread or task descriptor the kernel inserted
into our IPC space. The `bingo_stop_the_world` drain path has the same leak.
Introduced by the #92/#93 pure-Mach rearchitecture.

## Fix

- `bingo_mach_recv`: deallocate the task descriptor (`desc[1].name`)
  unconditionally after extracting the exception — safe because we hold the
  cached `taskPort` (uref stays >= 1). Covers both the main `Wait` path and the
  drain path.
- `Wait` (`BINGO_MSG_EXC`): reconcile the returned thread right into the
  retained `threadPorts` set (`adoptExcThreadPort`, adopt-or-release under
  `threadMu`), mirroring `Threads()`, on **every** received exception (including
  intermediate step-over traps, so the retire loop doesn't leak).
- `bingo_stop_the_world` drain loop: release each absorbed straggler's thread
  right.

## Tests / coverage

- New darwin-only `hygiene`-labelled E2E spec (`declarePortHygieneSpec`) asserts
  the task-port SEND uref stays bounded across dozens of breakpoint stops.
- Adds `DarwinTaskPortSendRefs` (Go) + `bingo_port_send_refs` (C) introspection
  hooks and a CI step in `debugger-e2e.yml`.
- AGENTS.md documents the new exception-message port-right ownership invariant.

**Fails before / passes after** (real Mach backend, Apple Silicon):

```
# leak restored:  [FAILED] task port send-ref leak: base=2 after=14985 over 40 stops
# with the fix:   hygiene-task-send-refs -> map[after:1 base:1]  (flat, PASS)
```

## Local heavy-loop validation (real darwin Mach backend, `-race`, codesigned)

All by exit code, **0 failures**:

| label | runs | knob | fails |
|-------|------|------|-------|
| hygiene | 25 | `HYGIENE_ITERS=60` | 0 |
| basic | 15 | `ITERS=40` | 0 |
| kill | 20 | — | 0 |
| pause | 15 | `PAUSE_ITERS=5` | 0 |
| churn | 10 | `CHURN_ITERS=300` | 0 |
| stepping | 10 | — | 0 |
| breakpoints | 10 | — | 0 |
| inspect | 10 | — | 0 |
| restart | 8 | — | 0 |
| fullstack | 8 | — | 0 |

**131 runs, 0 failures.** Plus `go vet -tags bingonative ./...` clean and the
non-e2e unit suites (`internal/debugger`, `internal/hub`, `pkg/protocol`) green.

## Note on CI

This touches darwin-native code, so it will trip the **Darwin E2E verified**
gate. Per the sweep protocol I have **not** self-added the `darwin-e2e-verified`
label; the heavy-loop counts above are my local verification on real Apple
Silicon. The hosted darwin CI job compiles + codesigns (execution is gated to
self-hosted runners because Sonoma blocks `task_for_pid`).
