### PR TITLE
fix(ci): pin goimports via go tool to satisfy SonarCloud S8545

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,8 +23,7 @@ jobs:
 
       - name: Check imports formatting
         run: |
-          go install golang.org/x/tools/cmd/goimports@latest
-          unformatted=$(goimports -l .)
+          unformatted=$(go tool goimports -l .)
           if [ -n "$unformatted" ]; then
             echo "The following files need goimports formatting:"
             echo "$unformatted"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ follow them so reviews stay about substance, not style.
 ### Code style
 
 - `gofmt` / `goimports` are mandatory — the lefthook pre-commit hook runs
-  `goimports -w` on staged `*.go` files. Match the surrounding style otherwise.
+  `go tool goimports -w` on staged `*.go` files. Match the surrounding style otherwise.
 - Make surgical, focused changes. Don't opportunistically reformat or refactor
   unrelated code in the same commit.
 - Return errors; don't `panic` in server/hub/debugger control paths. Panics

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/bingosuite/bingo
 
 go 1.25.5
 
-tool github.com/evilmartians/lefthook
+tool (
+	github.com/evilmartians/lefthook
+	golang.org/x/tools/cmd/goimports
+)
 
 require (
 	github.com/chzyer/readline v1.5.1

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,7 +6,7 @@ pre-commit:
   commands:
     imports:
       glob: "*.go"
-      run: goimports -w {staged_files} && git add {staged_files}
+      run: go tool goimports -w {staged_files} && git add {staged_files}
 
 commit-msg:
   commands:


### PR DESCRIPTION
## Summary

Fixes SonarCloud security-audit rule [`githubactions:S8545`](https://rules.sonarsource.com/github-actions/RSPEC-8545/) (MAJOR / Security) on `.github/workflows/go.yml`, the **"Check imports formatting"** step.

**Message:** _"Dependency versions are not predictable. Use a lock-file enforcing command instead."_

**Root cause:** the step ran `go install golang.org/x/tools/cmd/goimports@latest` — the `@latest` makes the installed dependency version non-deterministic.

## Fix

The repo already uses Go's `go tool` mechanism (there is a `tool github.com/evilmartians/lefthook` directive in `go.mod`, resolved/verified via `go.sum`), and `golang.org/x/tools v0.36.0` is already in the module graph and `go.sum`. So goimports is added as a **pinned `go tool` dependency** and invoked via `go tool goimports`, which resolves the version from `go.mod`/`go.sum` (the lock file) — satisfying S8545.

- `go get -tool golang.org/x/tools/cmd/goimports@v0.36.0` expanded the single `tool` line into a `tool ( ... )` block with both `lefthook` and `goimports`. **No `go.sum` changes** were required (x/tools v0.36.0 was already fully covered).

## Files changed

- **`.github/workflows/go.yml`** — dropped `go install ...@latest`; the step now runs `go tool goimports -l .`.
- **`lefthook.yml`** — the pre-commit `imports` hook now runs `go tool goimports -w ...` for the same predictable-version goal.
- **`go.mod`** — `tool ( ... )` block adding `golang.org/x/tools/cmd/goimports`.
- **`AGENTS.md`** — kept the documented invariant in sync (`goimports -w` → `go tool goimports -w`), per repo convention that AGENTS.md is updated in the same commit as the invariant.

## Verification

- `go tool goimports -l .` prints nothing (clean tree)
- `go vet` / `go build` / unit tests (`./pkg/...`, `./internal/dap/...`) pass
- `go.sum` unchanged

## Notes

- Pre-existing finding (created 2026-03-30), re-surfaced on the PR #113 merge re-analysis.
- Touches **no darwin-native or debugger paths**, so the darwin verification gate is a green no-op.