### PR TITLE
fix(protocol): preserve empty args/env override in RestartPayload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -746,6 +746,12 @@ through the justfile.
   with the engine's Kill path which also calls `bps.clearAll`.
 - `CmdNone` is the empty string and gets `omitempty`'d off the wire. The
   protocol test pins this behaviour.
+- `RestartPayload.Args`/`Env` deliberately **omit** `omitempty` (unlike
+  `LaunchPayload`). The hub's `handleRestart` gates the override on nil-ness
+  (`if override.Args != nil`), so a non-nil empty slice must survive the wire
+  as `[]` to mean "clear", distinct from `null`/absent meaning "reuse the
+  original Launch value". `omitempty` would collapse both to `{}`. The protocol
+  test pins the nil-vs-empty round trip. See issue #102.
 - Hub `New(dbg, log)` (without a session ID) is for tests / single-session
   setups: the debugger is pre-attached, no state events are broadcast,
   managed-session machinery is bypassed. Real sessions go through

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -29,7 +29,8 @@ type Client interface {
 
 	// Restart kills the current process (if any launched via Launch) and
 	// relaunches it, reinstalling previously-set breakpoints. Pass nil for
-	// args/env to reuse the values from the original Launch. Blocks until
+	// args/env to reuse the values from the original Launch; pass a non-nil
+	// slice (including an empty one, to clear them) to override. Blocks until
 	// the server confirms via EventRestarted.
 	Restart(args, env []string) (protocol.RestartedPayload, error)
 

--- a/pkg/client/ws_test.go
+++ b/pkg/client/ws_test.go
@@ -1,0 +1,233 @@
+package client_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/bingosuite/bingo/pkg/client"
+	"github.com/bingosuite/bingo/pkg/protocol"
+
+	"github.com/gorilla/websocket"
+)
+
+// fakeServer is a minimal WebSocket bingo server that drives the real client
+// through its actual dial → command → confirmation flow. It records every
+// command it receives and answers each with an optional reply event.
+type fakeServer struct {
+	ts    *httptest.Server
+	reply func(protocol.Command) (protocol.Event, bool)
+
+	mu       sync.Mutex
+	commands []protocol.Command
+}
+
+func newFakeServer(reply func(protocol.Command) (protocol.Event, bool)) *fakeServer {
+	fs := &fakeServer{reply: reply}
+	up := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+
+	fs.ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		// Welcome message: the client blocks in dial until this arrives.
+		welcome := protocol.MustEvent(protocol.EventSessionState, 1, protocol.SessionStatePayload{
+			SessionID: "test-session",
+			State:     protocol.StateIdle,
+			Clients:   1,
+		})
+		if b, err := protocol.MarshalEvent(welcome); err == nil {
+			_ = conn.WriteMessage(websocket.TextMessage, b)
+		}
+
+		for {
+			_, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			cmd, err := protocol.UnmarshalCommand(data)
+			if err != nil {
+				continue
+			}
+			fs.mu.Lock()
+			fs.commands = append(fs.commands, cmd)
+			fs.mu.Unlock()
+
+			if fs.reply != nil {
+				if evt, ok := fs.reply(cmd); ok {
+					if b, err := protocol.MarshalEvent(evt); err == nil {
+						_ = conn.WriteMessage(websocket.TextMessage, b)
+					}
+				}
+			}
+		}
+	}))
+	return fs
+}
+
+func (fs *fakeServer) addr() string { return strings.TrimPrefix(fs.ts.URL, "http://") }
+func (fs *fakeServer) close()       { fs.ts.Close() }
+
+func (fs *fakeServer) lastCommand() (protocol.Command, bool) {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if len(fs.commands) == 0 {
+		return protocol.Command{}, false
+	}
+	return fs.commands[len(fs.commands)-1], true
+}
+
+func replyEvent(kind protocol.EventKind, payload any) protocol.Event {
+	return protocol.MustEvent(kind, 2, payload)
+}
+
+func dialTestClient(t *testing.T, fs *fakeServer) client.Client {
+	t.Helper()
+	c, err := client.Create(fs.addr())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	return c
+}
+
+// TestRestartEmptyArgsOverrideReachesWire is the client-side regression for
+// issue #102: an explicit empty-slice override must serialise as [] so the hub
+// can distinguish "clear the args" from "reuse the original Launch args".
+func TestRestartEmptyArgsOverrideReachesWire(t *testing.T) {
+	fs := newFakeServer(func(cmd protocol.Command) (protocol.Event, bool) {
+		if cmd.Kind == protocol.CmdRestart {
+			return replyEvent(protocol.EventRestarted, protocol.RestartedPayload{Program: "/app"}), true
+		}
+		return protocol.Event{}, false
+	})
+	defer fs.close()
+
+	c := dialTestClient(t, fs)
+	defer func() { _ = c.Close() }()
+
+	if _, err := c.Restart([]string{}, []string{}); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+
+	cmd, ok := fs.lastCommand()
+	if !ok || cmd.Kind != protocol.CmdRestart {
+		t.Fatalf("server did not receive a Restart command; got %+v ok=%v", cmd, ok)
+	}
+	payload := string(cmd.Payload)
+	if !strings.Contains(payload, `"args":[]`) {
+		t.Errorf("empty Args override dropped from wire; payload=%s", payload)
+	}
+	if !strings.Contains(payload, `"env":[]`) {
+		t.Errorf("empty Env override dropped from wire; payload=%s", payload)
+	}
+}
+
+// TestRestartNilArgsDoesNotClearOnWire is the companion: nil means "reuse", so
+// it must NOT serialise as an empty [] that the hub would read as "clear".
+func TestRestartNilArgsDoesNotClearOnWire(t *testing.T) {
+	fs := newFakeServer(func(cmd protocol.Command) (protocol.Event, bool) {
+		if cmd.Kind == protocol.CmdRestart {
+			return replyEvent(protocol.EventRestarted, protocol.RestartedPayload{Program: "/app"}), true
+		}
+		return protocol.Event{}, false
+	})
+	defer fs.close()
+
+	c := dialTestClient(t, fs)
+	defer func() { _ = c.Close() }()
+
+	if _, err := c.Restart(nil, nil); err != nil {
+		t.Fatalf("Restart: %v", err)
+	}
+
+	cmd, ok := fs.lastCommand()
+	if !ok {
+		t.Fatal("server did not receive a Restart command")
+	}
+	if strings.Contains(string(cmd.Payload), `"args":[]`) {
+		t.Errorf("nil Args must not encode as []; payload=%s", cmd.Payload)
+	}
+}
+
+// TestSetBreakpointReturnsConfirmation exercises the synchronous demux happy
+// path: the confirmation event's payload is decoded and returned to the caller.
+func TestSetBreakpointReturnsConfirmation(t *testing.T) {
+	fs := newFakeServer(func(cmd protocol.Command) (protocol.Event, bool) {
+		if cmd.Kind == protocol.CmdSetBreakpoint {
+			return replyEvent(protocol.EventBreakpointSet, protocol.BreakpointSetPayload{
+				Breakpoint: protocol.Breakpoint{
+					ID:       7,
+					Enabled:  true,
+					Location: protocol.Location{File: "main.go", Line: 42},
+				},
+			}), true
+		}
+		return protocol.Event{}, false
+	})
+	defer fs.close()
+
+	c := dialTestClient(t, fs)
+	defer func() { _ = c.Close() }()
+
+	bp, err := c.SetBreakpoint("main.go", 42)
+	if err != nil {
+		t.Fatalf("SetBreakpoint: %v", err)
+	}
+	if bp.ID != 7 || bp.Location.Line != 42 {
+		t.Errorf("unexpected breakpoint: %+v", bp)
+	}
+}
+
+// TestSyncCommandRoutesServerError verifies an EventError for the same command
+// kind satisfies (and fails) the pending synchronous request.
+func TestSyncCommandRoutesServerError(t *testing.T) {
+	fs := newFakeServer(func(cmd protocol.Command) (protocol.Event, bool) {
+		if cmd.Kind == protocol.CmdSetBreakpoint {
+			return replyEvent(protocol.EventError, protocol.ErrorPayload{
+				Command: protocol.CmdSetBreakpoint,
+				Message: "no address for main.go:42",
+			}), true
+		}
+		return protocol.Event{}, false
+	})
+	defer fs.close()
+
+	c := dialTestClient(t, fs)
+	defer func() { _ = c.Close() }()
+
+	_, err := c.SetBreakpoint("main.go", 42)
+	if err == nil || !strings.Contains(err.Error(), "no address for main.go:42") {
+		t.Fatalf("expected routed server error, got %v", err)
+	}
+}
+
+// TestCloseUnblocksPendingSyncCall ensures a synchronous call returns promptly
+// (rather than blocking until its timeout) when the client is closed while the
+// server never answers.
+func TestCloseUnblocksPendingSyncCall(t *testing.T) {
+	fs := newFakeServer(func(protocol.Command) (protocol.Event, bool) {
+		return protocol.Event{}, false // never reply
+	})
+	defer fs.close()
+
+	c := dialTestClient(t, fs)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := c.SetBreakpoint("main.go", 42)
+		errCh <- err
+	}()
+
+	// Give the command time to reach the server and register the pending req.
+	_ = c.Close()
+
+	err := <-errCh
+	if err == nil {
+		t.Fatal("expected an error after Close, got nil")
+	}
+}

