### PR TITLE
feat(debugger): emit EventContinued on resume

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,15 @@ The hub blocks after broadcasting any of these "suspending" events until a
 While suspended, **non-resuming** commands (`SetBreakpoint`, `Locals`, …) are
 still executed immediately — the process is paused, so it's safe.
 
+A successful `Continue` emits a **non-suspending** `EventContinued` from the
+engine (`engine.Continue` → `emitContinued`) before the process runs free. It is
+not in the suspending set and does not gate the hub — it's a fire-and-forget
+notification so a client that did *not* issue the resume (another WebSocket
+observer, or a DAP adapter mapping it to a `continued` event) learns the tracee
+is running again instead of waiting for the next stop. Steps do **not** emit it:
+they self-complete into a suspending `Stepped`, which DAP maps to `stopped`
+reason=step, not `continued`.
+
 `Pause` and `Kill` are the odd ones out: both must act **while the process is
 running**, not only while suspended, so neither is a resuming command. They ride
 the ordinary `cmdCh` (like `SetBreakpoint`), which both Run's main loop and the

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -267,13 +267,18 @@ func (e *engine) Continue() error {
 			return err
 		}
 		if e.lastBP != nil {
-			return e.resumeFromBreakpoint(bpResumeContinue, 0)
+			if err := e.resumeFromBreakpoint(bpResumeContinue, 0); err != nil {
+				return err
+			}
+			e.emitContinued()
+			return nil
 		}
 		if err := e.backend.ContinueProcess(); err != nil {
 			return err
 		}
 		e.setState(stateRunning)
 		go e.waitLoop()
+		e.emitContinued()
 		return nil
 	})
 }
@@ -1168,6 +1173,17 @@ func (e *engine) emitPaused(stop StopEvent) {
 		Location:  loc,
 		Frames:    frames,
 	})
