### PR TITLE
feat(telemetry): wsmon WS observer + DAP-drives/WS-observes runbook

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "bingo DAP: launch spawntree (stop on entry)",
+      "type": "go",
+      "request": "launch",
+      "mode": "exec",
+      "program": "${workspaceFolder}/build/spawntree",
+      "stopOnEntry": true,
+      "debugServer": 4711
+    },
+    {
+      "name": "bingo DAP: join running session",
+      "type": "go",
+      "request": "attach",
+      "mode": "remote",
+      "session": "${input:bingoSession}",
+      "debugServer": 4711
+    }
+  ],
+  "inputs": [
+    {
+      "id": "bingoSession",
+      "type": "promptString",
+      "description": "bingo session ID to join (from the server's console line or /api/sessions)"
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,9 @@ follow them so reviews stay about substance, not style.
 | [cmd/bingo](cmd/bingo/) | Server entry point — flag parsing, signal handler, calls into `internal/server`. |
 | [cmd/cli](cmd/cli/) | Interactive readline client. |
 | [cmd/dapcli](cmd/dapcli/) | Interactive readline client that drives a session over DAP (mirrors `cmd/cli`'s UX). Talks to the server's `-dap-addr` listener; can create a session or `-session` join an existing one. |
+| [cmd/wsmon](cmd/wsmon/) | Read-only terminal telemetry observer. `-session`-joins a running session over WebSocket and live-renders the goroutine spawn tree + OS threads + created/exited lifecycle deltas from the `EventGoroutineSnapshot` stream. Never drives execution — the WS-observes half of the DAP-drives/WS-observes demo. |
 | [cmd/target](cmd/target/) | Trivial target program for manual testing. |
+| [examples/spawntree](examples/spawntree/) | Concurrency demo target: a deterministic main → supervisor → worker×N goroutine spawn tree for exercising the telemetry stream (see [docs/ConcurrencyTelemetry.md](docs/ConcurrencyTelemetry.md)). |
 | [cmd/githook](cmd/githook/) | Conventional-commits commitlint, wired via [lefthook.yml](lefthook.yml). |
 | [pkg/protocol](pkg/protocol/) | Wire types: `Event`, `Command`, payload structs, `EventKind`, `CommandKind`, `SessionState`. Single source of truth. |
 | [pkg/client](pkg/client/) | Reference Go client. WebSocket-backed. Public surface: `Client` interface + `Create` / `Join` / `ListSessions`. |
@@ -553,6 +555,14 @@ translating it would corrupt the FIFO that correlates a DAP `threads` request to
 `EventGoroutines` (snapshots are unsolicited, with no matching request). DAP
 clients get goroutine data from the `threads` request (`EventGoroutines`, which
 now returns the rich list); the snapshot stream is WebSocket-only.
+
+**Reference observer + runbook.** [cmd/wsmon](cmd/wsmon/) is the reference
+WebSocket telemetry consumer: it `-session`-joins read-only and live-renders the
+spawn tree / thread set / lifecycle deltas from this stream (a UI-agnostic view
+of exactly the data a spawn-hierarchy visualization needs). The end-to-end
+DAP-drives + WS-observes walkthrough — server, VS Code (or `cmd/dapcli`) driver,
+and `wsmon` against the [examples/spawntree](examples/spawntree/) target — is in
+[docs/ConcurrencyTelemetry.md](docs/ConcurrencyTelemetry.md).
 
 **Lifecycle deltas.** `engine.prevGoids` (loop-thread-only, no lock, like
 `manualStopPending`) remembers the previous live goid set; `diffGoids` returns

--- a/README.md
+++ b/README.md
@@ -43,8 +43,13 @@ drive a debug session over a TCP socket while BinGo's own visual clients observe
 Start the server with a DAP listener:
 
 ```sh
+just server                       # builds + runs with -addr :6060 -dap-addr :4711
+# or, from a prebuilt binary:
 bingo -addr :6060 -dap-addr :4711
 ```
+
+`just server` starts both listeners with the defaults above; use `just server-ws`
+for a WebSocket-only run (DAP disabled).
 
 Point your editor's debug adapter at `127.0.0.1:4711`. The DAP client creates a
 managed session on `launch`/`attach`; WebSocket observers join that same session
@@ -65,6 +70,23 @@ just dapcli -session <id>         # join an existing session as another client
 Any number of `dapcli` and `cli` clients can drive and observe the **same**
 session at once — start one, `launch` a target, then join from other terminals
 with the announced session id.
+
+## Concurrency telemetry (WebSocket)
+
+Alongside the DAP debug loop, BinGo streams **concurrency telemetry** over its
+native WebSocket protocol — a goroutine spawn hierarchy (parent/child linkage),
+the live OS-thread set, and per-stop created/exited goroutine lifecycle deltas —
+so any UI can build a concurrency view on top of the data. `cmd/wsmon` is a
+read-only terminal observer that joins a session and live-renders these streams:
+
+```sh
+go run ./cmd/wsmon -session <id>  # connects to -addr localhost:6060 by default
+```
+
+It never issues run-control commands, so it coexists with a DAP driver and other
+WebSocket clients on the same session. For an end-to-end walkthrough — server, a
+DAP driver (VS Code or `cmd/dapcli`), and the `wsmon` observer against one shared
+session — see [docs/ConcurrencyTelemetry.md](docs/ConcurrencyTelemetry.md).
 
 ## Documentation
 

--- a/cmd/wsmon/main.go
+++ b/cmd/wsmon/main.go
@@ -1,0 +1,412 @@
+// Command wsmon joins an existing bingo WebSocket session and renders the
+// streaming goroutine/thread telemetry in a terminal.
+//
+//	wsmon -session id [-addr host:port] [-once]
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/bingosuite/bingo/pkg/client"
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+type monitor struct {
+	sessionID string
+	state     protocol.SessionState
+	clients   int
+
+	lastEvent  string
+	lastUpdate time.Time
+
+	snapshot    protocol.GoroutineSnapshotPayload
+	hasSnapshot bool
+}
+
+func main() {
+	addr := flag.String("addr", "localhost:6060", "server address (host:port)")
+	sessionID := flag.String("session", "", "session ID to join")
+	once := flag.Bool("once", false, "print one snapshot then exit")
+	flag.Usage = func() {
+		_, _ = fmt.Fprintf(flag.CommandLine.Output(), "usage: wsmon -session <id> [-addr host:port] [-once]\n\n")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	if strings.TrimSpace(*sessionID) == "" {
+		fmt.Fprintln(os.Stderr, "error: -session is required")
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	fmt.Printf("joining session %s on %s...\n", *sessionID, *addr)
+	c, err := client.Join(*addr, *sessionID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: join session %s on %s: %v\n", *sessionID, *addr, err)
+		os.Exit(1)
+	}
+	defer func() { _ = c.Close() }()
+
+	m := &monitor{
+		sessionID:  c.SessionID(),
+		state:      c.State(),
+		clients:    -1,
+		lastEvent:  "joined",
+		lastUpdate: time.Now(),
+	}
+	fmt.Printf("joined — session %s (state: %s)\n", m.sessionID, m.state)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		<-sigCh
+		_ = c.Close()
+	}()
+
+	if snap, err := c.GoroutineSnapshot(); err == nil {
+		m.applySnapshot(snap)
+		m.render()
+		if *once {
+			return
+		}
+	} else if !*once {
+		m.render()
+	}
+
+	for evt := range c.Events() {
+		renderedSnapshot, redraw := m.applyEvent(evt)
+		if !redraw {
+			continue
+		}
+		if *once && !renderedSnapshot {
+			continue
+		}
+		m.render()
+		if *once && renderedSnapshot {
+			return
+		}
+	}
+
+	fmt.Println("\nconnection closed; monitor stopped")
+}
+
+func (m *monitor) applyEvent(evt protocol.Event) (bool, bool) {
+	switch evt.Kind {
+	case protocol.EventGoroutineSnapshot:
+		var p protocol.GoroutineSnapshotPayload
+		if protocol.DecodeEventPayload(evt, &p) != nil {
+			return false, false
+		}
+		m.applySnapshot(p)
+		return true, true
+
+	case protocol.EventSessionState:
+		var p protocol.SessionStatePayload
+		if protocol.DecodeEventPayload(evt, &p) != nil {
+			return false, false
+		}
+		if p.SessionID != "" {
+			m.sessionID = p.SessionID
+		}
+		m.state = p.State
+		m.clients = p.Clients
+		m.lastUpdate = time.Now()
+		return false, true
+
+	default:
+		last, ok := describeEvent(evt)
+		if !ok {
+			return false, false
+		}
+		m.lastEvent = last
+		m.lastUpdate = time.Now()
+		return false, true
+	}
+}
+
+func (m *monitor) applySnapshot(snap protocol.GoroutineSnapshotPayload) {
+	m.snapshot = snap
+	m.hasSnapshot = true
+	m.lastUpdate = time.Now()
+}
+
+func describeEvent(evt protocol.Event) (string, bool) {
+	switch evt.Kind {
+	case protocol.EventBreakpointHit:
+		var p protocol.BreakpointHitPayload
+		if protocol.DecodeEventPayload(evt, &p) != nil {
+			return "", false
+		}
+		return fmt.Sprintf("BreakpointHit #%d at %s", p.Breakpoint.ID, locString(p.Breakpoint.Location)), true
+
+	case protocol.EventPaused:
+		var p protocol.PausedPayload
+		if protocol.DecodeEventPayload(evt, &p) != nil {
+			return "", false
+		}
+		return fmt.Sprintf("Paused at %s", locString(p.Location)), true
+
+	case protocol.EventStepped:
+		var p protocol.SteppedPayload
+		if protocol.DecodeEventPayload(evt, &p) != nil {
+			return "", false
+		}
+		return fmt.Sprintf("Stepped at %s", locString(p.Location)), true
+
+	case protocol.EventProcessExited:
+		var p protocol.ProcessExitedPayload
+		if protocol.DecodeEventPayload(evt, &p) != nil {
+			return "", false
+		}
+		reason := ""
+		if p.Reason != "" {
+			reason = " reason=" + p.Reason
+		}
+		return fmt.Sprintf("exited code=%d%s", p.ExitCode, reason), true
+
+	case protocol.EventPanic:
+		var p protocol.PanicPayload
+		if protocol.DecodeEventPayload(evt, &p) != nil {
+			return "", false
+		}
+		return fmt.Sprintf("Panic %q at %s", oneLine(p.Message), locString(p.Goroutine.CurrentLoc)), true
+
+	case protocol.EventOutput:
+		var p protocol.OutputPayload
+		if protocol.DecodeEventPayload(evt, &p) != nil {
+			return "", false
+		}
+		return fmt.Sprintf("Output %s: %s", p.Stream, oneLine(p.Content)), true
+
+	default:
+		return "", false
+	}
+}
+
+func (m *monitor) render() {
+	fmt.Print("\033[H\033[2J")
+	fmt.Printf("bingo telemetry monitor — session %s — state %s", m.sessionID, m.state)
+	if m.clients >= 0 {
+		fmt.Printf(" — clients %d", m.clients)
+	}
+	fmt.Println()
+	fmt.Printf("updated: %s\n", m.lastUpdate.Format(time.RFC3339))
+	fmt.Printf("last: %s\n\n", m.lastEvent)
+
+	fmt.Println("Goroutine spawn tree")
+	if !m.hasSnapshot {
+		fmt.Println("  (waiting for GoroutineSnapshot)")
+	} else {
+		renderGoroutineTree(m.snapshot.Goroutines)
+	}
+
+	fmt.Println()
+	fmt.Println("OS threads")
+	if !m.hasSnapshot {
+		fmt.Println("  (waiting for GoroutineSnapshot)")
+	} else {
+		renderThreads(m.snapshot.Threads)
+	}
+
+	fmt.Println()
+	fmt.Println("Lifecycle deltas")
+	if !m.hasSnapshot {
+		fmt.Println("  created: -  exited: -")
+	} else {
+		fmt.Printf("  created: %s  exited: %s\n", formatIDs(m.snapshot.Created), formatIDs(m.snapshot.Exited))
+	}
+
+	fmt.Println()
+	fmt.Printf("counts: goroutines=%d threads=%d\n", len(m.snapshot.Goroutines), len(m.snapshot.Threads))
+}
+
+func renderGoroutineTree(goroutines []protocol.Goroutine) {
+	if len(goroutines) == 0 {
+		fmt.Println("  (none)")
+		return
+	}
+
+	nodes := make(map[int]protocol.Goroutine, len(goroutines))
+	for _, g := range goroutines {
+		nodes[g.ID] = g
+	}
+
+	children := make(map[int][]int, len(goroutines))
+	roots := make(map[int]bool, len(goroutines))
+	for _, g := range goroutines {
+		if g.ParentID == 0 || g.ParentID == g.ID {
+			roots[g.ID] = true
+			continue
+		}
+		if _, ok := nodes[g.ParentID]; !ok {
+			roots[g.ID] = true
+			continue
+		}
+		children[g.ParentID] = append(children[g.ParentID], g.ID)
+	}
+
+	visited := make(map[int]bool, len(nodes))
+	rootIDs := sortedKeys(roots)
+	for i, id := range rootIDs {
+		renderTreeNode(id, "", i == len(rootIDs)-1, nodes, children, visited)
+	}
+
+	extras := unvisitedIDs(nodes, visited)
+	for i, id := range extras {
+		renderTreeNode(id, "", i == len(extras)-1, nodes, children, visited)
+	}
+}
+
+func renderTreeNode(
+	id int,
+	prefix string,
+	last bool,
+	nodes map[int]protocol.Goroutine,
+	children map[int][]int,
+	visited map[int]bool,
+) {
+	connector, childPrefix := "├─", prefix+"│ "
+	if last {
+		connector, childPrefix = "└─", prefix+"  "
+	}
+
+	if visited[id] {
+		fmt.Printf("  %s%s G%d (cycle)\n", prefix, connector, id)
+		return
+	}
+
+	g, ok := nodes[id]
+	if !ok {
+		return
+	}
+	visited[id] = true
+	fmt.Printf("  %s%s %s\n", prefix, connector, goroutineLine(g))
+
+	childIDs := sortedInts(children[id])
+	for i, childID := range childIDs {
+		renderTreeNode(childID, childPrefix, i == len(childIDs)-1, nodes, children, visited)
+	}
+}
+
+func renderThreads(threads []protocol.Thread) {
+	if len(threads) == 0 {
+		fmt.Println("  (none)")
+		return
+	}
+
+	sorted := append([]protocol.Thread(nil), threads...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].ID == sorted[j].ID {
+			return sorted[i].MID < sorted[j].MID
+		}
+		return sorted[i].ID < sorted[j].ID
+	})
+
+	for _, t := range sorted {
+		marker := " "
+		if t.Current {
+			marker = "*"
+		}
+		spin := ""
+		if t.Spinning {
+			spin = " [spinning]"
+		}
+		fmt.Printf("  %s T%d mid=%d goid=%d%s %s\n",
+			marker, t.ID, t.MID, t.GoID, spin, locString(t.CurrentLoc))
+	}
+}
+
+func goroutineLine(g protocol.Goroutine) string {
+	marker := " "
+	if g.Current {
+		marker = "*"
+	}
+
+	status := g.Status
+	if status == "" {
+		status = "unknown"
+	}
+	if g.WaitReason != "" {
+		status += " (" + g.WaitReason + ")"
+	}
+
+	parts := []string{fmt.Sprintf("%s G%d", marker, g.ID), status}
+	if g.CurrentLoc.Function != "" {
+		parts = append(parts, g.CurrentLoc.Function)
+	}
+	parts = append(parts, locString(g.CurrentLoc))
+	if g.StartLoc.Function != "" {
+		parts = append(parts, "start="+g.StartLoc.Function)
+	}
+	if g.ThreadID != 0 {
+		parts = append(parts, fmt.Sprintf("thr=%d", g.ThreadID))
+	}
+	return strings.Join(parts, " ")
+}
+
+func locString(loc protocol.Location) string {
+	if loc.File != "" {
+		base := filepath.Base(loc.File)
+		if loc.Line > 0 {
+			return fmt.Sprintf("%s:%d", base, loc.Line)
+		}
+		return base
+	}
+	if loc.Function != "" {
+		return loc.Function
+	}
+	return "-"
+}
+
+func formatIDs(ids []int) string {
+	if len(ids) == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%v", sortedInts(ids))
+}
+
+func sortedKeys(values map[int]bool) []int {
+	keys := make([]int, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Ints(keys)
+	return keys
+}
+
+func sortedInts(values []int) []int {
+	sorted := append([]int(nil), values...)
+	sort.Ints(sorted)
+	return sorted
+}
+
+func unvisitedIDs(nodes map[int]protocol.Goroutine, visited map[int]bool) []int {
+	ids := make([]int, 0, len(nodes))
+	for id := range nodes {
+		if !visited[id] {
+			ids = append(ids, id)
+		}
+	}
+	sort.Ints(ids)
+	return ids
+}
+
+func oneLine(s string) string {
+	s = strings.TrimSpace(strings.ReplaceAll(s, "\n", `\n`))
+	if len(s) > 120 {
+		return s[:117] + "..."
+	}
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -52,9 +52,16 @@ breakpoint is the `fmt.Printf` inside `worker` (`examples/spawntree/main.go:27`)
 ## 2. Start the server with DAP enabled
 
 ```sh
+just server                       # builds + runs everything: -addr :6060 -dap-addr :4711
+# override addresses:   just server darwin arm64 :7070 :4712
+# verbose / extra flags: just server darwin arm64 :6060 :4711 -v
+# or run the binary directly:
 ./build/bingo/bingo_darwin_arm64 -addr :6060 -dap-addr :4711 -v
 # linux: ./build/bingo/bingo_linux_amd64 -addr :6060 -dap-addr :4711 -v
 ```
+
+`just server` starts both listeners with the defaults below. For a WebSocket-only
+run (DAP disabled) use `just server-ws` instead.
 
 - `:6060` — WebSocket + REST (`/ws`, `/api/sessions`). `cmd/wsmon` connects here.
 - `:4711` — DAP. VS Code / `cmd/dapcli` connect here.

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -1,0 +1,122 @@
+# Concurrency telemetry — end-to-end runbook
+
+bingo speaks two protocols against **one** debug session at the same time:
+
+- **DAP** (`-dap-addr`) — an IDE (VS Code) or `cmd/dapcli` *drives* the session:
+  breakpoints, stepping, continue/pause, stack/variables. This is the
+  least-common-denominator debug loop.
+- **WebSocket** (`-addr`) — any number of clients *observe* (and can also drive)
+  the same session. The richer concurrency telemetry — the goroutine spawn tree,
+  the OS-thread set, and created/exited lifecycle deltas — streams here as
+  `EventGoroutineSnapshot`.
+
+This runbook wires both together A–Z: a server, a **DAP driver** (VS Code or
+`cmd/dapcli`), and a terminal **WS observer** (`cmd/wsmon`) that live-renders the
+telemetry while the driver steps through a goroutine spawn tree.
+
+```
+             drives (DAP :4711)                observes (WS :6060)
+  VS Code  ─────────────────────►  bingo server  ◄─────────────────  cmd/wsmon
+  / dapcli                          (one session)                    (spawn tree,
+                                          │                            threads,
+                                          ▼                            lifecycle)
+                                    spawntree tracee
+```
+
+See [AGENTS.md](../AGENTS.md) → *DAP* and *Goroutine / thread snapshot* for the
+architecture behind this.
+
+## 0. Prerequisites
+
+- macOS **darwin/arm64** (needs `-tags bingonative` + the codesigned server
+  entitlement) or **linux/amd64**. The `just` recipes handle the tag/codesign.
+- For the VS Code driver: the **Go extension** (the repo already sets
+  `go.buildTags: bingonative` in `.vscode/settings.json`). The DAP driver uses
+  VS Code's `debugServer` mode to connect straight to bingo's DAP port — the Go
+  extension is only needed so VS Code recognises the `"type": "go"` config; it
+  does **not** launch its own debugger. If the extension gets in the way, use the
+  `cmd/dapcli` driver in step 3b instead — it proves the exact same coexistence.
+
+## 1. Build the server and the demo target
+
+```sh
+just build                        # server → ./build/bingo/bingo_<os>_<arch> (codesigned on darwin)
+go build -o build/spawntree ./examples/spawntree
+```
+
+`examples/spawntree` is a deterministic **main → supervisor → worker×3** spawn
+tree that churns a fresh worker pool each round, so consecutive snapshots show
+workers appearing in the `created` delta and leaving in `exited`. The intended
+breakpoint is the `fmt.Printf` inside `worker` (`examples/spawntree/main.go:27`).
+
+## 2. Start the server with DAP enabled
+
+```sh
+./build/bingo/bingo_darwin_arm64 -addr :6060 -dap-addr :4711 -v
+# linux: ./build/bingo/bingo_linux_amd64 -addr :6060 -dap-addr :4711 -v
+```
+
+- `:6060` — WebSocket + REST (`/ws`, `/api/sessions`). `cmd/wsmon` connects here.
+- `:4711` — DAP. VS Code / `cmd/dapcli` connect here.
+
+Leave it running.
+
+## 3a. Drive with VS Code (DAP)
+
+1. Open this repo in VS Code.
+2. Run the **“bingo DAP: launch spawntree (stop on entry)”** configuration
+   (`.vscode/launch.json`). VS Code connects to `:4711`, bingo launches
+   `build/spawntree`, and stops at entry.
+3. Set a breakpoint on `examples/spawntree/main.go:27` and **Continue** — the
+   tracee stops there with several worker goroutines alive.
+4. Grab the **session id** so the observer can join: it is printed on the server
+   console (`bingo session <id> ready …`) and in the bingo DAP `console` output,
+   and is listed by `curl -s localhost:6060/api/sessions`.
+
+> A second VS Code window can *join* the same session (observe/drive over DAP)
+> with the **“bingo DAP: join running session”** config, which sends a DAP
+> `attach` carrying only the `session` id (no `pid`) — bingo's join path.
+
+## 3b. Drive with cmd/dapcli (DAP, no IDE)
+
+Equivalent driver in a terminal — use this if VS Code isn't set up:
+
+```sh
+just dapcli            # or: go run -tags bingonative ./cmd/dapcli -addr localhost:4711
+# in the REPL:
+launch ./build/spawntree      # creates a session, stops on entry
+break examples/spawntree/main.go:27
+c                             # continue → hits the breakpoint
+```
+
+`dapcli` prints the session id it created (also on the server console). Continue
+again to churn rounds; each stop pushes a fresh telemetry snapshot to observers.
+
+## 4. Observe the telemetry with cmd/wsmon
+
+In another terminal, join the **same session id** read-only and watch it update:
+
+```sh
+go run ./cmd/wsmon -addr localhost:6060 -session <session-id>
+# one-shot (print a single snapshot and exit): add -once
+```
+
+`wsmon` redraws in place on every `EventGoroutineSnapshot`, showing:
+
+- the **goroutine spawn tree** built from `ParentID` (the `go` statement that
+  spawned each goroutine), with the current goroutine marked;
+- the **OS thread set** (runtime M's) and which goroutine each is running;
+- the **created / exited** goid deltas since the previous snapshot;
+- the **last stop event** (breakpoint / pause / step / exit) and session state.
+
+Each time you Continue in the driver and hit the breakpoint again, `wsmon`
+repaints with the new round's workers — the plumbing, end to end.
+
+## Notes
+
+- `wsmon` is a pure observer: it never sends run-control commands, so it cannot
+  disturb the DAP driver. Many `wsmon` + DAP clients can share one session.
+- Snapshots stream on **breakpoint / pause / entry**, not per single-step (steps
+  stay cheap). Use the driver's breakpoints/continue to advance between frames.
+- If the tracee is a stripped binary or stopped before runtime init, the snapshot
+  degrades to a single synthetic goroutine; `wsmon` renders whatever is present.

--- a/examples/spawntree/main.go
+++ b/examples/spawntree/main.go
@@ -1,0 +1,68 @@
+// Command spawntree is a concurrency demo target for bingo's telemetry stream.
+//
+// It builds a small, deterministic goroutine spawn tree — main → supervisor →
+// worker×N — that stays alive across breakpoint stops, so the goroutine/thread
+// snapshot stream has something meaningful to show: parent linkage (the go
+// statement that spawned each worker), created/exited lifecycle deltas as rounds
+// churn workers, and a live thread set.
+//
+// Set a breakpoint on the marked line inside worker and drive execution over DAP
+// (VS Code or cmd/dapcli) while watching the spawn tree update in cmd/wsmon.
+// See docs/ConcurrencyTelemetry.md for the end-to-end runbook.
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// worker consumes jobs until the channel closes. The Printf line is the intended
+// breakpoint site: several workers park there under one supervisor, which is what
+// makes the spawn tree and the current-goroutine marker interesting to observe.
+func worker(id int, jobs <-chan int, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for j := range jobs {
+		result := j * j
+		fmt.Printf("worker %d processed job %d -> %d\n", id, j, result) // <-- breakpoint here
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+// supervisor spawns a fresh pool of workers each round and feeds them jobs. Each
+// round's workers exit when the round's channel closes, so consecutive snapshots
+// show workers in the Exited delta and the next round's workers in Created.
+func supervisor(rounds, workers, jobsPerRound int) {
+	for r := 0; r < rounds; r++ {
+		var wg sync.WaitGroup
+		jobs := make(chan int)
+		for w := 0; w < workers; w++ {
+			wg.Add(1)
+			go worker(w, jobs, &wg)
+		}
+		for j := 0; j < jobsPerRound; j++ {
+			jobs <- j
+		}
+		close(jobs)
+		wg.Wait()
+		time.Sleep(300 * time.Millisecond)
+	}
+}
+
+func main() {
+	const (
+		rounds       = 8
+		workers      = 3
+		jobsPerRound = 6
+	)
+
+	var done sync.WaitGroup
+	done.Add(1)
+	go func() {
+		defer done.Done()
+		supervisor(rounds, workers, jobsPerRound)
+	}()
+	done.Wait()
+
+	fmt.Println("spawntree: done")
+}

--- a/justfile
+++ b/justfile
@@ -27,8 +27,24 @@ build OS=os_name ARCH=arch_name:
 run OS=os_name ARCH=arch_name *ARGS="":
 	./build/bingo/bingo_{{OS}}_{{ARCH}} {{ARGS}}
 
-# Builds then runs the bingo binary for the target OS and architecture (Must be valid `go build` targets).
-server OS=os_name ARCH=arch_name *ARGS="": build-target (build OS ARCH) (run OS ARCH ARGS)
+# Default WS (-addr) and DAP (-dap-addr) listen addresses for the server recipes.
+# Override on the CLI, e.g. `just server darwin arm64 :7070 :4712`.
+ws_addr := ":6060"
+dap_addr := ":4711"
+
+# Build then run the server with EVERYTHING enabled: both the WebSocket (-addr)
+# and DAP (-dap-addr) listeners, using the standard defaults so a DAP driver
+# (VS Code / `just dapcli`) and a `go run ./cmd/wsmon` observer can share one
+# session out of the box (see docs/ConcurrencyTelemetry.md). Override addresses
+# via the ADDR/DAP_ADDR positionals; extra flags (e.g. -v) pass through in ARGS.
+server OS=os_name ARCH=arch_name ADDR=ws_addr DAP_ADDR=dap_addr *ARGS="": build-target (build OS ARCH)
+	./build/bingo/bingo_{{OS}}_{{ARCH}} -addr {{ADDR}} -dap-addr {{DAP_ADDR}} {{ARGS}}
+
+# Build then run the server with ONLY the WebSocket (-addr) listener; DAP stays
+# disabled (the binary leaves -dap-addr empty). Override the address via ADDR;
+# extra flags (e.g. -v) pass through in ARGS.
+server-ws OS=os_name ARCH=arch_name ADDR=ws_addr *ARGS="": build-target (build OS ARCH)
+	./build/bingo/bingo_{{OS}}_{{ARCH}} -addr {{ADDR}} {{ARGS}}
 
 # Build the Target with maximum debugging information
 build-target:


### PR DESCRIPTION
## What & why

The goroutine/thread/lifecycle **data foundation** landed in `main` (PR #117). This PR builds the **plumbing that consumes it end-to-end** so any UI can work with the stream, and proves it A–Z: a **DAP driver** (VS Code) drives a session while a **terminal WS client** observes the live concurrency telemetry — exactly the two-protocol model the project targets.

No visualization polish — just clean plumbing.

## Changes

- **`cmd/wsmon`** — a read-only terminal WebSocket telemetry observer on `pkg/client`. It `-session`-joins a running session, subscribes to `Events()`, and live-renders (ANSI redraw-in-place):
  - the **goroutine spawn tree** built from `ParentID` (current goroutine marked),
  - the **OS thread set** (runtime M's) and what each runs,
  - the **created/exited lifecycle deltas** since the previous snapshot,
  - the last stop/lifecycle event + session state.

  Pure observer — it never sends run-control commands, so many `wsmon` + DAP clients can share one session without disturbing run state. Degrades gracefully to the synthetic single-goroutine fallback; guards against cycles / missing parents / empty input. Supports `-once` for scripting.
- **`examples/spawntree`** — a deterministic `main → supervisor → worker×N` demo target that churns worker pools each round, so consecutive snapshots exercise the created/exited deltas. Breakpoint site: `examples/spawntree/main.go:27`.
- **`.vscode/launch.json`** — VS Code DAP driver configs (`debugServer` → `:4711`) to launch the demo or join an existing session.
- **`docs/ConcurrencyTelemetry.md`** — the A–Z runbook wiring the server, a DAP driver (VS Code or `cmd/dapcli`), and the `wsmon` observer against one session.
- **`AGENTS.md`** — layout entries for `cmd/wsmon` + `examples/spawntree` and a reference pointer from the goroutine-snapshot section to `wsmon` and the runbook.

Scoped to clients/docs/example only — no changes to `server`/`hub`/`debugger`/`protocol`.

## Verification

- `go build -tags bingonative ./...`, `go vet -tags bingonative ./...` — clean.
- `GOOS=linux GOARCH=amd64 golangci-lint run ./...` — **0 issues** (CI parity).
- `go test -tags bingonative ./...` — all packages pass.
- **Live A–Z on darwin/arm64**: server (`-addr :6060 -dap-addr :4711`) → a DAP driver launched `build/spawntree`, set the breakpoint, and continued through rounds → `wsmon` joined read-only and rendered the spawn tree (`G1 runtime.main → main.main.func1 → worker×3`, current worker at `main.go:27` on its thread), the thread set, and the lifecycle deltas evolving live (`exited: [21]` → `created: [23 24 25] exited: [20 22]` → `created: [33 34 35] exited: [23 25]`).

## Notes

- Snapshots stream on breakpoint/pause/entry (not per-step), matching the foundation's cadence.
- No server/protocol changes → no darwin-native code touched, so the darwin verification gate is a no-op here. Linux e2e is exercised in CI.