### PR TITLE
feat(debugger): stream goroutine/thread concurrency snapshots

### DIFF
--- a/.github/workflows/debugger-e2e.yml
+++ b/.github/workflows/debugger-e2e.yml
@@ -84,6 +84,9 @@ jobs:
       - name: E2E attach (attach to a running process)
         run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=attach
 
+      - name: E2E concurrency (goroutine/thread snapshot foundation)
+        run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=concurrency
+
   darwin-arm64:
     name: Darwin arm64 (Mach exceptions)
     runs-on: macos-14
@@ -153,6 +156,10 @@ jobs:
       - name: E2E attach (attach to a running process)
         if: runner.environment == 'self-hosted'
         run: ./e2e.test -test.v -test.timeout 300s -ginkgo.label-filter=attach
+
+      - name: E2E concurrency (goroutine/thread snapshot foundation)
+        if: runner.environment == 'self-hosted'
+        run: ./e2e.test -test.v -test.timeout 300s -ginkgo.label-filter=concurrency
 
       - name: E2E hygiene (Mach port-right leak regression)
         if: runner.environment == 'self-hosted'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -445,8 +445,19 @@ are detected by a `mach_msg` receive loop.
   the true `ExitCode`, or `StopKilled` on signal death. Returning a hardcoded 0
   here dropped every tracee's exit code (#94).
 - ptrace stops are per-thread. The backend records the last stopped TID and
-  targets `ContinueProcess` / memory reads / memory writes at that TID, not
+  targets `ContinueProcess` / memory writes at that TID, not
   blindly at the process PID. Non-main thread exits are absorbed inside `Wait`.
+- `ReadMemory` uses **`process_vm_readv(2)`** as the fast path, falling back to
+  `PTRACE_PEEKDATA` only when it is unavailable or short-reads. `process_vm_readv`
+  bulk-copies the whole buffer in one syscall and — unlike ptrace ops — is NOT
+  thread-bound, so it runs directly off the caller and skips the `execPtrace`
+  tracer-thread handoff entirely (mirrors Delve). This is load-bearing for the
+  goroutine snapshot: it issues dozens of small reads per stop across every live
+  goroutine, and the old word-at-a-time-PEEKDATA-through-execPtrace path made a
+  snapshot-on-every-breakpoint so slow it pushed the `churn` e2e past its
+  target's 180s watchdog. The fallback keeps the original error semantics for
+  genuinely-unmapped addresses. (Darwin was never affected — it already
+  bulk-reads via `mach_vm_read`.)
 - Single-step vs breakpoint disambiguation uses **both** `stepping` and
   `stepTID` (the exact TID `SingleStep` was issued against). Only a `cause==0`
   SIGTRAP on `stepTID` is the step's completion; the same stop on any other

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -488,9 +488,89 @@ are detected by a `mach_msg` receive loop.
   address with line > afterLine. After a step-over completes we **prefer the
   remembered destination** over re-querying `locationForPC` from the new PC,
   because the new PC can land on a DWARF entry with line==0.
+- `locationForPC` must **bracket** the PC (`prev.Address <= pc < next.Address`,
+  `prev` a non-end-sequence row), not merely pick the greatest address `<= pc`.
+  Go emits CUs with `DW_AT_ranges` (no contiguous low/high pc), so `cuContainsPC`
+  can't pre-filter them and every CU is scanned; without the bracket check a CU
+  whose whole line program lies below `pc` would falsely "match" on its trailing
+  end-sequence row and return a bogus file:line. The function name comes from the
+  independent `funcIndex` (binary search over subprograms) and is always right;
+  only the file:line needs the bracket. This matters for the goroutine snapshot,
+  which resolves creation-site file:line for many off-CPU PCs.
+- Runtime-introspection helpers (`runtimeVarAddr`, `structMemberOffset`,
+  `runtimeArrayInfo`) resolve a package var's address, a struct field's byte
+  offset, and an array's base/count/stride from DWARF **by name** (cached). They
+  back the goroutine/thread snapshot reader (`goroutines.go`), which never
+  hardcodes runtime layout — offsets shift between Go versions. See the
+  concurrency snapshot section below.
 - `LocalsForFrame` only handles `DW_OP_addr` (0x03) and `DW_OP_fbreg` (0x91).
   Register-allocated variables come back as `<optimized out>`. Values are
   read as 8 bytes and returned hex; type-aware formatting is a TODO.
+
+## Goroutine / thread snapshot — the concurrency data foundation
+
+Source: [internal/debugger/goroutines.go](internal/debugger/goroutines.go)
+(reader) + the emit sites in [engine.go](internal/debugger/engine.go).
+
+**What it is / why.** The data foundation for concurrency visualization (a
+goroutine-spawn-hierarchy tree, a live-thread view, lifecycle tracking). It
+reads the Go runtime's `runtime.allgs` (every goroutine) and `runtime.allm`
+(every OS thread) straight from tracee memory via DWARF-resolved struct offsets,
+and streams a `GoroutineSnapshotPayload` carrying: the goroutine set with
+`ParentID` spawn linkage, each goroutine's `StartLoc` (startpc) and `CreatedLoc`
+(the `go` statement, gopc), the thread set, the current goroutine, and
+**created/exited goid deltas** since the previous snapshot.
+
+**Version 1.1** (`pkg/protocol`): reshaped `Goroutine` (added `ParentID`,
+`StartLoc`, `CreatedLoc`, `ThreadID`, `Current`; renamed `GoLoc`→`CreatedLoc`),
+new `Thread`, new `GoroutineSnapshotPayload`, new `EventGoroutineSnapshot` +
+`CmdGoroutineSnapshot`.
+
+**Streaming cadence (the load-bearing invariant).** `EventGoroutineSnapshot` is
+auto-emitted on exactly the suspends that can change the concurrency picture —
+**breakpoint hit, pause, and the launch/attach entry stop** — and on demand via
+`CmdGoroutineSnapshot`. It is **NOT** emitted per step: `emitStepped` stays cheap
+(embeds a synthetic single goroutine, no `allgs` scan) to protect the fragile
+single-step/step-over path from extra per-step memory reads. `emitBreakpointHit`
+/ `emitPaused` build the snapshot **once**, embed its current goroutine in the
+stop event, then stream the same snapshot — one build, no double scan, no double
+delta pass.
+
+**Not a suspending event.** It follows a suspending event (or answers a query)
+and never gates the hub. DAP `translateEvent` **deliberately ignores** it:
+translating it would corrupt the FIFO that correlates a DAP `threads` request to
+`EventGoroutines` (snapshots are unsolicited, with no matching request). DAP
+clients get goroutine data from the `threads` request (`EventGoroutines`, which
+now returns the rich list); the snapshot stream is WebSocket-only.
+
+**Lifecycle deltas.** `engine.prevGoids` (loop-thread-only, no lock, like
+`manualStopPending`) remembers the previous live goid set; `diffGoids` returns
+created/exited and adopts the new set. First snapshot returns nil deltas (a fresh
+session must not report every goroutine as "created"). A **degraded** snapshot
+(runtime unreadable — e.g. the pre-init entry stop) does **not** touch
+`prevGoids`: an empty read must not look like every goroutine exited.
+
+**Graceful fallback.** Every read is best-effort. `resolveGoLayout` marks the
+layout invalid if any required `g`/`gobuf`/`stack`/`m` offset is missing, and any
+unreadable address degrades the whole snapshot to the legacy single synthetic
+goroutine (`ID:1, Status:"waiting"`, current PC) rather than erroring the stop.
+This preserves behavior for stripped binaries / attach-without-DWARF and keeps
+the `fakeBackend` engine unit tests green.
+
+**Current goroutine = SP-containment** (platform-independent): the stopped
+thread's SP within `[g.stack.lo, g.stack.hi)`. The current *thread* is the M
+whose `curg` goid equals the current goid. A non-current goroutine's
+`CurrentLoc` uses `gobuf.pc` (where it resumes); the current one uses the live
+PC. Status strings are hardcoded (stable across Go versions); wait-reason
+strings are read dynamically from `runtime.waitReasonStrings`. Goroutines with
+goid<=0 or status `_Gdead` (scan bit stripped) are filtered out — their exit
+surfaces in the next Exited delta.
+
+**Note on `go f(args)` wrappers.** A goroutine started with arguments gets a
+compiler-generated `<caller>.gowrapN` closure as its startpc, so `StartLoc`
+resolves to the wrapper, not `f`. Argument-less `go f()` points startpc straight
+at `f`. `CreatedLoc` (the `go` statement site) and `ParentID` are unaffected —
+they're the robust identifiers for a spawn tree.
 
 ## Logging — one injected logger per component
 
@@ -770,7 +850,10 @@ reason=step; `EventBreakpointHit`→`stopped` reason=breakpoint;
 `EventProcessExited`→`exited`(code)+`terminated`; `EventOutput`→`output`;
 `EventRestarted`→delayed `restart` response; `EventSessionState`→ignored on the
 launch/attach path, but consumed **once** as the initial state on the join path
-(see *Joining an existing session*).
+(see *Joining an existing session*); `EventGoroutineSnapshot`→**deliberately
+ignored** (WebSocket-only concurrency stream with no DAP equivalent; translating
+it would corrupt the `threads`→`EventGoroutines` FIFO — see the goroutine
+snapshot section).
 
 `EventContinued` → DAP `continued` **only for out-of-band resumes**. The Handler
 increments `pendingContinues` before enqueuing its OWN continue and decrements it
@@ -914,7 +997,11 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   (a cleared breakpoint stops firing), `kill` (Kill terminates a
   freely-running tracee), `exit` (EventProcessExited reports the tracee's real
   exit code), `attach` (attach by PID to an already-running tracee — one the
-  debugger did not launch — then breakpoint it), and `restart` (hub-level
+  debugger did not launch — then breakpoint it), `concurrency` (the
+  goroutine/thread snapshot data foundation — drives a known spawn-tree target
+  and asserts parent linkage, start/created locations, the thread set with a
+  single current thread, and created/exited lifecycle deltas across stops), and
+  `restart` (hub-level
   kill+relaunch reinstalls
   breakpoints and reruns from the top), all driving `debugger.Debugger`
   in-process (except `restart`/`fullstack`/`dap`, which go through the stack); plus
@@ -940,7 +1027,8 @@ side `chan error` — every debugger outcome, failures included, rides the singl
 
   **Platform scoping — both containers run the full set.** The darwin container
   wires the same specs as linux: `basic`, `stepping`, `breakpoints`, `churn`,
-  `kill`, `exit`, `attach`, `pause`, `inspect`, `restart`, `fullstack`, and `dap`,
+  `kill`, `exit`, `attach`, `concurrency`, `pause`, `inspect`, `restart`,
+  `fullstack`, and `dap`,
   plus the
   darwin-only `hygiene` (Mach exception port-right leak regression). This was NOT
   always so:
