### PR TITLE
feat(server): add managed lifecycle discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1040,6 +1040,46 @@ observers. `Server.StartDAP(addr)` opens the DAP TCP accept loop; `Shutdown`
 closes it. The DAP client emits a `console` output naming the session id;
 observers join `/ws?session=<id>` (also discoverable via `/api/sessions`).
 
+**Management discovery contract.** `GET /api/health` is the stable,
+non-cacheable process-discovery endpoint frontends use for connect-or-start. Its
+explicit JSON response carries `service:"bingo"`, `managementApiVersion:1`, the
+independent `wireProtocolVersion` from `pkg/protocol.Version`, a per-process
+UUID `instanceId`, the enabled/resolved DAP listener address, managed-idle
+configuration in milliseconds, and the current session count. Management API
+compatibility and WebSocket wire compatibility are separate checks: changing
+one does not implicitly version the other. A DAP bind to `:0` MUST publish the
+actual listener address, never the unresolved configured address. Health
+polling has no lifecycle effect.
+
+**Connect-or-start and ownership.** A frontend health-checks the known
+management address and reuses a compatible process; otherwise it starts bingo
+and lets listener binding arbitrate concurrent startup attempts. Frontends
+NEVER directly kill a potentially shared server. `-idle-timeout` is the opt-in
+process-owner mechanism; omitted/zero keeps manually started servers persistent.
+The server arms the grace at startup and whenever its managed-session count
+reaches zero, cancels it while any session exists, and shuts itself down only
+when the count stayed zero for the whole grace. A bare DAP TCP connection does
+not count: DAP creates a session only on launch/attach, so process owners must
+allow enough startup grace for health-check + connect + handshake.
+
+**Idle generation and shutdown invariants.** `sessionStore` broadcasts changes
+by closing and replacing a channel under its map mutex; snapshots return
+`count`, a monotonically increasing generation, and the current channel after
+releasing the lock. The generation prevents a create/remove burst from looking
+like uninterrupted zero-session time, and close-broadcast lets the idle monitor
+and shutdown waiter observe the same transition without stealing it from each
+other. Never block on the change channel while holding the store lock.
+
+The idle monitor starts only after HTTP binds, owns one reset/drain-safe timer,
+and exits on server cancellation. It may call `Shutdown` itself, so Shutdown
+must not wait for the monitor goroutine. Shutdown is idempotent: mark admission
+closed; close DAP and gracefully stop HTTP; wait for any WebSocket
+create/join operation that crossed the admission gate; cancel all hub contexts;
+then wait event-driven for the session store to empty. DAP Close already waits
+for its handlers, including clients that connected but never created a session.
+This ordering prevents a late client add from escaping registry teardown while
+still allowing every established session to close gracefully.
+
 **One-driver vs many-driver.** DAP assumes a single driver; bingo does not
 enforce it. WebSocket clients CAN also drive (the hub's `resumeCh` is
 first-writer-wins). The recommended posture is DAP-drives + WebSocket-observes,
@@ -1281,6 +1321,10 @@ through the justfile.
   event with `EvaluatePayloadCmd`/`EvaluatePayload`). 1.1 had reshaped
   `Goroutine` and added `Thread`/`GoroutineSnapshotPayload` +
   `EventGoroutineSnapshot`/`CmdGoroutineSnapshot`.
+- **Management API** (`internal/server`): `ManagementAPIVersion` is independent
+  of the wire protocol. Bump it for incompatible `/api/health` or management
+  semantics, keep the response structs/tags and README example aligned, and
+  preserve no-cache + GET-only behavior.
 - **Goroutine snapshot layout**: the reader resolves runtime struct offsets from
   DWARF **by name** (`goroutines.go`), never hardcoded. If you add a field, add
   it to `goLayout`/`resolveGoLayout`; a missing *required* offset invalidates the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1072,6 +1072,15 @@ like uninterrupted zero-session time, and close-broadcast lets the idle monitor
 and shutdown waiter observe the same transition without stealing it from each
 other. Never block on the change channel while holding the store lock.
 
+The server also increments an admission generation under `lifecycleMu` before
+every WS or DAP create/join operation. When an idle timer fires, it takes that
+same lock, rechecks both the store and admission generations, and marks
+`shutting` before releasing the lock. An operation admitted after the timer's
+snapshot therefore invalidates the expiry; an operation arriving after the
+commit is rejected. Do not hold `lifecycleMu` over hub/client work: the
+generation increment + WaitGroup admission happen under the lock, while the
+operation runs after release.
+
 The idle monitor starts only after HTTP binds, owns one reset/drain-safe timer,
 and exits on server cancellation. It may call `Shutdown` itself, so Shutdown
 must not wait for the monitor goroutine. Shutdown is idempotent: mark admission
@@ -1093,11 +1102,16 @@ final client triggers one-shot hub teardown. Do not hold the registry lock
 across socket writes.
 
 `http.Server.Shutdown` closes the listener before session draining completes,