--- a/pkg/protocol/payload.go
+++ b/pkg/protocol/payload.go
@@ -150,10 +150,19 @@ type LocalsPayloadCmd struct {
 }
 
 // RestartPayload optionally overrides the args/env used for the relaunch.
-// Leave both nil to reuse the values from the original Launch.
+// Leave a field nil to reuse the value from the original Launch; pass a
+// non-nil slice (including an empty one) to override it — an empty slice
+// clears the args/env entirely.
+//
+// The fields deliberately omit `omitempty`: encoding/json treats a nil slice
+// and a non-nil empty slice identically under omitempty (both are dropped),
+// which would make an explicit "clear to empty" override indistinguishable
+// from "reuse" on the wire. The hub gates the override on nil-ness
+// (internal/hub handleRestart: `if override.Args != nil`), so that distinction
+// must survive the round trip. See issue #102.
 type RestartPayload struct {
-	Args []string `json:"args,omitempty"`
-	Env  []string `json:"env,omitempty"`
+	Args []string `json:"args"`
+	Env  []string `json:"env"`
 }
 
 // DiscardedBreakpoint reports a previously-set breakpoint that could not be

--- a/pkg/protocol/protocol_test.go
+++ b/pkg/protocol/protocol_test.go
@@ -525,6 +525,59 @@ var _ = Describe("Command", func() {
 		})
 	})
 