@@ -1044,7 +1132,17 @@ through the justfile.
 ## When you change something
 
 - **Wire protocol** (`pkg/protocol`): bump `Version` for breaking changes,
-  and update the round-trip table in `protocol_test.go`.
+  and update the round-trip table in `protocol_test.go`. Currently **1.1** (the
+  goroutine/thread concurrency snapshot reshaped `Goroutine` and added
+  `Thread`/`GoroutineSnapshotPayload` + `EventGoroutineSnapshot`/
+  `CmdGoroutineSnapshot`).
+- **Goroutine snapshot layout**: the reader resolves runtime struct offsets from
+  DWARF **by name** (`goroutines.go`), never hardcoded. If you add a field, add
+  it to `goLayout`/`resolveGoLayout`; a missing *required* offset invalidates the
+  layout and falls back to the synthetic goroutine — keep new fields optional
+  unless they're truly required. Preserve the streaming-cadence invariant
+  (snapshot on breakpoint/pause/entry, never per-step) and the degraded-snapshot
+  rule (don't touch `prevGoids` on an unreadable read).
 - **Suspend/resume sets**: update both `suspendingEvents` and
   `resumingCommands` in [hub.go](internal/hub/hub.go), and the matching
   hub_test cases.

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -316,6 +316,16 @@ func printEvent(evt protocol.Event) {
 				p.Location.File, p.Location.Line, p.Location.Function)
 		}
 
+	default:
+		printAuxEvent(evt)
+	}
+}
+
+// printAuxEvent renders the non-stop events. Split out of printEvent so neither
+// switch trips the cyclomatic-complexity linter as event kinds grow.
+func printAuxEvent(evt protocol.Event) {
+	switch evt.Kind {
+
 	case protocol.EventContinued:
 		fmt.Print("\n  [continued]\nbingo> ")
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -238,13 +238,16 @@ func main() {
 				continue
 			}
 			for _, g := range grs {
-				loc := fmt.Sprintf("%s:%d", g.CurrentLoc.File, g.CurrentLoc.Line)
-				if g.WaitReason != "" {
-					fmt.Printf("  G%-4d %-10s %s  (%s)\n", g.ID, g.Status, loc, g.WaitReason)
-				} else {
-					fmt.Printf("  G%-4d %-10s %s\n", g.ID, g.Status, loc)
-				}
+				printGoroutine(g)
 			}
+
+		case "snapshot", "snap":
+			snap, err := c.GoroutineSnapshot()
+			if err != nil {
+				printErr(err)
+				continue
+			}
+			printSnapshot(snap)
 
 		case "help", "h", "?":
 			printHelp()
@@ -329,8 +332,70 @@ func printEvent(evt protocol.Event) {
 				p.Program, len(p.Breakpoints), len(p.Discarded))
 		}
 
+	case protocol.EventGoroutineSnapshot:
+		var p protocol.GoroutineSnapshotPayload
+		if protocol.DecodeEventPayload(evt, &p) == nil {
+			msg := fmt.Sprintf("\n  [goroutines] %d live, %d threads, current G%d",
+				len(p.Goroutines), len(p.Threads), p.Current)
+			if len(p.Created) > 0 {
+				msg += fmt.Sprintf(", +%v", p.Created)
+			}
+			if len(p.Exited) > 0 {
+				msg += fmt.Sprintf(", -%v", p.Exited)
+			}
+			fmt.Print(msg + "\nbingo> ")
+		}
+
 	default:
 		fmt.Printf("\n  [%s] seq=%d\nbingo> ", evt.Kind, evt.Seq)
+	}
+}
+
+// printGoroutine renders one goroutine line, marking the current one and
+// showing parent linkage and its start function so a spawn tree is visible.
+func printGoroutine(g protocol.Goroutine) {
+	marker := " "
+	if g.Current {
+		marker = "*"
+	}
+	loc := fmt.Sprintf("%s:%d", g.CurrentLoc.File, g.CurrentLoc.Line)
+	line := fmt.Sprintf("%s G%-4d %-10s %s", marker, g.ID, g.Status, loc)
+	if g.ParentID != 0 {
+		line += fmt.Sprintf("  <-G%d", g.ParentID)
+	}
+	if g.StartLoc.Function != "" {
+		line += fmt.Sprintf("  start=%s", g.StartLoc.Function)
+	}
+	if g.WaitReason != "" {
+		line += fmt.Sprintf("  (%s)", g.WaitReason)
+	}
+	fmt.Println(line)
+}
+
+// printSnapshot renders a full concurrency snapshot: goroutines (with spawn
+// linkage), OS threads, and the created/exited lifecycle deltas.
+func printSnapshot(snap protocol.GoroutineSnapshotPayload) {
+	fmt.Printf("  goroutines: %d  threads: %d  current: G%d\n",
+		len(snap.Goroutines), len(snap.Threads), snap.Current)
+	for _, g := range snap.Goroutines {
+		printGoroutine(g)
+	}
+	for _, t := range snap.Threads {
+		marker := " "
+		if t.Current {
+			marker = "*"
+		}
+		spin := ""
+		if t.Spinning {
+			spin = " spinning"
+		}
+		fmt.Printf("%s M%-4d tid=%-6d G%d%s\n", marker, t.MID, t.ID, t.GoID, spin)
+	}
+	if len(snap.Created) > 0 {
+		fmt.Printf("  created: %v\n", snap.Created)
+	}
+	if len(snap.Exited) > 0 {
+		fmt.Printf("  exited:  %v\n", snap.Exited)
 	}
 }
 