+}
+
+// emitContinued reports that the tracee has resumed free execution in response
+// to a Continue. Unlike a step — which self-completes into EventStepped — a
+// plain resume produces no later stop of its own, so without this event a
+// client that did not issue the resume (another WebSocket observer, or a DAP
+// adapter translating it into a `continued` event) has no way to learn the
+// process is running again until it happens to hit the next breakpoint. Steps
+// deliberately do not emit it.
+func (e *engine) emitContinued() {
+	e.emit(protocol.EventContinued, protocol.ContinuedPayload{})
 }
 
 func (e *engine) emitProcessExited(code int) {

--- a/internal/debugger/engine_curtid_test.go
+++ b/internal/debugger/engine_curtid_test.go
@@ -132,7 +132,7 @@ var _ = Describe("current-thread inspection", func() {
 	stopOnThread2 := func() {
 		debugger.ExportedForceSuspended(d)
 		debugger.ExportedSetBreakpointAt(d, pcBeta)
-		Expect(d.Continue()).To(Succeed())
+		continueAndConsumeContinued(d)
 		fb.pushStop(debugger.StopEvent{Reason: debugger.StopBreakpoint, TID: 2, PC: pcBeta})
 		Expect(mustNextEvent(d).Kind).To(Equal(protocol.EventBreakpointHit))
 	}

--- a/internal/debugger/engine_test.go
+++ b/internal/debugger/engine_test.go
@@ -136,6 +136,14 @@ func mustNextEvent(d debugger.Debugger) protocol.Event {
 	return evt
 }
 
+// continueAndConsumeContinued issues Continue and consumes the EventContinued
+// that a successful resume emits, leaving the following stop event for the
+// caller to assert on.
+func continueAndConsumeContinued(d debugger.Debugger) {
+	ExpectWithOffset(1, d.Continue()).To(Succeed())
+	ExpectWithOffset(1, mustNextEvent(d).Kind).To(Equal(protocol.EventContinued))
+}
+
 func drainEvents(d debugger.Debugger) {
 	for {
 		select {
@@ -341,7 +349,7 @@ var _ = Describe("Engine", func() {
 		})
 
 		It("emits EventBreakpointHit when a breakpoint stop arrives", func() {
-			Expect(d.Continue()).To(Succeed())
+			continueAndConsumeContinued(d)
 			fb.pushStop(debugger.StopEvent{
 				Reason: debugger.StopBreakpoint,
 				TID:    1,
@@ -366,7 +374,7 @@ var _ = Describe("Engine", func() {
 			}
 			fb.regs[2] = debugger.Registers{PC: hitPC}
 
-			Expect(d.Continue()).To(Succeed())
+			continueAndConsumeContinued(d)
 			fb.pushStop(debugger.StopEvent{Reason: debugger.StopBreakpoint})
 
 			evt := mustNextEvent(d)
@@ -377,7 +385,7 @@ var _ = Describe("Engine", func() {
 		})
 
 		It("emits nothing (resumes silently) for an unrecognised breakpoint PC", func() {
-			Expect(d.Continue()).To(Succeed())
+			continueAndConsumeContinued(d)
 			fb.pushStop(debugger.StopEvent{
 				Reason: debugger.StopBreakpoint,
 				TID:    1,
@@ -404,7 +412,7 @@ var _ = Describe("Engine", func() {
 			}()
 
 			debugger.ExportedForceSuspended(d2)
-			Expect(d2.Continue()).To(Succeed())
+			continueAndConsumeContinued(d2)
 			fb2.pushStop(debugger.StopEvent{
 				Reason:   debugger.StopExited,
 				TID:      1,
@@ -565,6 +573,11 @@ var _ = Describe("Engine", func() {
 			Expect(d.Continue()).To(Succeed())
 			Expect(d.Continue()).To(MatchError(debugger.ErrNotSuspended))
 		})
+
+		It("emits EventContinued when it resumes", func() {
+			Expect(d.Continue()).To(Succeed())
+			Expect(mustNextEvent(d).Kind).To(Equal(protocol.EventContinued))
+		})
 	})
 
 	Describe("Pause", func() {
@@ -591,7 +604,7 @@ var _ = Describe("Engine", func() {
 
 		It("fires StopProcess and emits EventPaused for the resulting SIGSTOP", func() {
 			debugger.ExportedForceSuspended(d)
-			Expect(d.Continue()).To(Succeed())
+			continueAndConsumeContinued(d)
 
 			before := fb.stopProcessCalls
 			Expect(d.Pause()).To(Succeed())
@@ -611,7 +624,7 @@ var _ = Describe("Engine", func() {
 
 		It("does not emit EventPaused for a SIGSTOP when no Pause is pending", func() {
 			debugger.ExportedForceSuspended(d)
-			Expect(d.Continue()).To(Succeed())
+			continueAndConsumeContinued(d)
 
 			// A SIGSTOP with no armed Pause is a leftover: suppress and resume
 			// silently rather than reporting a bogus Paused.
@@ -639,7 +652,7 @@ var _ = Describe("Engine", func() {
 			})
 
 			It("suspends for the breakpoint, then suppresses the leftover SIGSTOP", func() {
-				Expect(d.Continue()).To(Succeed())
+				continueAndConsumeContinued(d)
 				Expect(d.Pause()).To(Succeed())
 
 				// The real breakpoint stop arrives before the SIGSTOP does.
@@ -654,7 +667,7 @@ var _ = Describe("Engine", func() {
 				// Resume; the queued SIGSTOP now surfaces but the Pause flag was
 				// cleared by the breakpoint suspend, so it must be swallowed —
 				// no spurious EventPaused.
-				Expect(d.Continue()).To(Succeed())
+				continueAndConsumeContinued(d)
 				pushSIGSTOP()
 
 				_, ok := nextEvent(d)


### PR DESCRIPTION
## What

A successful `Continue` now emits a **non-suspending** `EventContinued` from the engine before the tracee runs free.

Previously `EventContinued` was defined in `pkg/protocol` and handled by `cmd/cli` but **never emitted** by the engine/hub, so a client that did *not* issue the resume had no way to learn the process was running again until it hit the next stop.

## Why

This is the notification a WebSocket observer — or a future DAP adapter mapping it to a `continued` event — needs to stay in sync when *any* client drives execution. It's a prerequisite for the DAP interop work (multiple clients on one session).

Steps keep self-completing into the suspending `Stepped` event and deliberately **do not** emit `Continued`, matching DAP's `stopped(reason=step)` semantics.

## Changes

- **`internal/debugger/engine.go`** — `Continue()` emits `emitContinued()` on both success paths (breakpoint step-over resume and direct `ContinueProcess`); added the `emitContinued()` helper with a why-comment.
- **`internal/debugger/engine_test.go` / `engine_curtid_test.go`** — added a `continueAndConsumeContinued` helper, converted the Continue-then-read sites to it, and added a dedicated `emits EventContinued when it resumes` test.
- **`AGENTS.md`** — documented the new non-suspending event in the suspend/resume section.

## Verification

`go vet`, full `go build`, and the entire `-tags bingonative` unit suite pass (`internal/debugger`, `internal/hub`, `pkg/protocol`, and the rest).

No hub changes needed — `broadcast()` already fans the new event to every client, and hub tests use a `fakeDebugger` that emits nothing on `Continue()`.