### PR TITLE
fix(hub): drain stale resumes before broadcasting the suspend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,11 +156,16 @@ benign no-op success (nothing to terminate).
 Stale resumes: a resuming command sent **while the process is still running**
 (an erroneous or racing client) lands in `resumeCh` but is not drained by Run's
 main loop. To stop it from satisfying a *future* suspend — auto-continuing past
-a fresh `BreakpointHit`/`Stepped` before the client can inspect — the wait loop
-**drains `resumeCh` on entry**, immediately after broadcasting the suspending
-event. Any resume buffered at that instant is necessarily stale: a legitimate
-resume can only follow the client observing the suspend, which hasn't been
-delivered over the wire yet.
+a fresh `BreakpointHit`/`Stepped` before the client can inspect — `handleEvent`
+**drains `resumeCh` before broadcasting the suspending event**. Draining *before*
+(not after) the broadcast is load-bearing: the broadcast is the starting gun, so
+any *legitimate* resume the client sends in response necessarily lands in
+`resumeCh` after the drain and is caught by the wait loop, while any resume
+already buffered when the drain runs is necessarily stale (a legitimate resume
+can only follow the client observing the suspend). Draining *after* the broadcast
+raced a zero-latency in-process client, which could put its legitimate resume in
+`resumeCh` before the drain ran and have it silently eaten — wedging the session
+(and flaking the hub tests under randomized load).
 
 When multiple clients race resume commands: **first writer wins**, the rest
 are dropped (`resumeCh` has capacity 1; see [hub.go injectCommand](internal/hub/hub.go)).

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -242,6 +242,24 @@ func (h *Hub) removeClient(c *Client) {
 // ends. Re-stamping is needed because the engine has its own seq and the hub
 // also synthesises errors/confirmations.
 func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
+	suspending := suspendingEvents[evt.Kind]
+
+	// Discard any resuming command buffered while the process was still running
+	// BEFORE broadcasting the suspending event. Such a command is necessarily
+	// stale — a legitimate resume can only be sent in response to this event,
+	// which the client hasn't observed yet — so dropping it stops it
+	// auto-continuing past the suspend and robbing the client of its chance to
+	// inspect. Draining *before* the broadcast is what makes that safe: the
+	// broadcast is the starting gun, so any resume the client sends back
+	// necessarily lands in resumeCh after the drain and is caught by the wait
+	// loop below. Draining after the broadcast left a race — an in-process
+	// client with no network latency could put its legitimate resume in
+	// resumeCh before the drain ran, and the drain would silently eat it,
+	// wedging the session (and flaking the hub tests under load).
+	if suspending {
+		h.drainResumeCh()
+	}
+
 	evt.Seq = h.seq.Add(1)
 	h.broadcast(evt)
 
@@ -252,19 +270,11 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 		h.transitionState(protocol.StateExited)
 	}
 
-	if !suspendingEvents[evt.Kind] {
+	if !suspending {
 		return
 	}
 
 	h.log.Info("suspended — waiting for resuming command", "event", evt.Kind)
-
-	// Discard any resuming command that was buffered while the process was
-	// still running. Such a command is necessarily stale: a legitimate resume
-	// can only be sent after the client observes this suspending event, which
-	// hasn't been delivered over the network yet. Without this drain, that
-	// stale resume would be consumed immediately below and auto-continue past
-	// the suspend, robbing the client of its chance to inspect.
-	h.drainResumeCh()
 
 	timeout := time.NewTimer(30 * time.Minute)
 	defer timeout.Stop()


### PR DESCRIPTION
## Problem

The `internal/hub` suite flakes ~20% under `-ginkgo.randomize-all` (and has already tripped CI on unrelated PRs), clustered in the `failed resume keeps the hub suspended` block added by #96, timing out in `waitForEventKind`.

`handleEvent` drained `resumeCh` **immediately after** broadcasting a suspending event, on the assumption that a legitimate resume can only arrive after the client sees the broadcast over the network (latency far exceeds the broadcast→drain window). That assumption is false for a **zero-latency in-process client**: the test observes the broadcast and injects its legitimate `Continue`/`StepOver` into `resumeCh` **before** the hub reaches `drainResumeCh()`, which then silently eats it. The wait loop never advances → timeout. In production the same window can strand a session (`Run`'s outer loop never selects on `resumeCh`).

## Fix

Drain `resumeCh` **before** broadcasting the suspending event. The broadcast becomes the starting gun: any legitimate resume the client sends in response necessarily lands in `resumeCh` *after* the drain and is caught by the wait loop, while any resume already buffered when the drain runs is necessarily stale (buffered before the suspending event was even generated). No timing assumption; the stale-resume-drop guarantee is preserved (still covered by the existing `stale resume handling` spec).

Surgical: 2 files. No test churn — the existing #96 behavioral tests *are* the regression (they flaked ~20% before, 0% now). AGENTS.md's suspend/resume note updated in the same commit.

## Verification (local, Apple Silicon)

- Baseline on `main`: **8/40** seeds fail (`-ginkgo.randomize-all`), all in the `failed resume` block at `waitForEventKind`.
- With the fix: **0/40** (same seeds), and **0/60** under `-race`.
- `go vet -tags bingonative ./internal/hub/... ./internal/server/...` clean; `gofmt`/`goimports` clean; `internal/hub` + `internal/server` pass under `-race`; full `go build -tags bingonative ./...` OK.

Closes #104