+	// Regression for issue #102. The hub's handleRestart distinguishes a nil
+	// slice ("reuse the original Launch args/env") from a non-nil empty slice
+	// ("clear them") via `if override.Args != nil`. RestartPayload therefore
+	// must NOT use omitempty on Args/Env: omitempty collapses both nil and a
+	// non-nil empty slice to {} on the wire, silently turning an explicit
+	// "clear" into a "reuse".
+	Describe("RestartPayload override semantics", func() {
+		roundTrip := func(in protocol.RestartPayload) protocol.RestartPayload {
+			cmd := protocol.Command{
+				Version: protocol.Version,
+				Kind:    protocol.CmdRestart,
+				Payload: mustRaw(in),
+			}
+			wire, err := json.Marshal(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			decoded, err := protocol.UnmarshalCommand(wire)
+			Expect(err).NotTo(HaveOccurred())
+			var out protocol.RestartPayload
+			Expect(protocol.DecodeCommandPayload(decoded, &out)).To(Succeed())
+			return out
+		}
+
+		It("keeps a nil slice nil after the round trip (reuse original Launch)", func() {
+			out := roundTrip(protocol.RestartPayload{Args: nil, Env: nil})
+			Expect(out.Args).To(BeNil())
+			Expect(out.Env).To(BeNil())
+		})
+
+		It("keeps a non-nil empty slice non-nil after the round trip (clear)", func() {
+			out := roundTrip(protocol.RestartPayload{Args: []string{}, Env: []string{}})
+			Expect(out.Args).NotTo(BeNil(),
+				"empty Args override must survive the wire, not decode as nil")
+			Expect(out.Args).To(HaveLen(0))
+			Expect(out.Env).NotTo(BeNil(),
+				"empty Env override must survive the wire, not decode as nil")
+			Expect(out.Env).To(HaveLen(0))
+		})
+
+		It("serialises a non-nil empty slice distinctly from a nil one", func() {
+			empty := mustRaw(protocol.RestartPayload{Args: []string{}, Env: nil})
+			Expect(string(empty)).To(ContainSubstring(`"args":[]`),
+				"empty Args must encode as [] so the hub can tell clear from reuse")
+			nilArgs := mustRaw(protocol.RestartPayload{Args: nil, Env: nil})
+			Expect(string(nilArgs)).NotTo(ContainSubstring(`"args":[]`))
+		})
+
+		It("preserves explicit non-empty override values", func() {
+			out := roundTrip(protocol.RestartPayload{Args: []string{"--flag"}, Env: []string{"K=V"}})
+			Expect(out.Args).To(ConsistOf("--flag"))
+			Expect(out.Env).To(ConsistOf("K=V"))
+		})
+	})
+
 	Describe("UnmarshalCommand", func() {
 		It("returns an error for malformed JSON", func() {
 			_, err := protocol.UnmarshalCommand([]byte("not json"))


### PR DESCRIPTION
Closes #102

## What

`RestartPayload.Args`/`Env` carried `omitempty`. Go's `encoding/json` drops a **non-nil empty slice** (`[]string{}`) under `omitempty` exactly as it drops a `nil` slice — both marshal to `{}`. The hub's `handleRestart`, however, distinguishes them:

```go
// internal/hub/hub.go
args := h.lastLaunch.Args
if override.Args != nil {   // nil = reuse; non-nil (empty included) = override
    args = override.Args
}
```

So `client.Restart([]string{}, nil)` — the idiomatic way to say "restart with **no** args" — was serialized as `{}`, decoded back to `nil`, and the hub silently **reused the original Launch arguments** instead of clearing them. The client could never express the "clear" operation the hub already supports: an encode/decode contract mismatch between `pkg/protocol`/`pkg/client` (encode) and the hub (decode).

`LaunchPayload` uses the same `omitempty` but is unaffected — its launch path never distinguishes nil from empty. Only `RestartPayload` feeds a nil-vs-non-nil decision.

## Fix

Remove `omitempty` from `RestartPayload.Args`/`Env` so an empty override serializes as `[]` (distinct from `null`/absent). The hub's existing `!= nil` gate then works as intended — no hub change needed.

This is **backward compatible**: old `{}`/`null` payloads still decode to `nil` = "reuse". Per [AGENTS.md → When you change something], a `Version` bump is only for **breaking** wire changes, so none is required; the round-trip table is extended instead.

## Tests (fail on `main`, pass here)

- **`pkg/protocol/protocol_test.go`** — new `RestartPayload override semantics` block pinning the round trip: a nil slice stays `nil` (reuse), a non-nil empty slice stays non-nil len-0 (clear), an empty slice encodes as `"args":[]` while nil does not, and explicit values survive. The two empty-slice specs fail on `main` (decode as `nil` / wire `{}`).
- **`pkg/client/ws_test.go`** — first tests for `pkg/client` (previously zero). A minimal fake WebSocket server drives the real client through dial → command → confirmation:
  - `TestRestartEmptyArgsOverrideReachesWire` — asserts the client puts `"args":[]`/`"env":[]` on the wire for an empty override (fails on `main` with `payload={}`).
  - `TestRestartNilArgsDoesNotClearOnWire` — nil override must not encode as `[]`.
  - `TestSetBreakpointReturnsConfirmation`, `TestSyncCommandRoutesServerError`, `TestCloseUnblocksPendingSyncCall` — adjacent coverage for the synchronous `sendAndWait` demux (confirmation, routed `EventError`, and `Close` cancellation).

## Docs

- Updated the `RestartPayload` doc comment and the `Client.Restart` interface comment to state the nil-vs-empty semantics.
- Added a bullet under AGENTS.md → *Things that look weird but are intentional* recording why `RestartPayload` deliberately omits `omitempty`, so it isn't reintroduced.

## Verification

`go vet ./...`, `golangci-lint run ./pkg/...`, `goimports -l` clean; full suite green locally (`-tags bingonative` on macOS): `pkg/protocol`, `pkg/client` (incl. `-race`), `internal/hub`, `internal/server`, `internal/debugger`.