-so `Server.Start` can return while `Server.Shutdown` is still working. The
-`cmd/bingo` main goroutine MUST wait on `Server.Done()` after a clean Start
-return; otherwise a signal- or idle-triggered shutdown can be preempted by
-process exit before hijacked WebSockets, hubs, and debuggees are cleaned up.
-Start errors return directly and do not wait for Done.
+and Start can also be delayed in listener setup. `cmd/bingo` therefore runs
+Start in a goroutine with a one-result buffered channel and selects it against
+`Server.Done()`: Start errors return immediately, a clean Start return waits for
+Done, and completed shutdown can win while Start is still unwinding without
+parking its eventual result send. The HTTP bind uses `net.ListenConfig` with the
+server context so cancellation reaches listener setup. Fatal bind/Serve errors
+must run the same one-time Shutdown before Start returns the original error;
+this closes a DAP listener that may have started first and guarantees Done.
+Concurrent duplicate Start calls return `ErrServerStarted` without tearing down
+the first caller.
 
 **One-driver vs many-driver.** DAP assumes a single driver; bingo does not
 enforce it. WebSocket clients CAN also drive (the hub's `resumeCh` is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1064,7 +1064,7 @@ when the count stayed zero for the whole grace. A bare DAP TCP connection does
 not count: DAP creates a session only on launch/attach, so process owners must
 allow enough startup grace for health-check + connect + handshake.
 
-**Idle generation and shutdown invariants.** `sessionStore` broadcasts changes
+**Idle admission and shutdown invariants.** `sessionStore` broadcasts changes
 by closing and replacing a channel under its map mutex; snapshots return
 `count`, a monotonically increasing generation, and the current channel after
 releasing the lock. The generation prevents a create/remove burst from looking
@@ -1072,24 +1072,38 @@ like uninterrupted zero-session time, and close-broadcast lets the idle monitor
 and shutdown waiter observe the same transition without stealing it from each
 other. Never block on the change channel while holding the store lock.
 
-The server also increments an admission generation under `lifecycleMu` before
-every WS or DAP create/join operation. When an idle timer fires, it takes that
-same lock, rechecks both the store and admission generations, and marks
-`shutting` before releasing the lock. An operation admitted after the timer's
-snapshot therefore invalidates the expiry; an operation arriving after the
-commit is rejected. Do not hold `lifecycleMu` over hub/client work: the
-generation increment + WaitGroup admission happen under the lock, while the
-operation runs after release.
+Every WS and DAP create/join increments `activeAdmissions` under `lifecycleMu`
+before doing store, hub, or socket work; its deferred completion decrements the
+count and close-broadcasts `admissionChanged`. Timer expiry takes the same lock
+and may mark `shutting` only when the armed zero-session generation is still
+current, the fresh store count is zero, and no admission is active. Lock order
+is lifecycle then a store read snapshot; neither lock is held across hub or
+socket I/O.
+
+An admission already active when the deadline expires gets to finish, but the
+expired gate rejects further operations so repeated failed joins cannot keep
+the process alive. The original deadline is not reset while that operation is
+in flight: success produces a live session and disarms shutdown; failure with
+the same zero-session generation commits shutdown immediately on completion.
+If the store generation changed because a session became active and later
+returned to zero, the monitor starts a fresh full grace period.
 
 The idle monitor starts only after HTTP binds, owns one reset/drain-safe timer,
 and exits on server cancellation. It may call `Shutdown` itself, so Shutdown
 must not wait for the monitor goroutine. Shutdown is idempotent: mark admission
-closed; close DAP and gracefully stop HTTP; wait for any WebSocket
-create/join operation that crossed the admission gate; cancel all hub contexts;
-then wait event-driven for the session store to empty. DAP Close already waits
-for its handlers, including clients that connected but never created a session.
-This ordering prevents a late client add from escaping registry teardown while
-still allowing every established session to close gracefully.
+closed and cancel the server context; join any in-flight DAP listener startup;
+close DAP and gracefully stop HTTP; wait for every admitted WS/DAP create/join;
+then wait event-driven for the canceled session store to empty. DAP Close
+already waits for its handlers, including clients that connected but never
+created a session. This ordering prevents a late client add from escaping
+registry teardown while still allowing every established session to close.
+
+`StartDAP` reserves its at-most-once start under `lifecycleMu`, releases the
+lock before context-aware listener binding, and publishes the server/address
+only if shutdown has not won. Shutdown cancellation unblocks the bind and waits
+for that start attempt before closing Done, so no DAP listener can appear after
+finalization. A genuine bind failure remains retryable only while the server is
+not shutting down.
 
 Hub admission has a second, session-local gate: `registry.add`, `remove`, and
 `closeAll` serialize on the registry mutex. Removing the final client marks the
@@ -1105,13 +1119,13 @@ across socket writes.
 and Start can also be delayed in listener setup. `cmd/bingo` therefore runs
 Start in a goroutine with a one-result buffered channel and selects it against
 `Server.Done()`: Start errors return immediately, a clean Start return waits for
-Done, and completed shutdown can win while Start is still unwinding without
-parking its eventual result send. The HTTP bind uses `net.ListenConfig` with the
-server context so cancellation reaches listener setup. Fatal bind/Serve errors
-must run the same one-time Shutdown before Start returns the original error;
-this closes a DAP listener that may have started first and guarantees Done.
-Concurrent duplicate Start calls return `ErrServerStarted` without tearing down
-the first caller.
+Done, and a Done-first result still waits for Start to unwind and consumes its
+result. The HTTP bind uses `net.ListenConfig` with the server context so
+Shutdown always unblocks listener setup; lifecycle-owned cancellation is clean,
+while genuine bind/Serve errors run the same one-time Shutdown and remain the
+Start result. This closes a DAP listener that may have started first and
+guarantees Done. Concurrent duplicate Start calls return `ErrServerStarted`
+without tearing down the first caller.
 
 **One-driver vs many-driver.** DAP assumes a single driver; bingo does not
 enforce it. WebSocket clients CAN also drive (the hub's `resumeCh` is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1049,7 +1049,9 @@ configuration in milliseconds, and the current session count. Management API
 compatibility and WebSocket wire compatibility are separate checks: changing
 one does not implicitly version the other. A DAP bind to `:0` MUST publish the
 actual listener address, never the unresolved configured address. Health
-polling has no lifecycle effect.
+polling has no lifecycle effect. Positive idle durations below `1ms` or with a
+fractional millisecond are rejected so the timer and integer `timeoutMs` field
+always describe the exact same interval.
 
 **Connect-or-start and ownership.** A frontend health-checks the known
 management address and reuses a compatible process; otherwise it starts bingo
@@ -1079,6 +1081,23 @@ then wait event-driven for the session store to empty. DAP Close already waits
 for its handlers, including clients that connected but never created a session.
 This ordering prevents a late client add from escaping registry teardown while
 still allowing every established session to close gracefully.
+
+Hub admission has a second, session-local gate: `registry.add`, `remove`, and
+`closeAll` serialize on the registry mutex. Removing the final client marks the
+registry closed in the same critical section, before `removeClient` schedules
+hub shutdown; closeAll also marks it closed before removing clients.
+`Hub.AddClient` returns `ErrHubClosed` and closes the supplied connection when
+admission is closed. WebSocket and DAP callers must propagate/handle that error.
+This is what closes the race where a join resolves a session just before its
+final client triggers one-shot hub teardown. Do not hold the registry lock
+across socket writes.
+
+`http.Server.Shutdown` closes the listener before session draining completes,
+so `Server.Start` can return while `Server.Shutdown` is still working. The
+`cmd/bingo` main goroutine MUST wait on `Server.Done()` after a clean Start
+return; otherwise a signal- or idle-triggered shutdown can be preempted by
+process exit before hijacked WebSockets, hubs, and debuggees are cleaned up.
+Start errors return directly and do not wait for Done.
 
 **One-driver vs many-driver.** DAP assumes a single driver; bingo does not
 enforce it. WebSocket clients CAN also drive (the hub's `resumeCh` is

--- a/README.md
+++ b/README.md
@@ -51,6 +51,57 @@ bingo -addr :6060 -dap-addr :4711
 `just server` starts both listeners with the defaults above; use `just server-ws`
 for a WebSocket-only run (DAP disabled).
 
+### Server discovery and managed lifetime
+
+Frontends can identify and reuse a compatible bingo process through
+`GET /api/health` on the management/WebSocket listener:
+
+```json
+{
+  "service": "bingo",
+  "managementApiVersion": 1,
+  "wireProtocolVersion": "1.2",
+  "instanceId": "4dd4dfdd-7f55-41a5-bd95-c086ce6f3c2a",
+  "dap": {
+    "enabled": true,
+    "address": "0.0.0.0:4711"
+  },
+  "managedIdleShutdown": {
+    "enabled": false,
+    "timeoutMs": 0
+  },
+  "sessionCount": 0
+}
+```
+
+The response is non-cacheable. `managementApiVersion` versions this HTTP
+contract independently of `wireProtocolVersion`; integrations should require
+management API v1 and separately check that they support the advertised bingo
+wire version. `instanceId` changes on every process start. The DAP address is the
+actual bound listener address, including the selected port when bingo was
+started with `-dap-addr ...:0`.
+
+The intended process-owner flow is **connect or start**: health-check the known
+management address, reuse a compatible bingo if present, otherwise start one
+and let listener binding arbitrate concurrent startup attempts. Frontends do not
+kill a shared bingo process directly.
+
+Manual servers remain persistent by default. Process-managing integrations may
+opt into server-owned idle shutdown:
+
+```sh
+bingo -addr 127.0.0.1:6060 -dap-addr 127.0.0.1:4711 -idle-timeout 30s
+# equivalent development recipe:
+just server darwin arm64 :6060 :4711 -idle-timeout 30s
+```
+
+The timeout is armed at startup and whenever the last managed session
+disconnects. Any active session suppresses it, and a new session resets the full
+grace period. Health polling and a DAP connection that has not yet created or
+joined a session do not keep the process alive, so a process owner must allow
+enough grace for its health check and DAP handshake. A zero or omitted timeout
+disables idle shutdown.
+
 ### VS Code companion extension
 
 Build and install the repository's companion extension:
@@ -65,7 +116,9 @@ directly to `127.0.0.1:4711`. Keep Microsoft's Go extension installed for
 debug configuration does **not** invoke or validate Delve (`dlv`) or take over
 the Go extension's `"go"` debugger type. See
 [editors/vscode/README.md](editors/vscode/README.md) for launch, session-join,
-PID-attach, update, and uninstall instructions.
+PID-attach, update, and uninstall instructions. The current extension still
+connects to an already-running server; it does not yet consume the lifecycle
+contract above to start or own a process.
 
 After installing, run `just server`, select the `"type": "bingo"` spawntree
 configuration from `.vscode/launch.json`, and press F5. Its pre-launch task runs

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ disconnects. Any active session suppresses it, and a new session resets the full
 grace period. Health polling and a DAP connection that has not yet created or
 joined a session do not keep the process alive, so a process owner must allow
 enough grace for its health check and DAP handshake. A zero or omitted timeout
-disables idle shutdown.
+disables idle shutdown. Positive values must be at least `1ms` and use whole
+milliseconds so the enforced duration exactly matches `timeoutMs`.
 
 ### VS Code companion extension
 

--- a/cmd/bingo/main.go
+++ b/cmd/bingo/main.go
@@ -1,10 +1,13 @@
 // Command bingo starts the bingo debug server.
 //
-//	bingo [-addr host:port] [-dap-addr host:port] [-v]
+//	bingo [-addr host:port] [-dap-addr host:port] [-idle-timeout duration] [-v]
 package main
 
 import (
+	"errors"
 	"flag"
+	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -14,24 +17,39 @@ import (
 	"github.com/bingosuite/bingo/internal/server"
 )
 
+type config struct {
+	addr        string
+	dapAddr     string
+	idleTimeout time.Duration
+	verbose     bool
+}
+
 func main() {
-	addr := flag.String("addr", ":6060", "listen address (host:port)")
-	dapAddr := flag.String("dap-addr", "", "DAP listen address (host:port); empty disables the DAP server")
-	verbose := flag.Bool("v", false, "enable verbose (debug) logging")
-	flag.Parse()
+	cfg, err := parseConfig(os.Args[1:], os.Stderr)
+	if errors.Is(err, flag.ErrHelp) {
+		return
+	}
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, "bingo:", err)
+		os.Exit(2)
+	}
 
 	level := slog.LevelInfo
-	if *verbose {
+	if cfg.verbose {
 		level = slog.LevelDebug
 	}
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		Level: level,
 	}))
 
-	srv := server.New(*addr, log)
+	srv, err := server.NewWithIdleTimeout(cfg.addr, cfg.idleTimeout, log)
+	if err != nil {
+		log.Error("invalid server configuration", "err", err)
+		os.Exit(2)
+	}
 
-	if *dapAddr != "" {
-		if err := srv.StartDAP(*dapAddr); err != nil {
+	if cfg.dapAddr != "" {
+		if err := srv.StartDAP(cfg.dapAddr); err != nil {
 			log.Error("dap server error", "err", err)
 			os.Exit(1)
 		}
@@ -50,4 +68,21 @@ func main() {
 		log.Error("server error", "err", err)
 		os.Exit(1)
 	}
+}
+
+func parseConfig(args []string, output io.Writer) (config, error) {
+	var cfg config
+	flags := flag.NewFlagSet("bingo", flag.ContinueOnError)
+	flags.SetOutput(output)
+	flags.StringVar(&cfg.addr, "addr", ":6060", "listen address (host:port)")
+	flags.StringVar(&cfg.dapAddr, "dap-addr", "", "DAP listen address (host:port); empty disables the DAP server")
+	flags.DurationVar(&cfg.idleTimeout, "idle-timeout", 0, "exit after no managed sessions for this duration; 0 disables")
+	flags.BoolVar(&cfg.verbose, "v", false, "enable verbose (debug) logging")
+	if err := flags.Parse(args); err != nil {
+		return config{}, err
+	}
+	if cfg.idleTimeout < 0 {
+		return config{}, fmt.Errorf("idle timeout must not be negative: %s", cfg.idleTimeout)
+	}
+	return cfg, nil
 }

--- a/cmd/bingo/main.go
+++ b/cmd/bingo/main.go
@@ -89,12 +89,7 @@ func runServer(srv serverRunner) error {
 		<-srv.Done()
 		return nil
 	case <-srv.Done():
-		select {
-		case err := <-startResult:
-			return err
-		default:
-			return nil
-		}
+		return <-startResult
 	}
 }
 

--- a/cmd/bingo/main.go
+++ b/cmd/bingo/main.go
@@ -76,11 +76,26 @@ type serverRunner interface {
 }
 
 func runServer(srv serverRunner) error {
-	if err := srv.Start(); err != nil {
-		return err
+	startResult := make(chan error, 1)
+	go func() {
+		startResult <- srv.Start()
+	}()
+
+	select {
+	case err := <-startResult:
+		if err != nil {
+			return err
+		}
+		<-srv.Done()
+		return nil
+	case <-srv.Done():
+		select {
+		case err := <-startResult:
+			return err
+		default:
+			return nil
+		}
 	}
-	<-srv.Done()
-	return nil
 }
 
 func parseConfig(args []string, output io.Writer) (config, error) {

--- a/cmd/bingo/main.go
+++ b/cmd/bingo/main.go
@@ -64,10 +64,23 @@ func main() {
 		srv.Shutdown(10 * time.Second)
 	}()
 
-	if err := srv.Start(); err != nil {
+	if err := runServer(srv); err != nil {
 		log.Error("server error", "err", err)
 		os.Exit(1)
 	}
+}
+
+type serverRunner interface {
+	Start() error
+	Done() <-chan struct{}
+}
+
+func runServer(srv serverRunner) error {
+	if err := srv.Start(); err != nil {
+		return err
+	}
+	<-srv.Done()
+	return nil
 }
 
 func parseConfig(args []string, output io.Writer) (config, error) {
@@ -81,8 +94,8 @@ func parseConfig(args []string, output io.Writer) (config, error) {
 	if err := flags.Parse(args); err != nil {
 		return config{}, err
 	}
-	if cfg.idleTimeout < 0 {
-		return config{}, fmt.Errorf("idle timeout must not be negative: %s", cfg.idleTimeout)
+	if err := server.ValidateIdleTimeout(cfg.idleTimeout); err != nil {
+		return config{}, err
 	}
 	return cfg, nil
 }

--- a/cmd/bingo/main_test.go
+++ b/cmd/bingo/main_test.go
@@ -113,7 +113,7 @@ func TestRunServerWaitsForShutdownCompletion(t *testing.T) {
 	}
 }
 
-func TestRunServerReturnsWhenDoneWinsBlockedStart(t *testing.T) {
+func TestRunServerWaitsForBlockedStartAfterDone(t *testing.T) {
 	runner := &fakeServerRunner{
 		start:       make(chan struct{}),
 		startExited: make(chan struct{}),
@@ -127,18 +127,23 @@ func TestRunServerReturnsWhenDoneWinsBlockedStart(t *testing.T) {
 	close(runner.done)
 	select {
 	case err := <-result:
-		if err != nil {
-			t.Fatalf("runServer: %v", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("Done did not unblock runServer while Start was blocked")
+		t.Fatalf("runServer abandoned blocked Start after Done: %v", err)
+	case <-time.After(50 * time.Millisecond):
 	}
 
 	close(runner.start)
 	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("runServer: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("runServer did not consume Start after Done")
+	}
+	select {
 	case <-runner.startExited:
 	case <-time.After(time.Second):
-		t.Fatal("buffered Start result left the Start goroutine blocked")
+		t.Fatal("Start goroutine did not exit")
 	}
 }
 

--- a/cmd/bingo/main_test.go
+++ b/cmd/bingo/main_test.go
@@ -1,11 +1,27 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"io"
 	"testing"
 	"time"
 )
+
+type fakeServerRunner struct {
+	start chan struct{}
+	done  chan struct{}
+	err   error
+}
+
+func (f *fakeServerRunner) Start() error {
+	<-f.start
+	return f.err
+}
+
+func (f *fakeServerRunner) Done() <-chan struct{} {
+	return f.done
+}
 
 func TestParseConfigDefaultsToPersistentServer(t *testing.T) {
 	cfg, err := parseConfig(nil, io.Discard)
@@ -41,6 +57,15 @@ func TestParseConfigRejectsNegativeIdleTimeout(t *testing.T) {
 	}
 }
 
+func TestParseConfigRejectsSubMillisecondIdleTimeout(t *testing.T) {
+	if _, err := parseConfig([]string{"-idle-timeout", "1ns"}, io.Discard); err == nil {
+		t.Fatal("expected sub-millisecond idle timeout error")
+	}
+	if _, err := parseConfig([]string{"-idle-timeout", "1500us"}, io.Discard); err == nil {
+		t.Fatal("expected fractional-millisecond idle timeout error")
+	}
+}
+
 func TestParseConfigRejectsInvalidDuration(t *testing.T) {
 	if _, err := parseConfig([]string{"-idle-timeout", "later"}, io.Discard); err == nil {
 		t.Fatal("expected invalid duration error")
@@ -50,5 +75,47 @@ func TestParseConfigRejectsInvalidDuration(t *testing.T) {
 func TestParseConfigHelp(t *testing.T) {
 	if _, err := parseConfig([]string{"-h"}, io.Discard); err != flag.ErrHelp {
 		t.Fatalf("expected flag.ErrHelp, got %v", err)
+	}
+}
+
+func TestRunServerWaitsForShutdownCompletion(t *testing.T) {
+	runner := &fakeServerRunner{
+		start: make(chan struct{}),
+		done:  make(chan struct{}),
+	}
+	result := make(chan error, 1)
+	go func() {
+		result <- runServer(runner)
+	}()
+
+	close(runner.start)
+	select {
+	case err := <-result:
+		t.Fatalf("runServer returned before shutdown completed: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(runner.done)
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("runServer: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("runServer did not return after shutdown completed")
+	}
+}
+
+func TestRunServerReturnsStartError(t *testing.T) {
+	startErr := errors.New("bind failed")
+	runner := &fakeServerRunner{
+		start: make(chan struct{}),
+		done:  make(chan struct{}),
+		err:   startErr,
+	}
+	close(runner.start)
+
+	if err := runServer(runner); !errors.Is(err, startErr) {
+		t.Fatalf("expected start error, got %v", err)
 	}
 }

--- a/cmd/bingo/main_test.go
+++ b/cmd/bingo/main_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"testing"
+	"time"
+)
+
+func TestParseConfigDefaultsToPersistentServer(t *testing.T) {
+	cfg, err := parseConfig(nil, io.Discard)
+	if err != nil {
+		t.Fatalf("parse defaults: %v", err)
+	}
+	if cfg.addr != ":6060" || cfg.dapAddr != "" || cfg.idleTimeout != 0 || cfg.verbose {
+		t.Fatalf("unexpected defaults: %+v", cfg)
+	}
+}
+
+func TestParseConfigIdleTimeout(t *testing.T) {
+	cfg, err := parseConfig([]string{
+		"-addr", "127.0.0.1:16060",
+		"-dap-addr", "127.0.0.1:14711",
+		"-idle-timeout", "30s",
+		"-v",
+	}, io.Discard)
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if cfg.addr != "127.0.0.1:16060" ||
+		cfg.dapAddr != "127.0.0.1:14711" ||
+		cfg.idleTimeout != 30*time.Second ||
+		!cfg.verbose {
+		t.Fatalf("unexpected config: %+v", cfg)
+	}
+}
+
+func TestParseConfigRejectsNegativeIdleTimeout(t *testing.T) {
+	if _, err := parseConfig([]string{"-idle-timeout", "-1s"}, io.Discard); err == nil {
+		t.Fatal("expected negative idle timeout error")
+	}
+}
+
+func TestParseConfigRejectsInvalidDuration(t *testing.T) {
+	if _, err := parseConfig([]string{"-idle-timeout", "later"}, io.Discard); err == nil {
+		t.Fatal("expected invalid duration error")
+	}
+}
+
+func TestParseConfigHelp(t *testing.T) {
+	if _, err := parseConfig([]string{"-h"}, io.Discard); err != flag.ErrHelp {
+		t.Fatalf("expected flag.ErrHelp, got %v", err)
+	}
+}

--- a/cmd/bingo/main_test.go
+++ b/cmd/bingo/main_test.go
@@ -4,17 +4,24 @@ import (
 	"errors"
 	"flag"
 	"io"
+	"net"
 	"testing"
 	"time"
+
+	"github.com/bingosuite/bingo/internal/server"
 )
 
 type fakeServerRunner struct {
-	start chan struct{}
-	done  chan struct{}
-	err   error
+	start       chan struct{}
+	startExited chan struct{}
+	done        chan struct{}
+	err         error
 }
 
 func (f *fakeServerRunner) Start() error {
+	if f.startExited != nil {
+		defer close(f.startExited)
+	}
 	<-f.start
 	return f.err
 }
@@ -106,6 +113,35 @@ func TestRunServerWaitsForShutdownCompletion(t *testing.T) {
 	}
 }
 
+func TestRunServerReturnsWhenDoneWinsBlockedStart(t *testing.T) {
+	runner := &fakeServerRunner{
+		start:       make(chan struct{}),
+		startExited: make(chan struct{}),
+		done:        make(chan struct{}),
+	}
+	result := make(chan error, 1)
+	go func() {
+		result <- runServer(runner)
+	}()
+
+	close(runner.done)
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("runServer: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Done did not unblock runServer while Start was blocked")
+	}
+
+	close(runner.start)
+	select {
+	case <-runner.startExited:
+	case <-time.After(time.Second):
+		t.Fatal("buffered Start result left the Start goroutine blocked")
+	}
+}
+
 func TestRunServerReturnsStartError(t *testing.T) {
 	startErr := errors.New("bind failed")
 	runner := &fakeServerRunner{
@@ -117,5 +153,28 @@ func TestRunServerReturnsStartError(t *testing.T) {
 
 	if err := runServer(runner); !errors.Is(err, startErr) {
 		t.Fatalf("expected start error, got %v", err)
+	}
+}
+
+func TestRunServerReturnsFinalizedBindError(t *testing.T) {
+	occupied, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = occupied.Close() }()
+
+	srv := server.New(occupied.Addr().String(), nil)
+	err = runServer(srv)
+	if err == nil {
+		t.Fatal("expected bind error")
+	}
+	var netErr *net.OpError
+	if !errors.As(err, &netErr) || netErr.Op != "listen" {
+		t.Fatalf("expected listen error, got %v", err)
+	}
+	select {
+	case <-srv.Done():
+	default:
+		t.Fatal("bind error returned before lifecycle finalization")
 	}
 }

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -3,6 +3,7 @@ package dap
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net"
 	"sync"
@@ -65,15 +66,20 @@ type fakeSession struct {
 	id      string
 	cmds    *cmdRecorder
 	welcome protocol.SessionState
+	addErr  error
 }
 
 func (s *fakeSession) SessionID() string { return s.id }
 
 // AddClient mirrors the hub: it optionally delivers a welcome EventSessionState
 // (as the real hub's sendStateTo does) and starts a read pump draining the
-// handler's enqueued commands. Returns nil — the handler never calls methods on
-// the *hub.Client it stores.
-func (s *fakeSession) AddClient(conn hub.WSConn, _ *slog.Logger) *hub.Client {
+// handler's enqueued commands. The handler never calls methods on the
+// *hub.Client it stores.
+func (s *fakeSession) AddClient(conn hub.WSConn, _ *slog.Logger) (*hub.Client, error) {
+	if s.addErr != nil {
+		_ = conn.Close()
+		return nil, s.addErr
+	}
 	if s.welcome != "" {
 		// Deliver the welcome asynchronously, mirroring the hub's write pump so
 		// it lands after AddClient returns (the join path sets its flags before
@@ -96,13 +102,36 @@ func (s *fakeSession) AddClient(conn hub.WSConn, _ *slog.Logger) *hub.Client {
 			s.cmds.add(data)
 		}
 	}()
-	return nil
+	return nil, nil
 }
 
 type fakeProvider struct{ sess *fakeSession }
 
 func (p *fakeProvider) CreateSession() (Session, error)   { return p.sess, nil }
 func (p *fakeProvider) GetSession(string) (Session, bool) { return p.sess, true }
+
+func TestStartSessionRejectsClosedHub(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer func() { _ = clientConn.Close() }()
+
+	session := &fakeSession{
+		id:     "closed-session",
+		cmds:   &cmdRecorder{},
+		addErr: hub.ErrHubClosed,
+	}
+	handler := NewHandler(serverConn, &fakeProvider{sess: session}, nil)
+	defer func() { _ = handler.Close() }()
+
+	err := handler.startSession("")
+	if !errors.Is(err, hub.ErrHubClosed) {
+		t.Fatalf("expected ErrHubClosed, got %v", err)
+	}
+	handler.mu.Lock()
+	defer handler.mu.Unlock()
+	if handler.session != nil || handler.client != nil {
+		t.Fatal("rejected session was retained by DAP handler")
+	}
+}
 
 // harness wires a Handler to a loopback TCP socket so the test can speak real
 // DAP wire messages to it and inject bingo events via WriteMessage.

--- a/internal/dap/provider.go
+++ b/internal/dap/provider.go
@@ -15,7 +15,7 @@ type Session interface {
 	// AddClient registers a hub client (here, the DAP handler as a WSConn) so it
 	// receives the session's event stream and can inject commands. Must be called
 	// before the Launch/Attach command is enqueued so the entry stop is delivered.
-	AddClient(conn hub.WSConn, log *slog.Logger) *hub.Client
+	AddClient(conn hub.WSConn, log *slog.Logger) (*hub.Client, error)
 }
 
 // Provider creates and looks up managed sessions. internal/server implements it

--- a/internal/dap/requests.go
+++ b/internal/dap/requests.go
@@ -227,7 +227,10 @@ func (h *Handler) startSession(existingID string) error {
 		sess = s
 	}
 
-	client := sess.AddClient(h, h.log)
+	client, err := sess.AddClient(h, h.log)
+	if err != nil {
+		return fmt.Errorf("add client: %w", err)
+	}
 
 	h.mu.Lock()
 	h.session = sess

--- a/internal/dap/server.go
+++ b/internal/dap/server.go
@@ -1,6 +1,7 @@
 package dap
 
 import (
+	"context"
 	"log/slog"
 	"net"
 	"sync"
@@ -35,18 +36,37 @@ func NewServer(provider Provider, log *slog.Logger) *Server {
 // the bound address so callers can log it or, in tests, dial an ephemeral port.
 // The accept loop runs in the background; Serve returns once listening.
 func (s *Server) Serve(addr string) (net.Addr, error) {
+	return s.ServeContext(context.Background(), addr)
+}
+
+// ServeContext is Serve with cancellation support for listener setup.
+func (s *Server) ServeContext(ctx context.Context, addr string) (net.Addr, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	// tcp4 to match the rest of bingo's local-only listeners and keep the
 	// address predictable for IDE launch configs.
-	ln, err := net.Listen("tcp4", addr)
+	var listenConfig net.ListenConfig
+	ln, err := listenConfig.Listen(ctx, "tcp4", addr)
 	if err != nil {
 		return nil, err
 	}
 
 	s.mu.Lock()
+	if err := ctx.Err(); err != nil {
+		s.mu.Unlock()
+		_ = ln.Close()
+		return nil, err
+	}
+	if s.closed {
+		s.mu.Unlock()
+		_ = ln.Close()
+		return nil, net.ErrClosed
+	}
 	s.listener = ln
+	s.wg.Add(1)
 	s.mu.Unlock()
 
-	s.wg.Add(1)
 	go s.acceptLoop(ln)
 
 	s.log.Info("dap server listening", "addr", ln.Addr().String())

--- a/internal/dap/server_test.go
+++ b/internal/dap/server_test.go
@@ -2,6 +2,7 @@ package dap
 
 import (
 	"bufio"
+	"context"
 	"log/slog"
 	"net"
 	"testing"
@@ -86,5 +87,18 @@ func TestServerCloseAfterInitialize(t *testing.T) {
 	case <-done:
 	case <-time.After(3 * time.Second):
 		t.Fatal("Server.Close hung after initialize with no session")
+	}
+}
+
+func TestServeContextRejectsCanceledStartup(t *testing.T) {
+	s := quietServer(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := s.ServeContext(ctx, "127.0.0.1:0"); err == nil {
+		t.Fatal("ServeContext succeeded after cancellation")
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
 	}
 }

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -5,6 +5,7 @@ package hub
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -15,6 +16,8 @@ import (
 	"github.com/bingosuite/bingo/internal/debugger"
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
+
+var ErrHubClosed = errors.New("hub is shutting down")
 
 // suspendingEvents pause the hub and require a resuming command before the
 // process is allowed to continue. EventPaused is included: a Pause request
@@ -207,10 +210,15 @@ func (h *Hub) setDbg(d debugger.Debugger) {
 	h.dbgMu.Unlock()
 }
 
-// AddClient registers conn as a new client. Safe from any goroutine.
-func (h *Hub) AddClient(conn WSConn, log *slog.Logger) *Client {
+// AddClient registers conn as a new client. Safe from any goroutine. Admission
+// closes atomically with registry teardown so a late join cannot enter a dead
+// hub after its one-shot shutdown has completed.
+func (h *Hub) AddClient(conn WSConn, log *slog.Logger) (*Client, error) {
 	c := newClient(conn, h, log)
-	h.registry.add(c)
+	if !h.registry.add(c) {
+		_ = conn.Close()
+		return nil, ErrHubClosed
+	}
 	go c.writePump()
 	go c.readPump()
 	h.log.Info("client connected", "total", h.registry.count())
@@ -219,16 +227,15 @@ func (h *Hub) AddClient(conn WSConn, log *slog.Logger) *Client {
 		h.sendStateTo(c)
 	}
 
-	return c
+	return c, nil
 }
 
 func (h *Hub) removeClient(c *Client) {
-	removed := h.registry.remove(c)
+	removed, remaining := h.registry.remove(c)
 	c.closeSend()
 	if !removed {
 		return
 	}
-	remaining := h.registry.count()
 	h.log.Info("client disconnected", "remaining", remaining)
 	if remaining == 0 {
 		h.log.Info("last client disconnected — shutting down")

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -268,6 +268,22 @@ var _ = Describe("Hub", func() {
 				Eventually(managed.Done(), "500ms", "10ms").Should(BeClosed())
 			}
 		})
+
+		It("rejects and closes a client after teardown begins", func() {
+			cancel()
+			Eventually(h.Done(), "500ms", "10ms").Should(BeClosed())
+
+			conn := newFakeWSConn()
+			client, err := h.AddClient(conn, nil)
+
+			Expect(err).To(MatchError(hub.ErrHubClosed))
+			Expect(client).To(BeNil())
+			Expect(h.ClientCount()).To(Equal(0))
+			conn.mu.Lock()
+			closed := conn.closed
+			conn.mu.Unlock()
+			Expect(closed).To(BeTrue())
+		})
 	})
 
 	Describe("managed session start failures", func() {

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -126,6 +126,11 @@ func newFakeWSConn() *fakeWSConn {
 	}
 }
 
+func mustAddClient(h *hub.Hub, conn *fakeWSConn) {
+	_, err := h.AddClient(conn, nil)
+	Expect(err).NotTo(HaveOccurred())
+}
+
 func (f *fakeWSConn) recv() ([]byte, bool) {
 	select {
 	case msg := <-f.incoming:
@@ -243,8 +248,10 @@ var _ = Describe("Hub", func() {
 		It("accepts multiple concurrent clients without panicking", func() {
 			conn1 := newFakeWSConn()
 			conn2 := newFakeWSConn()
-			h.AddClient(conn1, nil)
-			h.AddClient(conn2, nil)
+			_, err := h.AddClient(conn1, nil)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = h.AddClient(conn2, nil)
+			Expect(err).NotTo(HaveOccurred())
 			closeFakeWS(conn1)
 			closeFakeWS(conn2)
 		})
@@ -258,7 +265,8 @@ var _ = Describe("Hub", func() {
 
 				go func() {
 					defer GinkgoRecover()
-					managed.AddClient(conn, nil)
+					_, err := managed.AddClient(conn, nil)
+					Expect(err).To(Or(BeNil(), MatchError(hub.ErrHubClosed)))
 					close(done)
 				}()
 				cancelManaged()
@@ -293,7 +301,8 @@ var _ = Describe("Hub", func() {
 			defer cancelManaged()
 
 			conn := newFakeWSConn()
-			managed.AddClient(conn, nil)
+			_, err := managed.AddClient(conn, nil)
+			Expect(err).NotTo(HaveOccurred())
 			_, _ = recvEvent(conn)
 
 			fd.launchErr = errors.New("launch failed")
@@ -321,7 +330,8 @@ var _ = Describe("Hub", func() {
 	Describe("event sequence numbers", func() {
 		It("assigns strictly increasing hub-managed seq to all outbound events", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			_, err := h.AddClient(conn, nil)
+			Expect(err).NotTo(HaveOccurred())
 
 			// Engine-level seq values 99 and 100 must both be rewritten.
 			evt1, _ := protocol.NewEvent(protocol.EventOutput, 99,
@@ -342,7 +352,8 @@ var _ = Describe("Hub", func() {
 
 		It("interleaves debugger events and confirmation events in a single seq stream", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			_, err := h.AddClient(conn, nil)
+			Expect(err).NotTo(HaveOccurred())
 			fd.setBPResult = protocol.Breakpoint{ID: 1}
 
 			fd.push(protocol.MustEvent(protocol.EventOutput, 1,
@@ -362,8 +373,10 @@ var _ = Describe("Hub", func() {
 		It("delivers an informational event to all connected clients", func() {
 			conn1 := newFakeWSConn()
 			conn2 := newFakeWSConn()
-			h.AddClient(conn1, nil)
-			h.AddClient(conn2, nil)
+			_, err := h.AddClient(conn1, nil)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = h.AddClient(conn2, nil)
+			Expect(err).NotTo(HaveOccurred())
 
 			fd.push(protocol.MustEvent(protocol.EventOutput, 1,
 				protocol.OutputPayload{Stream: "stdout", Content: "hello bingo"}))
@@ -378,7 +391,7 @@ var _ = Describe("Hub", func() {
 
 		It("does not deliver events to clients that disconnected before the event", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 			closeFakeWS(conn)
 			time.Sleep(30 * time.Millisecond) // let readPump notice the close
 
@@ -393,7 +406,7 @@ var _ = Describe("Hub", func() {
 	Describe("BreakpointHit suspend/resume cycle", func() {
 		It("broadcasts the event then waits before calling Continue", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 
 			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
 				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
@@ -413,7 +426,7 @@ var _ = Describe("Hub", func() {
 
 		It("accepts StepOver as a resuming command", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 
 			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
 				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
@@ -427,7 +440,7 @@ var _ = Describe("Hub", func() {
 
 		It("accepts StepInto as a resuming command", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 
 			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
 				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
@@ -441,7 +454,7 @@ var _ = Describe("Hub", func() {
 
 		It("accepts StepOut as a resuming command", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 
 			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
 				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
@@ -455,7 +468,7 @@ var _ = Describe("Hub", func() {
 
 		It("allows non-resuming commands (SetBreakpoint) while suspended", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 			fd.setBPResult = protocol.Breakpoint{ID: 2}
 
 			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
@@ -480,7 +493,7 @@ var _ = Describe("Hub", func() {
 
 		It("allows Locals while suspended", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 			fd.localsResult = []protocol.Variable{{Name: "x", Value: "42", Type: "int"}}
 
 			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
@@ -501,7 +514,7 @@ var _ = Describe("Hub", func() {
 
 		It("allows Evaluate while suspended", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 			fd.evalResult = protocol.Variable{Name: "total", Value: "7", Type: "int", Kind: "int"}
 
 			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
@@ -524,8 +537,8 @@ var _ = Describe("Hub", func() {
 		It("only the first resuming command wins when multiple clients race", func() {
 			conn1 := newFakeWSConn()
 			conn2 := newFakeWSConn()
-			h.AddClient(conn1, nil)
-			h.AddClient(conn2, nil)
+			mustAddClient(h, conn1)
+			mustAddClient(h, conn2)
 
 			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 2,
 				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
@@ -550,7 +563,7 @@ var _ = Describe("Hub", func() {
 	Describe("Kill while running", func() {
 		It("terminates the process even with no breakpoint set (no suspend first)", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 
 			// A runaway target with no breakpoints never suspends. Kill must
 			// still reach the debugger: it rides cmdCh (main loop), not
@@ -563,7 +576,7 @@ var _ = Describe("Hub", func() {
 
 		It("still terminates the process while suspended", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 
 			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
 				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
@@ -578,7 +591,7 @@ var _ = Describe("Hub", func() {
 	Describe("stale resume handling", func() {
 		It("discards a resume buffered while running so it can't auto-continue a later suspend", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 			fd.setBPResult = protocol.Breakpoint{ID: 7}
 
 			// Erroneously send Continue while the process is still running: it
@@ -619,7 +632,7 @@ var _ = Describe("Hub", func() {
 		// wedge the session with no way to resume.
 		It("lets a retry Continue reach the debugger after the first fails", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 			fd.continueErr = errors.New("reinstall failed")
 
 			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
@@ -642,7 +655,7 @@ var _ = Describe("Hub", func() {
 
 		It("still resumes via Continue after a failed StepOver", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 			fd.stepOverErr = errors.New("step failed")
 
 			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
@@ -660,7 +673,7 @@ var _ = Describe("Hub", func() {
 
 		It("still services non-resuming commands after a failed resume", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 			fd.setBPResult = protocol.Breakpoint{ID: 9}
 			fd.continueErr = errors.New("boom")
 
@@ -682,7 +695,7 @@ var _ = Describe("Hub", func() {
 	Describe("Pause", func() {
 		It("routes CmdPause to the debugger while the process runs", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 
 			// CmdPause is not a resuming command: it reaches the debugger via
 			// the main-loop cmdCh path, without any suspending event first.
@@ -694,7 +707,7 @@ var _ = Describe("Hub", func() {
 
 		It("suspends the hub on EventPaused, then resumes on Continue", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 
 			fd.push(protocol.MustEvent(protocol.EventPaused, 1,
 				protocol.PausedPayload{Location: protocol.Location{File: "main.go", Line: 7}}))
@@ -716,7 +729,7 @@ var _ = Describe("Hub", func() {
 	Describe("SetBreakpoint confirmation", func() {
 		It("broadcasts BreakpointSet with the assigned breakpoint", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 			fd.setBPResult = protocol.Breakpoint{
 				ID:       1,
 				Location: protocol.Location{File: "main.go", Line: 42},
@@ -738,7 +751,7 @@ var _ = Describe("Hub", func() {
 	Describe("ClearBreakpoint confirmation", func() {
 		It("broadcasts BreakpointCleared with the removed ID", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 
 			conn.inject(mustCommand(protocol.CmdClearBreakpoint,
 				protocol.ClearBreakpointPayload{ID: 5}))
@@ -756,7 +769,7 @@ var _ = Describe("Hub", func() {
 	Describe("command error propagation", func() {
 		It("broadcasts EventError when a command fails", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 			fd.setBPErr = fmt.Errorf("address not found")
 
 			conn.inject(mustCommand(protocol.CmdSetBreakpoint,
@@ -773,7 +786,7 @@ var _ = Describe("Hub", func() {
 
 		It("includes the failing command kind in the error payload", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 			fd.setBPErr = fmt.Errorf("no such file")
 
 			conn.inject(mustCommand(protocol.CmdSetBreakpoint,
@@ -794,7 +807,7 @@ var _ = Describe("Hub", func() {
 	Describe("shutdown when last client disconnects", func() {
 		It("calls Kill on the debugger", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 			closeFakeWS(conn)
 
 			Eventually(fd.recordedCalls, "500ms", "10ms").
@@ -803,7 +816,7 @@ var _ = Describe("Hub", func() {
 
 		It("calls Kill exactly once even when cancel and disconnect race", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 			closeFakeWS(conn)
 			cancel() // races with the disconnect-triggered shutdown
 
@@ -832,7 +845,7 @@ var _ = Describe("Hub", func() {
 
 		It("unblocks the suspend loop when the process exits while paused", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 
 			// Suspend the hub.
 			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
@@ -856,7 +869,7 @@ var _ = Describe("Hub", func() {
 	Describe("unknown command kind", func() {
 		It("broadcasts EventError without panicking", func() {
 			conn := newFakeWSConn()
-			h.AddClient(conn, nil)
+			mustAddClient(h, conn)
 
 			conn.inject(protocol.Command{
 				Version: protocol.Version,
@@ -881,7 +894,8 @@ func newManagedRestartHub(fd *fakeDebugger) (*hub.Hub, *fakeWSConn, context.Canc
 	managed := hub.NewSession("session", func() debugger.Debugger { return fd }, nil)
 	cancel := runHub(managed)
 	conn := newFakeWSConn()
-	managed.AddClient(conn, nil)
+	_, err := managed.AddClient(conn, nil)
+	Expect(err).NotTo(HaveOccurred())
 	_, _ = recvEvent(conn) // welcome/state event
 	return managed, conn, cancel
 }
@@ -933,7 +947,7 @@ var _ = Describe("Restart", func() {
 		defer cancel()
 
 		conn := newFakeWSConn()
-		h.AddClient(conn, nil)
+		mustAddClient(h, conn)
 
 		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
 		waitForEventKind(conn, protocol.EventError, nil)
@@ -1028,7 +1042,8 @@ var _ = Describe("dbg access during shutdown", func() {
 			cancel := runHub(managed)
 
 			conn := newFakeWSConn()
-			managed.AddClient(conn, nil)
+			_, err := managed.AddClient(conn, nil)
+			Expect(err).NotTo(HaveOccurred())
 
 			// Launch writes h.dbg on the Run goroutine; closing the only client
 			// spawns `go h.shutdown()`, which reads h.dbg concurrently.

--- a/internal/hub/registry.go
+++ b/internal/hub/registry.go
@@ -7,26 +7,35 @@ import "sync"
 type registry struct {
 	mu      sync.RWMutex
 	clients map[*Client]struct{}
+	closed  bool
 }
 
 func newRegistry() *registry {
 	return &registry{clients: make(map[*Client]struct{})}
 }
 
-func (r *registry) add(c *Client) {
+func (r *registry) add(c *Client) bool {
 	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return false
+	}
 	r.clients[c] = struct{}{}
-	r.mu.Unlock()
+	return true
 }
 
-func (r *registry) remove(c *Client) bool {
+func (r *registry) remove(c *Client) (bool, int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if _, ok := r.clients[c]; !ok {
-		return false
+		return false, len(r.clients)
 	}
 	delete(r.clients, c)
-	return true
+	remaining := len(r.clients)
+	if remaining == 0 {
+		r.closed = true
+	}
+	return true, remaining
 }
 
 func (r *registry) count() int {
@@ -51,6 +60,7 @@ func (r *registry) snapshot() []*Client {
 func (r *registry) closeAll() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.closed = true
 	for c := range r.clients {
 		c.closeSend()
 		delete(r.clients, c)

--- a/internal/hub/registry_test.go
+++ b/internal/hub/registry_test.go
@@ -1,0 +1,36 @@
+package hub
+
+import "testing"
+
+func TestRegistryLastRemovalClosesAdmission(t *testing.T) {
+	registry := newRegistry()
+	first := &Client{}
+	if !registry.add(first) {
+		t.Fatal("initial client was rejected")
+	}
+
+	removed, remaining := registry.remove(first)
+	if !removed || remaining != 0 {
+		t.Fatalf("remove = (%v, %d), want (true, 0)", removed, remaining)
+	}
+	if registry.add(&Client{}) {
+		t.Fatal("client admitted after last removal initiated teardown")
+	}
+}
+
+func TestRegistryConcurrentReplacementKeepsAdmissionOpen(t *testing.T) {
+	registry := newRegistry()
+	first := &Client{}
+	second := &Client{}
+	if !registry.add(first) || !registry.add(second) {
+		t.Fatal("clients were rejected before teardown")
+	}
+
+	removed, remaining := registry.remove(first)
+	if !removed || remaining != 1 {
+		t.Fatalf("remove = (%v, %d), want (true, 1)", removed, remaining)
+	}
+	if !registry.add(&Client{}) {
+		t.Fatal("client rejected while another client kept the hub alive")
+	}
+}

--- a/internal/server/dap.go
+++ b/internal/server/dap.go
@@ -16,17 +16,19 @@ type dapProvider struct {
 }
 
 func (p dapProvider) CreateSession() (dap.Session, error) {
-	if !p.srv.acceptingSessions() {
+	if !p.srv.beginSessionOperation() {
 		return nil, ErrServerClosed
 	}
+	defer p.srv.sessionOps.Done()
 	sess := p.srv.sessions.create(p.srv.ctx)
 	return sess.hub, nil
 }
 
 func (p dapProvider) GetSession(id string) (dap.Session, bool) {
-	if !p.srv.acceptingSessions() {
+	if !p.srv.beginSessionOperation() {
 		return nil, false
 	}
+	defer p.srv.sessionOps.Done()
 	sess := p.srv.sessions.get(id)
 	if sess == nil {
 		return nil, false

--- a/internal/server/dap.go
+++ b/internal/server/dap.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"fmt"
+
 	"github.com/bingosuite/bingo/internal/dap"
 )
 
@@ -14,11 +16,17 @@ type dapProvider struct {
 }
 
 func (p dapProvider) CreateSession() (dap.Session, error) {
+	if !p.srv.acceptingSessions() {
+		return nil, ErrServerClosed
+	}
 	sess := p.srv.sessions.create(p.srv.ctx)
 	return sess.hub, nil
 }
 
 func (p dapProvider) GetSession(id string) (dap.Session, bool) {
+	if !p.srv.acceptingSessions() {
+		return nil, false
+	}
 	sess := p.srv.sessions.get(id)
 	if sess == nil {
 		return nil, false
@@ -30,10 +38,22 @@ func (p dapProvider) GetSession(id string) (dap.Session, bool) {
 // returns immediately once listening; connections are handled in the
 // background. Safe to call at most once.
 func (s *Server) StartDAP(addr string) error {
-	ds := dap.NewServer(dapProvider{srv: s}, s.log.With("component", "dap"))
-	if _, err := ds.Serve(addr); err != nil {
-		return err
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	if s.shutting {
+		return ErrServerClosed
 	}
+	if s.dapStarted {
+		return ErrDAPAlreadyStarted
+	}
+
+	ds := dap.NewServer(dapProvider{srv: s}, s.log.With("component", "dap"))
+	bound, err := ds.Serve(addr)
+	if err != nil {
+		return fmt.Errorf("listen for DAP: %w", err)
+	}
+	s.dapStarted = true
 	s.dapServer = ds
+	s.dapAddress = bound.String()
 	return nil
 }

--- a/internal/server/dap.go
+++ b/internal/server/dap.go
@@ -19,7 +19,7 @@ func (p dapProvider) CreateSession() (dap.Session, error) {
 	if !p.srv.beginSessionOperation() {
 		return nil, ErrServerClosed
 	}
-	defer p.srv.sessionOps.Done()
+	defer p.srv.endSessionOperation()
 	sess := p.srv.sessions.create(p.srv.ctx)
 	return sess.hub, nil
 }
@@ -28,7 +28,7 @@ func (p dapProvider) GetSession(id string) (dap.Session, bool) {
 	if !p.srv.beginSessionOperation() {
 		return nil, false
 	}
-	defer p.srv.sessionOps.Done()
+	defer p.srv.endSessionOperation()
 	sess := p.srv.sessions.get(id)
 	if sess == nil {
 		return nil, false
@@ -41,21 +41,47 @@ func (p dapProvider) GetSession(id string) (dap.Session, bool) {
 // background. Safe to call at most once.
 func (s *Server) StartDAP(addr string) error {
 	s.lifecycleMu.Lock()
-	defer s.lifecycleMu.Unlock()
 	if s.shutting {
+		s.lifecycleMu.Unlock()
 		return ErrServerClosed
 	}
-	if s.dapStarted {
+	if s.dapStarted || s.dapStarting {
+		s.lifecycleMu.Unlock()
 		return ErrDAPAlreadyStarted
 	}
+	s.dapStarting = true
+	startDone := make(chan struct{})
+	s.dapStartDone = startDone
+	serve := s.dapServe
+	s.lifecycleMu.Unlock()
 
 	ds := dap.NewServer(dapProvider{srv: s}, s.log.With("component", "dap"))
-	bound, err := ds.Serve(addr)
+	bound, err := serve(s.ctx, ds, addr)
+
+	s.lifecycleMu.Lock()
+	s.dapStarting = false
 	if err != nil {
+		stopping := s.shutting || s.ctx.Err() != nil
+		if stopping {
+			s.lifecycleMu.Unlock()
+			_ = ds.Close()
+			close(startDone)
+			return ErrServerClosed
+		}
+		close(startDone)
+		s.lifecycleMu.Unlock()
 		return fmt.Errorf("listen for DAP: %w", err)
+	}
+	if s.shutting {
+		s.lifecycleMu.Unlock()
+		_ = ds.Close()
+		close(startDone)
+		return ErrServerClosed
 	}
 	s.dapStarted = true
 	s.dapServer = ds
 	s.dapAddress = bound.String()
+	close(startDone)
+	s.lifecycleMu.Unlock()
 	return nil
 }

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -6,9 +6,36 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
+	"github.com/bingosuite/bingo/pkg/protocol"
 	"github.com/gorilla/websocket"
 )
+
+const (
+	serviceIdentity      = "bingo"
+	ManagementAPIVersion = 1
+)
+
+type DAPHealth struct {
+	Enabled bool   `json:"enabled"`
+	Address string `json:"address"`
+}
+
+type ManagedIdleShutdownHealth struct {
+	Enabled   bool  `json:"enabled"`
+	TimeoutMS int64 `json:"timeoutMs"`
+}
+
+type HealthResponse struct {
+	Service              string                    `json:"service"`
+	ManagementAPIVersion int                       `json:"managementApiVersion"`
+	WireProtocolVersion  string                    `json:"wireProtocolVersion"`
+	InstanceID           string                    `json:"instanceId"`
+	DAP                  DAPHealth                 `json:"dap"`
+	ManagedIdleShutdown  ManagedIdleShutdownHealth `json:"managedIdleShutdown"`
+	SessionCount         int                       `json:"sessionCount"`
+}
 
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  4096,
@@ -26,6 +53,52 @@ func sameHostOrigin(r *http.Request) bool {
 		return false
 	}
 	return strings.EqualFold(u.Host, r.Host)
+}
+
+// handleHealth is the stable process-discovery contract frontends use before
+// deciding whether an existing bingo instance is compatible.
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	s.lifecycleMu.RLock()
+	dapAddress := s.dapAddress
+	idleTimeout := s.idleTimeout
+	instanceID := s.instanceID
+	s.lifecycleMu.RUnlock()
+
+	response := HealthResponse{
+		Service:              serviceIdentity,
+		ManagementAPIVersion: ManagementAPIVersion,
+		WireProtocolVersion:  protocol.Version,
+		InstanceID:           instanceID,
+		DAP: DAPHealth{
+			Enabled: dapAddress != "",
+			Address: dapAddress,
+		},
+		ManagedIdleShutdown: ManagedIdleShutdownHealth{
+			Enabled:   idleTimeout > 0,
+			TimeoutMS: durationMilliseconds(idleTimeout),
+		},
+		SessionCount: s.sessions.count(),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		s.log.Error("failed to encode health response", "err", err)
+	}
+}
+
+func durationMilliseconds(duration time.Duration) int64 {
+	millis := duration / time.Millisecond
+	if duration%time.Millisecond != 0 {
+		millis++
+	}
+	return int64(millis)
 }
 
 // handleListSessions: GET /api/sessions
@@ -46,6 +119,11 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 //	GET /ws?create        — create + join
 //	GET /ws?session={id}  — join existing
 func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
+	if !s.acceptingSessions() {
+		http.Error(w, "server is shutting down", http.StatusServiceUnavailable)
+		return
+	}
+
 	query := r.URL.Query()
 
 	_, wantCreate := query["create"]
@@ -73,6 +151,12 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) wsCreate(conn *websocket.Conn, log *slog.Logger) {
+	if !s.beginSessionOperation() {
+		s.closeShuttingDown(conn)
+		return
+	}
+	defer s.sessionOps.Done()
+
 	sess := s.sessions.create(s.ctx)
 	log = log.With("session", sess.id, "action", "create")
 	log.Info("client creating new session")
@@ -80,6 +164,12 @@ func (s *Server) wsCreate(conn *websocket.Conn, log *slog.Logger) {
 }
 
 func (s *Server) wsJoin(conn *websocket.Conn, sessionID string, log *slog.Logger) {
+	if !s.beginSessionOperation() {
+		s.closeShuttingDown(conn)
+		return
+	}
+	defer s.sessionOps.Done()
+
 	log = log.With("session", sessionID, "action", "join")
 
 	sess := s.sessions.get(sessionID)
@@ -96,4 +186,10 @@ func (s *Server) wsJoin(conn *websocket.Conn, sessionID string, log *slog.Logger
 
 	log.Info("client joining existing session")
 	sess.hub.AddClient(conn, log)
+}
+
+func (s *Server) closeShuttingDown(conn *websocket.Conn) {
+	msg := websocket.FormatCloseMessage(websocket.CloseGoingAway, "server is shutting down")
+	_ = conn.WriteMessage(websocket.CloseMessage, msg)
+	_ = conn.Close()
 }

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -94,11 +94,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func durationMilliseconds(duration time.Duration) int64 {
-	millis := duration / time.Millisecond
-	if duration%time.Millisecond != 0 {
-		millis++
-	}
-	return int64(millis)
+	return int64(duration / time.Millisecond)
 }
 
 // handleListSessions: GET /api/sessions
@@ -160,7 +156,9 @@ func (s *Server) wsCreate(conn *websocket.Conn, log *slog.Logger) {
 	sess := s.sessions.create(s.ctx)
 	log = log.With("session", sess.id, "action", "create")
 	log.Info("client creating new session")
-	sess.hub.AddClient(conn, log)
+	if _, err := sess.hub.AddClient(conn, log); err != nil {
+		log.Warn("session closed while adding client", "err", err)
+	}
 }
 
 func (s *Server) wsJoin(conn *websocket.Conn, sessionID string, log *slog.Logger) {
@@ -185,7 +183,9 @@ func (s *Server) wsJoin(conn *websocket.Conn, sessionID string, log *slog.Logger
 	}
 
 	log.Info("client joining existing session")
-	sess.hub.AddClient(conn, log)
+	if _, err := sess.hub.AddClient(conn, log); err != nil {
+		log.Warn("session closed while joining", "err", err)
+	}
 }
 
 func (s *Server) closeShuttingDown(conn *websocket.Conn) {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -115,11 +115,6 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 //	GET /ws?create        — create + join
 //	GET /ws?session={id}  — join existing
 func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
-	if !s.acceptingSessions() {
-		http.Error(w, "server is shutting down", http.StatusServiceUnavailable)
-		return
-	}
-
 	query := r.URL.Query()
 
 	_, wantCreate := query["create"]
@@ -129,6 +124,12 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "specify ?create or ?session={id}", http.StatusBadRequest)
 		return
 	}
+
+	if !s.beginSessionOperation() {
+		http.Error(w, "server is shutting down", http.StatusServiceUnavailable)
+		return
+	}
+	defer s.endSessionOperation()
 
 	// Upgrade before session logic so we can send descriptive close frames on error.
 	conn, err := upgrader.Upgrade(w, r, nil)
@@ -147,12 +148,6 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) wsCreate(conn *websocket.Conn, log *slog.Logger) {
-	if !s.beginSessionOperation() {
-		s.closeShuttingDown(conn)
-		return
-	}
-	defer s.sessionOps.Done()
-
 	sess := s.sessions.create(s.ctx)
 	log = log.With("session", sess.id, "action", "create")
 	log.Info("client creating new session")
@@ -162,12 +157,6 @@ func (s *Server) wsCreate(conn *websocket.Conn, log *slog.Logger) {
 }
 
 func (s *Server) wsJoin(conn *websocket.Conn, sessionID string, log *slog.Logger) {
-	if !s.beginSessionOperation() {
-		s.closeShuttingDown(conn)
-		return
-	}
-	defer s.sessionOps.Done()
-
 	log = log.With("session", sessionID, "action", "join")
 
 	sess := s.sessions.get(sessionID)
@@ -186,10 +175,4 @@ func (s *Server) wsJoin(conn *websocket.Conn, sessionID string, log *slog.Logger
 	if _, err := sess.hub.AddClient(conn, log); err != nil {
 		log.Warn("session closed while joining", "err", err)
 	}
-}
-
-func (s *Server) closeShuttingDown(conn *websocket.Conn) {
-	msg := websocket.FormatCloseMessage(websocket.CloseGoingAway, "server is shutting down")
-	_ = conn.WriteMessage(websocket.CloseMessage, msg)
-	_ = conn.Close()
 }

--- a/internal/server/lifecycle_test.go
+++ b/internal/server/lifecycle_test.go
@@ -1,0 +1,364 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	. "github.com/onsi/gomega"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+const testIdleTimeout = 150 * time.Millisecond
+
+type runningServer struct {
+	server *Server
+	url    string
+	errCh  chan error
+}
+
+func startServer(t *testing.T, idleTimeout time.Duration) runningServer {
+	t.Helper()
+	g := NewWithT(t)
+	srv, err := NewWithIdleTimeout("127.0.0.1:0", idleTimeout, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Start()
+	}()
+
+	var address string
+	g.Eventually(func() string {
+		srv.lifecycleMu.RLock()
+		defer srv.lifecycleMu.RUnlock()
+		address = srv.httpAddress
+		return address
+	}, time.Second).ShouldNot(BeEmpty())
+
+	return runningServer{
+		server: srv,
+		url:    "http://" + address,
+		errCh:  errCh,
+	}
+}
+
+func (r runningServer) stop(t *testing.T) {
+	t.Helper()
+	r.server.Shutdown(time.Second)
+	g := NewWithT(t)
+	g.Eventually(r.errCh, time.Second).Should(Receive(BeNil()))
+}
+
+func dialCreate(t *testing.T, baseURL string) *websocket.Conn {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(baseURL, "http") + "/ws?create"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	NewWithT(t).Expect(err).NotTo(HaveOccurred())
+	return conn
+}
+
+func getHealth(t *testing.T, handler http.Handler) (*httptest.ResponseRecorder, HealthResponse) {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	var health HealthResponse
+	NewWithT(t).Expect(json.NewDecoder(response.Body).Decode(&health)).To(Succeed())
+	return response, health
+}
+
+func TestHealthDiscovery(t *testing.T) {
+	g := NewWithT(t)
+	srv := New(":0", nil)
+
+	response, health := getHealth(t, srv.httpServer.Handler)
+	g.Expect(response.Code).To(Equal(http.StatusOK))
+	g.Expect(response.Header().Get("Content-Type")).To(Equal("application/json"))
+	g.Expect(response.Header().Get("Cache-Control")).To(Equal("no-store"))
+	g.Expect(health.Service).To(Equal("bingo"))
+	g.Expect(health.ManagementAPIVersion).To(Equal(ManagementAPIVersion))
+	g.Expect(health.WireProtocolVersion).To(Equal(protocol.Version))
+	g.Expect(uuid.Validate(health.InstanceID)).To(Succeed())
+	g.Expect(health.DAP).To(Equal(DAPHealth{}))
+	g.Expect(health.ManagedIdleShutdown).To(Equal(ManagedIdleShutdownHealth{}))
+	g.Expect(health.SessionCount).To(Equal(0))
+
+	rawResponse := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rawResponse, httptest.NewRequest(http.MethodGet, "/api/health", nil))
+	var fields map[string]json.RawMessage
+	g.Expect(json.NewDecoder(rawResponse.Body).Decode(&fields)).To(Succeed())
+	g.Expect(fields).To(HaveLen(7))
+	for _, field := range []string{
+		"service",
+		"managementApiVersion",
+		"wireProtocolVersion",
+		"instanceId",
+		"dap",
+		"managedIdleShutdown",
+		"sessionCount",
+	} {
+		g.Expect(fields).To(HaveKey(field))
+	}
+
+	_, repeated := getHealth(t, srv.httpServer.Handler)
+	g.Expect(repeated.InstanceID).To(Equal(health.InstanceID))
+	g.Expect(New(":0", nil).instanceID).NotTo(Equal(health.InstanceID))
+}
+
+func TestHealthRejectsNonGET(t *testing.T) {
+	g := NewWithT(t)
+	srv := New(":0", nil)
+	request := httptest.NewRequest(http.MethodPost, "/api/health", nil)
+	response := httptest.NewRecorder()
+
+	srv.httpServer.Handler.ServeHTTP(response, request)
+
+	g.Expect(response.Code).To(Equal(http.StatusMethodNotAllowed))
+	g.Expect(response.Header().Get("Allow")).To(Equal(http.MethodGet))
+	g.Expect(response.Header().Get("Cache-Control")).To(Equal("no-store"))
+}
+
+func TestHealthReportsResolvedDAPAddress(t *testing.T) {
+	g := NewWithT(t)
+	srv, err := NewWithIdleTimeout(":0", 30*time.Second, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(srv.StartDAP("127.0.0.1:0")).To(Succeed())
+	t.Cleanup(func() {
+		srv.Shutdown(time.Second)
+	})
+
+	_, health := getHealth(t, srv.httpServer.Handler)
+	g.Expect(health.DAP.Enabled).To(BeTrue())
+	g.Expect(health.DAP.Address).To(MatchRegexp(`^127\.0\.0\.1:\d+$`))
+	g.Expect(health.DAP.Address).NotTo(HaveSuffix(":0"))
+	g.Expect(health.ManagedIdleShutdown).To(Equal(ManagedIdleShutdownHealth{
+		Enabled:   true,
+		TimeoutMS: 30000,
+	}))
+	g.Expect(srv.StartDAP("127.0.0.1:0")).To(MatchError(ErrDAPAlreadyStarted))
+}
+
+func TestHealthReportsSessionCount(t *testing.T) {
+	g := NewWithT(t)
+	srv := New(":0", nil)
+	srv.sessions.create(srv.ctx)
+
+	_, health := getHealth(t, srv.httpServer.Handler)
+	g.Expect(health.SessionCount).To(Equal(1))
+
+	srv.Shutdown(time.Second)
+	g.Expect(srv.sessions.count()).To(Equal(0))
+}
+
+func TestIdleTimeoutValidation(t *testing.T) {
+	g := NewWithT(t)
+	srv, err := NewWithIdleTimeout(":0", -time.Second, nil)
+	g.Expect(err).To(MatchError("idle timeout must not be negative: -1s"))
+	g.Expect(srv).To(BeNil())
+}
+
+func TestIdleShutdownDisabled(t *testing.T) {
+	g := NewWithT(t)
+	running := startServer(t, 0)
+
+	g.Consistently(running.errCh, testIdleTimeout).ShouldNot(Receive())
+	running.stop(t)
+}
+
+func TestIdleShutdownExpiresAtStartup(t *testing.T) {
+	g := NewWithT(t)
+	running := startServer(t, testIdleTimeout)
+
+	g.Eventually(running.errCh, time.Second).Should(Receive(BeNil()))
+	g.Expect(running.server.sessions.count()).To(Equal(0))
+}
+
+func TestHealthAndBareDAPConnectionDoNotSuppressIdleShutdown(t *testing.T) {
+	g := NewWithT(t)
+	running := startServer(t, testIdleTimeout)
+	g.Expect(running.server.StartDAP("127.0.0.1:0")).To(Succeed())
+
+	running.server.lifecycleMu.RLock()
+	dapAddress := running.server.dapAddress
+	running.server.lifecycleMu.RUnlock()
+	conn, err := net.Dial("tcp4", dapAddress)
+	g.Expect(err).NotTo(HaveOccurred())
+	defer func() { _ = conn.Close() }()
+
+	response, err := http.Get(running.url + "/api/health")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(response.Body.Close()).To(Succeed())
+
+	g.Eventually(running.errCh, time.Second).Should(Receive(BeNil()))
+	g.Expect(conn.SetReadDeadline(time.Now().Add(time.Second))).To(Succeed())
+	_, err = conn.Read(make([]byte, 1))
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestDAPCreatedSessionSuppressesIdleShutdown(t *testing.T) {
+	g := NewWithT(t)
+	running := startServer(t, testIdleTimeout)
+	_, err := (dapProvider{srv: running.server}).CreateSession()
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Eventually(running.server.sessions.count, time.Second).Should(Equal(1))
+	g.Consistently(running.errCh, 2*testIdleTimeout).ShouldNot(Receive())
+	running.stop(t)
+}
+
+func TestActiveSessionSuppressesIdleShutdown(t *testing.T) {
+	g := NewWithT(t)
+	running := startServer(t, testIdleTimeout)
+	conn := dialCreate(t, running.url)
+	defer func() { _ = conn.Close() }()
+
+	g.Eventually(running.server.sessions.count, time.Second).Should(Equal(1))
+	g.Consistently(running.errCh, 2*testIdleTimeout).ShouldNot(Receive())
+
+	g.Expect(conn.Close()).To(Succeed())
+	g.Eventually(running.errCh, time.Second).Should(Receive(BeNil()))
+}
+
+func TestNewSessionRearmsIdleShutdown(t *testing.T) {
+	g := NewWithT(t)
+	running := startServer(t, testIdleTimeout)
+	first := dialCreate(t, running.url)
+	g.Eventually(running.server.sessions.count, time.Second).Should(Equal(1))
+
+	g.Expect(first.Close()).To(Succeed())
+	g.Eventually(running.server.sessions.count, time.Second).Should(Equal(0))
+	g.Consistently(running.errCh, testIdleTimeout/3).ShouldNot(Receive())
+
+	second := dialCreate(t, running.url)
+	defer func() { _ = second.Close() }()
+	g.Eventually(running.server.sessions.count, time.Second).Should(Equal(1))
+	g.Consistently(running.errCh, 2*testIdleTimeout).ShouldNot(Receive())
+
+	g.Expect(second.Close()).To(Succeed())
+	g.Eventually(running.errCh, time.Second).Should(Receive(BeNil()))
+}
+
+func TestMultipleSessionsSuppressIdleShutdown(t *testing.T) {
+	g := NewWithT(t)
+	running := startServer(t, testIdleTimeout)
+	first := dialCreate(t, running.url)
+	second := dialCreate(t, running.url)
+	defer func() { _ = first.Close() }()
+	defer func() { _ = second.Close() }()
+	g.Eventually(running.server.sessions.count, time.Second).Should(Equal(2))
+
+	g.Expect(first.Close()).To(Succeed())
+	g.Eventually(running.server.sessions.count, time.Second).Should(Equal(1))
+	g.Consistently(running.errCh, 2*testIdleTimeout).ShouldNot(Receive())
+
+	g.Expect(second.Close()).To(Succeed())
+	g.Eventually(running.errCh, time.Second).Should(Receive(BeNil()))
+}
+
+func TestSessionStoreBroadcastSupportsMultipleWaiters(t *testing.T) {
+	g := NewWithT(t)
+	store := newSessionStore(slog.Default())
+	ctx, cancel := context.WithCancel(context.Background())
+	store.create(ctx)
+	g.Expect(store.count()).To(Equal(1))
+
+	waiters := make(chan bool, 2)
+	for range 2 {
+		go func() {
+			waitCtx, stop := context.WithTimeout(context.Background(), time.Second)
+			defer stop()
+			waiters <- store.waitEmpty(waitCtx)
+		}()
+	}
+
+	cancel()
+	g.Eventually(waiters, time.Second).Should(Receive(BeTrue()))
+	g.Eventually(waiters, time.Second).Should(Receive(BeTrue()))
+}
+
+func TestShutdownIsConcurrentAndIdempotent(t *testing.T) {
+	g := NewWithT(t)
+	running := startServer(t, 0)
+	g.Expect(running.server.StartDAP("127.0.0.1:0")).To(Succeed())
+	running.server.lifecycleMu.RLock()
+	dapAddress := running.server.dapAddress
+	running.server.lifecycleMu.RUnlock()
+	dapConn, err := net.Dial("tcp4", dapAddress)
+	g.Expect(err).NotTo(HaveOccurred())
+	defer func() { _ = dapConn.Close() }()
+
+	conn := dialCreate(t, running.url)
+	defer func() { _ = conn.Close() }()
+	g.Eventually(running.server.sessions.count, time.Second).Should(Equal(1))
+
+	var callers sync.WaitGroup
+	callers.Add(8)
+	for range 8 {
+		go func() {
+			defer callers.Done()
+			running.server.Shutdown(time.Second)
+		}()
+	}
+	done := make(chan struct{})
+	go func() {
+		callers.Wait()
+		close(done)
+	}()
+
+	g.Eventually(done, 2*time.Second).Should(BeClosed())
+	g.Eventually(running.errCh, time.Second).Should(Receive(BeNil()))
+	g.Expect(running.server.sessions.count()).To(Equal(0))
+	running.server.Shutdown(time.Second)
+	g.Expect(running.server.StartDAP("127.0.0.1:0")).To(MatchError(ErrServerClosed))
+}
+
+func TestStartIsAtMostOnce(t *testing.T) {
+	g := NewWithT(t)
+	running := startServer(t, 0)
+	g.Expect(running.server.Start()).To(MatchError(ErrServerStarted))
+	running.stop(t)
+
+	g.Expect(running.server.Start()).To(Succeed())
+}
+
+func TestShutdownBeforeStartDoesNotResurrectServer(t *testing.T) {
+	g := NewWithT(t)
+	srv := New("127.0.0.1:0", nil)
+	srv.Shutdown(time.Second)
+
+	g.Expect(srv.Start()).To(Succeed())
+	g.Expect(srv.StartDAP("127.0.0.1:0")).To(MatchError(ErrServerClosed))
+
+	response := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/ws?create", nil))
+	g.Expect(response.Code).To(Equal(http.StatusServiceUnavailable))
+}
+
+func TestDAPBindFailureIsRetryable(t *testing.T) {
+	g := NewWithT(t)
+	running := startServer(t, 0)
+	defer running.stop(t)
+
+	g.Expect(running.server.StartDAP(running.server.httpAddress)).To(HaveOccurred())
+	g.Expect(running.server.StartDAP("127.0.0.1:0")).To(Succeed())
+	g.Expect(running.server.StartDAP("127.0.0.1:0")).To(MatchError(ErrDAPAlreadyStarted))
+}
+
+func TestDurationMillisecondsRoundsUp(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(durationMilliseconds(0)).To(Equal(int64(0)))
+	g.Expect(durationMilliseconds(time.Nanosecond)).To(Equal(int64(1)))
+	g.Expect(durationMilliseconds(1500 * time.Microsecond)).To(Equal(int64(2)))
+}

--- a/internal/server/lifecycle_test.go
+++ b/internal/server/lifecycle_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net"
 	"net/http"
@@ -32,7 +33,12 @@ func startServer(t *testing.T, idleTimeout time.Duration) runningServer {
 	g := NewWithT(t)
 	srv, err := NewWithIdleTimeout("127.0.0.1:0", idleTimeout, nil)
 	g.Expect(err).NotTo(HaveOccurred())
+	return startConstructedServer(t, srv)
+}
 
+func startConstructedServer(t *testing.T, srv *Server) runningServer {
+	t.Helper()
+	g := NewWithT(t)
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- srv.Start()
@@ -232,6 +238,59 @@ func TestDAPCreatedSessionSuppressesIdleShutdown(t *testing.T) {
 	running.stop(t)
 }
 
+func TestIdleExpiryYieldsToWebSocketAdmission(t *testing.T) {
+	g := NewWithT(t)
+	srv, err := NewWithIdleTimeout("127.0.0.1:0", testIdleTimeout, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	ready := make(chan struct{})
+	proceed := make(chan struct{})
+	var hookOnce sync.Once
+	srv.idleCommitHook = func() {
+		hookOnce.Do(func() {
+			close(ready)
+			<-proceed
+		})
+	}
+	running := startConstructedServer(t, srv)
+	g.Eventually(ready, time.Second).Should(BeClosed())
+
+	conn := dialCreate(t, running.url)
+	defer func() { _ = conn.Close() }()
+	g.Eventually(srv.sessions.count, time.Second).Should(Equal(1))
+	close(proceed)
+
+	g.Consistently(running.errCh, 2*testIdleTimeout).ShouldNot(Receive())
+	g.Expect(conn.Close()).To(Succeed())
+	g.Eventually(running.errCh, time.Second).Should(Receive(BeNil()))
+}
+
+func TestIdleExpiryYieldsToDAPAdmission(t *testing.T) {
+	g := NewWithT(t)
+	srv, err := NewWithIdleTimeout("127.0.0.1:0", testIdleTimeout, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	ready := make(chan struct{})
+	proceed := make(chan struct{})
+	var hookOnce sync.Once
+	srv.idleCommitHook = func() {
+		hookOnce.Do(func() {
+			close(ready)
+			<-proceed
+		})
+	}
+	running := startConstructedServer(t, srv)
+	g.Eventually(ready, time.Second).Should(BeClosed())
+
+	_, err = (dapProvider{srv: srv}).CreateSession()
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Eventually(srv.sessions.count, time.Second).Should(Equal(1))
+	close(proceed)
+
+	g.Consistently(running.errCh, 2*testIdleTimeout).ShouldNot(Receive())
+	running.stop(t)
+}
+
 func TestActiveSessionSuppressesIdleShutdown(t *testing.T) {
 	g := NewWithT(t)
 	running := startServer(t, testIdleTimeout)
@@ -345,6 +404,38 @@ func TestStartIsAtMostOnce(t *testing.T) {
 	running.stop(t)
 
 	g.Expect(running.server.Start()).To(Succeed())
+}
+
+func TestStartBindFailureFinalizesDAPAndDone(t *testing.T) {
+	g := NewWithT(t)
+	occupied, err := net.Listen("tcp4", "127.0.0.1:0")
+	g.Expect(err).NotTo(HaveOccurred())
+	defer func() { _ = occupied.Close() }()
+
+	srv := New(occupied.Addr().String(), nil)
+	g.Expect(srv.StartDAP("127.0.0.1:0")).To(Succeed())
+	srv.lifecycleMu.RLock()
+	dapAddress := srv.dapAddress
+	srv.lifecycleMu.RUnlock()
+
+	startResult := make(chan error, 1)
+	go func() {
+		startResult <- srv.Start()
+	}()
+	var startErr error
+	g.Eventually(startResult, time.Second).Should(Receive(&startErr))
+	g.Expect(startErr).To(HaveOccurred())
+	g.Expect(errors.Is(startErr, ErrServerStarted)).To(BeFalse())
+	var netErr *net.OpError
+	g.Expect(errors.As(startErr, &netErr)).To(BeTrue())
+	g.Expect(netErr.Op).To(Equal("listen"))
+	g.Expect(srv.Done()).To(BeClosed())
+
+	conn, err := net.DialTimeout("tcp4", dapAddress, 100*time.Millisecond)
+	if conn != nil {
+		_ = conn.Close()
+	}
+	g.Expect(err).To(HaveOccurred())
 }
 
 func TestShutdownBeforeStartDoesNotResurrectServer(t *testing.T) {

--- a/internal/server/lifecycle_test.go
+++ b/internal/server/lifecycle_test.go
@@ -164,9 +164,23 @@ func TestHealthReportsSessionCount(t *testing.T) {
 
 func TestIdleTimeoutValidation(t *testing.T) {
 	g := NewWithT(t)
-	srv, err := NewWithIdleTimeout(":0", -time.Second, nil)
-	g.Expect(err).To(MatchError("idle timeout must not be negative: -1s"))
-	g.Expect(srv).To(BeNil())
+	tests := []struct {
+		timeout time.Duration
+		message string
+	}{
+		{timeout: -time.Second, message: "idle timeout must not be negative: -1s"},
+		{timeout: time.Nanosecond, message: "idle timeout must be zero or at least 1ms: 1ns"},
+		{timeout: 1500 * time.Microsecond, message: "idle timeout must use whole milliseconds: 1.5ms"},
+	}
+	for _, test := range tests {
+		srv, err := NewWithIdleTimeout(":0", test.timeout, nil)
+		g.Expect(err).To(MatchError(test.message))
+		g.Expect(srv).To(BeNil())
+	}
+
+	srv, err := NewWithIdleTimeout(":0", time.Millisecond, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(srv.idleTimeout).To(Equal(time.Millisecond))
 }
 
 func TestIdleShutdownDisabled(t *testing.T) {
@@ -346,6 +360,38 @@ func TestShutdownBeforeStartDoesNotResurrectServer(t *testing.T) {
 	g.Expect(response.Code).To(Equal(http.StatusServiceUnavailable))
 }
 
+func TestWebSocketJoinRejectsClosedHub(t *testing.T) {
+	g := NewWithT(t)
+	srv := New(":0", nil)
+	sessionCtx, cancelSession := context.WithCancel(context.Background())
+	sess := srv.sessions.create(sessionCtx)
+	cancelSession()
+	g.Eventually(sess.hub.Done(), time.Second).Should(BeClosed())
+	g.Eventually(srv.sessions.count, time.Second).Should(Equal(0))
+
+	srv.sessions.mu.Lock()
+	srv.sessions.sessions[sess.id] = sess
+	srv.sessions.notifyLocked()
+	srv.sessions.mu.Unlock()
+
+	httpServer := httptest.NewServer(srv.httpServer.Handler)
+	defer httpServer.Close()
+	conn, _, err := websocket.DefaultDialer.Dial(
+		"ws"+strings.TrimPrefix(httpServer.URL, "http")+"/ws?session="+sess.id,
+		nil,
+	)
+	g.Expect(err).NotTo(HaveOccurred())
+	defer func() { _ = conn.Close() }()
+
+	g.Expect(conn.SetReadDeadline(time.Now().Add(time.Second))).To(Succeed())
+	_, _, err = conn.ReadMessage()
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(sess.hub.ClientCount()).To(Equal(0))
+
+	srv.sessions.remove(sess.id)
+	srv.Shutdown(time.Second)
+}
+
 func TestDAPBindFailureIsRetryable(t *testing.T) {
 	g := NewWithT(t)
 	running := startServer(t, 0)
@@ -356,9 +402,9 @@ func TestDAPBindFailureIsRetryable(t *testing.T) {
 	g.Expect(running.server.StartDAP("127.0.0.1:0")).To(MatchError(ErrDAPAlreadyStarted))
 }
 
-func TestDurationMillisecondsRoundsUp(t *testing.T) {
+func TestDurationMillisecondsIsExact(t *testing.T) {
 	g := NewWithT(t)
 	g.Expect(durationMilliseconds(0)).To(Equal(int64(0)))
-	g.Expect(durationMilliseconds(time.Nanosecond)).To(Equal(int64(1)))
-	g.Expect(durationMilliseconds(1500 * time.Microsecond)).To(Equal(int64(2)))
+	g.Expect(durationMilliseconds(time.Millisecond)).To(Equal(int64(1)))
+	g.Expect(durationMilliseconds(150 * time.Millisecond)).To(Equal(int64(150)))
 }

--- a/internal/server/lifecycle_test.go
+++ b/internal/server/lifecycle_test.go
@@ -17,10 +17,12 @@ import (
 	"github.com/gorilla/websocket"
 	. "github.com/onsi/gomega"
 
+	"github.com/bingosuite/bingo/internal/dap"
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
 
 const testIdleTimeout = 150 * time.Millisecond
+const admissionRaceTimeout = 500 * time.Millisecond
 
 type runningServer struct {
 	server *Server
@@ -240,55 +242,152 @@ func TestDAPCreatedSessionSuppressesIdleShutdown(t *testing.T) {
 
 func TestIdleExpiryYieldsToWebSocketAdmission(t *testing.T) {
 	g := NewWithT(t)
-	srv, err := NewWithIdleTimeout("127.0.0.1:0", testIdleTimeout, nil)
+	srv, err := NewWithIdleTimeout("127.0.0.1:0", admissionRaceTimeout, nil)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	ready := make(chan struct{})
-	proceed := make(chan struct{})
-	var hookOnce sync.Once
-	srv.idleCommitHook = func() {
-		hookOnce.Do(func() {
-			close(ready)
-			<-proceed
+	admissionReady := make(chan struct{})
+	releaseAdmission := make(chan struct{})
+	timerExpired := make(chan struct{})
+	var admissionOnce sync.Once
+	var timerOnce sync.Once
+	srv.admissionHook = func() {
+		admissionOnce.Do(func() {
+			close(admissionReady)
+			<-releaseAdmission
 		})
 	}
+	srv.idleTimerHook = func() {
+		timerOnce.Do(func() { close(timerExpired) })
+	}
 	running := startConstructedServer(t, srv)
-	g.Eventually(ready, time.Second).Should(BeClosed())
 
-	conn := dialCreate(t, running.url)
+	type dialResult struct {
+		conn *websocket.Conn
+		err  error
+	}
+	dialed := make(chan dialResult, 1)
+	go func() {
+		conn, _, dialErr := websocket.DefaultDialer.Dial(
+			"ws"+strings.TrimPrefix(running.url, "http")+"/ws?create",
+			nil,
+		)
+		dialed <- dialResult{conn: conn, err: dialErr}
+	}()
+	g.Eventually(admissionReady, time.Second).Should(BeClosed())
+	g.Eventually(timerExpired, time.Second).Should(BeClosed())
+	g.Expect(srv.beginSessionOperation()).To(BeFalse())
+	select {
+	case err := <-running.errCh:
+		t.Fatalf("server shut down with an active admission: %v", err)
+	default:
+	}
+	close(releaseAdmission)
+	var result dialResult
+	g.Eventually(dialed, time.Second).Should(Receive(&result))
+	g.Expect(result.err).NotTo(HaveOccurred())
+	conn := result.conn
 	defer func() { _ = conn.Close() }()
 	g.Eventually(srv.sessions.count, time.Second).Should(Equal(1))
-	close(proceed)
 
-	g.Consistently(running.errCh, 2*testIdleTimeout).ShouldNot(Receive())
+	g.Consistently(running.errCh, testIdleTimeout).ShouldNot(Receive())
 	g.Expect(conn.Close()).To(Succeed())
 	g.Eventually(running.errCh, time.Second).Should(Receive(BeNil()))
 }
 
 func TestIdleExpiryYieldsToDAPAdmission(t *testing.T) {
 	g := NewWithT(t)
-	srv, err := NewWithIdleTimeout("127.0.0.1:0", testIdleTimeout, nil)
+	srv, err := NewWithIdleTimeout("127.0.0.1:0", admissionRaceTimeout, nil)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	ready := make(chan struct{})
-	proceed := make(chan struct{})
-	var hookOnce sync.Once
-	srv.idleCommitHook = func() {
-		hookOnce.Do(func() {
-			close(ready)
-			<-proceed
+	admissionReady := make(chan struct{})
+	releaseAdmission := make(chan struct{})
+	timerExpired := make(chan struct{})
+	var admissionOnce sync.Once
+	var timerOnce sync.Once
+	srv.admissionHook = func() {
+		admissionOnce.Do(func() {
+			close(admissionReady)
+			<-releaseAdmission
+		})
+	}
+	srv.idleTimerHook = func() {
+		timerOnce.Do(func() { close(timerExpired) })
+	}
+	running := startConstructedServer(t, srv)
+
+	createResult := make(chan error, 1)
+	go func() {
+		_, createErr := (dapProvider{srv: srv}).CreateSession()
+		createResult <- createErr
+	}()
+	g.Eventually(admissionReady, time.Second).Should(BeClosed())
+	g.Eventually(timerExpired, time.Second).Should(BeClosed())
+	close(releaseAdmission)
+	g.Eventually(createResult, time.Second).Should(Receive(BeNil()))
+	g.Eventually(srv.sessions.count, time.Second).Should(Equal(1))
+
+	g.Consistently(running.errCh, testIdleTimeout).ShouldNot(Receive())
+	running.stop(t)
+}
+
+func TestExpiredIdleWaitsForFailedAdmissionThenShutsDown(t *testing.T) {
+	g := NewWithT(t)
+	srv, err := NewWithIdleTimeout("127.0.0.1:0", admissionRaceTimeout, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	admissionReady := make(chan struct{})
+	releaseAdmission := make(chan struct{})
+	timerExpired := make(chan struct{})
+	releaseTimer := make(chan struct{})
+	var admissionOnce sync.Once
+	var timerOnce sync.Once
+	srv.admissionHook = func() {
+		admissionOnce.Do(func() {
+			close(admissionReady)
+			<-releaseAdmission
+		})
+	}
+	srv.idleTimerHook = func() {
+		timerOnce.Do(func() {
+			close(timerExpired)
+			<-releaseTimer
 		})
 	}
 	running := startConstructedServer(t, srv)
-	g.Eventually(ready, time.Second).Should(BeClosed())
 
-	_, err = (dapProvider{srv: srv}).CreateSession()
-	g.Expect(err).NotTo(HaveOccurred())
-	g.Eventually(srv.sessions.count, time.Second).Should(Equal(1))
-	close(proceed)
+	joinResult := make(chan bool, 1)
+	go func() {
+		_, ok := (dapProvider{srv: srv}).GetSession("missing")
+		joinResult <- ok
+	}()
+	g.Eventually(admissionReady, time.Second).Should(BeClosed())
+	g.Eventually(timerExpired, time.Second).Should(BeClosed())
+	g.Expect(srv.beginSessionOperation()).To(BeFalse())
+	select {
+	case err := <-running.errCh:
+		t.Fatalf("server shut down before failed admission completed: %v", err)
+	default:
+	}
 
-	g.Consistently(running.errCh, 2*testIdleTimeout).ShouldNot(Receive())
-	running.stop(t)
+	close(releaseAdmission)
+	g.Eventually(joinResult, time.Second).Should(Receive(BeFalse()))
+	close(releaseTimer)
+	g.Eventually(running.errCh, time.Second).Should(Receive(BeNil()))
+}
+
+func TestFailedAdmissionsDoNotExtendExpiredDeadline(t *testing.T) {
+	g := NewWithT(t)
+	srv := New("127.0.0.1:0", nil)
+
+	for range 100 {
+		_, ok := (dapProvider{srv: srv}).GetSession("missing")
+		g.Expect(ok).To(BeFalse())
+	}
+	g.Expect(srv.commitIdleShutdown(0).committed).To(BeTrue())
+	g.Expect(srv.beginSessionOperation()).To(BeFalse())
+	_, err := (dapProvider{srv: srv}).CreateSession()
+	g.Expect(err).To(MatchError(ErrServerClosed))
+	srv.Shutdown(time.Second)
 }
 
 func TestActiveSessionSuppressesIdleShutdown(t *testing.T) {
@@ -436,6 +535,86 @@ func TestStartBindFailureFinalizesDAPAndDone(t *testing.T) {
 		_ = conn.Close()
 	}
 	g.Expect(err).To(HaveOccurred())
+}
+
+func TestStartCancellationDuringListenReturnsCleanly(t *testing.T) {
+	g := NewWithT(t)
+	srv := New("127.0.0.1:0", nil)
+	listenStarted := make(chan struct{})
+	srv.listen = func(ctx context.Context, _, _ string) (net.Listener, error) {
+		close(listenStarted)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	startResult := make(chan error, 1)
+	go func() {
+		startResult <- srv.Start()
+	}()
+	g.Eventually(listenStarted, time.Second).Should(BeClosed())
+	srv.Shutdown(time.Second)
+
+	g.Eventually(startResult, time.Second).Should(Receive(BeNil()))
+	g.Expect(srv.Done()).To(BeClosed())
+}
+
+func TestStartPreservesBindErrorDuringShutdown(t *testing.T) {
+	g := NewWithT(t)
+	srv := New("127.0.0.1:0", nil)
+	listenStarted := make(chan struct{})
+	bindErr := errors.New("bind failed")
+	srv.listen = func(ctx context.Context, _, _ string) (net.Listener, error) {
+		close(listenStarted)
+		<-ctx.Done()
+		return nil, bindErr
+	}
+
+	startResult := make(chan error, 1)
+	go func() {
+		startResult <- srv.Start()
+	}()
+	g.Eventually(listenStarted, time.Second).Should(BeClosed())
+	srv.Shutdown(time.Second)
+
+	g.Eventually(startResult, time.Second).Should(Receive(MatchError(bindErr)))
+	g.Expect(srv.Done()).To(BeClosed())
+}
+
+func TestShutdownCancelsAndJoinsDAPStart(t *testing.T) {
+	g := NewWithT(t)
+	srv := New("127.0.0.1:0", nil)
+	listenStarted := make(chan struct{})
+	listenCanceled := make(chan struct{})
+	releaseListen := make(chan struct{})
+	srv.dapServe = func(ctx context.Context, _ *dap.Server, _ string) (net.Addr, error) {
+		close(listenStarted)
+		<-ctx.Done()
+		close(listenCanceled)
+		<-releaseListen
+		return nil, ctx.Err()
+	}
+
+	startResult := make(chan error, 1)
+	go func() {
+		startResult <- srv.StartDAP("127.0.0.1:0")
+	}()
+	g.Eventually(listenStarted, time.Second).Should(BeClosed())
+	shutdownResult := make(chan struct{})
+	go func() {
+		srv.Shutdown(time.Second)
+		close(shutdownResult)
+	}()
+	g.Eventually(listenCanceled, time.Second).Should(BeClosed())
+	select {
+	case <-srv.Done():
+		t.Fatal("Done closed before the in-flight DAP start completed")
+	default:
+	}
+
+	close(releaseListen)
+	g.Eventually(startResult, time.Second).Should(Receive(MatchError(ErrServerClosed)))
+	g.Eventually(shutdownResult, time.Second).Should(BeClosed())
+	g.Expect(srv.Done()).To(BeClosed())
 }
 
 func TestShutdownBeforeStartDoesNotResurrectServer(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -36,23 +36,31 @@ type Server struct {
 	instanceID  string
 	idleTimeout time.Duration
 
-	lifecycleMu sync.RWMutex
-	started     bool
-	shutting    bool
-	admissions  uint64
-	httpAddress string
-	dapStarted  bool
-	dapServer   *dap.Server
-	dapAddress  string
+	lifecycleMu      sync.RWMutex
+	started          bool
+	shutting         bool
+	httpAddress      string
+	dapStarted       bool
+	dapStarting      bool
+	dapStartDone     chan struct{}
+	dapServer        *dap.Server
+	dapAddress       string
+	activeAdmissions int
+	admissionChanged chan struct{}
+	idleExpired      bool
 
 	monitorOnce  sync.Once
 	sessionOps   sync.WaitGroup
 	shutdownOnce sync.Once
 	shutdownDone chan struct{}
 
-	// The hook lets tests hold the narrow timer-fire-to-shutdown-commit window
-	// open without making production timing assumptions.
-	idleCommitHook func()
+	listen   func(context.Context, string, string) (net.Listener, error)
+	dapServe func(context.Context, *dap.Server, string) (net.Addr, error)
+
+	// These hooks expose admission and timer ordering without making tests rely
+	// on scheduler timing. Production leaves both nil.
+	admissionHook func()
+	idleTimerHook func()
 }
 
 // New creates a Server that will listen on addr (e.g. ":6060").
@@ -93,13 +101,19 @@ func newServer(addr string, idleTimeout time.Duration, log *slog.Logger) *Server
 	ctx, cancel := context.WithCancel(context.Background())
 
 	s := &Server{
-		sessions:     newSessionStore(log.With("component", "sessions")),
-		log:          log,
-		ctx:          ctx,
-		cancel:       cancel,
-		instanceID:   uuid.NewString(),
-		idleTimeout:  idleTimeout,
-		shutdownDone: make(chan struct{}),
+		sessions:         newSessionStore(log.With("component", "sessions")),
+		log:              log,
+		ctx:              ctx,
+		cancel:           cancel,
+		instanceID:       uuid.NewString(),
+		idleTimeout:      idleTimeout,
+		shutdownDone:     make(chan struct{}),
+		admissionChanged: make(chan struct{}),
+	}
+	var listenConfig net.ListenConfig
+	s.listen = listenConfig.Listen
+	s.dapServe = func(ctx context.Context, ds *dap.Server, addr string) (net.Addr, error) {
+		return ds.ServeContext(ctx, addr)
 	}
 
 	mux := http.NewServeMux()
@@ -130,9 +144,11 @@ func (s *Server) Start() error {
 	s.started = true
 	s.lifecycleMu.Unlock()
 
-	var listenConfig net.ListenConfig
-	ln, err := listenConfig.Listen(s.ctx, "tcp4", s.httpServer.Addr)
+	ln, err := s.listen(s.ctx, "tcp4", s.httpServer.Addr)
 	if err != nil {
+		if s.lifecycleStopping() && errors.Is(err, context.Canceled) {
+			return nil
+		}
 		s.Shutdown(idleShutdownGrace)
 		return err
 	}
@@ -177,11 +193,17 @@ func (s *Server) shutdown(timeout time.Duration) {
 	s.lifecycleMu.Lock()
 	s.shutting = true
 	ds := s.dapServer
+	dapStartDone := s.dapStartDone
 	s.dapServer = nil
 	s.dapAddress = ""
 	s.lifecycleMu.Unlock()
 
 	s.log.Info("shutting down server")
+	s.cancel()
+
+	if dapStartDone != nil {
+		<-dapStartDone
+	}
 
 	if ds != nil {
 		if err := ds.Close(); err != nil {
@@ -195,48 +217,92 @@ func (s *Server) shutdown(timeout time.Duration) {
 		s.log.Error("http shutdown error", "err", err)
 	}
 	s.sessionOps.Wait()
-	s.cancel()
 	if !s.sessions.waitEmpty(ctx) {
 		s.log.Error("session shutdown timed out", "remaining", s.sessions.count())
 	}
 }
 
-func (s *Server) acceptingSessions() bool {
-	s.lifecycleMu.RLock()
-	defer s.lifecycleMu.RUnlock()
-	return !s.shutting
-}
-
 func (s *Server) beginSessionOperation() bool {
 	s.lifecycleMu.Lock()
-	defer s.lifecycleMu.Unlock()
-	if s.shutting {
+	if s.shutting || s.idleExpired {
+		s.lifecycleMu.Unlock()
 		return false
 	}
-	s.admissions++
+	s.activeAdmissions++
 	s.sessionOps.Add(1)
+	hook := s.admissionHook
+	s.lifecycleMu.Unlock()
+	if hook != nil {
+		hook()
+	}
 	return true
 }
 
-func (s *Server) idleSnapshot() (int, uint64, uint64, <-chan struct{}) {
+func (s *Server) endSessionOperation() {
+	s.lifecycleMu.Lock()
+	s.activeAdmissions--
+	close(s.admissionChanged)
+	s.admissionChanged = make(chan struct{})
+	s.lifecycleMu.Unlock()
+	s.sessionOps.Done()
+}
+
+func (s *Server) admissionSnapshot() (int, <-chan struct{}) {
 	s.lifecycleMu.RLock()
 	defer s.lifecycleMu.RUnlock()
-	count, generation, changed := s.sessions.snapshot()
-	return count, generation, s.admissions, changed
+	return s.activeAdmissions, s.admissionChanged
 }
 
-func (s *Server) commitIdleShutdown(generation, admissions uint64) bool {
+type idleDecision struct {
+	committed        bool
+	expired          bool
+	count            int
+	generation       uint64
+	sessionChanged   <-chan struct{}
+	admissionChanged <-chan struct{}
+}
+
+func (s *Server) commitIdleShutdown(generation uint64) idleDecision {
 	s.lifecycleMu.Lock()
 	defer s.lifecycleMu.Unlock()
-	if s.shutting || s.admissions != admissions {
-		return false
+	count, currentGeneration, sessionChanged := s.sessions.snapshot()
+	decision := idleDecision{
+		count:            count,
+		generation:       currentGeneration,
+		sessionChanged:   sessionChanged,
+		admissionChanged: s.admissionChanged,
 	}
-	count, currentGeneration, _ := s.sessions.snapshot()
-	if count != 0 || currentGeneration != generation {
-		return false
+	if s.shutting {
+		return decision
+	}
+	if count != 0 {
+		s.idleExpired = false
+		return decision
+	}
+	if currentGeneration != generation {
+		s.idleExpired = false
+		return decision
+	}
+	s.idleExpired = true
+	decision.expired = true
+	if s.activeAdmissions != 0 {
+		return decision
 	}
 	s.shutting = true
-	return true
+	decision.committed = true
+	return decision
+}
+
+func (s *Server) clearIdleExpiry() {
+	s.lifecycleMu.Lock()
+	s.idleExpired = false
+	s.lifecycleMu.Unlock()
+}
+
+func (s *Server) lifecycleStopping() bool {
+	s.lifecycleMu.RLock()
+	defer s.lifecycleMu.RUnlock()
+	return s.shutting
 }
 
 func (s *Server) startIdleMonitor() {
@@ -252,8 +318,10 @@ func (s *Server) monitorIdle() {
 	timer := time.NewTimer(time.Hour)
 	stopTimer(timer)
 	var timerC <-chan time.Time
-	count, armedGeneration, armedAdmissions, changed := s.idleSnapshot()
-	if count == 0 {
+	sessionCount, armedGeneration, sessionChanged := s.sessions.snapshot()
+	_, admissionChanged := s.admissionSnapshot()
+	deadlineExpired := false
+	if sessionCount == 0 {
 		resetTimer(timer, s.idleTimeout)
 		timerC = timer.C
 	}
@@ -263,35 +331,74 @@ func (s *Server) monitorIdle() {
 		select {
 		case <-s.ctx.Done():
 			return
-		case <-changed:
-			count, generation, admissions, nextChanged := s.idleSnapshot()
-			changed = nextChanged
-			if count > 0 {
+		case <-sessionChanged:
+			count, generation, nextChanged := s.sessions.snapshot()
+			sessionChanged = nextChanged
+			sessionCount = count
+			if sessionCount > 0 {
 				stopTimer(timer)
 				timerC = nil
+				deadlineExpired = false
+				s.clearIdleExpiry()
+				continue
+			}
+			if deadlineExpired && generation == armedGeneration {
 				continue
 			}
 			resetTimer(timer, s.idleTimeout)
 			timerC = timer.C
+			deadlineExpired = false
 			armedGeneration = generation
-			armedAdmissions = admissions
-		case <-timerC:
-			timerC = nil
-			if s.idleCommitHook != nil {
-				s.idleCommitHook()
+			s.clearIdleExpiry()
+		case <-admissionChanged:
+			if !deadlineExpired {
+				_, admissionChanged = s.admissionSnapshot()
+				continue
 			}
-			if s.commitIdleShutdown(armedGeneration, armedAdmissions) {
+			decision := s.commitIdleShutdown(armedGeneration)
+			sessionChanged = decision.sessionChanged
+			admissionChanged = decision.admissionChanged
+			if decision.committed {
 				s.log.Info("managed server idle timeout elapsed", "timeout", s.idleTimeout)
 				s.Shutdown(idleShutdownGrace)
 				return
 			}
-			count, generation, admissions, nextChanged := s.idleSnapshot()
-			changed = nextChanged
-			if count == 0 {
+			sessionCount = decision.count
+			if sessionCount > 0 {
+				stopTimer(timer)
+				timerC = nil
+				deadlineExpired = false
+				continue
+			}
+			if !decision.expired {
 				resetTimer(timer, s.idleTimeout)
 				timerC = timer.C
-				armedGeneration = generation
-				armedAdmissions = admissions
+				deadlineExpired = false
+				armedGeneration = decision.generation
+			}
+		case <-timerC:
+			timerC = nil
+			decision := s.commitIdleShutdown(armedGeneration)
+			sessionChanged = decision.sessionChanged
+			admissionChanged = decision.admissionChanged
+			deadlineExpired = decision.expired
+			if s.idleTimerHook != nil {
+				s.idleTimerHook()
+			}
+			if decision.committed {
+				s.log.Info("managed server idle timeout elapsed", "timeout", s.idleTimeout)
+				s.Shutdown(idleShutdownGrace)
+				return
+			}
+			sessionCount = decision.count
+			if sessionCount > 0 {
+				deadlineExpired = false
+				continue
+			}
+			if !decision.expired {
+				resetTimer(timer, s.idleTimeout)
+				timerC = timer.C
+				armedGeneration = decision.generation
 			}
 		}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -59,10 +59,25 @@ func New(addr string, log *slog.Logger) *Server {
 // count remains zero for idleTimeout. A zero timeout preserves persistent
 // server behavior.
 func NewWithIdleTimeout(addr string, idleTimeout time.Duration, log *slog.Logger) (*Server, error) {
-	if idleTimeout < 0 {
-		return nil, fmt.Errorf("idle timeout must not be negative: %s", idleTimeout)
+	if err := ValidateIdleTimeout(idleTimeout); err != nil {
+		return nil, err
 	}
 	return newServer(addr, idleTimeout, log), nil
+}
+
+// ValidateIdleTimeout ensures the timer and timeoutMs health field can represent
+// the configured duration identically.
+func ValidateIdleTimeout(idleTimeout time.Duration) error {
+	switch {
+	case idleTimeout < 0:
+		return fmt.Errorf("idle timeout must not be negative: %s", idleTimeout)
+	case idleTimeout > 0 && idleTimeout < time.Millisecond:
+		return fmt.Errorf("idle timeout must be zero or at least 1ms: %s", idleTimeout)
+	case idleTimeout%time.Millisecond != 0:
+		return fmt.Errorf("idle timeout must use whole milliseconds: %s", idleTimeout)
+	default:
+		return nil
+	}
 }
 
 func newServer(addr string, idleTimeout time.Duration, log *slog.Logger) *Server {
@@ -144,6 +159,12 @@ func (s *Server) Shutdown(timeout time.Duration) {
 		close(s.shutdownDone)
 	})
 	<-s.shutdownDone
+}
+
+// Done closes after the server has finished closing listeners and draining all
+// managed sessions.
+func (s *Server) Done() <-chan struct{} {
+	return s.shutdownDone
 }
 
 func (s *Server) shutdown(timeout time.Duration) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -262,6 +262,43 @@ type idleDecision struct {
 	admissionChanged <-chan struct{}
 }
 
+type idleMonitorState struct {
+	timer            *time.Timer
+	timerC           <-chan time.Time
+	sessionCount     int
+	armedGeneration  uint64
+	sessionChanged   <-chan struct{}
+	admissionChanged <-chan struct{}
+	deadlineExpired  bool
+}
+
+func (state *idleMonitorState) disarm() {
+	stopTimer(state.timer)
+	state.timerC = nil
+	state.deadlineExpired = false
+}
+
+func (state *idleMonitorState) rearm(timeout time.Duration, generation uint64) {
+	resetTimer(state.timer, timeout)
+	state.timerC = state.timer.C
+	state.deadlineExpired = false
+	state.armedGeneration = generation
+}
+
+func (state *idleMonitorState) apply(decision idleDecision, timeout time.Duration) {
+	state.sessionCount = decision.count
+	state.sessionChanged = decision.sessionChanged
+	state.admissionChanged = decision.admissionChanged
+	state.deadlineExpired = decision.expired
+	if state.sessionCount > 0 {
+		state.disarm()
+		return
+	}
+	if !decision.expired {
+		state.rearm(timeout, decision.generation)
+	}
+}
+
 func (s *Server) commitIdleShutdown(generation uint64) idleDecision {
 	s.lifecycleMu.Lock()
 	defer s.lifecycleMu.Unlock()
@@ -314,16 +351,54 @@ func (s *Server) startIdleMonitor() {
 	})
 }
 
+func (s *Server) resolveIdleDecision(state *idleMonitorState, decision idleDecision) bool {
+	state.apply(decision, s.idleTimeout)
+	if !decision.committed {
+		return false
+	}
+	s.log.Info("managed server idle timeout elapsed", "timeout", s.idleTimeout)
+	s.Shutdown(idleShutdownGrace)
+	return true
+}
+
+func (s *Server) handleIdleSessionChange(state *idleMonitorState) {
+	count, generation, nextChanged := s.sessions.snapshot()
+	state.sessionChanged = nextChanged
+	state.sessionCount = count
+	if state.sessionCount > 0 {
+		state.disarm()
+		s.clearIdleExpiry()
+		return
+	}
+	if state.deadlineExpired && generation == state.armedGeneration {
+		return
+	}
+	state.rearm(s.idleTimeout, generation)
+	s.clearIdleExpiry()
+}
+
+func (s *Server) handleIdleAdmissionChange(state *idleMonitorState) bool {
+	if !state.deadlineExpired {
+		_, state.admissionChanged = s.admissionSnapshot()
+		return false
+	}
+	return s.resolveIdleDecision(state, s.commitIdleShutdown(state.armedGeneration))
+}
+
 func (s *Server) monitorIdle() {
 	timer := time.NewTimer(time.Hour)
 	stopTimer(timer)
-	var timerC <-chan time.Time
-	sessionCount, armedGeneration, sessionChanged := s.sessions.snapshot()
+	sessionCount, generation, sessionChanged := s.sessions.snapshot()
 	_, admissionChanged := s.admissionSnapshot()
-	deadlineExpired := false
+	state := idleMonitorState{
+		timer:            timer,
+		sessionCount:     sessionCount,
+		armedGeneration:  generation,
+		sessionChanged:   sessionChanged,
+		admissionChanged: admissionChanged,
+	}
 	if sessionCount == 0 {
-		resetTimer(timer, s.idleTimeout)
-		timerC = timer.C
+		state.rearm(s.idleTimeout, generation)
 	}
 	defer stopTimer(timer)
 
@@ -331,74 +406,20 @@ func (s *Server) monitorIdle() {
 		select {
 		case <-s.ctx.Done():
 			return
-		case <-sessionChanged:
-			count, generation, nextChanged := s.sessions.snapshot()
-			sessionChanged = nextChanged
-			sessionCount = count
-			if sessionCount > 0 {
-				stopTimer(timer)
-				timerC = nil
-				deadlineExpired = false
-				s.clearIdleExpiry()
-				continue
-			}
-			if deadlineExpired && generation == armedGeneration {
-				continue
-			}
-			resetTimer(timer, s.idleTimeout)
-			timerC = timer.C
-			deadlineExpired = false
-			armedGeneration = generation
-			s.clearIdleExpiry()
-		case <-admissionChanged:
-			if !deadlineExpired {
-				_, admissionChanged = s.admissionSnapshot()
-				continue
-			}
-			decision := s.commitIdleShutdown(armedGeneration)
-			sessionChanged = decision.sessionChanged
-			admissionChanged = decision.admissionChanged
-			if decision.committed {
-				s.log.Info("managed server idle timeout elapsed", "timeout", s.idleTimeout)
-				s.Shutdown(idleShutdownGrace)
+		case <-state.sessionChanged:
+			s.handleIdleSessionChange(&state)
+		case <-state.admissionChanged:
+			if s.handleIdleAdmissionChange(&state) {
 				return
 			}
-			sessionCount = decision.count
-			if sessionCount > 0 {
-				stopTimer(timer)
-				timerC = nil
-				deadlineExpired = false
-				continue
-			}
-			if !decision.expired {
-				resetTimer(timer, s.idleTimeout)
-				timerC = timer.C
-				deadlineExpired = false
-				armedGeneration = decision.generation
-			}
-		case <-timerC:
-			timerC = nil
-			decision := s.commitIdleShutdown(armedGeneration)
-			sessionChanged = decision.sessionChanged
-			admissionChanged = decision.admissionChanged
-			deadlineExpired = decision.expired
+		case <-state.timerC:
+			state.timerC = nil
+			decision := s.commitIdleShutdown(state.armedGeneration)
 			if s.idleTimerHook != nil {
 				s.idleTimerHook()
 			}
-			if decision.committed {
-				s.log.Info("managed server idle timeout elapsed", "timeout", s.idleTimeout)
-				s.Shutdown(idleShutdownGrace)
+			if s.resolveIdleDecision(&state, decision) {
 				return
-			}
-			sessionCount = decision.count
-			if sessionCount > 0 {
-				deadlineExpired = false
-				continue
-			}
-			if !decision.expired {
-				resetTimer(timer, s.idleTimeout)
-				timerC = timer.C
-				armedGeneration = decision.generation
 			}
 		}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -39,6 +39,7 @@ type Server struct {
 	lifecycleMu sync.RWMutex
 	started     bool
 	shutting    bool
+	admissions  uint64
 	httpAddress string
 	dapStarted  bool
 	dapServer   *dap.Server
@@ -48,6 +49,10 @@ type Server struct {
 	sessionOps   sync.WaitGroup
 	shutdownOnce sync.Once
 	shutdownDone chan struct{}
+
+	// The hook lets tests hold the narrow timer-fire-to-shutdown-commit window
+	// open without making production timing assumptions.
+	idleCommitHook func()
 }
 
 // New creates a Server that will listen on addr (e.g. ":6060").
@@ -113,32 +118,32 @@ func newServer(addr string, idleTimeout time.Duration, log *slog.Logger) *Server
 
 // Start blocks until shutdown or a fatal listener error.
 func (s *Server) Start() error {
-	s.lifecycleMu.RLock()
-	shutting := s.shutting
-	s.lifecycleMu.RUnlock()
-	if shutting {
+	s.lifecycleMu.Lock()
+	if s.shutting {
+		s.lifecycleMu.Unlock()
 		return nil
 	}
+	if s.started {
+		s.lifecycleMu.Unlock()
+		return ErrServerStarted
+	}
+	s.started = true
+	s.lifecycleMu.Unlock()
 
-	ln, err := net.Listen("tcp4", s.httpServer.Addr)
+	var listenConfig net.ListenConfig
+	ln, err := listenConfig.Listen(s.ctx, "tcp4", s.httpServer.Addr)
 	if err != nil {
+		s.Shutdown(idleShutdownGrace)
 		return err
 	}
 
 	s.lifecycleMu.Lock()
-	switch {
-	case s.shutting:
+	if s.shutting {
 		s.lifecycleMu.Unlock()
 		_ = ln.Close()
 		return nil
-	case s.started:
-		s.lifecycleMu.Unlock()
-		_ = ln.Close()
-		return ErrServerStarted
-	default:
-		s.started = true
-		s.httpAddress = ln.Addr().String()
 	}
+	s.httpAddress = ln.Addr().String()
 	s.lifecycleMu.Unlock()
 
 	s.log.Info("bingo server listening", "addr", ln.Addr().String())
@@ -148,6 +153,7 @@ func (s *Server) Start() error {
 	if errors.Is(err, http.ErrServerClosed) {
 		return nil
 	}
+	s.Shutdown(idleShutdownGrace)
 	return err
 }
 
@@ -207,7 +213,29 @@ func (s *Server) beginSessionOperation() bool {
 	if s.shutting {
 		return false
 	}
+	s.admissions++
 	s.sessionOps.Add(1)
+	return true
+}
+
+func (s *Server) idleSnapshot() (int, uint64, uint64, <-chan struct{}) {
+	s.lifecycleMu.RLock()
+	defer s.lifecycleMu.RUnlock()
+	count, generation, changed := s.sessions.snapshot()
+	return count, generation, s.admissions, changed
+}
+
+func (s *Server) commitIdleShutdown(generation, admissions uint64) bool {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	if s.shutting || s.admissions != admissions {
+		return false
+	}
+	count, currentGeneration, _ := s.sessions.snapshot()
+	if count != 0 || currentGeneration != generation {
+		return false
+	}
+	s.shutting = true
 	return true
 }
 
@@ -224,7 +252,7 @@ func (s *Server) monitorIdle() {
 	timer := time.NewTimer(time.Hour)
 	stopTimer(timer)
 	var timerC <-chan time.Time
-	count, armedGeneration, changed := s.sessions.snapshot()
+	count, armedGeneration, armedAdmissions, changed := s.idleSnapshot()
 	if count == 0 {
 		resetTimer(timer, s.idleTimeout)
 		timerC = timer.C
@@ -236,7 +264,7 @@ func (s *Server) monitorIdle() {
 		case <-s.ctx.Done():
 			return
 		case <-changed:
-			count, generation, nextChanged := s.sessions.snapshot()
+			count, generation, admissions, nextChanged := s.idleSnapshot()
 			changed = nextChanged
 			if count > 0 {
 				stopTimer(timer)
@@ -246,19 +274,24 @@ func (s *Server) monitorIdle() {
 			resetTimer(timer, s.idleTimeout)
 			timerC = timer.C
 			armedGeneration = generation
+			armedAdmissions = admissions
 		case <-timerC:
-			count, generation, nextChanged := s.sessions.snapshot()
-			changed = nextChanged
 			timerC = nil
-			if count == 0 && generation == armedGeneration {
+			if s.idleCommitHook != nil {
+				s.idleCommitHook()
+			}
+			if s.commitIdleShutdown(armedGeneration, armedAdmissions) {
 				s.log.Info("managed server idle timeout elapsed", "timeout", s.idleTimeout)
 				s.Shutdown(idleShutdownGrace)
 				return
 			}
+			count, generation, admissions, nextChanged := s.idleSnapshot()
+			changed = nextChanged
 			if count == 0 {
 				resetTimer(timer, s.idleTimeout)
 				timerC = timer.C
 				armedGeneration = generation
+				armedAdmissions = admissions
 			}
 		}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,27 +5,67 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/bingosuite/bingo/internal/dap"
+	"github.com/google/uuid"
+)
+
+const idleShutdownGrace = 10 * time.Second
+
+var (
+	ErrServerClosed      = errors.New("server is shutting down")
+	ErrServerStarted     = errors.New("server already started")
+	ErrDAPAlreadyStarted = errors.New("DAP server already started")
 )
 
 // Server owns the HTTP listener, the session store, and the lifecycle of all
 // debug sessions.
 type Server struct {
 	httpServer *http.Server
-	dapServer  *dap.Server
 	sessions   *sessionStore
 	log        *slog.Logger
 	ctx        context.Context
 	cancel     context.CancelFunc
+
+	instanceID  string
+	idleTimeout time.Duration
+
+	lifecycleMu sync.RWMutex
+	started     bool
+	shutting    bool
+	httpAddress string
+	dapStarted  bool
+	dapServer   *dap.Server
+	dapAddress  string
+
+	monitorOnce  sync.Once
+	sessionOps   sync.WaitGroup
+	shutdownOnce sync.Once
+	shutdownDone chan struct{}
 }
 
 // New creates a Server that will listen on addr (e.g. ":6060").
 func New(addr string, log *slog.Logger) *Server {
+	return newServer(addr, 0, log)
+}
+
+// NewWithIdleTimeout creates a Server that exits after its managed-session
+// count remains zero for idleTimeout. A zero timeout preserves persistent
+// server behavior.
+func NewWithIdleTimeout(addr string, idleTimeout time.Duration, log *slog.Logger) (*Server, error) {
+	if idleTimeout < 0 {
+		return nil, fmt.Errorf("idle timeout must not be negative: %s", idleTimeout)
+	}
+	return newServer(addr, idleTimeout, log), nil
+}
+
+func newServer(addr string, idleTimeout time.Duration, log *slog.Logger) *Server {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -33,13 +73,17 @@ func New(addr string, log *slog.Logger) *Server {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	s := &Server{
-		sessions: newSessionStore(log.With("component", "sessions")),
-		log:      log,
-		ctx:      ctx,
-		cancel:   cancel,
+		sessions:     newSessionStore(log.With("component", "sessions")),
+		log:          log,
+		ctx:          ctx,
+		cancel:       cancel,
+		instanceID:   uuid.NewString(),
+		idleTimeout:  idleTimeout,
+		shutdownDone: make(chan struct{}),
 	}
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("/api/health", s.handleHealth)
 	mux.HandleFunc("/api/sessions", s.handleListSessions)
 	mux.HandleFunc("/ws", s.handleWS)
 
@@ -54,11 +98,36 @@ func New(addr string, log *slog.Logger) *Server {
 
 // Start blocks until shutdown or a fatal listener error.
 func (s *Server) Start() error {
+	s.lifecycleMu.RLock()
+	shutting := s.shutting
+	s.lifecycleMu.RUnlock()
+	if shutting {
+		return nil
+	}
+
 	ln, err := net.Listen("tcp4", s.httpServer.Addr)
 	if err != nil {
 		return err
 	}
+
+	s.lifecycleMu.Lock()
+	switch {
+	case s.shutting:
+		s.lifecycleMu.Unlock()
+		_ = ln.Close()
+		return nil
+	case s.started:
+		s.lifecycleMu.Unlock()
+		_ = ln.Close()
+		return ErrServerStarted
+	default:
+		s.started = true
+		s.httpAddress = ln.Addr().String()
+	}
+	s.lifecycleMu.Unlock()
+
 	s.log.Info("bingo server listening", "addr", ln.Addr().String())
+	s.startIdleMonitor()
 
 	err = s.httpServer.Serve(ln)
 	if errors.Is(err, http.ErrServerClosed) {
@@ -70,11 +139,25 @@ func (s *Server) Start() error {
 // Shutdown closes the HTTP listener, drains in-flight requests, and cancels
 // all session contexts.
 func (s *Server) Shutdown(timeout time.Duration) {
-	s.log.Info("shutting down server")
-	s.cancel()
+	s.shutdownOnce.Do(func() {
+		s.shutdown(timeout)
+		close(s.shutdownDone)
+	})
+	<-s.shutdownDone
+}
 
-	if s.dapServer != nil {
-		if err := s.dapServer.Close(); err != nil {
+func (s *Server) shutdown(timeout time.Duration) {
+	s.lifecycleMu.Lock()
+	s.shutting = true
+	ds := s.dapServer
+	s.dapServer = nil
+	s.dapAddress = ""
+	s.lifecycleMu.Unlock()
+
+	s.log.Info("shutting down server")
+
+	if ds != nil {
+		if err := ds.Close(); err != nil {
 			s.log.Error("dap shutdown error", "err", err)
 		}
 	}
@@ -84,4 +167,92 @@ func (s *Server) Shutdown(timeout time.Duration) {
 	if err := s.httpServer.Shutdown(ctx); err != nil {
 		s.log.Error("http shutdown error", "err", err)
 	}
+	s.sessionOps.Wait()
+	s.cancel()
+	if !s.sessions.waitEmpty(ctx) {
+		s.log.Error("session shutdown timed out", "remaining", s.sessions.count())
+	}
+}
+
+func (s *Server) acceptingSessions() bool {
+	s.lifecycleMu.RLock()
+	defer s.lifecycleMu.RUnlock()
+	return !s.shutting
+}
+
+func (s *Server) beginSessionOperation() bool {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	if s.shutting {
+		return false
+	}
+	s.sessionOps.Add(1)
+	return true
+}
+
+func (s *Server) startIdleMonitor() {
+	if s.idleTimeout <= 0 {
+		return
+	}
+	s.monitorOnce.Do(func() {
+		go s.monitorIdle()
+	})
+}
+
+func (s *Server) monitorIdle() {
+	timer := time.NewTimer(time.Hour)
+	stopTimer(timer)
+	var timerC <-chan time.Time
+	count, armedGeneration, changed := s.sessions.snapshot()
+	if count == 0 {
+		resetTimer(timer, s.idleTimeout)
+		timerC = timer.C
+	}
+	defer stopTimer(timer)
+
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-changed:
+			count, generation, nextChanged := s.sessions.snapshot()
+			changed = nextChanged
+			if count > 0 {
+				stopTimer(timer)
+				timerC = nil
+				continue
+			}
+			resetTimer(timer, s.idleTimeout)
+			timerC = timer.C
+			armedGeneration = generation
+		case <-timerC:
+			count, generation, nextChanged := s.sessions.snapshot()
+			changed = nextChanged
+			timerC = nil
+			if count == 0 && generation == armedGeneration {
+				s.log.Info("managed server idle timeout elapsed", "timeout", s.idleTimeout)
+				s.Shutdown(idleShutdownGrace)
+				return
+			}
+			if count == 0 {
+				resetTimer(timer, s.idleTimeout)
+				timerC = timer.C
+				armedGeneration = generation
+			}
+		}
+	}
+}
+
+func stopTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}
+
+func resetTimer(timer *time.Timer, timeout time.Duration) {
+	stopTimer(timer)
+	timer.Reset(timeout)
 }

--- a/internal/server/session.go
+++ b/internal/server/session.go
@@ -38,14 +38,17 @@ func (s *session) info() SessionInfo {
 
 // sessionStore is the goroutine-safe set of active sessions.
 type sessionStore struct {
-	mu       sync.RWMutex
-	sessions map[string]*session
-	log      *slog.Logger
+	mu         sync.RWMutex
+	sessions   map[string]*session
+	generation uint64
+	changed    chan struct{}
+	log        *slog.Logger
 }
 
 func newSessionStore(log *slog.Logger) *sessionStore {
 	return &sessionStore{
 		sessions: make(map[string]*session),
+		changed:  make(chan struct{}),
 		log:      log,
 	}
 }
@@ -74,6 +77,7 @@ func (ss *sessionStore) create(ctx context.Context) *session {
 
 	ss.mu.Lock()
 	ss.sessions[id] = s
+	ss.notifyLocked()
 	ss.mu.Unlock()
 
 	go func() {
@@ -94,8 +98,12 @@ func (ss *sessionStore) get(id string) *session {
 
 func (ss *sessionStore) remove(id string) {
 	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	if _, ok := ss.sessions[id]; !ok {
+		return
+	}
 	delete(ss.sessions, id)
-	ss.mu.Unlock()
+	ss.notifyLocked()
 }
 
 func (ss *sessionStore) list() []SessionInfo {
@@ -109,7 +117,32 @@ func (ss *sessionStore) list() []SessionInfo {
 }
 
 func (ss *sessionStore) count() int {
+	count, _, _ := ss.snapshot()
+	return count
+}
+
+func (ss *sessionStore) snapshot() (int, uint64, <-chan struct{}) {
 	ss.mu.RLock()
 	defer ss.mu.RUnlock()
-	return len(ss.sessions)
+	return len(ss.sessions), ss.generation, ss.changed
+}
+
+func (ss *sessionStore) notifyLocked() {
+	ss.generation++
+	close(ss.changed)
+	ss.changed = make(chan struct{})
+}
+
+func (ss *sessionStore) waitEmpty(ctx context.Context) bool {
+	for {
+		count, _, changed := ss.snapshot()
+		if count == 0 {
+			return true
+		}
+		select {
+		case <-changed:
+		case <-ctx.Done():
+			return false
+		}
+	}
 }

--- a/justfile
+++ b/justfile
@@ -22,6 +22,9 @@ build OS=os_name ARCH=arch_name:
 #		 just run linux amd64 -addr 127.0.0.1:6061 -v 	->  runs ./build/bingo/bingo_linux_amd64 -addr 127.0.0.1:6061 -v
 
 # ARGS:  -addr string    listen address (default ":6060")
+#		 -idle-timeout duration
+#		                 exit after no managed sessions for this duration;
+#		                 omitted/0 keeps the server persistent
 #		 -v              verbose logging (debug level)
 # Run the BinGo binary. Takes positional arguments for the target OS and architecture (Must be existing binaries).
 run OS=os_name ARCH=arch_name *ARGS="":
@@ -36,7 +39,9 @@ dap_addr := ":4711"
 # and DAP (-dap-addr) listeners, using the standard defaults so a DAP driver
 # (VS Code / `just dapcli`) and a `go run ./cmd/wsmon` observer can share one
 # session out of the box (see docs/ConcurrencyTelemetry.md). Override addresses
-# via the ADDR/DAP_ADDR positionals; extra flags (e.g. -v) pass through in ARGS.
+# via the ADDR/DAP_ADDR positionals; extra flags (e.g. `-idle-timeout 30s`) pass
+# through in ARGS. No idle timeout is supplied by default, so manual servers
+# remain persistent.
 server OS=os_name ARCH=arch_name ADDR=ws_addr DAP_ADDR=dap_addr *ARGS="": build-target (build OS ARCH)
 	./build/bingo/bingo_{{OS}}_{{ARCH}} -addr {{ADDR}} -dap-addr {{DAP_ADDR}} {{ARGS}}
 

--- a/justfile
+++ b/justfile
@@ -24,7 +24,8 @@ build OS=os_name ARCH=arch_name:
 # ARGS:  -addr string    listen address (default ":6060")
 #		 -idle-timeout duration
 #		                 exit after no managed sessions for this duration;
-#		                 omitted/0 keeps the server persistent
+#		                 omitted/0 keeps the server persistent; positive values
+#		                 use whole milliseconds (minimum 1ms)
 #		 -v              verbose logging (debug level)
 # Run the BinGo binary. Takes positional arguments for the target OS and architecture (Must be existing binaries).
 run OS=os_name ARCH=arch_name *ARGS="":


### PR DESCRIPTION
## Summary

- add a stable, non-cacheable `GET /api/health` management API v1 with bingo identity, wire protocol version, per-process instance UUID, resolved DAP listener address, managed-idle configuration, and current session count
- add opt-in `-idle-timeout` self-shutdown while preserving persistent manual servers by default
- make session-count notifications, timer rearming, DAP/HTTP admission, and repeated shutdown race-safe and event-driven
- document connect-or-start ownership and independent management/wire compatibility without changing the current VS Code extension's connect-only behavior

## Health contract

```json
{
  "service": "bingo",
  "managementApiVersion": 1,
  "wireProtocolVersion": "1.2",
  "instanceId": "<per-process UUID>",
  "dap": {
    "enabled": true,
    "address": "127.0.0.1:4711"
  },
  "managedIdleShutdown": {
    "enabled": true,
    "timeoutMs": 30000
  },
  "sessionCount": 0
}
```

`managementApiVersion` is independent of `pkg/protocol.Version`. DAP reports the actual bound address, including the selected port for `:0`.

## Idle lifecycle

- `0`/unset keeps the server persistent
- zero sessions at startup arms the full grace period
- any active managed session suppresses shutdown
- the final disconnect starts a fresh grace period
- a new session cancels/rearms the timer using a generation-stamped store transition
- health polling and bare DAP TCP connections do not count as sessions
- frontends never directly kill the shared process; DAP + HTTP admission closes before hub contexts are canceled and drained

## Validation

- `go test -race -tags bingonative ./internal/server/... ./cmd/bingo/... ./internal/dap/...`
- `go vet -tags bingonative ./...`
- `go test -tags bingonative ./...`
- `git diff --check`