### PR TITLE
test(e2e): add Attach acceptance spec for linux and darwin

### DIFF
--- a/.github/workflows/debugger-e2e.yml
+++ b/.github/workflows/debugger-e2e.yml
@@ -79,6 +79,9 @@ jobs:
       - name: E2E exit (process exit status)
         run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=exit
 
+      - name: E2E attach (attach to a running process)
+        run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=attach
+
   darwin-arm64:
     name: Darwin arm64 (Mach exceptions)
     runs-on: macos-14
@@ -144,6 +147,10 @@ jobs:
       - name: E2E exit (process exit status)
         if: runner.environment == 'self-hosted'
         run: ./e2e.test -test.v -test.timeout 300s -ginkgo.label-filter=exit
+
+      - name: E2E attach (attach to a running process)
+        if: runner.environment == 'self-hosted'
+        run: ./e2e.test -test.v -test.timeout 300s -ginkgo.label-filter=attach
 
       - name: E2E hygiene (Mach port-right leak regression)
         if: runner.environment == 'self-hosted'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -686,7 +686,9 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   (StackFrames chain + Locals + Goroutines at a breakpoint), `breakpoints`
   (a cleared breakpoint stops firing), `kill` (Kill terminates a
   freely-running tracee), `exit` (EventProcessExited reports the tracee's real
-  exit code), and `restart` (hub-level kill+relaunch reinstalls
+  exit code), `attach` (attach by PID to an already-running tracee — one the
+  debugger did not launch — then breakpoint it), and `restart` (hub-level
+  kill+relaunch reinstalls
   breakpoints and reruns from the top), all driving `debugger.Debugger`
   in-process (except `restart`/`fullstack`, which go through the stack); plus
   `fullstack`, which drives operations through the ENTIRE stack (pkg/client →
@@ -704,7 +706,7 @@ side `chan error` — every debugger outcome, failures included, rides the singl
 
   **Platform scoping — both containers run the full set.** The darwin container
   wires the same specs as linux: `basic`, `stepping`, `breakpoints`, `churn`,
-  `kill`, `exit`, `pause`, `inspect`, `restart`, and `fullstack`, plus the
+  `kill`, `exit`, `attach`, `pause`, `inspect`, `restart`, and `fullstack`, plus the
   darwin-only `hygiene` (Mach exception port-right leak regression). This was NOT
   always so:
   under the old darwin wait4/ptrace model the step-off-an-armed-trap specs

--- a/justfile
+++ b/justfile
@@ -58,13 +58,15 @@ integration:
 # Runs every label (no filter): `basic` correctness, `churn` robustness, `pause`
 # async-interrupt, `stepping` (StepInto/StepOut), `inspect` (StackFrames/Locals/
 # Goroutines), `breakpoints` (ClearBreakpoint), `kill` (kill-while-running),
+# `exit` (real exit code), `attach` (attach by PID to a running process),
 # `restart`, and `fullstack` transport, all under -race.
 e2e-linux:
 	go test -tags e2e -race -count=1 -v -timeout 600s ./test/integration
 
 # Run the debugger E2E acceptance tests on darwin/arm64 (native pure-Mach
 # exception-port backend). Runs every label (no filter): `basic`, `stepping`,
-# `breakpoints`, `churn`, `kill`, `pause`, `inspect`, `restart`, and `fullstack`,
+# `breakpoints`, `churn`, `kill`, `exit`, `attach`, `pause`, `inspect`,
+# `restart`, `fullstack`, and the darwin-only `hygiene` (Mach port-right leak),
 # matching linux. The step-off-an-armed-trap specs and kill-while-running, once
 # linux-only under the old wait4 model, are reliable on darwin under the
 # Mach-exception rearchitecture (#92) — per-thread exception delivery, a

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -215,6 +215,46 @@ func main() {
 }
 `
 
+// attachTargetSrc is the target for the Attach spec: a process the debugger did
+// NOT launch. It pins the main goroutine to the main OS thread. Attach on linux
+// only traces the single thread we PTRACE_ATTACH to (the main thread; the
+// PTRACE_O_TRACECLONE option that launch relies on cannot be applied
+// retroactively to the runtime's pre-existing threads), so the breakpointed
+// line must only ever execute on that thread for its SIGTRAP to reach the
+// tracer — otherwise the Go runtime takes the trap as "fatal: trace trap".
+// LockOSThread guarantees it; darwin's task-level exception port would catch
+// the fault on any thread regardless. Otherwise it mirrors basicTargetSrc: a
+// quiet hot loop calling a function on a clearly-marked line.
+const attachTargetSrc = `package main
+
+import (
+	"os"
+	"runtime"
+	"time"
+)
+
+func compute(n int) int {
+	s := 0
+	for i := 0; i < n; i++ {
+		s += i
+	}
+	return s
+}
+
+func main() {
+	runtime.LockOSThread()
+	// Safety net: self-exit if the debugger detaches and abandons us.
+	go func() { time.Sleep(180 * time.Second); os.Exit(0) }()
+	x := 0
+	for i := 0; i < 100000000; i++ {
+		x += compute(i % 10) // BP
+		x++
+		time.Sleep(time.Millisecond)
+		_ = x
+	}
+}
+`
+
 // declareBasicStepOverSpec adds the continue+step-over acceptance spec to the
 // enclosing Ginkgo container. It is the correctness gate: set a breakpoint on a
 // line that calls a function, repeatedly Continue to it and StepOver the call,
@@ -602,6 +642,45 @@ func declareExitCodeSpec() {
 	})
 }
 
+// declareAttachSpec adds the Attach acceptance spec — the only e2e that drives
+// Debugger.Attach against a process the debugger did NOT launch. It starts the
+// target independently, attaches by PID (linux PTRACE_ATTACH; darwin
+// task_for_pid + a task-level Mach exception port, which needs the debugger
+// entitlement), sets a breakpoint through the attached binary's DWARF, and
+// asserts the already-running tracee is caught at that breakpoint across
+// several resume cycles. Runs on both containers so the two attach paths stay
+// in agreement.
+//
+// Cleanup detaches rather than kills: Kill of an *attached* tracee deliberately
+// detaches without terminating it (neither backend owns a process it merely
+// attached to — linux PTRACE_DETACH, darwin resume-all-threads), so
+// newAttachHarness separately reaps the process the spec started.
+func declareAttachSpec() {
+	It("attaches to a running process and catches it at a breakpoint", Label("attach"), func() {
+		line := markerLine(attachTargetSrc, "// BP")
+		bin := buildTarget("attach_target", attachTargetSrc)
+
+		h := newAttachHarness(bin)
+		h.waitFor(15*time.Second, protocol.EventStepped) // initial attach stop
+
+		bp, err := h.d.SetBreakpoint("attach_target.go", line)
+		Expect(err).NotTo(HaveOccurred(), "SetBreakpoint after attach")
+		Expect(bp.Location.Line).To(Equal(line), "breakpoint resolved to the requested line")
+
+		iters := envInt("BINGO_E2E_ATTACH_ITERS", 3)
+		for i := 0; i < iters; i++ {
+			Expect(h.d.Continue()).To(Succeed(), "Continue #%d", i)
+			evt := h.waitFor(20*time.Second,
+				protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+			Expect(evt.Kind).To(Equal(protocol.EventBreakpointHit),
+				"Continue #%d expected BreakpointHit on the attached tracee, got %s: %s",
+				i, evt.Kind, evt.Payload)
+			Expect(bpLine(evt)).To(Equal(line), "BreakpointHit #%d at BP line", i)
+		}
+		AddReportEntry("attach-iterations", iters)
+	})
+}
+
 // bpLine decodes a BreakpointHit event and returns its resolved line.
 func bpLine(evt protocol.Event) int {
 	GinkgoHelper()
@@ -674,6 +753,43 @@ func newE2EHarness(bin string) *e2eHarness {
 			AddReportEntry("kill-timeout", "Kill did not return within 5s (backend may be wedged)")
 		}
 	})
+	return &e2eHarness{d: d}
+}
+
+// newAttachHarness starts bin as an independent OS process (NOT under the
+// debugger) and attaches the real backend to it by PID — the only path that
+// exercises Debugger.Attach end to end. Cleanups are registered LIFO so that at
+// teardown the debugger detaches FIRST (Debugger.Kill on an attached tracee
+// detaches without killing) and the process the spec owns is reaped LAST.
+func newAttachHarness(bin string) *e2eHarness {
+	GinkgoHelper()
+	cmd := exec.Command(bin)
+	Expect(cmd.Start()).To(Succeed(), "start target for attach")
+	// Registered first → runs last: SIGKILL and reap the process we own, since
+	// detaching left it alive.
+	DeferCleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	// Let the Go runtime reach its steady-state loop before attaching so the
+	// breakpoint we set lands promptly on the next iteration rather than racing
+	// process startup.
+	time.Sleep(200 * time.Millisecond)
+
+	d := debugger.New(nil)
+	// Registered second → runs first: detach the debugger (bounded, to surface a
+	// wedged Kill instead of hanging the suite).
+	DeferCleanup(func() {
+		done := make(chan struct{})
+		go func() { _ = d.Kill(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			AddReportEntry("kill-timeout", "attach Kill did not return within 5s (backend may be wedged)")
+		}
+	})
+	Expect(d.Attach(cmd.Process.Pid, bin)).To(Succeed(), "Attach to running target")
 	return &e2eHarness{d: d}
 }
 

--- a/test/integration/debugger_e2e_darwin_arm64_test.go
+++ b/test/integration/debugger_e2e_darwin_arm64_test.go
@@ -35,6 +35,7 @@ import (
 //   - churn: hundreds of step-overs under continuous thread creation.
 //   - kill: Kill terminates a freely-running tracee.
 //   - exit: EventProcessExited reports the tracee's real exit code.
+//   - attach: attach by PID to an already-running tracee, then breakpoint it.
 //   - pause: Continue -> Pause -> Paused round-trips (async interrupt).
 //   - inspect: continue into a breakpoint, then StackFrames/Locals/Goroutines.
 //   - restart: hub kill + relaunch + reinstall, reaching the breakpoint again.
@@ -51,6 +52,7 @@ var _ = Describe("Darwin arm64 debugger backend (Mach exceptions) E2E", Label("d
 	declareClearBreakpointSpec()
 	declareKillRunningSpec()
 	declareExitCodeSpec()
+	declareAttachSpec()
 	declareFullStackSpec()
 	declareRestartSpec()
 	declarePortHygieneSpec()

--- a/test/integration/debugger_e2e_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_linux_amd64_test.go
@@ -17,6 +17,7 @@ var _ = Describe("Linux amd64 debugger backend (ptrace) E2E", Label("linux"), fu
 	declareClearBreakpointSpec()
 	declareKillRunningSpec()
 	declareExitCodeSpec()
+	declareAttachSpec()
 	declareFullStackSpec()
 	declareRestartSpec()
 })


### PR DESCRIPTION
Closes #107.

## What

Adds a portable `attach` e2e acceptance spec — the only `debugger.Debugger` operation that had **no** e2e coverage — wired into both the linux and darwin native-backend containers.

The spec drives `Debugger.Attach` against a process the debugger did **not** launch:
1. starts the target independently (`exec.Command(bin).Start()`),
2. attaches by PID (linux `PTRACE_ATTACH`; darwin `task_for_pid` + a task-level Mach exception port),
3. sets a breakpoint through the attached binary's DWARF,
4. asserts the already-running tracee is caught at that breakpoint across several resume cycles (`BINGO_E2E_ATTACH_ITERS`, default 3).

## Why the target pins the main thread

`attachTargetSrc` calls `runtime.LockOSThread()` in `main`. Linux `Attach` traces only the single thread it `PTRACE_ATTACH`es (the main thread); `PTRACE_O_TRACECLONE` — which the *launch* path relies on — cannot be applied retroactively to the runtime's pre-existing threads. So the breakpointed line must only ever run on the attached thread, or the Go runtime takes the `SIGTRAP` as `fatal: trace trap`. Darwin's task-level exception port catches the fault on any thread, so the lock is harmless there.

## Cleanup detaches, then reaps

`Kill` of an *attached* tracee deliberately **detaches** without terminating it (neither backend owns a process it merely attached to — linux `PTRACE_DETACH`, darwin resume-all-threads). So `newAttachHarness` registers LIFO `DeferCleanup`s: the debugger detaches first, and the process the spec started is SIGKILL'd + reaped last. The detach is bounded by a 5s watchdog so a wedged backend fails loudly instead of hanging the suite.

## CI + docs

- Adds an `E2E attach` step to both jobs in `debugger-e2e.yml` (darwin gated `if: runner.environment == 'self-hosted'`, matching every other darwin e2e step).
- Keeps AGENTS.md's two label enumerations in sync.

## Verification

- **darwin/arm64 (real hardware, `-race`, codesigned):** `attach` passes; **0 failures across 20 repeat runs** (15 at default iters, 5 at `BINGO_E2E_ATTACH_ITERS=25`); `attach || basic || restart` smoke green. `go vet -tags 'e2e bingonative'` clean; `gofmt`/`goimports` clean.
- **linux/amd64:** cross-compiled the e2e test binary (`GOOS=linux GOARCH=amd64 go test -tags e2e -c`) — compiles clean. Runtime execution relies on the Linux ptrace CI job (I can't run the linux backend on Apple Silicon).

## Heads up — darwin verification gate

This PR touches `test/integration/debugger_e2e_darwin_arm64_test.go`, so it trips the **Darwin E2E verified** gate and needs the `darwin-e2e-verified` label. I verified the spec locally on Apple Silicon (counts above) but per protocol did **not** self-add the label — a maintainer running `just e2e-darwin` should confirm and label. Note the `attach` darwin CI step is self-hosted-gated, so it won't actually execute on hosted macOS runners (same as all darwin e2e).