@@ -371,7 +436,8 @@ func printHelp() {
 
   locals [frame]             show local variables (default frame 0)
   bt / backtrace             show call stack
-  goroutines / grs           list goroutines
+  goroutines / grs           list goroutines (with parent/start)
+  snapshot / snap            full concurrency snapshot (goroutines + threads + deltas)
 
   help / h / ?               show this help
   quit / q / exit            disconnect and exit`)

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -28,6 +28,13 @@ func (h *Handler) translateEvent(evt protocol.Event) {
 		h.onFrames(evt)
 	case protocol.EventGoroutines:
 		h.onGoroutines(evt)
+	case protocol.EventGoroutineSnapshot:
+		// Deliberately ignored. The auto-streamed concurrency snapshot has no
+		// DAP equivalent, and translating it would corrupt the FIFO that
+		// correlates a DAP `threads` request to EventGoroutines (snapshots are
+		// broadcast unsolicited, with no matching request). DAP clients that
+		// want goroutine data use the threads request; the rich snapshot is a
+		// WebSocket-only concurrency-visualization stream.
 	case protocol.EventRestarted:
 		h.onRestarted()
 	case protocol.EventError:

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"sync"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 func newBackend() Backend {
@@ -305,7 +307,26 @@ func (b *linuxBackend) StopProcess() error {
 // that the engine turns into EventPaused. See Backend.PauseSignal.
 func (b *linuxBackend) PauseSignal() int { return int(syscall.SIGSTOP) }
 
+// ReadMemory bulk-copies the tracee's address space. process_vm_readv(2) is the
+// fast path: a single syscall for the whole buffer that — unlike ptrace(2) — is
+// NOT thread-bound, so it runs directly off the calling goroutine without the
+// tracer-thread handoff and never word-at-a-times. This is what keeps the
+// goroutine snapshot (dozens of small reads per stop, across every live
+// goroutine) cheap; the old PTRACE_PEEKDATA-through-execPtrace path was orders
+// of magnitude slower and pushed the churn e2e past its target's watchdog.
+// PTRACE_PEEKDATA remains the fallback for the rare case process_vm_readv is
+// unavailable (old kernel) or short-reads.
 func (b *linuxBackend) ReadMemory(addr uint64, dst []byte) error {
+	if len(dst) == 0 {
+		return nil
+	}
+	if b.pid > 0 {
+		local := []unix.Iovec{{Base: &dst[0], Len: uint64(len(dst))}}
+		remote := []unix.RemoteIovec{{Base: uintptr(addr), Len: len(dst)}}
+		if n, err := unix.ProcessVMReadv(b.pid, local, remote, 0); err == nil && n == len(dst) {
+			return nil
+		}
+	}
 	tid := b.traceTID()
 	var n int
 	var err error

--- a/internal/debugger/debugger.go
+++ b/internal/debugger/debugger.go
@@ -51,6 +51,12 @@ type Debugger interface {
 	StackFrames() ([]protocol.Frame, error)
 	Goroutines() ([]protocol.Goroutine, error)
 
+	// GoroutineSnapshot returns the full concurrency picture — every goroutine
+	// (with parent linkage), every OS thread, the current goroutine, and the
+	// created/exited lifecycle deltas since the previous snapshot. Requires the
+	// process to be suspended.
+	GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error)
+
 	// Events delivers async notifications. Closed on shutdown; caller must drain.
 	Events() <-chan protocol.Event
 }

--- a/internal/debugger/dwarf.go
+++ b/internal/debugger/dwarf.go
@@ -33,6 +33,23 @@ type dwarfReader struct {
 	// wedge the single-threaded engine loop past the client's timeout.
 	funcIndexOnce sync.Once
 	funcIndex     []funcRange
+
+	// cacheMu guards the lazily-populated runtime-introspection caches below.
+	// Struct layouts and variable addresses never change for a loaded image, so
+	// each is resolved from DWARF at most once. Inspection already runs on the
+	// serialized engine loop, but these are guarded anyway so the reader is safe
+	// to share.
+	cacheMu    sync.Mutex
+	varAddrs   map[string]uint64       // package var name → runtime DW_OP_addr (slid); 0 means "resolved, absent"
+	structOffs map[string]structLayout // struct name → member offsets
+}
+
+// structLayout maps a struct's member names to their byte offsets. found is
+// false when the struct type was absent from DWARF, so callers can distinguish
+// "no such struct" from "struct with a zero-offset first member".
+type structLayout struct {
+	found   bool
+	offsets map[string]int64
 }
 
 // funcRange is one subprogram's DWARF PC range (unslid) and name.
@@ -182,25 +199,28 @@ func (r *dwarfReader) locationForPC(pc uint64) protocol.Location {
 			continue
 		}
 
-		// Keep the entry whose address is the greatest <= dwarfPC.
-		var best dwarf.LineEntry
-		var found bool
+		// Keep the entry that brackets dwarfPC: prev.Address <= dwarfPC <
+		// next.Address, with prev a real (non-end-sequence) row. Merely being
+		// the greatest address <= dwarfPC is not enough — a CU whose whole line
+		// program lies below dwarfPC would otherwise match on its trailing
+		// end-sequence row and return a bogus file:line. Go emits CUs with
+		// DW_AT_ranges (no contiguous low/high pc), so cuContainsPC can't
+		// pre-filter them; the bracket check is what makes the lookup correct.
+		var prev dwarf.LineEntry
+		var havePrev bool
 		var le dwarf.LineEntry
 		for {
 			if err := lr.Next(&le); err != nil {
 				break
 			}
-			if le.Address <= dwarfPC {
-				best = le
-				found = true
-			} else {
-				break
+			if havePrev && !prev.EndSequence && prev.File != nil &&
+				prev.Address <= dwarfPC && dwarfPC < le.Address {
+				loc.File = prev.File.Name
+				loc.Line = prev.Line
+				return loc
 			}
-		}
-		if found && best.File != nil {
-			loc.File = best.File.Name
-			loc.Line = best.Line
-			return loc
+			prev = le
+			havePrev = true
 		}
 	}
 	return loc
@@ -431,6 +451,213 @@ func decodeSLEB128(b []byte) (int64, int) {
 			}
 			return result, i + 1
 		}
+	}
+	return result, len(b)
+}
+
+// --- Runtime introspection helpers -----------------------------------------
+//
+// These resolve Go-runtime symbols and struct layouts straight from DWARF so
+// the goroutine/thread reader never hardcodes offsets, which shift between Go
+// versions. See AGENTS.md → goroutine snapshot reading.
+
+// runtimeVarAddr returns the runtime (slid) address of a package-level variable
+// declared with a DW_OP_addr location (e.g. runtime.allgs, runtime.allm). The
+// second result is false when the variable is absent or not a static address.
+func (r *dwarfReader) runtimeVarAddr(name string) (uint64, bool) {
+	r.cacheMu.Lock()
+	defer r.cacheMu.Unlock()
+	if r.varAddrs == nil {
+		r.varAddrs = make(map[string]uint64)
+	}
+	if addr, ok := r.varAddrs[name]; ok {
+		return addr, addr != 0
+	}
+
+	addr := r.resolveVarAddr(name)
+	r.varAddrs[name] = addr
+	return addr, addr != 0
+}
+
+func (r *dwarfReader) resolveVarAddr(name string) uint64 {
+	rd := r.data.Reader()
+	for {
+		entry, err := rd.Next()
+		if err != nil || entry == nil {
+			break
+		}
+		if entry.Tag != dwarf.TagVariable {
+			// Variables live at CU top level in Go DWARF; don't descend into
+			// subprograms (their locals share the tag and would shadow globals).
+			if entry.Tag == dwarf.TagSubprogram {
+				rd.SkipChildren()
+			}
+			continue
+		}
+		n, _ := entry.Val(dwarf.AttrName).(string)
+		if n != name {
+			continue
+		}
+		loc, ok := entry.Val(dwarf.AttrLocation).([]byte)
+		if !ok || len(loc) < 9 || loc[0] != 0x03 { // DW_OP_addr
+			return 0
+		}
+		return uint64(int64(binary.LittleEndian.Uint64(loc[1:9])) + r.slide)
+	}
+	return 0
+}
+
+// structMemberOffset returns the byte offset of member field within the struct
+// type named structName (both as they appear in DWARF, e.g. "runtime.g" /
+// "goid"). ok is false when the struct or the member is absent.
+func (r *dwarfReader) structMemberOffset(structName, field string) (int64, bool) {
+	layout := r.structLayout(structName)
+	if !layout.found {
+		return 0, false
+	}
+	off, ok := layout.offsets[field]
+	return off, ok
+}
+
+func (r *dwarfReader) structLayout(structName string) structLayout {
+	r.cacheMu.Lock()
+	defer r.cacheMu.Unlock()
+	if r.structOffs == nil {
+		r.structOffs = make(map[string]structLayout)
+	}
+	if l, ok := r.structOffs[structName]; ok {
+		return l
+	}
+	l := r.resolveStructLayout(structName)
+	r.structOffs[structName] = l
+	return l
+}
+
+func (r *dwarfReader) resolveStructLayout(structName string) structLayout {
+	rd := r.data.Reader()
+	for {
+		entry, err := rd.Next()
+		if err != nil || entry == nil {
+			break
+		}
+		if entry.Tag != dwarf.TagStructType {
+			continue
+		}
+		n, _ := entry.Val(dwarf.AttrName).(string)
+		if n != structName {
+			rd.SkipChildren()
+			continue
+		}
+		offsets := make(map[string]int64)
+		for {
+			child, err := rd.Next()
+			if err != nil || child == nil || child.Tag == 0 {
+				break
+			}
+			if child.Tag != dwarf.TagMember {
+				continue
+			}
+			mn, _ := child.Val(dwarf.AttrName).(string)
+			if mn == "" {
+				continue
+			}
+			if off, ok := memberOffset(child); ok {
+				offsets[mn] = off
+			}
+		}
+		return structLayout{found: true, offsets: offsets}
+	}
+	return structLayout{}
+}
+
+// memberOffset extracts DW_AT_data_member_location, which Go emits as a plain
+// integer constant but the DWARF spec also permits as a location expression
+// (DW_OP_plus_uconst). Both are handled.
+func memberOffset(entry *dwarf.Entry) (int64, bool) {
+	v := entry.Val(dwarf.AttrDataMemberLoc)
+	switch val := v.(type) {
+	case int64:
+		return val, true
+	case []byte:
+		if len(val) >= 2 && val[0] == 0x23 { // DW_OP_plus_uconst
+			u, _ := decodeULEB128(val[1:])
+			return int64(u), true
+		}
+	}
+	return 0, false
+}
+
+// runtimeArrayInfo returns the base address, element count, and element stride
+// (bytes) of a package-level array variable declared with a static address
+// (e.g. runtime.waitReasonStrings). ok is false when it can't be resolved.
+func (r *dwarfReader) runtimeArrayInfo(name string) (base uint64, count int, stride int, ok bool) {
+	base, ok = r.runtimeVarAddr(name)
+	if !ok {
+		return 0, 0, 0, false
+	}
+	rd := r.data.Reader()
+	for {
+		entry, err := rd.Next()
+		if err != nil || entry == nil {
+			break
+		}
+		if entry.Tag != dwarf.TagVariable {
+			if entry.Tag == dwarf.TagSubprogram {
+				rd.SkipChildren()
+			}
+			continue
+		}
+		n, _ := entry.Val(dwarf.AttrName).(string)
+		if n != name {
+			continue
+		}
+		toff, ok := entry.Val(dwarf.AttrType).(dwarf.Offset)
+		if !ok {
+			return 0, 0, 0, false
+		}
+		tr := r.data.Reader()
+		tr.Seek(toff)
+		te, err := tr.Next()
+		if err != nil || te == nil || te.Tag != dwarf.TagArrayType {
+			return 0, 0, 0, false
+		}
+		total, _ := te.Val(dwarf.AttrByteSize).(int64)
+		for {
+			ce, err := tr.Next()
+			if err != nil || ce == nil || ce.Tag == 0 {
+				break
+			}
+			if ce.Tag != dwarf.TagSubrangeType {
+				continue
+			}
+			if c, ok := ce.Val(dwarf.AttrCount).(int64); ok {
+				count = int(c)
+			} else if ub, ok := ce.Val(dwarf.AttrUpperBound).(int64); ok {
+				count = int(ub) + 1
+			}
+			break
+		}
+		if count <= 0 {
+			return 0, 0, 0, false
+		}
+		if total > 0 {
+			stride = int(total) / count
+		}
+		return base, count, stride, true
+	}
+	return 0, 0, 0, false
+}
+
+// decodeULEB128 decodes an unsigned LEB128 integer. Returns (value, bytesRead).
+func decodeULEB128(b []byte) (uint64, int) {
+	var result uint64
+	var shift uint
+	for i, byt := range b {
+		result |= uint64(byt&0x7f) << shift
+		if byt&0x80 == 0 {
+			return result, i + 1
+		}
+		shift += 7
 	}
 	return result, len(b)
 }

--- a/internal/debugger/dwarf.go
+++ b/internal/debugger/dwarf.go
@@ -591,15 +591,26 @@ func memberOffset(entry *dwarf.Entry) (int64, bool) {
 // (bytes) of a package-level array variable declared with a static address
 // (e.g. runtime.waitReasonStrings). ok is false when it can't be resolved.
 func (r *dwarfReader) runtimeArrayInfo(name string) (base uint64, count int, stride int, ok bool) {
-	base, ok = r.runtimeVarAddr(name)
+	if base, ok = r.runtimeVarAddr(name); !ok {
+		return 0, 0, 0, false
+	}
+	toff, ok := r.varTypeOffset(name)
 	if !ok {
 		return 0, 0, 0, false
 	}
+	if count, stride, ok = r.arrayTypeInfo(toff); !ok {
+		return 0, 0, 0, false
+	}
+	return base, count, stride, true
+}
+
+// varTypeOffset finds the DWARF type offset of a package-level variable by name.
+func (r *dwarfReader) varTypeOffset(name string) (dwarf.Offset, bool) {
 	rd := r.data.Reader()
 	for {
 		entry, err := rd.Next()
 		if err != nil || entry == nil {
-			break
+			return 0, false
 		}
 		if entry.Tag != dwarf.TagVariable {
 			if entry.Tag == dwarf.TagSubprogram {
@@ -607,45 +618,46 @@ func (r *dwarfReader) runtimeArrayInfo(name string) (base uint64, count int, str
 			}
 			continue
 		}
-		n, _ := entry.Val(dwarf.AttrName).(string)
-		if n != name {
+		if n, _ := entry.Val(dwarf.AttrName).(string); n != name {
 			continue
 		}
-		toff, ok := entry.Val(dwarf.AttrType).(dwarf.Offset)
-		if !ok {
-			return 0, 0, 0, false
-		}
-		tr := r.data.Reader()
-		tr.Seek(toff)
-		te, err := tr.Next()
-		if err != nil || te == nil || te.Tag != dwarf.TagArrayType {
-			return 0, 0, 0, false
-		}
-		total, _ := te.Val(dwarf.AttrByteSize).(int64)
-		for {
-			ce, err := tr.Next()
-			if err != nil || ce == nil || ce.Tag == 0 {
-				break
-			}
-			if ce.Tag != dwarf.TagSubrangeType {
-				continue
-			}
-			if c, ok := ce.Val(dwarf.AttrCount).(int64); ok {
-				count = int(c)
-			} else if ub, ok := ce.Val(dwarf.AttrUpperBound).(int64); ok {
-				count = int(ub) + 1
-			}
+		off, ok := entry.Val(dwarf.AttrType).(dwarf.Offset)
+		return off, ok
+	}
+}
+
+// arrayTypeInfo resolves an array type's element count and per-element stride
+// (bytes) from the DWARF type entry at toff.
+func (r *dwarfReader) arrayTypeInfo(toff dwarf.Offset) (count int, stride int, ok bool) {
+	tr := r.data.Reader()
+	tr.Seek(toff)
+	te, err := tr.Next()
+	if err != nil || te == nil || te.Tag != dwarf.TagArrayType {
+		return 0, 0, false
+	}
+	total, _ := te.Val(dwarf.AttrByteSize).(int64)
+	for {
+		ce, err := tr.Next()
+		if err != nil || ce == nil || ce.Tag == 0 {
 			break
 		}
-		if count <= 0 {
-			return 0, 0, 0, false
+		if ce.Tag != dwarf.TagSubrangeType {
+			continue
 		}
-		if total > 0 {
-			stride = int(total) / count
+		if c, ok := ce.Val(dwarf.AttrCount).(int64); ok {
+			count = int(c)
+		} else if ub, ok := ce.Val(dwarf.AttrUpperBound).(int64); ok {
+			count = int(ub) + 1
 		}
-		return base, count, stride, true
+		break
 	}
-	return 0, 0, 0, false
+	if count <= 0 {
+		return 0, 0, false
+	}
+	if total > 0 {
+		stride = int(total) / count
+	}
+	return count, stride, true
 }
 
 // decodeULEB128 decodes an unsigned LEB128 integer. Returns (value, bytesRead).

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -94,6 +94,16 @@ type engine struct {
 	// the single engine loop thread. See AGENTS.md → Pause.
 	manualStopPending bool
 
+	// goLayout caches the DWARF-resolved runtime struct offsets used by the
+	// goroutine/thread snapshot reader. Resolved lazily per loaded image and
+	// reset in loadDWARF. nil until first use; see goroutines.go.
+	goLayout *goLayout
+
+	// prevGoids is the set of live goids from the previous snapshot, used to
+	// compute created/exited lifecycle deltas. Loop-thread-only (like
+	// manualStopPending); needs no synchronization. See goroutines.go.
+	prevGoids map[int]struct{}
+
 	// log is the single sink for all engine logging. Never call the
 	// package-level slog functions directly — they bypass the per-session
 	// logger the hub/server configure, producing duplicate, uncorrelated
@@ -430,6 +440,24 @@ func (e *engine) Goroutines() ([]protocol.Goroutine, error) {
 		return err
 	})
 	return goroutines, err
+}
+
+// GoroutineSnapshot returns the full concurrency picture on demand: every
+// goroutine (with parent linkage for a spawn tree), every OS thread, the
+// current goroutine, and the created/exited lifecycle deltas since the previous
+// snapshot. Only valid while suspended (the tracee must be stopped for the
+// memory reads to be race-free). Like the auto-streamed snapshots it advances
+// the lifecycle-delta baseline.
+func (e *engine) GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error) {
+	var snap protocol.GoroutineSnapshotPayload
+	err := e.dispatch(func() error {
+		if err := e.requireSuspended(); err != nil {
+			return err
+		}
+		snap = e.goroutineSnapshot()
+		return nil
+	})
+	return snap, err
 }
 
 func (e *engine) loop() {
@@ -1035,29 +1063,11 @@ func (e *engine) walkStack(regs Registers) []uint64 {
 	return pcs
 }
 
-func (e *engine) readGoroutines() ([]protocol.Goroutine, error) {
-	// Report the stopped thread's location (curTID via activeTID); threads[0] may
-	// be an idle runtime M and would misreport where execution is paused.
-	tid, err := e.activeTID()
-	if err != nil {
-		return nil, nil
-	}
-	regs, err := e.backend.GetRegisters(tid)
-	if err != nil {
-		return nil, fmt.Errorf("Goroutines: %w", err)
-	}
-	loc := protocol.Location{}
-	if e.dw != nil {
-		loc = e.dw.locationForPC(regs.PC)
-	}
-	return []protocol.Goroutine{{
-		ID:         1,
-		Status:     "waiting",
-		CurrentLoc: loc,
-	}}, nil
-}
-
 func (e *engine) loadDWARF(binaryPath string) {
+	// A new image invalidates the cached runtime struct offsets and the
+	// lifecycle delta baseline.
+	e.goLayout = nil
+	e.prevGoids = nil
 	dr, err := openDWARF(binaryPath)
 	if err != nil {
 		e.dw = nil
@@ -1106,16 +1116,23 @@ func (e *engine) emitBreakpointHit(bp *breakpointEntry, stop StopEvent) {
 	// resume.
 	e.manualStopPending = false
 	frames, _ := e.collectFrames(stop.TID)
-	goroutines, _ := e.readGoroutines()
-	var g protocol.Goroutine
-	if len(goroutines) > 0 {
-		g = goroutines[0]
-	}
+	// Build the concurrency snapshot once: the current goroutine is embedded in
+	// the stop event, then the full snapshot is streamed as its own event. One
+	// build avoids a double allgs scan and a double lifecycle-delta pass.
+	snap := e.goroutineSnapshot()
 	e.emit(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{
 		Breakpoint: bp.toProtocol(),
-		Goroutine:  g,
+		Goroutine:  currentGoroutineFrom(snap),
 		Frames:     frames,
 	})
+	e.emit(protocol.EventGoroutineSnapshot, snap)
+}
+
+// emitGoroutineSnapshot builds and streams a standalone concurrency snapshot.
+// Used at the entry stop and on the CmdGoroutineSnapshot on-demand path. It is
+// a non-suspending event, so the hub forwards it without gating.
+func (e *engine) emitGoroutineSnapshot() {
+	e.emit(protocol.EventGoroutineSnapshot, e.goroutineSnapshot())
 }
 
 // emitStoppedAtCurrentPC emits EventStepped at the current PC (used after
@@ -1130,6 +1147,12 @@ func (e *engine) emitStoppedAtCurrentPC() {
 		}
 	}
 	e.emitStepped(stop)
+	// The entry stop is the one Stepped that carries a full snapshot: it seeds a
+	// UI with the initial goroutine/thread picture and establishes the
+	// lifecycle-delta baseline. Regular steps stay cheap (no snapshot). At the
+	// very first entry the runtime may be pre-init, so the snapshot degrades to
+	// the synthetic goroutine.
+	e.emitGoroutineSnapshot()
 }
 
 func (e *engine) emitStepped(stop StopEvent) {
@@ -1140,17 +1163,16 @@ func (e *engine) emitStepped(stop StopEvent) {
 	// Pause the same way a breakpoint hit does (see emitBreakpointHit).
 	e.manualStopPending = false
 	frames, _ := e.collectFrames(stop.TID)
-	goroutines, _ := e.readGoroutines()
-	var g protocol.Goroutine
-	if len(goroutines) > 0 {
-		g = goroutines[0]
-	}
 	loc := protocol.Location{}
 	if e.dw != nil {
 		loc = e.dw.locationForPC(stop.PC)
 	}
+	// Steps are high-frequency and must stay cheap: embed a synthetic goroutine
+	// for the stopped thread rather than scanning runtime.allgs. The rich
+	// snapshot is streamed only on breakpoint/pause/entry stops, protecting the
+	// fragile single-step/step-over path from extra per-step memory reads.
 	e.emit(protocol.EventStepped, protocol.SteppedPayload{
-		Goroutine: g,
+		Goroutine: e.syntheticGoroutine(stop.PC),
 		Location:  loc,
 		Frames:    frames,
 	})
@@ -1158,26 +1180,24 @@ func (e *engine) emitStepped(stop StopEvent) {
 
 // emitPaused reports an asynchronous Pause halt. It mirrors emitStepped but
 // carries EventPaused/PausedPayload: the location is wherever execution was
-// interrupted, not a source-line boundary.
+// interrupted, not a source-line boundary. Like a breakpoint hit it also
+// streams a full concurrency snapshot.
 func (e *engine) emitPaused(stop StopEvent) {
 	if stop.TID != 0 {
 		e.curTID = stop.TID
 	}
 	frames, _ := e.collectFrames(stop.TID)
-	goroutines, _ := e.readGoroutines()
-	var g protocol.Goroutine
-	if len(goroutines) > 0 {
-		g = goroutines[0]
-	}
+	snap := e.goroutineSnapshot()
 	loc := protocol.Location{}
 	if e.dw != nil {
 		loc = e.dw.locationForPC(stop.PC)
 	}
 	e.emit(protocol.EventPaused, protocol.PausedPayload{
-		Goroutine: g,
+		Goroutine: currentGoroutineFrom(snap),
 		Location:  loc,
 		Frames:    frames,
 	})
+	e.emit(protocol.EventGoroutineSnapshot, snap)
 }
 
 // emitContinued reports that the tracee has resumed free execution in response

--- a/internal/debugger/engine_test.go
+++ b/internal/debugger/engine_test.go
@@ -118,15 +118,26 @@ func (f *fakeBackend) Wait() (debugger.StopEvent, error) {
 
 const eventTimeout = 500 * time.Millisecond
 
+// nextEvent returns the next event, transparently skipping the auxiliary
+// EventGoroutineSnapshot stream. Snapshots are emitted alongside stop events
+// (breakpoint/pause/entry) as an out-of-band concurrency feed; ordering-based
+// assertions here care about the primary event flow, so they are filtered out.
+// A test that specifically exercises snapshots reads d.Events() directly.
 func nextEvent(d debugger.Debugger) (protocol.Event, bool) {
-	select {
-	case evt, ok := <-d.Events():
-		if !ok {
+	deadline := time.After(eventTimeout)
+	for {
+		select {
+		case evt, ok := <-d.Events():
+			if !ok {
+				return protocol.Event{}, false
+			}
+			if evt.Kind == protocol.EventGoroutineSnapshot {
+				continue
+			}
+			return evt, true
+		case <-deadline:
 			return protocol.Event{}, false
 		}
-		return evt, true
-	case <-time.After(eventTimeout):
-		return protocol.Event{}, false
 	}
 }
 

--- a/internal/debugger/goroutines.go
+++ b/internal/debugger/goroutines.go
@@ -1,0 +1,494 @@
+package debugger
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sort"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+// This file reads the Go runtime's goroutine (runtime.allgs) and OS-thread
+// (runtime.allm) tables straight from the tracee's memory, using struct offsets
+// resolved from DWARF at runtime (never hardcoded — they shift between Go
+// versions). It powers the concurrency snapshot: the goroutine set with parent
+// linkage for a spawn tree, the thread set, the current goroutine, and the
+// created/exited lifecycle deltas. See AGENTS.md → goroutine snapshot reading.
+//
+// Everything here runs on the serialized engine loop while the tracee is
+// suspended, so memory reads are race-free. Every read is best-effort: any
+// failure (no DWARF, an unexpected layout, an unreadable address, or a runtime
+// not yet initialized at the entry stop) degrades gracefully to the legacy
+// single-synthetic goroutine rather than erroring the stop.
+
+const (
+	// maxGoroutineScan bounds the runtime.allgs walk so a corrupt slice header
+	// or a pathological target can't make one snapshot read unboundedly.
+	maxGoroutineScan = 8192
+	// maxThreadScan bounds the runtime.allm linked-list walk likewise.
+	maxThreadScan = 2048
+	// maxGoStringLen caps a wait-reason string read from tracee memory.
+	maxGoStringLen = 256
+
+	gScanBit    = 0x1000 // _Gscan — OR'd onto a status while the GC scans a stack
+	gStatusDead = 6      // _Gdead
+)
+
+// goLayout holds the DWARF-resolved byte offsets of the runtime structs the
+// reader touches. Resolved once per loaded image. valid is false when any
+// required field is missing, which sends callers down the fallback path.
+type goLayout struct {
+	valid bool
+
+	gStack        int64 // g: embedded runtime.stack
+	gM            int64 // g: *m
+	gSched        int64 // g: embedded runtime.gobuf
+	gAtomicstatus int64
+	gGoid         int64
+	gWaitreason   int64
+	gParentGoid   int64
+	gGopc         int64
+	gStartpc      int64
+
+	stackLo int64 // stack.lo, relative to gStack
+	stackHi int64 // stack.hi, relative to gStack
+
+	bufPC int64 // gobuf.pc, relative to gSched
+
+	mProcid   int64
+	mCurg     int64
+	mID       int64
+	mAlllink  int64
+	mSpinning int64
+
+	// waitReasonStrings array, for turning g.waitreason into a human string.
+	wrBase   uint64
+	wrCount  int
+	wrStride int
+}
+
+// resolveGoLayout builds the layout from DWARF. Missing required offsets yield
+// an invalid layout (valid=false); wait-reason resolution is optional.
+func resolveGoLayout(dw *dwarfReader) goLayout {
+	var l goLayout
+	ok := true
+	req := func(structName, field string) int64 {
+		off, found := dw.structMemberOffset(structName, field)
+		if !found {
+			ok = false
+		}
+		return off
+	}
+
+	l.gStack = req("runtime.g", "stack")
+	l.gM = req("runtime.g", "m")
+	l.gSched = req("runtime.g", "sched")
+	l.gAtomicstatus = req("runtime.g", "atomicstatus")
+	l.gGoid = req("runtime.g", "goid")
+	l.gWaitreason = req("runtime.g", "waitreason")
+	l.gParentGoid = req("runtime.g", "parentGoid")
+	l.gGopc = req("runtime.g", "gopc")
+	l.gStartpc = req("runtime.g", "startpc")
+
+	l.stackLo = req("runtime.stack", "lo")
+	l.stackHi = req("runtime.stack", "hi")
+
+	l.bufPC = req("runtime.gobuf", "pc")
+
+	l.mProcid = req("runtime.m", "procid")
+	l.mCurg = req("runtime.m", "curg")
+	l.mID = req("runtime.m", "id")
+	l.mAlllink = req("runtime.m", "alllink")
+	l.mSpinning = req("runtime.m", "spinning")
+
+	if base, count, stride, wrOK := dw.runtimeArrayInfo("runtime.waitReasonStrings"); wrOK {
+		l.wrBase, l.wrCount = base, count
+		if stride > 0 {
+			l.wrStride = stride
+		} else {
+			l.wrStride = 16 // a Go string header is 2 words on 64-bit
+		}
+	}
+
+	l.valid = ok
+	return l
+}
+
+// getGoLayout returns the cached layout, resolving it on first use for the
+// currently loaded image. Returns false when DWARF is absent or the layout
+// can't be resolved.
+func (e *engine) getGoLayout() (*goLayout, bool) {
+	if e.dw == nil {
+		return nil, false
+	}
+	if e.goLayout == nil {
+		l := resolveGoLayout(e.dw)
+		e.goLayout = &l
+	}
+	if !e.goLayout.valid {
+		return nil, false
+	}
+	return e.goLayout, true
+}
+
+func (e *engine) readU64(addr uint64) (uint64, bool) {
+	var b [8]byte
+	if err := e.backend.ReadMemory(addr, b[:]); err != nil {
+		return 0, false
+	}
+	return binary.LittleEndian.Uint64(b[:]), true
+}
+
+func (e *engine) readU32(addr uint64) (uint32, bool) {
+	var b [4]byte
+	if err := e.backend.ReadMemory(addr, b[:]); err != nil {
+		return 0, false
+	}
+	return binary.LittleEndian.Uint32(b[:]), true
+}
+
+func (e *engine) readU8(addr uint64) (uint8, bool) {
+	var b [1]byte
+	if err := e.backend.ReadMemory(addr, b[:]); err != nil {
+		return 0, false
+	}
+	return b[0], true
+}
+
+// readGoStringHeader reads a Go string header (ptr,len) at hdrAddr and returns
+// its bytes, capped at maxGoStringLen.
+func (e *engine) readGoStringHeader(hdrAddr uint64) string {
+	ptr, ok := e.readU64(hdrAddr)
+	if !ok || ptr == 0 {
+		return ""
+	}
+	n, ok := e.readU64(hdrAddr + 8)
+	if !ok || n == 0 {
+		return ""
+	}
+	if n > maxGoStringLen {
+		n = maxGoStringLen
+	}
+	buf := make([]byte, n)
+	if err := e.backend.ReadMemory(ptr, buf); err != nil {
+		return ""
+	}
+	return string(buf)
+}
+
+// waitReasonString maps a g.waitreason enum value to its runtime string by
+// indexing runtime.waitReasonStrings in tracee memory. "" when unresolved or
+// out of range (index 0 is the zero reason, deliberately blank).
+func (e *engine) waitReasonString(l *goLayout, reason uint8) string {
+	if l.wrBase == 0 || l.wrCount == 0 || reason == 0 || int(reason) >= l.wrCount {
+		return ""
+	}
+	return e.readGoStringHeader(l.wrBase + uint64(int(reason)*l.wrStride))
+}
+
+// goStatusString maps a goroutine's atomicstatus (scan bit already stripped) to
+// a human-readable string. Values are stable across Go versions; unknowns fall
+// back to a numeric form.
+func goStatusString(s uint32) string {
+	switch s {
+	case 0:
+		return "idle"
+	case 1:
+		return "runnable"
+	case 2:
+		return "running"
+	case 3:
+		return "syscall"
+	case 4:
+		return "waiting"
+	case gStatusDead:
+		return "dead"
+	case 8:
+		return "copystack"
+	case 9:
+		return "preempted"
+	case 10:
+		return "leaked"
+	case 11:
+		return "waiting for cgo callback"
+	default:
+		return fmt.Sprintf("status(%d)", s)
+	}
+}
+
+// locForPC resolves a PC to a Location, tolerating a zero PC (returns an empty
+// Location) so a parked goroutine with no scheduled PC doesn't error.
+func (e *engine) locForPC(pc uint64) protocol.Location {
+	if pc == 0 || e.dw == nil {
+		return protocol.Location{}
+	}
+	return e.dw.locationForPC(pc)
+}
+
+// readGoroutine reads one runtime.g at gptr into a protocol.Goroutine. It
+// returns ok=false when the goroutine should be skipped (freelist slot, dead,
+// or unreadable). liveSP/livePC identify the currently-stopped thread so the
+// goroutine running there is marked Current and gets its live PC as CurrentLoc.
+func (e *engine) readGoroutine(l *goLayout, gptr, liveSP, livePC uint64) (protocol.Goroutine, bool) {
+	rawStatus, ok := e.readU32(gptr + uint64(l.gAtomicstatus))
+	if !ok {
+		return protocol.Goroutine{}, false
+	}
+	status := rawStatus &^ gScanBit
+
+	goid, ok := e.readI64(gptr + uint64(l.gGoid))
+	if !ok || goid <= 0 || status == gStatusDead {
+		// Freelist / dead slots carry goid 0 or a stale id; a UI wants only the
+		// live set. Their departure is reported via the exited delta.
+		return protocol.Goroutine{}, false
+	}
+
+	g := protocol.Goroutine{
+		ID:     int(goid),
+		Status: goStatusString(status),
+	}
+	if parent, ok := e.readI64(gptr + uint64(l.gParentGoid)); ok && parent > 0 {
+		g.ParentID = int(parent)
+	}
+	if startpc, ok := e.readU64(gptr + uint64(l.gStartpc)); ok {
+		g.StartLoc = e.locForPC(startpc)
+	}
+	if gopc, ok := e.readU64(gptr + uint64(l.gGopc)); ok {
+		g.CreatedLoc = e.locForPC(gopc)
+	}
+	if status == 4 { // waiting
+		if wr, ok := e.readU8(gptr + uint64(l.gWaitreason)); ok {
+			g.WaitReason = e.waitReasonString(l, wr)
+		}
+	}
+
+	lo, okLo := e.readU64(gptr + uint64(l.gStack) + uint64(l.stackLo))
+	hi, okHi := e.readU64(gptr + uint64(l.gStack) + uint64(l.stackHi))
+	current := okLo && okHi && liveSP != 0 && liveSP >= lo && liveSP < hi
+	g.Current = current
+
+	if mptr, ok := e.readU64(gptr + uint64(l.gM)); ok && mptr != 0 {
+		if procid, ok := e.readU64(mptr + uint64(l.mProcid)); ok {
+			g.ThreadID = int(procid)
+		}
+	}
+
+	// The current goroutine's live PC is authoritative; a parked goroutine's
+	// scheduled PC (gobuf.pc) is where it will resume.
+	if current {
+		g.CurrentLoc = e.locForPC(livePC)
+	} else if schedPC, ok := e.readU64(gptr + uint64(l.gSched) + uint64(l.bufPC)); ok {
+		g.CurrentLoc = e.locForPC(schedPC)
+	}
+
+	return g, true
+}
+
+func (e *engine) readI64(addr uint64) (int64, bool) {
+	v, ok := e.readU64(addr)
+	return int64(v), ok
+}
+
+// buildGoroutineList enumerates runtime.allgs. ok is false when the runtime
+// can't be read (no DWARF, bad layout, unreadable slice, or no live goroutines
+// yet), so callers fall back to the synthetic goroutine.
+func (e *engine) buildGoroutineList(liveSP, livePC uint64) ([]protocol.Goroutine, bool) {
+	l, ok := e.getGoLayout()
+	if !ok {
+		return nil, false
+	}
+	base, ok := e.dw.runtimeVarAddr("runtime.allgs")
+	if !ok {
+		return nil, false
+	}
+	ptr, ok := e.readU64(base) // slice header: array pointer @ +0
+	if !ok || ptr == 0 {
+		return nil, false
+	}
+	length, ok := e.readU64(base + 8) // slice header: len @ +8
+	if !ok || length == 0 {
+		return nil, false
+	}
+	if length > maxGoroutineScan {
+		length = maxGoroutineScan
+	}
+
+	out := make([]protocol.Goroutine, 0, length)
+	for i := uint64(0); i < length; i++ {
+		gptr, ok := e.readU64(ptr + i*8)
+		if !ok || gptr == 0 {
+			continue
+		}
+		if g, ok := e.readGoroutine(l, gptr, liveSP, livePC); ok {
+			out = append(out, g)
+		}
+	}
+	if len(out) == 0 {
+		return nil, false
+	}
+	return out, true
+}
+
+// readThreads walks runtime.allm and reports every OS thread (M). currentGoid
+// (from the goroutine list) marks the thread whose goroutine is under
+// inspection as Current and gives it the live PC. Best-effort: nil on failure.
+func (e *engine) readThreads(currentGoid int, livePC uint64) []protocol.Thread {
+	l, ok := e.getGoLayout()
+	if !ok {
+		return nil
+	}
+	base, ok := e.dw.runtimeVarAddr("runtime.allm")
+	if !ok {
+		return nil
+	}
+	mptr, ok := e.readU64(base) // runtime.allm is a *m; read the head pointer
+	if !ok {
+		return nil
+	}
+
+	var out []protocol.Thread
+	for i := 0; i < maxThreadScan && mptr != 0; i++ {
+		t := protocol.Thread{}
+		if procid, ok := e.readU64(mptr + uint64(l.mProcid)); ok {
+			t.ID = int(procid)
+		}
+		if id, ok := e.readI64(mptr + uint64(l.mID)); ok {
+			t.MID = int(id)
+		}
+		if sp, ok := e.readU8(mptr + uint64(l.mSpinning)); ok {
+			t.Spinning = sp != 0
+		}
+		if curg, ok := e.readU64(mptr + uint64(l.mCurg)); ok && curg != 0 {
+			if goid, ok := e.readI64(curg + uint64(l.gGoid)); ok && goid > 0 {
+				t.GoID = int(goid)
+				if int(goid) == currentGoid {
+					t.Current = true
+					t.CurrentLoc = e.locForPC(livePC)
+				} else if schedPC, ok := e.readU64(curg + uint64(l.gSched) + uint64(l.bufPC)); ok {
+					t.CurrentLoc = e.locForPC(schedPC)
+				}
+			}
+		}
+		out = append(out, t)
+
+		next, ok := e.readU64(mptr + uint64(l.mAlllink))
+		if !ok {
+			break
+		}
+		mptr = next
+	}
+	return out
+}
+
+// liveRegisters reads the currently-stopped thread's SP and PC (used to locate
+// the current goroutine and to give it a live location). Zeroes on failure.
+func (e *engine) liveRegisters() (sp, pc uint64) {
+	tid, err := e.activeTID()
+	if err != nil {
+		return 0, 0
+	}
+	regs, err := e.backend.GetRegisters(tid)
+	if err != nil {
+		return 0, 0
+	}
+	return regs.SP, regs.PC
+}
+
+// syntheticGoroutine is the legacy fallback: a single goroutine standing in for
+// the stopped thread's location when the runtime can't be introspected. It
+// preserves behavior for stripped binaries, attach-without-DWARF, and the
+// pre-runtime-init entry stop (and keeps the fakeBackend unit tests green).
+func (e *engine) syntheticGoroutine(livePC uint64) protocol.Goroutine {
+	return protocol.Goroutine{
+		ID:         1,
+		Status:     "waiting",
+		CurrentLoc: e.locForPC(livePC),
+		Current:    true,
+	}
+}
+
+// readGoroutines returns the live goroutine set, falling back to a single
+// synthetic goroutine when the runtime can't be read. This backs the on-demand
+// Goroutines() query and the DAP threads list.
+func (e *engine) readGoroutines() ([]protocol.Goroutine, error) {
+	sp, pc := e.liveRegisters()
+	if gs, ok := e.buildGoroutineList(sp, pc); ok {
+		return gs, nil
+	}
+	return []protocol.Goroutine{e.syntheticGoroutine(pc)}, nil
+}
+
+// goroutineSnapshot builds the full concurrency picture and computes the
+// created/exited deltas against the previous snapshot. It updates the engine's
+// remembered live set, so successive snapshots report only what changed. Runs
+// on the engine loop thread; prevGoids needs no synchronization.
+func (e *engine) goroutineSnapshot() protocol.GoroutineSnapshotPayload {
+	sp, pc := e.liveRegisters()
+
+	gs, ok := e.buildGoroutineList(sp, pc)
+	if !ok {
+		// Degraded snapshot: still report where we're stopped, but don't touch
+		// the remembered live set — an empty read (e.g. at the entry stop before
+		// runtime init) must not look like every goroutine exited.
+		return protocol.GoroutineSnapshotPayload{
+			Goroutines: []protocol.Goroutine{e.syntheticGoroutine(pc)},
+		}
+	}
+
+	var current int
+	live := make(map[int]struct{}, len(gs))
+	for _, g := range gs {
+		live[g.ID] = struct{}{}
+		if g.Current {
+			current = g.ID
+		}
+	}
+
+	created, exited := e.diffGoids(live)
+
+	return protocol.GoroutineSnapshotPayload{
+		Goroutines: gs,
+		Threads:    e.readThreads(current, pc),
+		Current:    current,
+		Created:    created,
+		Exited:     exited,
+	}
+}
+
+// diffGoids compares the current live goid set against the previous snapshot's
+// and returns the created (new) and exited (gone) goids, then adopts the new
+// set. Returns nil slices on the first snapshot so a fresh session doesn't
+// report every existing goroutine as "created".
+func (e *engine) diffGoids(live map[int]struct{}) (created, exited []int) {
+	if e.prevGoids != nil {
+		for id := range live {
+			if _, seen := e.prevGoids[id]; !seen {
+				created = append(created, id)
+			}
+		}
+		for id := range e.prevGoids {
+			if _, still := live[id]; !still {
+				exited = append(exited, id)
+			}
+		}
+	}
+	e.prevGoids = live
+	sort.Ints(created)
+	sort.Ints(exited)
+	return created, exited
+}
+
+// currentGoroutineFrom returns the goroutine marked Current in a snapshot, used
+// as the single Goroutine embedded in a stop event. Falls back to the first
+// entry (snapshots always carry at least the synthetic goroutine).
+func currentGoroutineFrom(snap protocol.GoroutineSnapshotPayload) protocol.Goroutine {
+	for _, g := range snap.Goroutines {
+		if g.Current {
+			return g
+		}
+	}
+	if len(snap.Goroutines) > 0 {
+		return snap.Goroutines[0]
+	}
+	return protocol.Goroutine{}
+}

--- a/internal/hub/dispatcher.go
+++ b/internal/hub/dispatcher.go
@@ -129,6 +129,17 @@ func dispatch(dbg debugger.Debugger, cmd protocol.Command) (dispatchResult, erro
 		}
 		return dispatchResult{event: &evt}, nil
 
+	case protocol.CmdGoroutineSnapshot:
+		snap, err := dbg.GoroutineSnapshot()
+		if err != nil {
+			return dispatchResult{}, err
+		}
+		evt, err := protocol.NewEvent(protocol.EventGoroutineSnapshot, 0, snap)
+		if err != nil {
+			return dispatchResult{}, err
+		}
+		return dispatchResult{event: &evt}, nil
+
 	default:
 		return dispatchResult{}, fmt.Errorf("unknown command kind: %q", cmd.Kind)
 	}

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -40,6 +40,7 @@ type fakeDebugger struct {
 	localsResult     []protocol.Variable
 	framesResult     []protocol.Frame
 	goroutinesResult []protocol.Goroutine
+	snapshotResult   protocol.GoroutineSnapshotPayload
 }
 
 func newFakeDebugger() *fakeDebugger {
@@ -98,6 +99,10 @@ func (f *fakeDebugger) StackFrames() ([]protocol.Frame, error) {
 func (f *fakeDebugger) Goroutines() ([]protocol.Goroutine, error) {
 	f.record("Goroutines")
 	return f.goroutinesResult, nil
+}
+func (f *fakeDebugger) GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error) {
+	f.record("GoroutineSnapshot")
+	return f.snapshotResult, nil
 }
 
 type fakeWSConn struct {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -52,6 +52,11 @@ type Client interface {
 	StackFrames() ([]protocol.Frame, error)
 	Goroutines() ([]protocol.Goroutine, error)
 
+	// GoroutineSnapshot blocks until the server returns the full concurrency
+	// snapshot: every goroutine (with parent linkage), every OS thread, the
+	// current goroutine, and the created/exited lifecycle deltas.
+	GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error)
+
 	Close() error
 }
 

--- a/pkg/client/ws.go
+++ b/pkg/client/ws.go
@@ -389,6 +389,22 @@ func (c *wsClient) Goroutines() ([]protocol.Goroutine, error) {
 	return p.Goroutines, nil
 }
 
+func (c *wsClient) GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error) {
+	cmd, err := newCommand(protocol.CmdGoroutineSnapshot, struct{}{})
+	if err != nil {
+		return protocol.GoroutineSnapshotPayload{}, err
+	}
+	evt, err := c.sendAndWait(cmd, protocol.EventGoroutineSnapshot)
+	if err != nil {
+		return protocol.GoroutineSnapshotPayload{}, err
+	}
+	var p protocol.GoroutineSnapshotPayload
+	if err := protocol.DecodeEventPayload(evt, &p); err != nil {
+		return protocol.GoroutineSnapshotPayload{}, fmt.Errorf("decode GoroutineSnapshot: %w", err)
+	}
+	return p, nil
+}
+
 // Close disconnects from the server. Safe to call multiple times.
 func (c *wsClient) Close() error {
 	c.signalDone()

--- a/pkg/protocol/payload.go
+++ b/pkg/protocol/payload.go
@@ -29,13 +29,32 @@ type Frame struct {
 	Locals   []Variable `json:"locals,omitempty"`
 }
 
-// Goroutine is a snapshot of a running goroutine.
+// Goroutine is a snapshot of one goroutine in the tracee's runtime. It carries
+// enough to reconstruct a spawn hierarchy (ParentID links a goroutine to the
+// one that ran its `go` statement) and lifecycle state. IDs are the runtime's
+// goid (fits Go int on both supported 64-bit platforms).
 type Goroutine struct {
-	ID         int      `json:"id"`
-	Status     string   `json:"status"` // "running" | "waiting" | "syscall" | "dead"
-	CurrentLoc Location `json:"currentLoc"`
-	GoLoc      Location `json:"goLoc"` // where the goroutine was spawned
-	WaitReason string   `json:"waitReason,omitempty"`
+	ID         int      `json:"id"`                   // goid
+	ParentID   int      `json:"parentId,omitempty"`   // parent goroutine's goid; 0 for the root
+	Status     string   `json:"status"`               // scheduler status: "running" | "runnable" | "waiting" | "syscall" | "dead" | ...
+	WaitReason string   `json:"waitReason,omitempty"` // why a waiting goroutine is blocked (e.g. "chan receive")
+	CurrentLoc Location `json:"currentLoc"`           // where the goroutine is now (live PC if running, scheduled PC if parked)
+	StartLoc   Location `json:"startLoc,omitempty"`   // the goroutine's entry function (startpc)
+	CreatedLoc Location `json:"createdLoc,omitempty"` // the `go` statement that spawned it (gopc)
+	ThreadID   int      `json:"threadId,omitempty"`   // OS thread (m.procid) currently running it; 0 if not running
+	Current    bool     `json:"current,omitempty"`    // true for the goroutine the debugger is stopped in
+}
+
+// Thread is one OS thread (a runtime M) in the tracee. It complements the
+// goroutine view: a spawn/lifecycle UI needs both the logical goroutines and
+// the physical threads they are (or aren't) scheduled onto.
+type Thread struct {
+	ID         int      `json:"id"`                   // OS thread id (m.procid); 0 if not yet assigned
+	MID        int      `json:"mid,omitempty"`        // runtime m.id
+	GoID       int      `json:"goid,omitempty"`       // goid currently running on this thread (m.curg); 0 if idle
+	Spinning   bool     `json:"spinning,omitempty"`   // scheduler is spinning looking for work
+	CurrentLoc Location `json:"currentLoc,omitempty"` // where the running goroutine's code is
+	Current    bool     `json:"current,omitempty"`    // true for the thread the debugger is stopped on
 }
 
 // SessionState represents the lifecycle phase of a debug session.
@@ -107,6 +126,24 @@ type FramesPayload struct {
 
 type GoroutinesPayload struct {
 	Goroutines []Goroutine `json:"goroutines"`
+}
+
+// GoroutineSnapshotPayload is the full concurrency picture at a suspend point:
+// every goroutine (with ParentID linkage for a spawn tree), every OS thread,
+// which goroutine is current, and the created/exited goid deltas since the
+// previous snapshot. It powers lifecycle and spawn-hierarchy visualizations.
+//
+// It is emitted automatically on each suspend that changes the concurrency
+// picture (breakpoint hit, pause, launch/attach entry) and on demand via
+// CmdGoroutineSnapshot. Unlike EventGoroutines — which answers a single DAP
+// `threads` request and carries goroutines only — this event is not tied to a
+// request, so it also carries the thread list and the lifecycle deltas.
+type GoroutineSnapshotPayload struct {
+	Goroutines []Goroutine `json:"goroutines"`
+	Threads    []Thread    `json:"threads"`
+	Current    int         `json:"current,omitempty"` // goid of the current goroutine, 0 if unknown
+	Created    []int       `json:"created,omitempty"` // goids new since the previous snapshot
+	Exited     []int       `json:"exited,omitempty"`  // goids gone since the previous snapshot
 }
 
 type SessionStatePayload struct {

--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -4,7 +4,7 @@ package protocol
 
 import "encoding/json"
 
-const Version = "1.0"
+const Version = "1.1"
 
 // Event is the envelope for all server-to-client messages.
 type Event struct {
@@ -49,6 +49,15 @@ const (
 	EventFrames     EventKind = "Frames"
 	EventGoroutines EventKind = "Goroutines"
 
+	// EventGoroutineSnapshot streams the full concurrency picture (goroutines
+	// with parent linkage, OS threads, current goroutine, and created/exited
+	// lifecycle deltas). It is emitted automatically on every suspend that can
+	// change that picture — breakpoint hit, pause, and launch/attach entry —
+	// and on demand in response to CmdGoroutineSnapshot. It is NOT a suspending
+	// event: it follows a suspending event (or answers a query) and never gates
+	// the hub. See AGENTS.md → goroutine snapshot streaming.
+	EventGoroutineSnapshot EventKind = "GoroutineSnapshot"
+
 	EventSessionState EventKind = "SessionState"
 
 	EventError EventKind = "Error"
@@ -88,6 +97,12 @@ const (
 	CmdLocals     CommandKind = "Locals"
 	CmdFrames     CommandKind = "Frames"
 	CmdGoroutines CommandKind = "Goroutines"
+
+	// CmdGoroutineSnapshot requests a full concurrency snapshot on demand
+	// (answered with EventGoroutineSnapshot). The same snapshot is also pushed
+	// automatically on each suspend, so a UI only needs this to refresh out of
+	// band (e.g. right after connecting). Requires the process to be suspended.
+	CmdGoroutineSnapshot CommandKind = "GoroutineSnapshot"
 
 	// CmdRestart kills the current process (if any) and relaunches the last
 	// Launch'd binary, reinstalling previously-set breakpoints. Only

--- a/pkg/protocol/protocol_test.go
+++ b/pkg/protocol/protocol_test.go
@@ -29,9 +29,20 @@ var sampleBreakpoint = protocol.Breakpoint{
 
 var sampleGoroutine = protocol.Goroutine{
 	ID:         1,
+	ParentID:   0,
 	Status:     "waiting",
 	CurrentLoc: sampleLocation,
-	GoLoc:      protocol.Location{File: "runtime/proc.go", Line: 10},
+	StartLoc:   protocol.Location{File: "main.go", Line: 30, Function: "main.worker"},
+	CreatedLoc: protocol.Location{File: "runtime/proc.go", Line: 10},
+}
+
+var sampleThread = protocol.Thread{
+	ID:         4321,
+	MID:        3,
+	GoID:       1,
+	Spinning:   false,
+	CurrentLoc: sampleLocation,
+	Current:    true,
 }
 
 var sampleFrames = []protocol.Frame{
@@ -281,6 +292,29 @@ var _ = Describe("Event", func() {
 				},
 			),
 
+			Entry("GoroutineSnapshot",
+				protocol.EventGoroutineSnapshot,
+				protocol.GoroutineSnapshotPayload{
+					Goroutines: []protocol.Goroutine{sampleGoroutine},
+					Threads:    []protocol.Thread{sampleThread},
+					Current:    1,
+					Created:    []int{7, 8},
+					Exited:     []int{3},
+				},
+				func(e protocol.Event) {
+					var p protocol.GoroutineSnapshotPayload
+					Expect(protocol.DecodeEventPayload(e, &p)).To(Succeed())
+					Expect(p.Goroutines).To(HaveLen(1))
+					Expect(p.Goroutines[0].StartLoc.Function).To(Equal("main.worker"))
+					Expect(p.Threads).To(HaveLen(1))
+					Expect(p.Threads[0].ID).To(Equal(4321))
+					Expect(p.Threads[0].Current).To(BeTrue())
+					Expect(p.Current).To(Equal(1))
+					Expect(p.Created).To(Equal([]int{7, 8}))
+					Expect(p.Exited).To(Equal([]int{3}))
+				},
+			),
+
 			Entry("Error with command",
 				protocol.EventError,
 				protocol.ErrorPayload{Command: protocol.CmdSetBreakpoint, Message: "address not found"},
@@ -498,6 +532,14 @@ var _ = Describe("Command", func() {
 				json.RawMessage(`{}`),
 				func(c protocol.Command) {
 					Expect(c.Kind).To(Equal(protocol.CmdGoroutines))
+				},
+			),
+
+			Entry("GoroutineSnapshot",
+				protocol.CmdGoroutineSnapshot,
+				json.RawMessage(`{}`),
+				func(c protocol.Command) {
+					Expect(c.Kind).To(Equal(protocol.CmdGoroutineSnapshot))
 				},
 			),
 

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -255,6 +255,86 @@ func main() {
 }
 `
 
+// concurrencyTargetSrc builds a KNOWN goroutine spawn tree so the concurrency
+// snapshot can be asserted against a deterministic hierarchy:
+//
+//	main (g1)
+//	  └─ worker   (spawned in main.spawnAll via `go worker`)
+//	       └─ leaf (spawned in main.worker via `go leaf`)
+//
+// The children park in a spin-until-released loop so they are all simultaneously
+// alive when main hits the breakpoint. main hits the same breakpoint (BP_TICK)
+// three times: once BEFORE spawning (lifecycle-delta baseline), once AFTER both
+// children are confirmed running (they must appear in the Created delta with
+// correct parent linkage and start/created locations), and once AFTER they have
+// been released and reaped (they must appear in the Exited delta). The atomic
+// `ready` gate guarantees both children are scheduled and past their spawn point
+// before the second stop; the WaitGroup + GC guarantees they are fully dead
+// before the third.
+const concurrencyTargetSrc = `package main
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var (
+	ready   int32
+	release int32
+	wg      sync.WaitGroup
+)
+
+func leaf() {
+	defer wg.Done()
+	atomic.AddInt32(&ready, 1)
+	for atomic.LoadInt32(&release) == 0 {
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func worker() {
+	defer wg.Done()
+	wg.Add(1)
+	go leaf() // SPAWN_LEAF
+	atomic.AddInt32(&ready, 1)
+	for atomic.LoadInt32(&release) == 0 {
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func spawnAll() {
+	wg.Add(1)
+	go worker() // SPAWN_WORKER
+}
+
+func waitReady() {
+	for atomic.LoadInt32(&ready) < 2 {
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func tick() {
+	time.Sleep(2 * time.Millisecond) // BP_TICK
+}
+
+func main() {
+	tick() // stop #1: baseline, before any child exists
+	spawnAll()
+	waitReady()
+	tick() // stop #2: worker + leaf alive
+	atomic.StoreInt32(&release, 1)
+	wg.Wait()
+	runtime.GC()
+	runtime.GC()
+	tick() // stop #3: worker + leaf reaped
+	for i := 0; i < 100000; i++ {
+		tick() // keep the process alive for teardown
+	}
+}
+`
+
 // declareBasicStepOverSpec adds the continue+step-over acceptance spec to the
 // enclosing Ginkgo container. It is the correctness gate: set a breakpoint on a
 // line that calls a function, repeatedly Continue to it and StepOver the call,
@@ -696,6 +776,138 @@ func bpLine(evt protocol.Event) int {
 	var hit protocol.BreakpointHitPayload
 	Expect(json.Unmarshal(evt.Payload, &hit)).To(Succeed(), "decode BreakpointHit")
 	return hit.Breakpoint.Location.Line
+}
+
+// declareConcurrencySpec is the data-foundation gate for concurrency
+// visualization. It drives the known spawn-tree target (concurrencyTargetSrc)
+// and asserts the goroutine/thread snapshot exposes everything a UI needs to
+// render a goroutine-spawn hierarchy and a live-thread view:
+//
+//   - the rich goroutine set (not the legacy single synthetic goroutine),
+//   - parent linkage (leaf<-worker<-main) for the spawn tree,
+//   - each goroutine's start function and its `go`-statement creation site,
+//   - the OS-thread set with the current thread marked,
+//   - the current goroutine, consistent between the list and the snapshot, and
+//   - created/exited lifecycle deltas across stops.
+//
+// It runs on BOTH platforms: the reader is DWARF-driven and reads the runtime's
+// runtime.allgs / runtime.allm from tracee memory, which is platform-agnostic
+// (only the underlying memory-read primitive differs per backend).
+func declareConcurrencySpec() {
+	It("streams a goroutine spawn tree, threads, and lifecycle deltas", Label("concurrency"), func() {
+		lineTick := markerLine(concurrencyTargetSrc, "// BP_TICK")
+		bin := buildTarget("concurrency_target", concurrencyTargetSrc)
+
+		h := newE2EHarness(bin)
+		h.waitFor(15*time.Second, protocol.EventStepped) // initial launch stop
+
+		_, err := h.d.SetBreakpoint("concurrency_target.go", lineTick)
+		Expect(err).NotTo(HaveOccurred(), "SetBreakpoint on tick")
+
+		// The auto-streamed EventGoroutineSnapshot that follows each breakpoint
+		// hit is the delta-bearing one (its Created/Exited are computed relative
+		// to the previous auto snapshot). We must NOT call GoroutineSnapshot()
+		// on-demand between hits, as that would advance the delta baseline.
+		nextSnapshot := func(stop string) protocol.GoroutineSnapshotPayload {
+			GinkgoHelper()
+			Expect(h.d.Continue()).To(Succeed(), "Continue to %s", stop)
+			hit := h.waitFor(15*time.Second,
+				protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+			Expect(hit.Kind).To(Equal(protocol.EventBreakpointHit), "%s: breakpoint hit", stop)
+			evt := h.waitFor(15*time.Second, protocol.EventGoroutineSnapshot)
+			var snap protocol.GoroutineSnapshotPayload
+			Expect(json.Unmarshal(evt.Payload, &snap)).To(Succeed(), "%s: decode snapshot", stop)
+			return snap
+		}
+
+		// --- stop #1: baseline (before either child exists) ---
+		baseline := nextSnapshot("baseline")
+		Expect(baseline.Goroutines).NotTo(BeEmpty(), "baseline has goroutines")
+		Expect(baseline.Current).To(BeNumerically(">", 0), "baseline current goid resolved")
+		Expect(findByStart(baseline.Goroutines, "main.worker")).To(BeNil(),
+			"worker must not exist yet at the baseline stop")
+
+		// --- stop #2: worker + leaf alive ---
+		spawned := nextSnapshot("spawned")
+
+		worker := findByStart(spawned.Goroutines, "main.worker")
+		Expect(worker).NotTo(BeNil(), "worker goroutine present after spawn")
+		leaf := findByStart(spawned.Goroutines, "main.leaf")
+		Expect(leaf).NotTo(BeNil(), "leaf goroutine present after spawn")
+
+		// Spawn-tree linkage: worker's parent is main (the current goroutine),
+		// leaf's parent is worker. This is the core data a hierarchy view needs.
+		Expect(worker.ParentID).To(Equal(spawned.Current),
+			"worker parent is the main goroutine")
+		Expect(leaf.ParentID).To(Equal(worker.ID),
+			"leaf parent is the worker goroutine")
+
+		// Creation site (the `go` statement) and start function per goroutine.
+		Expect(worker.StartLoc.Function).To(Equal("main.worker"), "worker start function")
+		Expect(worker.CreatedLoc.Function).To(Equal("main.spawnAll"), "worker created in spawnAll")
+		Expect(leaf.StartLoc.Function).To(Equal("main.leaf"), "leaf start function")
+		Expect(leaf.CreatedLoc.Function).To(Equal("main.worker"), "leaf created in worker")
+
+		// Lifecycle: both children are new since the baseline stop.
+		Expect(spawned.Created).To(ContainElement(worker.ID), "worker in created delta")
+		Expect(spawned.Created).To(ContainElement(leaf.ID), "leaf in created delta")
+
+		// Threads: the OS-thread set is populated and exactly one thread is the
+		// current one, running the current goroutine.
+		Expect(spawned.Threads).NotTo(BeEmpty(), "thread set populated")
+		currentThreads := 0
+		for _, t := range spawned.Threads {
+			if t.Current {
+				currentThreads++
+				Expect(t.GoID).To(Equal(spawned.Current),
+					"the current thread runs the current goroutine")
+			}
+		}
+		Expect(currentThreads).To(Equal(1), "exactly one current thread")
+
+		// The current goroutine is consistent between the flag and the id.
+		cur := currentGoroutine(spawned.Goroutines)
+		Expect(cur).NotTo(BeNil(), "a goroutine is marked current")
+		Expect(cur.ID).To(Equal(spawned.Current), "current flag matches current id")
+
+		workerID, leafID := worker.ID, leaf.ID
+
+		// --- stop #3: children released and reaped ---
+		exited := nextSnapshot("exited")
+		Expect(exited.Exited).To(ContainElement(workerID), "worker in exited delta")
+		Expect(exited.Exited).To(ContainElement(leafID), "leaf in exited delta")
+		Expect(findByStart(exited.Goroutines, "main.worker")).To(BeNil(),
+			"worker gone from the live set")
+		Expect(findByStart(exited.Goroutines, "main.leaf")).To(BeNil(),
+			"leaf gone from the live set")
+
+		// The on-demand snapshot command returns a coherent live picture too.
+		onDemand, err := h.d.GoroutineSnapshot()
+		Expect(err).NotTo(HaveOccurred(), "GoroutineSnapshot on demand")
+		Expect(onDemand.Goroutines).NotTo(BeEmpty(), "on-demand snapshot has goroutines")
+		Expect(onDemand.Current).To(BeNumerically(">", 0), "on-demand current goid resolved")
+	})
+}
+
+// findByStart returns the first goroutine whose start function matches fn, or
+// nil. Used to locate a specific goroutine in a snapshot by what it runs.
+func findByStart(gs []protocol.Goroutine, fn string) *protocol.Goroutine {
+	for i := range gs {
+		if gs[i].StartLoc.Function == fn {
+			return &gs[i]
+		}
+	}
+	return nil
+}
+
+// currentGoroutine returns the goroutine marked Current, or nil.
+func currentGoroutine(gs []protocol.Goroutine) *protocol.Goroutine {
+	for i := range gs {
+		if gs[i].Current {
+			return &gs[i]
+		}
+	}
+	return nil
 }
 
 // --- shared acceptance loop ---

--- a/test/integration/debugger_e2e_darwin_arm64_test.go
+++ b/test/integration/debugger_e2e_darwin_arm64_test.go
@@ -55,6 +55,7 @@ var _ = Describe("Darwin arm64 debugger backend (Mach exceptions) E2E", Label("d
 	declareKillRunningSpec()
 	declareExitCodeSpec()
 	declareAttachSpec()
+	declareConcurrencySpec()
 	declareFullStackSpec()
 	declareRestartSpec()
 	declareDAPSpec()

--- a/test/integration/debugger_e2e_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_linux_amd64_test.go
@@ -18,6 +18,7 @@ var _ = Describe("Linux amd64 debugger backend (ptrace) E2E", Label("linux"), fu
 	declareKillRunningSpec()
 	declareExitCodeSpec()
 	declareAttachSpec()
+	declareConcurrencySpec()
 	declareFullStackSpec()
 	declareRestartSpec()
 	declareDAPSpec()


### PR DESCRIPTION
## What & why

The basic debugger works well; this PR lays the **data foundation** for the concurrency-visualization side of the project. It expands the WebSocket protocol to stream rich insight into **goroutines, OS threads, and their lifecycles** — everything a UI (including the future goroutine-spawn-hierarchy tree) needs, without building any UI yet. Works on **both** `darwin/arm64` and `linux/amd64`.

The old `readGoroutines()` was a stub returning one fake goroutine. It's replaced with a **DWARF-driven reader** of the Go runtime that reads `runtime.allgs` (every goroutine) and `runtime.allm` (every OS thread) straight from tracee memory, resolving every struct offset **by name** so it survives Go-version drift.

## Protocol (Version 1.0 → 1.1)

- **`Goroutine` reshaped**: adds `ParentID` (spawn linkage), `StartLoc` (startpc), `CreatedLoc` (the `go` statement, gopc), `ThreadID`, `Current`; `GoLoc`→`CreatedLoc`.
- **New `Thread`** (id / m.id / goid / spinning / loc / current).
- **New `GoroutineSnapshotPayload`**: goroutine set + thread set + current goroutine + **created/exited goid deltas** since the previous snapshot.
- **New `EventGoroutineSnapshot` + `CmdGoroutineSnapshot`**.

## Streaming cadence (the load-bearing invariant)

`EventGoroutineSnapshot` is auto-emitted on exactly the suspends that can change the concurrency picture — **breakpoint hit, pause, launch/attach entry** — and on demand via `CmdGoroutineSnapshot`. It is **not** emitted per-step, keeping the fragile single-step/step-over path cheap. Stop events embed the snapshot's current goroutine, built **once** to avoid a double `allgs` scan.

Every read is best-effort: an unreadable runtime (stripped binary, attach-without-DWARF, pre-init entry stop, `fakeBackend`) **degrades gracefully** to the legacy single synthetic goroutine rather than erroring the stop.

## Notable details

- **DAP deliberately ignores `EventGoroutineSnapshot`** — it has no DAP equivalent and translating it would corrupt the FIFO that correlates a DAP `threads` request to `EventGoroutines`. The rich list now also backs the DAP `threads` request and the CLI.
- **`locationForPC` bug fixed**: it now *brackets* the PC (`prev.Address <= pc < next.Address`) instead of taking the greatest address `<= pc`. Go emits CUs with `DW_AT_ranges`, so a CU whose whole line program lies below `pc` would otherwise match on its end-sequence row and return a bogus file:line. This surfaced while resolving creation-site file:line for off-CPU goroutine PCs; all existing e2e specs still pass.
- Wired through the `Debugger`/`Client` interfaces, hub dispatcher, ws client, and CLI (enriched `goroutines`, new `snapshot`/`snap` command).

## Testing

- New e2e **`concurrency`** label drives a known spawn tree (`main → worker → leaf`) and asserts: parent linkage, start/created functions **and file:line**, the thread set with exactly one current thread, and created/exited lifecycle deltas across three stops. Wired into **both** platform suites.
- ✅ Full **darwin/arm64** e2e suite: **20/20 pass** (incl. the new spec and all `locationForPC` consumers).
- ✅ Unit suite (`go test -tags bingonative ./...`) + `go vet` green.
- ✅ **linux/amd64** cross-compile build + e2e `go vet` green (ptrace execution runs in CI).

## Follow-ups (not in scope)

- The pre-made concurrency UI (spawn-tree visual) that consumes this data — TODO by design.
- Type-aware value formatting and PC-cache optimization for very large goroutine counts.

> **Note:** touches shared engine + darwin-native memory-read paths exercised by e2e, so this needs the `darwin-e2e-verified` label after a maintainer runs `just e2e-darwin` locally (done here: 20/20).