### PR TITLE
fix(debugger): reap killed tracee with wait4 to avoid Kill deadlock (linux)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -444,6 +444,22 @@ are detected by a `mach_msg` receive loop.
   breakpoint (or SIGURG) while a step is in flight — keying off `stepping`
   alone would misclassify it and corrupt the engine's step-over state machine.
 - `g` pointer for goroutine inspection lives at `FS_BASE` on amd64.
+- `killProcess` never reaps the zombie itself while the engine's `waitLoop` is
+  in flight (a *running* tracee). That waitLoop is blocked in `Wait4(-1, WALL)`
+  and is the **sole** legitimate reaper: it absorbs every thread's SIGKILL death
+  and surfaces `StopKilled`. A second reaper in `killProcess` deadlocks Kill two
+  ways (#111): it races the waitLoop for the same stops, and — because a Go
+  tracee is always multi-threaded — `Wait4(pid)` targets only the thread-group
+  leader, whose zombie stays unreapable until every sibling is reaped, which
+  `killProcess` cannot do. So `killProcess` only reaps when the tracee was
+  **suspended** at a stop (no waitLoop), via `reapAfterKill`, which loops
+  `Wait4(-1, WALL)` (any thread, never the leader's pid), resuming any
+  ptrace-stopped thread so the pending process-wide SIGKILL kills it, until
+  `ECHILD`. The engine passes `running` (state == running) down through
+  `process.kill` to drive this. (Darwin has no such race — its `waitLoop` blocks
+  on a Mach port, not `wait4`, so its `killProcess` `Wait4(pid)` is always the
+  sole reaper and ignores `running`.) Regression guard: the `kill` e2e loops the
+  launch→run→Kill cycle (`BINGO_E2E_KILL_ITERS`).
 - `SIGURG` re-delivery is mandatory here too — but only the `stepTID` thread is
   re-single-stepped on SIGURG; a SIGURG on any other thread is re-delivered and
   that thread continued.

--- a/internal/debugger/backend_darwin_arm64.go
+++ b/internal/debugger/backend_darwin_arm64.go
@@ -328,7 +328,10 @@ func attachToProcess(b Backend, pid int) error {
 	return nil
 }
 
-func killProcess(b Backend, pid int, _ *exec.Cmd) error {
+// running is unused on Darwin: the waitLoop blocks on a Mach exception port,
+// not wait4, so this Wait4(pid) reap is always the sole reaper — no race with
+// the waitLoop the way the linux backend has (see backend_linux_amd64.go).
+func killProcess(b Backend, pid int, _ *exec.Cmd, _ bool) error {
 	db, _ := b.(*darwinBackend)
 
 	// Attached (not launched): we don't own the process. Resume its threads so it

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -180,14 +180,31 @@ func attachToProcess(b Backend, pid int) error {
 	return attachErr
 }
 
-func killProcess(b Backend, pid int, cmd *exec.Cmd) error {
+// killProcess terminates a launched tracee (SIGKILL) or detaches from an
+// attached one. running reports whether the engine's waitLoop is in flight —
+// true for a running tracee, false for one suspended at a stop.
+func killProcess(b Backend, pid int, cmd *exec.Cmd, running bool) error {
 	if cmd != nil {
 		// SIGKILL via the OS handle is not a ptrace op, so it is safe from any
 		// thread and keeps Kill responsive even if the tracer thread is busy.
 		if err := cmd.Process.Kill(); err != nil && !isAlreadyExited(err) {
 			return err
 		}
-		_ = cmd.Wait()
+		// Reaping the zombie belongs to the waitLoop whenever one is in flight
+		// (a running tracee). It is blocked in Wait4(-1, WALL) and will absorb
+		// every thread's SIGKILL death and surface StopKilled. A second reaper
+		// here would both (a) race that waitLoop for the same stops and (b) —
+		// since a Go tracee is always multi-threaded — never make progress:
+		// Wait4(pid) targets only the thread-group leader, whose zombie is not
+		// reapable until all siblings are, and killProcess cannot reach the
+		// siblings. Either way Kill wedges (the deadlock reported in #111). So
+		// only reap here when there is NO waitLoop — the tracee was suspended at
+		// a stop, making killProcess the sole reaper.
+		if !running {
+			if lb, ok := b.(*linuxBackend); ok {
+				lb.reapAfterKill()
+			}
+		}
 		return nil
 	}
 	// Attached (not launched): detach, don't kill — we don't own the process.
@@ -198,6 +215,39 @@ func killProcess(b Backend, pid int, cmd *exec.Cmd) error {
 		_ = syscall.PtraceDetach(pid)
 	}
 	return nil
+}
+
+// reapAfterKill drains a SIGKILL'd tracee that has no waitLoop to reap it (it
+// was suspended at a ptrace stop when killed). It waits on Wait4(-1) — any
+// thread — never Wait4(pid): a Go tracee is always multi-threaded and the
+// thread-group leader's zombie stays unreapable until every sibling thread is
+// reaped, so waiting on the leader's pid alone blocks forever. A thread frozen
+// at a ptrace stop (e.g. the breakpoint we were suspended at) will not proceed
+// to death until resumed, so continue any stopped thread before waiting again;
+// the process-wide SIGKILL then kills it. Returns once ECHILD reports the whole
+// thread group gone.
+//
+// It must never run concurrently with the engine's waitLoop: two Wait4(-1)
+// callers would steal each other's stops. killProcess guarantees that by only
+// invoking it when the tracee was not running (no waitLoop in flight).
+func (b *linuxBackend) reapAfterKill() {
+	for {
+		var ws syscall.WaitStatus
+		wpid, err := syscall.Wait4(-1, &ws, syscall.WALL, nil)
+		switch {
+		case err == nil:
+			if ws.Stopped() {
+				_ = b.continueIfTraceeExists(wpid, 0)
+			}
+			// Exited/Signaled: that thread is reaped; loop for the rest.
+		case isNoChildProcess(err):
+			return // whole thread group reaped
+		case errors.Is(err, syscall.EINTR):
+			// interrupted by a signal; retry
+		default:
+			return // unexpected wait4 error: nothing left to reap
+		}
+	}
 }
 
 func isAlreadyExited(err error) bool {

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -218,11 +218,16 @@ func (e *engine) Kill() error {
 		if e.getState() == stateExited {
 			return nil
 		}
+		// A running tracee has an in-flight waitLoop blocked in Wait4(-1); on
+		// linux that waitLoop — not killProcess — must reap the SIGKILL death,
+		// since two concurrent wait4 callers race and wedge Kill (#111). Capture
+		// whether we're running before endThreadStep/clearAll touch anything.
+		running := e.getState() == stateRunning
 		// Release any threads held for an in-flight atomic step-over first, so
 		// a detach (attached-process Kill) never leaves them Mach-suspended.
 		e.endThreadStep()
 		e.bps.clearAll(e.backend)
-		if killErr := e.proc.kill(e.backend); killErr != nil {
+		if killErr := e.proc.kill(e.backend, running); killErr != nil {
 			return killErr
 		}
 		e.setState(stateExited)

--- a/internal/debugger/process.go
+++ b/internal/debugger/process.go
@@ -48,8 +48,9 @@ func (p *process) attach(b Backend, pid int) error {
 
 // kill terminates the tracee. The Backend argument lets platform kill paths run
 // PTRACE_DETACH on the tracer thread; the engine's Kill path also runs
-// bps.clearAll.
-func (p *process) kill(b Backend) error {
+// bps.clearAll. running reports whether a waitLoop is in flight (a running
+// tracee), which the linux backend needs to decide who reaps the zombie.
+func (p *process) kill(b Backend, running bool) error {
 	if !p.live {
 		return nil
 	}
@@ -58,7 +59,7 @@ func (p *process) kill(b Backend) error {
 		return nil
 	}
 	p.live = false
-	if err := killProcess(b, p.pid, p.cmd); err != nil {
+	if err := killProcess(b, p.pid, p.cmd, running); err != nil {
 		return fmt.Errorf("kill: %w", err)
 	}
 	return nil

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -568,25 +568,34 @@ func declareKillRunningSpec() {
 	It("kills a running process", Label("kill"), func() {
 		bin := buildTarget("kill_target", basicTargetSrc)
 
-		h := newE2EHarness(bin)
-		h.waitFor(15*time.Second, protocol.EventStepped) // initial launch stop
+		// Repeat the launch→run→Kill cycle. Killing a running tracee reaps it
+		// from the engine loop while a waitLoop concurrently reaps via
+		// Wait4(-1); the losing reaper must return promptly (ECHILD) rather than
+		// wedge Kill. That is a timing race, so a single kill only catches a
+		// regression intermittently — loop to make the reap path deterministic.
+		iters := envInt("BINGO_E2E_KILL_ITERS", 20)
+		for i := 0; i < iters; i++ {
+			h := newE2EHarness(bin)
+			h.waitFor(15*time.Second, protocol.EventStepped) // initial launch stop
 
-		Expect(h.d.Continue()).To(Succeed(), "Continue so the tracee is running")
-		// Let it actually be running before we kill, so this exercises the
-		// running→exited path rather than racing the resume.
-		time.Sleep(30 * time.Millisecond)
+			Expect(h.d.Continue()).To(Succeed(), "Continue so the tracee is running (iter %d)", i)
+			// Let it actually be running before we kill, so this exercises the
+			// running→exited path rather than racing the resume.
+			time.Sleep(30 * time.Millisecond)
 
-		Expect(h.d.Kill()).To(Succeed(), "Kill running process")
-		// Kill tears the engine down; which signal surfaces depends on which
-		// stop wins the race inside the loop. On linux the real wait4 exit
-		// typically arrives as ErrProcessExited and the loop emits
-		// EventProcessExited before closing; on darwin the synthetic StopExited
-		// injected by Kill wins and the loop returns straight to its deferred
-		// close(events) with no explicit exit event (see engine.loop's
-		// stateExited guard). Both outcomes prove the running tracee was reaped,
-		// so accept either. Only a timeout — neither event nor close — is a
-		// real failure (a wedged Kill that never reaped the process).
-		assertTerminated(h.d.Events(), 15*time.Second)
+			Expect(h.d.Kill()).To(Succeed(), "Kill running process (iter %d)", i)
+			// Kill tears the engine down; which signal surfaces depends on which
+			// stop wins the race inside the loop. On linux the real wait4 exit
+			// typically arrives as ErrProcessExited and the loop emits
+			// EventProcessExited before closing; on darwin the synthetic
+			// StopExited injected by Kill wins and the loop returns straight to
+			// its deferred close(events) with no explicit exit event (see
+			// engine.loop's stateExited guard). Both outcomes prove the running
+			// tracee was reaped, so accept either. Only a timeout — neither event
+			// nor close — is a real failure (a wedged Kill that never reaped it).
+			assertTerminated(h.d.Events(), 15*time.Second)
+		}
+		AddReportEntry("kill-iterations", iters)
 	})
 }
 


### PR DESCRIPTION
Closes #111.

## Symptom
Killing a tracee intermittently hung the whole engine until the 5-minute test
timeout — a flaky **`E2E kill`** hang on the Linux ptrace CI job (and, once the
kill path was exercised more, a **`restart`** hang on the Full-stack Linux job).

## Root cause
`engine.Kill` runs `killProcess` on the engine loop, which reaped the SIGKILL'd
child itself. Two independent defects made that wedge:

1. **Race** — while the tracee is *running*, the engine's `waitLoop` is
   concurrently blocked in `Wait4(-1, WALL)`. A second reaper on the engine loop
   races it for the same stops.
2. **Wrong wait target** — a Go tracee is always multi-threaded, and the
   thread-group leader's zombie is not reapable until *every sibling thread* is
   reaped. `killProcess` reaped with `Wait4(pid)` (only the leader) and could
   never reach the siblings, so `Wait4(pid)` blocked forever. The CI goroutine
   dump showed the engine loop parked in exactly that `Wait4(pid)` for 4 minutes.

## Fix
`killProcess` no longer reaps while a `waitLoop` is in flight (a running
tracee). That `waitLoop` is the sole legitimate reaper: it already absorbs every
thread's SIGKILL death via `Wait4(-1, WALL)` and surfaces `StopKilled`. Only
when the tracee was **suspended** at a stop (no `waitLoop`, e.g. `restart` kills
a tracee parked at a breakpoint) does `killProcess` reap — via `reapAfterKill`,
which loops `Wait4(-1)` (any thread, never the leader's pid), resuming any
ptrace-stopped thread so the pending process-wide SIGKILL kills it, until
`ECHILD`. The engine passes `running` (state == running) down through
`process.kill` to select the path.

Darwin is unaffected — its `waitLoop` blocks on a Mach exception port, not
`wait4`, so its `killProcess` `Wait4(pid)` is always the sole reaper (macOS
`wait4` reaps the whole process, not per-thread). It ignores the new `running`
arg.

## Verification
- Local (darwin/arm64, `-race`, codesigned): full e2e suite **15/15 pass**;
  `kill` at `BINGO_E2E_KILL_ITERS=30`, `restart`, and `fullstack` all green.
- Linux is validated in CI (can't run the ptrace backend locally). The `kill`
  e2e now loops the launch→run→Kill cycle (`BINGO_E2E_KILL_ITERS`, default 20)
  so the reap race is exercised deterministically rather than once.
- `go vet` + `gofmt` clean; linux cross-compile of the debugger package and the
  e2e test binary both build.

AGENTS.md updated in the same commit to document the corrected invariant.
