### PR TITLE
feat(vscode): autostart managed bingo server

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -9,11 +9,31 @@ permissions:
   contents: read
 
 jobs:
-  validate:
-    name: Lint, test, and package
-    runs-on: ubuntu-latest
+  package:
+    name: Package ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            target: linux-x64
+            goos: linux
+            goarch: amd64
+          - runner: macos-14
+            target: darwin-arm64
+            goos: darwin
+            goarch: arm64
+
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.5"
+          cache: true
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -22,14 +42,36 @@ jobs:
           cache: npm
           cache-dependency-path: editors/vscode/package-lock.json
 
-      - name: Install locked dependencies
+      - name: Confirm native package target
+        run: |
+          test "$(go env GOOS)" = "${{ matrix.goos }}"
+          test "$(go env GOARCH)" = "${{ matrix.goarch }}"
+          test "$(node -p 'process.platform + "/" + process.arch')" = "${{ matrix.goos }}/${{ matrix.target == 'linux-x64' && 'x64' || 'arm64' }}"
+
+      - name: Install locked dependencies without lifecycle scripts
         run: npm --prefix editors/vscode ci --ignore-scripts
 
-      - name: Validate extension
+      - name: Validate extension source
         run: npm --prefix editors/vscode run check
 
-      - name: Build VSIX
+      - name: Build reproducible native VSIX
         run: npm --prefix editors/vscode run package:reproducible
 
-      - name: Verify VSIX artifact
-        run: test -s dist/bingo.vsix
+      - name: Verify exact package contents
+        run: npm --prefix editors/vscode run package:verify
+
+      - name: Smoke packaged server health and idle exit
+        run: npm --prefix editors/vscode run smoke:server
+
+      - name: Print artifact hashes
+        run: shasum -a 256 "editors/vscode/bin/bingo" "dist/bingo-${{ matrix.target }}.vsix"
+
+      - name: Check generated outputs stay ignored
+        run: git diff --exit-code
+
+      - name: Upload platform VSIX
+        uses: actions/upload-artifact@v4
+        with:
+          name: bingo-${{ matrix.target }}
+          path: dist/bingo-${{ matrix.target }}.vsix
+          if-no-files-found: error

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -23,10 +23,14 @@ jobs:
             target: linux-x64
             goos: linux
             goarch: amd64
-          - runner: macos-14
+            nodearch: x64
+            unamearch: x86_64
+          - runner: macos-15
             target: darwin-arm64
             goos: darwin
             goarch: arm64
+            nodearch: arm64
+            unamearch: arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -47,16 +51,10 @@ jobs:
       - name: Confirm package builder
         run: |
           test "$(go env GOOS)" = "${{ matrix.goos }}"
+          test "$(go env GOARCH)" = "${{ matrix.goarch }}"
           test "$(node -p 'process.platform')" = "${{ matrix.goos }}"
-          if test "${{ matrix.target }}" = "linux-x64"; then
-            test "$(go env GOARCH)" = "${{ matrix.goarch }}"
-            test "$(node -p 'process.arch')" = "x64"
-          else
-            case "$(node -p 'process.arch')" in
-              arm64|x64) ;;
-              *) exit 1 ;;
-            esac
-          fi
+          test "$(node -p 'process.arch')" = "${{ matrix.nodearch }}"
+          test "$(uname -m)" = "${{ matrix.unamearch }}"
 
       - name: Install locked dependencies without lifecycle scripts
         run: npm --prefix editors/vscode ci --ignore-scripts
@@ -73,10 +71,6 @@ jobs:
       - name: Smoke packaged server health and idle exit
         if: matrix.target == 'linux-x64' || runner.arch == 'ARM64'
         run: npm --prefix editors/vscode run smoke:server
-
-      - name: Report cross-built Darwin smoke
-        if: matrix.target == 'darwin-arm64' && runner.arch != 'ARM64'
-        run: echo "darwin-arm64 package was cross-built, signed, and inspected; execution smoke requires an arm64 runner"
 
       - name: Print artifact hashes
         run: shasum -a 256 "editors/vscode/bin/bingo" "dist/bingo-${{ matrix.target }}.vsix"

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -13,6 +13,8 @@ jobs:
     name: Package ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
+    env:
+      BINGO_VSCODE_TARGET: ${{ matrix.target }}
     strategy:
       fail-fast: false
       matrix:
@@ -42,11 +44,19 @@ jobs:
           cache: npm
           cache-dependency-path: editors/vscode/package-lock.json
 
-      - name: Confirm native package target
+      - name: Confirm package builder
         run: |
           test "$(go env GOOS)" = "${{ matrix.goos }}"
-          test "$(go env GOARCH)" = "${{ matrix.goarch }}"
-          test "$(node -p 'process.platform + "/" + process.arch')" = "${{ matrix.goos }}/${{ matrix.target == 'linux-x64' && 'x64' || 'arm64' }}"
+          test "$(node -p 'process.platform')" = "${{ matrix.goos }}"
+          if test "${{ matrix.target }}" = "linux-x64"; then
+            test "$(go env GOARCH)" = "${{ matrix.goarch }}"
+            test "$(node -p 'process.arch')" = "x64"
+          else
+            case "$(node -p 'process.arch')" in
+              arm64|x64) ;;
+              *) exit 1 ;;
+            esac
+          fi
 
       - name: Install locked dependencies without lifecycle scripts
         run: npm --prefix editors/vscode ci --ignore-scripts
@@ -61,7 +71,12 @@ jobs:
         run: npm --prefix editors/vscode run package:verify
 
       - name: Smoke packaged server health and idle exit
+        if: matrix.target == 'linux-x64' || runner.arch == 'ARM64'
         run: npm --prefix editors/vscode run smoke:server
+
+      - name: Report cross-built Darwin smoke
+        if: matrix.target == 'darwin-arm64' && runner.arch != 'ARM64'
+        run: echo "darwin-arm64 package was cross-built, signed, and inspected; execution smoke requires an arm64 runner"
 
       - name: Print artifact hashes
         run: shasum -a 256 "editors/vscode/bin/bingo" "dist/bingo-${{ matrix.target }}.vsix"

--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,6 @@ test/coverage.out
 
 # VS Code companion extension outputs
 /editors/vscode/node_modules/
+/editors/vscode/bin/
 /editors/vscode/dist/
 /editors/vscode/*.vsix

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,22 +2,44 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Run bingo extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/editors/vscode"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/editors/vscode/dist/**/*.js"
+      ],
+      "preLaunchTask": "bingo: prepare F5"
+    },
+    {
       "name": "bingo DAP: launch spawntree (stop on entry)",
       "type": "bingo",
       "request": "launch",
       "program": "${workspaceFolder}/build/spawntree",
-      "preLaunchTask": "bingo: build spawntree",
+      "preLaunchTask": "bingo: prepare F5",
       "stopOnEntry": true,
+      "serverMode": "auto",
+      "managementHost": "127.0.0.1",
+      "managementPort": 6060,
       "dapHost": "127.0.0.1",
-      "dapPort": 4711
+      "dapPort": 4711,
+      "serverReadyTimeoutMs": 5000,
+      "managedIdleTimeoutMs": 30000
     },
     {
       "name": "bingo DAP: join running session",
       "type": "bingo",
       "request": "attach",
       "session": "${input:bingoSession}",
+      "serverMode": "auto",
+      "managementHost": "127.0.0.1",
+      "managementPort": 6060,
       "dapHost": "127.0.0.1",
-      "dapPort": 4711
+      "dapPort": 4711,
+      "serverReadyTimeoutMs": 5000,
+      "managedIdleTimeoutMs": 30000
     }
   ],
   "inputs": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,14 +11,14 @@
       "outFiles": [
         "${workspaceFolder}/editors/vscode/dist/**/*.js"
       ],
-      "preLaunchTask": "bingo: prepare F5"
+      "preLaunchTask": "bingo: prepare extension host"
     },
     {
       "name": "bingo DAP: launch spawntree (stop on entry)",
       "type": "bingo",
       "request": "launch",
       "program": "${workspaceFolder}/build/spawntree",
-      "preLaunchTask": "bingo: prepare F5",
+      "preLaunchTask": "bingo: build spawntree",
       "stopOnEntry": true,
       "serverMode": "auto",
       "managementHost": "127.0.0.1",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,11 +2,11 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "bingo: build spawntree",
+      "label": "bingo: prepare F5",
       "type": "process",
       "command": "just",
       "args": [
-        "build-spawntree"
+        "vscode-dev"
       ],
       "problemMatcher": []
     }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,11 +2,20 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "bingo: prepare F5",
+      "label": "bingo: prepare extension host",
       "type": "process",
       "command": "just",
       "args": [
         "vscode-dev"
+      ],
+      "problemMatcher": []
+    },
+    {
+      "label": "bingo: build spawntree",
+      "type": "process",
+      "command": "just",
+      "args": [
+        "build-spawntree"
       ],
       "problemMatcher": []
     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -885,8 +885,10 @@ incompatible occupant fails safely. `connectOnly` bypasses management and spawn
 for remote/custom workflows. Health reads have both response abort/error
 handling and an independent wall-clock deadline; readiness probes receive only
 the remaining overall budget, so a slow-drip HTTP peer cannot hold F5 open. The
-poller reserves a final 50ms probe budget, ensuring the schema's 100ms minimum
-cannot be consumed entirely by the initial delay.
+poller reserves a final 50ms probe budget, then after a fast absent response
+delays again while retaining a final 1ms probe; this ensures the schema's 100ms
+minimum both gets post-spawn probes and remains live for its full window without
+spinning.
 
 One extension host coalesces in-flight ensures by normalized endpoint. Across
 hosts, listener binding arbitrates races: a child that loses is success if the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -885,10 +885,11 @@ incompatible occupant fails safely. `connectOnly` bypasses management and spawn
 for remote/custom workflows. Health reads have both response abort/error
 handling and an independent wall-clock deadline; readiness probes receive only
 the remaining overall budget, so a slow-drip HTTP peer cannot hold F5 open. The
-poller reserves a final 50ms probe budget, then after a fast absent response
-delays again while retaining a final 1ms probe; this ensures the schema's 100ms
-minimum both gets post-spawn probes and remains live for its full window without
-spinning.
+poller probes immediately after spawn, uses the normal 100ms cadence outside
+the last 50ms, then a 10ms cadence while every request can retain at least a
+25ms wall-clock budget (covered by a real localhost test). When another useful
+probe no longer fits it waits out the absolute deadline rather than issuing a
+sub-millisecond request or spinning.
 
 One extension host coalesces in-flight ensures by normalized endpoint. Across
 hosts, listener binding arbitrates races: a child that loses is success if the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ follow them so reviews stay about substance, not style.
 | [cmd/cli](cmd/cli/) | Interactive readline client. |
 | [cmd/dapcli](cmd/dapcli/) | Interactive readline client that drives a session over DAP (mirrors `cmd/cli`'s UX). Talks to the server's `-dap-addr` listener; can create a session or `-session` join an existing one. |
 | [cmd/wsmon](cmd/wsmon/) | Read-only terminal telemetry observer. `-session`-joins a running session over WebSocket and live-renders the goroutine spawn tree + OS threads + created/exited lifecycle deltas from the `EventGoroutineSnapshot` stream. Never drives execution — the WS-observes half of the DAP-drives/WS-observes demo. |
-| [editors/vscode](editors/vscode/) | Locally packaged TypeScript companion extension. Owns VS Code debugger type `bingo`, enables Go breakpoints, and connects the built-in Debug UI to an already-running bingo DAP TCP listener. |
+| [editors/vscode](editors/vscode/) | Platform-packaged TypeScript companion extension. Owns VS Code debugger type `bingo`, enables Go breakpoints, and reuses or starts a compatible shared bingo server before connecting the built-in Debug UI to DAP. |
 | [cmd/target](cmd/target/) | Trivial target program for manual testing. |
 | [examples/spawntree](examples/spawntree/) | Concurrency demo target: a deterministic main → supervisor → worker×N goroutine spawn tree for exercising the telemetry stream (see [docs/ConcurrencyTelemetry.md](docs/ConcurrencyTelemetry.md)). |
 | [cmd/githook](cmd/githook/) | Conventional-commits commitlint, wired via [lefthook.yml](lefthook.yml). |
@@ -856,10 +856,11 @@ richer concurrency visualizations stay on the WebSocket side. The two coexist on
 one hub session (this is the whole point — an IDE gets a working debugger, the
 bingo UI gets its bonus features, both against the same tracee).
 
-**VS Code companion — transport only, separate from Go tooling.**
+**VS Code companion — managed transport, separate from Go tooling.**
 [editors/vscode](editors/vscode/) packages as extension ID
 `bingosuite.bingo`, registers a
-`DebugAdapterDescriptorFactory` for debugger type `bingo` and returns
+`DebugAdapterDescriptorFactory` for debugger type `bingo`. The async factory
+first ensures a compatible server, then returns
 `DebugAdapterServer(dapPort, dapHost)` (defaults `127.0.0.1:4711`). It never
 registers type `go`, launches or validates `dlv`, or calls into Microsoft's Go
 extension. Keep `golang.go` installed for gopls/navigation/formatting/tests; a
@@ -869,10 +870,41 @@ do not change it to `localhost`, which older VS Code/Node runtimes can resolve
 to `::1` without falling back to IPv4.
 The extension validates launch (`program`), existing-session join (`session`),
 and OS-process attach (`pid`, optional `binaryPath`) before connecting.
-`dapHost`/`dapPort` are client-owned endpoint fields that remain in VS Code's
-raw launch/attach arguments; Go's JSON decoder ignores those unknown fields, so
-they never enter the bingo command payload. Do not add them to the wire protocol
-or `launchConfig`.
+`serverMode`/management/DAP/timing fields are client-owned and remain in VS
+Code's raw launch/attach arguments; Go's JSON decoder ignores those unknown
+fields, so they never enter the bingo command payload. Do not add them to the
+wire protocol or `launchConfig`.
+
+**VS Code connect-or-start invariants.** Default `serverMode:"auto"` is local
+only: management `127.0.0.1:6060`, DAP `127.0.0.1:4711`, readiness 5s, managed
+idle grace 30s. It health-checks before spawning and requires
+`service:"bingo"`, management API 1, the exact wire version, enabled DAP, and
+the expected DAP port/host (wildcard advertised hosts retain the configured
+connect host). Only connection refusal permits spawning; a non-bingo or
+incompatible occupant fails safely. `connectOnly` bypasses management and spawn
+for remote/custom workflows.
+
+One extension host coalesces in-flight ensures by normalized endpoint. Across
+hosts, listener binding arbitrates races: a child that loses is success if the
+compatible winner becomes healthy before the deadline. The bundled child is
+spawned with argv (never a shell), detached/unref'd with ignored stdin and
+stdout/stderr inherited from a persistent extension-storage log file. The
+extension NEVER kills a server, including one it spawned; disposal only aborts
+bounded probes. Server-owned `-idle-timeout` is the sole teardown owner.
+
+VSIXes are platform-specific: `linux-x64` contains only linux/amd64 bingo;
+`darwin-arm64` contains only a `bingonative` arm64 binary codesigned with
+[entitlements.plist](entitlements.plist). Runtime resolves only
+`bin/bingo` + `bin/target.json` inside the installed/development extension,
+checks the target, and repairs executable mode if extraction lost it.
+Packaging rebuilds/signs twice and requires identical binary and VSIX hashes;
+tests drift-check service/API/wire constants against Go source and inspect exact
+archive contents, target metadata, architecture, mode, and entitlements.
+Apple's external linker can vary `LC_UUID` even for identical cgo inputs, but
+current dyld rejects binaries with `-no_uuid`; `normalize-mach-o-uuid.mjs`
+therefore derives a stable UUID from the unsigned Mach-O with its UUID and
+linker signature zeroed, writes it back, then codesigns. Preserve that
+normalize-before-sign order and the repeated two-build gate.
 
 **Architecture — a translator at the `hub.WSConn` seam, ZERO hub changes.**
 `dap.Handler` implements `hub.WSConn` and is registered via
@@ -1063,6 +1095,8 @@ reaches zero, cancels it while any session exists, and shuts itself down only
 when the count stayed zero for the whole grace. A bare DAP TCP connection does
 not count: DAP creates a session only on launch/attach, so process owners must
 allow enough startup grace for health-check + connect + handshake.
+The VS Code companion is the first implementation of this contract; future UI
+clients can follow it, but no bingo UI process manager is shipped here.
 
 **Idle admission and shutdown invariants.** `sessionStore` broadcasts changes
 by closing and replacing a channel under its map mutex; snapshots return
@@ -1323,8 +1357,10 @@ just test [PKG]                            # go test -v
 just coverage [PKG]                        # writes test/coverage.out
 just integration                           # ginkgo -r ./test/integration (no e2e tag)
 just build-spawntree                       # rebuilds the VS Code demo with -N -l
+just vscode-prepare                        # stage the current native server inside the extension
+just vscode-dev                            # build extension + native server + spawntree for F5
 just vscode-check                          # lint, typecheck, test, bundle, package-list smoke
-just vscode-package                        # verifies reproducibility, writes ignored dist/bingo.vsix
+just vscode-package                        # writes verified dist/bingo-<platform>.vsix
 just vscode-install                        # explicitly installs/updates bingosuite.bingo
 just e2e-linux                             # native linux/amd64 ptrace E2E (all labels)
 just e2e-darwin                            # native darwin/arm64 Mach-exception E2E (codesigned; all labels)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -884,7 +884,9 @@ connect host). Only connection refusal permits spawning; a non-bingo or
 incompatible occupant fails safely. `connectOnly` bypasses management and spawn
 for remote/custom workflows. Health reads have both response abort/error
 handling and an independent wall-clock deadline; readiness probes receive only
-the remaining overall budget, so a slow-drip HTTP peer cannot hold F5 open.
+the remaining overall budget, so a slow-drip HTTP peer cannot hold F5 open. The
+poller reserves a final 50ms probe budget, ensuring the schema's 100ms minimum
+cannot be consumed entirely by the initial delay.
 
 One extension host coalesces in-flight ensures by normalized endpoint. Across
 hosts, listener binding arbitrates races: a child that loses is success if the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -900,6 +900,12 @@ checks the target, and repairs executable mode if extraction lost it.
 Packaging rebuilds/signs twice and requires identical binary and VSIX hashes;
 tests drift-check service/API/wire constants against Go source and inspect exact
 archive contents, target metadata, architecture, mode, and entitlements.
+Normal repository `"type":"bingo"` F5 uses the installed VSIX and only rebuilds
+the target; source binary/build preparation belongs to the separate Extension
+Development Host task (`just vscode-dev`). The macOS packaging job may
+cross-build/sign/inspect darwin/arm64 on an Intel runner, but it must run the
+packaged-server smoke only when the runner is actually arm64; local Apple
+Silicon remains the native execution gate.
 Apple's external linker can vary `LC_UUID` even for identical cgo inputs, but
 current dyld rejects binaries with `-no_uuid`; `normalize-mach-o-uuid.mjs`
 therefore derives a stable UUID from the unsigned Mach-O with its UUID and
@@ -1358,7 +1364,7 @@ just coverage [PKG]                        # writes test/coverage.out
 just integration                           # ginkgo -r ./test/integration (no e2e tag)
 just build-spawntree                       # rebuilds the VS Code demo with -N -l
 just vscode-prepare                        # stage the current native server inside the extension
-just vscode-dev                            # build extension + native server + spawntree for F5
+just vscode-dev                            # stage source extension + native server + spawntree for Extension Host F5
 just vscode-check                          # lint, typecheck, test, bundle, package-list smoke
 just vscode-package                        # writes verified dist/bingo-<platform>.vsix
 just vscode-install                        # explicitly installs/updates bingosuite.bingo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -882,7 +882,9 @@ idle grace 30s. It health-checks before spawning and requires
 the expected DAP port/host (wildcard advertised hosts retain the configured
 connect host). Only connection refusal permits spawning; a non-bingo or
 incompatible occupant fails safely. `connectOnly` bypasses management and spawn
-for remote/custom workflows.
+for remote/custom workflows. Health reads have both response abort/error
+handling and an independent wall-clock deadline; readiness probes receive only
+the remaining overall budget, so a slow-drip HTTP peer cannot hold F5 open.
 
 One extension host coalesces in-flight ensures by normalized endpoint. Across
 hosts, listener binding arbitrates races: a child that loses is success if the
@@ -890,7 +892,10 @@ compatible winner becomes healthy before the deadline. The bundled child is
 spawned with argv (never a shell), detached/unref'd with ignored stdin and
 stdout/stderr inherited from a persistent extension-storage log file. The
 extension NEVER kills a server, including one it spawned; disposal only aborts
-bounded probes. Server-owned `-idle-timeout` is the sole teardown owner.
+bounded probes. Cancellation is rechecked after every awaited binary/log
+prerequisite and immediately before spawn, because a child started after
+deactivation cannot be reclaimed without violating the never-kill contract.
+Server-owned `-idle-timeout` is the sole teardown owner.
 
 VSIXes are platform-specific: `linux-x64` contains only linux/amd64 bingo;
 `darwin-arm64` contains only a `bingonative` arm64 binary codesigned with
@@ -902,10 +907,13 @@ tests drift-check service/API/wire constants against Go source and inspect exact
 archive contents, target metadata, architecture, mode, and entitlements.
 Normal repository `"type":"bingo"` F5 uses the installed VSIX and only rebuilds
 the target; source binary/build preparation belongs to the separate Extension
-Development Host task (`just vscode-dev`). The macOS packaging job may
-cross-build/sign/inspect darwin/arm64 on an Intel runner, but it must run the
-packaged-server smoke only when the runner is actually arm64; local Apple
-Silicon remains the native execution gate.
+Development Host task (`just vscode-dev`), which restores the exact npm lockfile
+with lifecycle scripts disabled before building. The macOS packaging job uses
+the supported `macos-15` arm64 image, asserts `uname -m`, and runs the real
+packaged-server smoke. That smoke observes server-owned idle exit on success;
+only its failure path may SIGKILL the exact detached process group it created,
+then it must await exit before deleting the extracted package. This cleanup
+helper is test-only and must never enter extension production code.
 Apple's external linker can vary `LC_UUID` even for identical cgo inputs, but
 current dyld rejects binaries with `-no_uuid`; `normalize-mach-o-uuid.mjs`
 therefore derives a stable UUID from the unsigned Mach-O with its UUID and

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ alongside its native WebSocket protocol, so a standard IDE (VS Code, neovim) can
 drive a debug session over a TCP socket while BinGo's own visual clients observe
 — and optionally also drive — the **same** session in parallel.
 
-Start the server with a DAP listener:
+Manual clients can start the server with a DAP listener:
 
 ```sh
 just server                       # builds + runs with -addr :6060 -dap-addr :4711
@@ -49,7 +49,8 @@ bingo -addr :6060 -dap-addr :4711
 ```
 
 `just server` starts both listeners with the defaults above; use `just server-ws`
-for a WebSocket-only run (DAP disabled).
+for a WebSocket-only run (DAP disabled). The VS Code companion can instead
+connect-or-start automatically.
 
 ### Server discovery and managed lifetime
 
@@ -112,19 +113,31 @@ just vscode-install
 ```
 
 It contributes debugger type `"bingo"` and connects VS Code's built-in Debug UI
-directly to `127.0.0.1:4711`. Keep Microsoft's Go extension installed for
+directly to bingo. In its default `auto` mode it health-checks
+`127.0.0.1:6060`, reuses a compatible server, or starts the matching bundled
+server with DAP on `127.0.0.1:4711` and a 30-second server-owned idle grace.
+Same-process requests coalesce; listener binding arbitrates concurrent extension
+hosts. The detached child logs to persistent extension storage and the extension
+never kills it. Keep Microsoft's Go extension installed for
 `gopls`, navigation, formatting, and tests: the extensions coexist, and a bingo
 debug configuration does **not** invoke or validate Delve (`dlv`) or take over
 the Go extension's `"go"` debugger type. See
 [editors/vscode/README.md](editors/vscode/README.md) for launch, session-join,
-PID-attach, update, and uninstall instructions. The current extension still
-connects to an already-running server; it does not yet consume the lifecycle
-contract above to start or own a process.
+PID-attach, lifecycle fields, connect-only remote use, log paths, update, and
+uninstall instructions.
 
-After installing, run `just server`, select the `"type": "bingo"` spawntree
-configuration from `.vscode/launch.json`, and press F5. Its pre-launch task runs
-`just build-spawntree`, so the demo binary is rebuilt with debugger-friendly
-compiler flags before every launch.
+Lifecycle configuration is explicit per launch: `serverMode`,
+`managementHost`/`managementPort`, `dapHost`/`dapPort`,
+`serverReadyTimeoutMs`, and `managedIdleTimeoutMs`. The defaults above use
+`auto`; remote, forwarded, and custom endpoints must use
+`"serverMode": "connectOnly"`, which neither probes nor spawns. Startup failures
+name the endpoint and persistent log path in the **bingo Server** output channel.
+
+After installing, select the `"type": "bingo"` spawntree configuration from
+`.vscode/launch.json` and press F5. Its pre-launch task prepares the bundled
+development server and rebuilds the demo with debugger-friendly compiler flags;
+no manual `just server` is required. Manual servers remain supported and are
+reused when compatible.
 
 Other DAP clients can point at `127.0.0.1:4711`. The DAP client creates a
 managed session on `launch`/`attach`; WebSocket observers join that same session

--- a/README.md
+++ b/README.md
@@ -134,10 +134,12 @@ Lifecycle configuration is explicit per launch: `serverMode`,
 name the endpoint and persistent log path in the **bingo Server** output channel.
 
 After installing, select the `"type": "bingo"` spawntree configuration from
-`.vscode/launch.json` and press F5. Its pre-launch task prepares the bundled
-development server and rebuilds the demo with debugger-friendly compiler flags;
-no manual `just server` is required. Manual servers remain supported and are
-reused when compatible.
+`.vscode/launch.json` and press F5. Its pre-launch task only rebuilds the demo
+with debugger-friendly compiler flags; the installed VSIX supplies the server,
+so target F5 stays fast and no manual `just server` is required. Use the
+separate **Run bingo extension** launch (or `just vscode-dev`) when changing the
+extension itself; that path stages the source extension binary and bundle.
+Manual servers remain supported and are reused when compatible.
 
 Other DAP clients can point at `127.0.0.1:4711`. The DAP client creates a
 managed session on `launch`/`attach`; WebSocket observers join that same session

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -53,41 +53,38 @@ tree that churns a fresh worker pool each round, so consecutive snapshots show
 workers appearing in the `created` delta and leaving in `exited`. The intended
 breakpoint is the `fmt.Printf` inside `worker` (`examples/spawntree/main.go:27`).
 There is no separate manual build step: the workspace launch configuration runs
-`just build-spawntree` as its pre-launch task and rebuilds the binary with
-`-N -l` before every F5.
+**bingo: prepare F5** (`just vscode-dev`) and rebuilds both the extension-local
+server and spawntree with debugger-friendly settings before F5.
 
-## 2. Start the server with DAP enabled
-
-```sh
-just server                       # builds + runs everything: -addr :6060 -dap-addr :4711
-# override addresses:   just server darwin arm64 :7070 :4712
-# verbose / extra flags: just server darwin arm64 :6060 :4711 -v
-# or run the binary directly:
-./build/bingo/bingo_darwin_arm64 -addr :6060 -dap-addr :4711 -v
-# linux: ./build/bingo/bingo_linux_amd64 -addr :6060 -dap-addr :4711 -v
-```
-
-`just server` starts both listeners with the defaults below. For a WebSocket-only
-run (DAP disabled) use `just server-ws` instead.
-
-- `:6060` — WebSocket + REST (`/ws`, `/api/sessions`). `cmd/wsmon` connects here.
-- `:4711` — DAP. VS Code / `cmd/dapcli` connect here.
-
-Leave it running.
-
-## 3a. Drive with VS Code (DAP)
+## 2. Drive with VS Code (DAP, automatic server)
 
 1. Open this repo in VS Code.
-2. Select **“bingo DAP: launch spawntree (stop on entry)”** from
-   `.vscode/launch.json` and press F5. VS Code first runs
-   **“bingo: build spawntree”**, then its `"type": "bingo"`, `dapHost`, and
-   `dapPort` fields make the companion connect to `127.0.0.1:4711`; bingo
-   launches the rebuilt `build/spawntree` and stops at entry.
-3. Set a breakpoint on `examples/spawntree/main.go:27` and **Continue** — the
+2. For an installed package, select
+   **“bingo DAP: launch spawntree (stop on entry)”** directly. To exercise the
+   source extension, first run **“Run bingo extension”**, then select the
+   spawntree configuration in the Extension Development Host.
+3. Press F5. VS Code runs **“bingo: prepare F5”**. The companion
+   health-checks `127.0.0.1:6060`,
+   reuses a compatible server or starts its detached bundled server, then
+   connects to DAP at `127.0.0.1:4711`. bingo launches the rebuilt
+   `build/spawntree` and stops at entry.
+4. Set a breakpoint on `examples/spawntree/main.go:27` and **Continue** — the
    tracee stops there with several worker goroutines alive.
-4. Grab the **session id** so the observer can join: it is printed on the server
-   console (`bingo session <id> ready …`) and in the bingo DAP `console` output,
-   and is listed by `curl -s localhost:6060/api/sessions`.
+5. Grab the **session id** so the observer can join: it is printed in the bingo
+   DAP `console` output and is listed by
+   `curl -s 127.0.0.1:6060/api/sessions`.
+
+The extension never kills the shared process. The default managed server exits
+only after its 30-second idle grace with no sessions. Open **bingo Server** for
+the persistent child log path. If another extension host starts concurrently,
+listener binding selects one server and both hosts reuse it.
+
+The lifecycle fields are `serverMode`, management host/port, DAP host/port,
+`serverReadyTimeoutMs`, and `managedIdleTimeoutMs`; the checked-in launch file
+pins their local defaults. Remote or forwarded endpoints must explicitly use
+`"serverMode": "connectOnly"`, which bypasses health and spawn. If F5 reports an
+occupied/incompatible endpoint or startup timeout, inspect the endpoint and log
+path in **bingo Server** rather than killing a potentially shared process.
 
 > A second VS Code window can *join* the same session (observe/drive over DAP)
 > with the **“bingo DAP: join running session”** config, which sends a DAP
@@ -96,11 +93,12 @@ Leave it running.
 > `binaryPath` attaches to an OS process instead; the extension README has the
 > full shape.
 
-## 3b. Drive with cmd/dapcli (DAP, no IDE)
+## 3. Drive with cmd/dapcli (DAP, no IDE)
 
-Equivalent driver in a terminal — use this if VS Code isn't set up:
+Equivalent driver in a terminal requires a manual server:
 
 ```sh
+just server
 just dapcli            # or: go run -tags bingonative ./cmd/dapcli -addr localhost:4711
 # in the REPL:
 launch ./build/spawntree      # creates a session, stops on entry

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -52,9 +52,11 @@ architecture behind this.
 tree that churns a fresh worker pool each round, so consecutive snapshots show
 workers appearing in the `created` delta and leaving in `exited`. The intended
 breakpoint is the `fmt.Printf` inside `worker` (`examples/spawntree/main.go:27`).
-There is no separate manual build step: the workspace launch configuration runs
-**bingo: prepare F5** (`just vscode-dev`) and rebuilds both the extension-local
-server and spawntree with debugger-friendly settings before F5.
+There is no separate manual target build step: the normal workspace launch
+configuration runs **bingo: build spawntree** before F5. It uses the installed
+VSIX's bundled server and does not rebuild or codesign extension sources.
+**Run bingo extension** separately runs **bingo: prepare extension host**
+(`just vscode-dev`) to stage the source extension binary and bundle.
 
 ## 2. Drive with VS Code (DAP, automatic server)
 
@@ -63,7 +65,7 @@ server and spawntree with debugger-friendly settings before F5.
    **“bingo DAP: launch spawntree (stop on entry)”** directly. To exercise the
    source extension, first run **“Run bingo extension”**, then select the
    spawntree configuration in the Extension Development Host.
-3. Press F5. VS Code runs **“bingo: prepare F5”**. The companion
+3. Press F5. VS Code runs **“bingo: build spawntree”**. The companion
    health-checks `127.0.0.1:6060`,
    reuses a compatible server or starts its detached bundled server, then
    connects to DAP at `127.0.0.1:4711`. bingo launches the rebuilt

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,50 +1,63 @@
 # bingo Debugger for VS Code
 
-This companion extension connects VS Code's built-in Debug UI directly to an
-already-running [bingo](https://github.com/bingosuite/bingo) Debug Adapter
-Protocol listener. Its extension ID is `bingosuite.bingo`; it owns debugger type
-`bingo`, does not launch or validate Delve (`dlv`), and does not replace the
-Microsoft Go extension's debugger type.
+The `bingosuite.bingo` companion connects VS Code's Debug UI directly to bingo.
+It owns debugger type `bingo`; it never registers `go`, invokes or validates
+Delve (`dlv`), or calls the Microsoft Go extension. Keep `golang.go` installed
+for gopls, navigation, formatting, and tests.
 
-Keep the Microsoft Go extension installed for `gopls`, navigation, formatting,
-and test integration. The two extensions coexist: Go language tooling comes from
-`golang.go`, while a launch configuration with `"type": "bingo"` uses this
-extension and the bingo server.
+Platform-specific packages are available for:
 
-## Build and install
+- `darwin-arm64` (Apple Silicon), with the bundled server codesigned for native
+  debugging;
+- `linux-x64`, with the bundled linux/amd64 server.
 
-From the repository root:
+## Install, update, and uninstall
+
+From the repository root on a supported host:
 
 ```sh
 just vscode-install
 ```
 
-Reload the VS Code window after installation. To update, rebuild the VSIX and
-reinstall it by rerunning `just vscode-install`. To package without installing,
-run `just vscode-package`; it writes `dist/bingo.vsix`.
-
-To uninstall:
+This builds, verifies, and installs `dist/bingo-<platform>.vsix`. Rerun the
+command to update. Package without installing with `just vscode-package`.
+Uninstall with:
 
 ```sh
 code --uninstall-extension bingosuite.bingo
 ```
 
-Generated dependencies, bundles, and VSIX files are ignored by Git.
-The package recipe builds twice with normalized ZIP metadata and fails if the
-two VSIX hashes differ.
+Generated binaries and VSIX files are ignored. Packaging rebuilds the native
+binary and VSIX twice and requires both SHA-256 hashes to match.
 
-## Use
+## F5: connect or start
 
-Start bingo's WebSocket and DAP listeners:
+Select a `bingo` configuration and press F5. In the default `auto` mode the
+extension:
 
-```sh
-just server
-```
+1. checks `http://127.0.0.1:6060/api/health`;
+2. reuses a compatible manual or managed bingo server;
+3. if and only if the endpoint refuses the connection, starts its bundled
+   server with management on `127.0.0.1:6060`, DAP on
+   `127.0.0.1:4711`, and a 30-second server-owned idle grace;
+4. waits up to five seconds for compatible health, then connects VS Code to DAP.
 
-Then select a `bingo` configuration in **Run and Debug** and press F5. This
-repository's `.vscode/launch.json` includes a launch and a session-join example.
-The launch example first runs the workspace's `just build-spawntree` task, then
-connects to the default DAP endpoint at `127.0.0.1:4711`.
+Concurrent VS Code extension hosts may both try to start. Listener binding
+chooses the winner; a child that loses the race is harmless because both hosts
+reuse the compatible winner. Requests in one extension host for the same
+endpoint share one readiness operation.
+
+The child is detached and logs to persistent extension storage. Open the
+**bingo Server** output channel to see the absolute server log path. The
+extension never kills a server, including one it spawned. Closing VS Code only
+disconnects its client; bingo's `-idle-timeout` owns managed shutdown so DAP and
+WebSocket clients can share the process safely.
+
+If the management port answers with non-bingo HTTP or an incompatible bingo,
+F5 fails without spawning over it. Errors include the endpoints and server log
+path.
+
+## Configurations
 
 ### Launch a binary
 
@@ -57,14 +70,19 @@ connects to the default DAP endpoint at `127.0.0.1:4711`.
   "args": [],
   "env": ["BINGO_MODE=debug"],
   "stopOnEntry": true,
+  "serverMode": "auto",
+  "managementHost": "127.0.0.1",
+  "managementPort": 6060,
   "dapHost": "127.0.0.1",
-  "dapPort": 4711
+  "dapPort": 4711,
+  "serverReadyTimeoutMs": 5000,
+  "managedIdleTimeoutMs": 30000
 }
 ```
 
-`env` follows bingo's current DAP contract: an array of `KEY=value` strings.
+`env` is an array of `KEY=value` strings.
 
-### Join an existing bingo session
+### Join a managed session
 
 ```json
 {
@@ -72,6 +90,9 @@ connects to the default DAP endpoint at `127.0.0.1:4711`.
   "type": "bingo",
   "request": "attach",
   "session": "replace-with-session-id",
+  "serverMode": "auto",
+  "managementHost": "127.0.0.1",
+  "managementPort": 6060,
   "dapHost": "127.0.0.1",
   "dapPort": 4711
 }
@@ -89,29 +110,84 @@ Joining does not relaunch, reattach, or automatically resume the shared session.
   "pid": 1234,
   "binaryPath": "/absolute/path/to/the/binary",
   "stopOnEntry": true,
+  "serverMode": "auto",
+  "managementHost": "127.0.0.1",
+  "managementPort": 6060,
   "dapHost": "127.0.0.1",
   "dapPort": 4711
 }
 ```
 
-`binaryPath` is optional for attaching, but bingo needs its DWARF data for
-source breakpoints, stack frames, and locals.
+`binaryPath` is optional, but bingo needs its DWARF data for source breakpoints,
+stack frames, and locals.
 
-## Endpoint and remote environments
+## Lifecycle fields
 
-`dapHost` and `dapPort` tell the extension host where bingo is listening. The
-extension only connects; it never starts the server. The default host is the
-explicit IPv4 loopback because bingo currently opens its DAP listener with
-`tcp4`; `localhost` can resolve to IPv6 first in older VS Code runtimes. For a
-remote extension host (SSH, a dev container, or Codespaces), use an address
-reachable from that host and bind bingo's `-dap-addr` accordingly.
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `serverMode` | `"auto"` | Health-check and reuse/start locally. Use `"connectOnly"` for remote or custom endpoints. |
+| `managementHost` | `"127.0.0.1"` | Management/health host. Auto mode requires this exact IPv4 loopback. |
+| `managementPort` | `6060` | Management, REST, and WebSocket port. |
+| `dapHost` | `"127.0.0.1"` | DAP connect host. Auto mode requires this exact IPv4 loopback. |
+| `dapPort` | `4711` | DAP connect/listen port. |
+| `serverReadyTimeoutMs` | `5000` | Bounded wait for compatible health. |
+| `managedIdleTimeoutMs` | `30000` | Idle grace passed only to a server the extension starts. |
+
+The explicit IPv4 defaults match bingo's `tcp4` DAP listener and avoid older
+Node runtimes resolving `localhost` to IPv6 first.
+
+### Remote and custom endpoints
+
+Autostart is local-only. For SSH, dev containers, Codespaces, port forwarding,
+or any custom host, explicitly select connect-only mode:
+
+```json
+{
+  "type": "bingo",
+  "request": "launch",
+  "program": "/workspace/build/target",
+  "serverMode": "connectOnly",
+  "dapHost": "debug.internal",
+  "dapPort": 14711
+}
+```
+
+Connect-only mode does not probe management health, inspect a bundled binary, or
+spawn. Start and secure the reachable bingo server through that environment's
+normal process manager. A future bingo UI can use the same management contract;
+no such UI is included in this extension.
+
+## Manual server option
+
+Autostart is not mandatory. A compatible server already listening on the
+configured endpoints is reused:
+
+```sh
+just server
+# persistent until interrupted; add -idle-timeout 30s for server-owned cleanup
+```
 
 ## Development
 
 ```sh
-just vscode-check
-just vscode-package
+just vscode-dev       # build extension, native bundled server, and spawntree
+just vscode-check     # clean install, lint, typecheck, tests, bundle/list smoke
+just vscode-package   # native reproducible package + content verification
 ```
 
-The check runs ESLint, strict TypeScript type checking, unit and manifest tests,
-the esbuild bundle, and a VSIX file-list smoke check.
+The repository's **bingo: prepare F5** task runs `just vscode-dev`, so extension
+development and the spawntree demo need no manually running server. Select
+**Run bingo extension** to open an Extension Development Host; in that window,
+select the spawntree bingo configuration to exercise the source extension.
+
+## Troubleshooting
+
+- **Unsupported platform:** auto mode packages only linux/x64 and darwin/arm64.
+  Use a matching package or `connectOnly`.
+- **Endpoint occupied/incompatible:** inspect the process on the reported
+  management port. The extension will not replace it.
+- **Startup timeout/child exit:** open **bingo Server** and inspect the persistent
+  log path printed there.
+- **Remote endpoint rejected:** set `"serverMode": "connectOnly"`.
+- **Server remains after VS Code closes:** expected while another session is
+  active or during the idle grace. The extension never sends a kill signal.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -176,7 +176,8 @@ just vscode-package   # native reproducible package + content verification
 ```
 
 The repository's **bingo: prepare extension host** task runs `just vscode-dev`
-before **Run bingo extension**, staging the source extension's binary and bundle.
+before **Run bingo extension**, restoring the exact npm lockfile with lifecycle
+scripts disabled and then staging the source extension's binary and bundle.
 The normal spawntree F5 configuration uses the installed VSIX and runs only
 **bingo: build spawntree**, so target debugging does not rebuild or codesign the
 extension-local server. In the Extension Development Host, select the same

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -175,10 +175,12 @@ just vscode-check     # clean install, lint, typecheck, tests, bundle/list smoke
 just vscode-package   # native reproducible package + content verification
 ```
 
-The repository's **bingo: prepare F5** task runs `just vscode-dev`, so extension
-development and the spawntree demo need no manually running server. Select
-**Run bingo extension** to open an Extension Development Host; in that window,
-select the spawntree bingo configuration to exercise the source extension.
+The repository's **bingo: prepare extension host** task runs `just vscode-dev`
+before **Run bingo extension**, staging the source extension's binary and bundle.
+The normal spawntree F5 configuration uses the installed VSIX and runs only
+**bingo: build spawntree**, so target debugging does not rebuild or codesign the
+extension-local server. In the Extension Development Host, select the same
+spawntree configuration to exercise the already-staged source extension.
 
 ## Troubleshooting
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bingo",
   "displayName": "bingo Debugger",
-  "description": "Connect VS Code's Debug UI to an already-running bingo DAP server.",
+  "description": "Connect VS Code's Debug UI to bingo, reusing or starting a managed local server.",
   "version": "0.1.0",
   "publisher": "bingosuite",
   "license": "MIT",
@@ -35,7 +35,7 @@
   "capabilities": {
     "untrustedWorkspaces": {
       "supported": false,
-      "description": "Debugging starts or attaches to native processes through a separately-running bingo server."
+      "description": "Debugging starts or attaches to native processes through a shared bingo server."
     }
   },
   "contributes": {
@@ -57,17 +57,52 @@
               "program"
             ],
             "properties": {
+              "serverMode": {
+                "type": "string",
+                "enum": [
+                  "auto",
+                  "connectOnly"
+                ],
+                "default": "auto",
+                "description": "Reuse or start a compatible local bingo server, or only connect to an existing endpoint."
+              },
+              "managementHost": {
+                "type": "string",
+                "default": "127.0.0.1",
+                "description": "Host of bingo's management API. Auto mode requires 127.0.0.1."
+              },
+              "managementPort": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65535,
+                "default": 6060,
+                "description": "Port of bingo's management API."
+              },
               "dapHost": {
                 "type": "string",
                 "default": "127.0.0.1",
-                "description": "Host of the already-running bingo DAP listener."
+                "description": "Host of the bingo DAP listener. Auto mode requires 127.0.0.1."
               },
               "dapPort": {
                 "type": "integer",
                 "minimum": 1,
                 "maximum": 65535,
                 "default": 4711,
-                "description": "Port of the already-running bingo DAP listener."
+                "description": "Port of the bingo DAP listener."
+              },
+              "serverReadyTimeoutMs": {
+                "type": "integer",
+                "minimum": 100,
+                "maximum": 120000,
+                "default": 5000,
+                "description": "Maximum time in milliseconds to wait for a managed server to become healthy."
+              },
+              "managedIdleTimeoutMs": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 86400000,
+                "default": 30000,
+                "description": "Server-owned idle grace in milliseconds for a server started by the extension."
               },
               "program": {
                 "type": "string",
@@ -111,17 +146,52 @@
               }
             ],
             "properties": {
+              "serverMode": {
+                "type": "string",
+                "enum": [
+                  "auto",
+                  "connectOnly"
+                ],
+                "default": "auto",
+                "description": "Reuse or start a compatible local bingo server, or only connect to an existing endpoint."
+              },
+              "managementHost": {
+                "type": "string",
+                "default": "127.0.0.1",
+                "description": "Host of bingo's management API. Auto mode requires 127.0.0.1."
+              },
+              "managementPort": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65535,
+                "default": 6060,
+                "description": "Port of bingo's management API."
+              },
               "dapHost": {
                 "type": "string",
                 "default": "127.0.0.1",
-                "description": "Host of the already-running bingo DAP listener."
+                "description": "Host of the bingo DAP listener. Auto mode requires 127.0.0.1."
               },
               "dapPort": {
                 "type": "integer",
                 "minimum": 1,
                 "maximum": 65535,
                 "default": 4711,
-                "description": "Port of the already-running bingo DAP listener."
+                "description": "Port of the bingo DAP listener."
+              },
+              "serverReadyTimeoutMs": {
+                "type": "integer",
+                "minimum": 100,
+                "maximum": 120000,
+                "default": 5000,
+                "description": "Maximum time in milliseconds to wait for a managed server to become healthy."
+              },
+              "managedIdleTimeoutMs": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 86400000,
+                "default": 30000,
+                "description": "Server-owned idle grace in milliseconds for a server started by the extension."
               },
               "session": {
                 "type": "string",
@@ -151,14 +221,19 @@
             "request": "launch",
             "program": "${workspaceFolder}/build/target/target",
             "stopOnEntry": true,
+            "serverMode": "auto",
+            "managementHost": "127.0.0.1",
+            "managementPort": 6060,
             "dapHost": "127.0.0.1",
-            "dapPort": 4711
+            "dapPort": 4711,
+            "serverReadyTimeoutMs": 5000,
+            "managedIdleTimeoutMs": 30000
           }
         ],
         "configurationSnippets": [
           {
             "label": "bingo: Launch binary",
-            "description": "Launch a compiled Go binary through an already-running bingo DAP server.",
+            "description": "Launch a compiled Go binary through a reused or managed bingo server.",
             "body": {
               "name": "bingo: Launch binary",
               "type": "bingo",
@@ -167,8 +242,13 @@
               "args": [],
               "env": [],
               "stopOnEntry": true,
+              "serverMode": "auto",
+              "managementHost": "127.0.0.1",
+              "managementPort": 6060,
               "dapHost": "127.0.0.1",
-              "dapPort": 4711
+              "dapPort": 4711,
+              "serverReadyTimeoutMs": 5000,
+              "managedIdleTimeoutMs": 30000
             }
           },
           {
@@ -179,8 +259,13 @@
               "type": "bingo",
               "request": "attach",
               "session": "replace-with-session-id",
+              "serverMode": "auto",
+              "managementHost": "127.0.0.1",
+              "managementPort": 6060,
               "dapHost": "127.0.0.1",
-              "dapPort": 4711
+              "dapPort": 4711,
+              "serverReadyTimeoutMs": 5000,
+              "managedIdleTimeoutMs": 30000
             }
           },
           {
@@ -193,8 +278,13 @@
               "pid": 1234,
               "binaryPath": "${workspaceFolder}/build/target/target",
               "stopOnEntry": true,
+              "serverMode": "auto",
+              "managementHost": "127.0.0.1",
+              "managementPort": 6060,
               "dapHost": "127.0.0.1",
-              "dapPort": 4711
+              "dapPort": 4711,
+              "serverReadyTimeoutMs": 5000,
+              "managedIdleTimeoutMs": 30000
             }
           }
         ]
@@ -202,12 +292,15 @@
     ]
   },
   "scripts": {
+    "binary:prepare": "node ./scripts/prepare-binary.mjs",
     "build": "node ./scripts/clean.mjs && esbuild ./src/extension.ts --bundle --tsconfig=./tsconfig.json --external:vscode --format=cjs --platform=node --target=node18 --outfile=dist/extension.js",
     "check": "npm run lint && npm run typecheck && npm test && npm run build && npm run package:list",
     "lint": "eslint src test scripts",
     "package": "node ./scripts/package.mjs",
     "package:list": "vsce ls --tree",
     "package:reproducible": "node ./scripts/verify-reproducible.mjs",
+    "package:verify": "node ./scripts/verify-package.mjs",
+    "smoke:server": "node ./scripts/smoke-server.mjs",
     "test": "tsx --test test/**/*.test.ts",
     "typecheck": "tsc --noEmit",
     "vscode:prepublish": "npm run build"

--- a/editors/vscode/scripts/normalize-mach-o-uuid.mjs
+++ b/editors/vscode/scripts/normalize-mach-o-uuid.mjs
@@ -1,0 +1,74 @@
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import {
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+
+const machMagic64 = 0xfeedfacf;
+const machHeader64Size = 32;
+const loadCommandUUID = 0x1b;
+const loadCommandCodeSignature = 0x1d;
+
+export function normalizeMachOUUID(path) {
+  const binary = readFileSync(path);
+  if (binary.readUInt32LE(0) !== machMagic64) {
+    throw new Error(`expected a little-endian 64-bit Mach-O: ${path}`);
+  }
+
+  const commandCount = binary.readUInt32LE(16);
+  let commandOffset = machHeader64Size;
+  let uuidOffset;
+  let signatureOffset;
+  let signatureSize;
+
+  for (let index = 0; index < commandCount; index += 1) {
+    ensureRange(binary, commandOffset, 8);
+    const command = binary.readUInt32LE(commandOffset);
+    const commandSize = binary.readUInt32LE(commandOffset + 4);
+    ensureRange(binary, commandOffset, commandSize);
+    if (command === loadCommandUUID) {
+      if (commandSize !== 24 || uuidOffset !== undefined) {
+        throw new Error(`unexpected LC_UUID layout in ${path}`);
+      }
+      uuidOffset = commandOffset + 8;
+    } else if (command === loadCommandCodeSignature) {
+      if (commandSize !== 16 || signatureOffset !== undefined) {
+        throw new Error(`unexpected LC_CODE_SIGNATURE layout in ${path}`);
+      }
+      signatureOffset = binary.readUInt32LE(commandOffset + 8);
+      signatureSize = binary.readUInt32LE(commandOffset + 12);
+    }
+    commandOffset += commandSize;
+  }
+
+  if (
+    uuidOffset === undefined ||
+    signatureOffset === undefined ||
+    signatureSize === undefined
+  ) {
+    throw new Error(`Mach-O lacks UUID or linker signature: ${path}`);
+  }
+  ensureRange(binary, signatureOffset, signatureSize);
+
+  const normalized = Buffer.from(binary);
+  normalized.fill(0, uuidOffset, uuidOffset + 16);
+  normalized.fill(0, signatureOffset, signatureOffset + signatureSize);
+  const uuid = createHash("sha256").update(normalized).digest().subarray(0, 16);
+  uuid[6] = (uuid[6] & 0x0f) | 0x50;
+  uuid[8] = (uuid[8] & 0x3f) | 0x80;
+  uuid.copy(binary, uuidOffset);
+  writeFileSync(path, binary);
+}
+
+function ensureRange(buffer, offset, size) {
+  if (
+    !Number.isInteger(offset) ||
+    !Number.isInteger(size) ||
+    offset < 0 ||
+    size < 0 ||
+    offset + size > buffer.length
+  ) {
+    throw new Error("invalid Mach-O load command range");
+  }
+}

--- a/editors/vscode/scripts/owned-process.d.mts
+++ b/editors/vscode/scripts/owned-process.d.mts
@@ -1,0 +1,10 @@
+export type ProcessSignal = (
+  pid: number,
+  signal: NodeJS.Signals,
+) => boolean;
+
+export function terminateOwnedProcessGroup(
+  pid: number,
+  exit: Promise<unknown>,
+  signalProcess?: ProcessSignal,
+): Promise<void>;

--- a/editors/vscode/scripts/owned-process.mjs
+++ b/editors/vscode/scripts/owned-process.mjs
@@ -1,0 +1,22 @@
+import process from "node:process";
+
+import { withTimeout } from "./timing.mjs";
+
+export async function terminateOwnedProcessGroup(
+  pid,
+  exit,
+  signalProcess = process.kill,
+) {
+  try {
+    signalProcess(-pid, "SIGKILL");
+  } catch (error) {
+    if (error?.code !== "ESRCH") {
+      throw error;
+    }
+  }
+  await withTimeout(
+    exit.catch(() => undefined),
+    2000,
+    "test-owned packaged server did not exit after emergency cleanup",
+  );
+}

--- a/editors/vscode/scripts/package.mjs
+++ b/editors/vscode/scripts/package.mjs
@@ -1,34 +1,57 @@
 import { spawnSync } from "node:child_process";
-import { mkdirSync } from "node:fs";
+import { log } from "node:console";
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import process from "node:process";
 import { fileURLToPath, URL } from "node:url";
 
-mkdirSync(new URL("../../../dist/", import.meta.url), { recursive: true });
+import { currentTarget } from "./platform.mjs";
+
+const target = currentTarget();
+const extensionRoot = fileURLToPath(new URL("../", import.meta.url));
+const outputDirectory = fileURLToPath(
+  new URL("../../../dist/", import.meta.url),
+);
+const outputPath = join(outputDirectory, `bingo-${target}.vsix`);
+mkdirSync(outputDirectory, { recursive: true });
+rmSync(outputPath, { force: true });
+
+run(process.execPath, [fileURLToPath(new URL("./prepare-binary.mjs", import.meta.url))]);
 
 const vsce = fileURLToPath(
   new URL("../node_modules/@vscode/vsce/vsce", import.meta.url),
 );
-const result = spawnSync(
+run(
   process.execPath,
   [
     vsce,
     "package",
     "--no-dependencies",
+    "--target",
+    target,
     "--out",
-    "../../dist/bingo.vsix",
+    outputPath,
   ],
   {
-    env: {
-      ...process.env,
-      SOURCE_DATE_EPOCH: "946684800",
-    },
-    stdio: "inherit",
+    ...process.env,
+    SOURCE_DATE_EPOCH: "946684800",
   },
 );
 
-if (result.error !== undefined) {
-  throw result.error;
-}
-if (result.status !== 0) {
-  throw new Error(`vsce exited with status ${String(result.status)}`);
+log(`Packaged ${outputPath}`);
+
+function run(command, args, env = process.env) {
+  const result = spawnSync(command, args, {
+    cwd: extensionRoot,
+    env,
+    stdio: "inherit",
+  });
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} exited with status ${String(result.status)}`,
+    );
+  }
 }

--- a/editors/vscode/scripts/platform.mjs
+++ b/editors/vscode/scripts/platform.mjs
@@ -1,0 +1,42 @@
+import process from "node:process";
+
+const targets = {
+  "darwin-arm64": {
+    platform: "darwin",
+    arch: "arm64",
+    goos: "darwin",
+    goarch: "arm64",
+  },
+  "linux-x64": {
+    platform: "linux",
+    arch: "x64",
+    goos: "linux",
+    goarch: "amd64",
+  },
+};
+
+export function currentTarget() {
+  const match = Object.entries(targets).find(
+    ([, target]) =>
+      target.platform === process.platform && target.arch === process.arch,
+  );
+  if (match === undefined) {
+    throw new Error(
+      `unsupported VS Code package host ${process.platform}/${process.arch}; expected linux/x64 or darwin/arm64`,
+    );
+  }
+  return match[0];
+}
+
+export function targetDetails(target = currentTarget()) {
+  const details = targets[target];
+  if (details === undefined) {
+    throw new Error(`unsupported VS Code package target ${target}`);
+  }
+  if (details.platform !== process.platform || details.arch !== process.arch) {
+    throw new Error(
+      `target ${target} requires native host ${details.platform}/${details.arch}, got ${process.platform}/${process.arch}`,
+    );
+  }
+  return { name: target, ...details };
+}

--- a/editors/vscode/scripts/platform.mjs
+++ b/editors/vscode/scripts/platform.mjs
@@ -16,6 +16,11 @@ const targets = {
 };
 
 export function currentTarget() {
+  const requested = process.env.BINGO_VSCODE_TARGET;
+  if (requested !== undefined) {
+    validateBuilder(requested);
+    return requested;
+  }
   const match = Object.entries(targets).find(
     ([, target]) =>
       target.platform === process.platform && target.arch === process.arch,
@@ -33,10 +38,24 @@ export function targetDetails(target = currentTarget()) {
   if (details === undefined) {
     throw new Error(`unsupported VS Code package target ${target}`);
   }
-  if (details.platform !== process.platform || details.arch !== process.arch) {
+  validateBuilder(target);
+  return { name: target, ...details };
+}
+
+function validateBuilder(target) {
+  const details = targets[target];
+  if (details === undefined) {
+    throw new Error(`unsupported VS Code package target ${target}`);
+  }
+  const native =
+    details.platform === process.platform && details.arch === process.arch;
+  const darwinCrossBuild =
+    target === "darwin-arm64" &&
+    process.platform === "darwin" &&
+    process.arch === "x64";
+  if (!native && !darwinCrossBuild) {
     throw new Error(
-      `target ${target} requires native host ${details.platform}/${details.arch}, got ${process.platform}/${process.arch}`,
+      `target ${target} requires ${details.platform}/${details.arch} or a darwin/x64 signing host, got ${process.platform}/${process.arch}`,
     );
   }
-  return { name: target, ...details };
 }

--- a/editors/vscode/scripts/prepare-binary.mjs
+++ b/editors/vscode/scripts/prepare-binary.mjs
@@ -1,0 +1,91 @@
+import { createHash } from "node:crypto";
+import { log } from "node:console";
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import process from "node:process";
+import { fileURLToPath, URL } from "node:url";
+import { spawnSync } from "node:child_process";
+
+import { normalizeMachOUUID } from "./normalize-mach-o-uuid.mjs";
+import { targetDetails } from "./platform.mjs";
+
+const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const extensionRoot = fileURLToPath(new URL("../", import.meta.url));
+const binDirectory = join(extensionRoot, "bin");
+const binaryPath = join(binDirectory, "bingo");
+const requestedTarget = process.env.BINGO_VSCODE_TARGET;
+const target = targetDetails(requestedTarget);
+
+rmSync(binDirectory, { force: true, recursive: true });
+mkdirSync(binDirectory, { recursive: true });
+
+const buildArguments = ["build"];
+if (target.name === "darwin-arm64") {
+  buildArguments.push("-tags", "bingonative");
+}
+buildArguments.push(
+  "-trimpath",
+  "-buildvcs=false",
+  "-ldflags=-buildid=",
+  "-o",
+  binaryPath,
+  "./cmd/bingo",
+);
+run("go", buildArguments, {
+  ...process.env,
+  CGO_ENABLED: target.name === "darwin-arm64" ? "1" : "0",
+  GOOS: target.goos,
+  GOARCH: target.goarch,
+});
+
+if (target.name === "darwin-arm64") {
+  normalizeMachOUUID(binaryPath);
+  run(
+    "codesign",
+    [
+      "--sign",
+      "-",
+      "--entitlements",
+      "entitlements.plist",
+      "--force",
+      "--timestamp=none",
+      binaryPath,
+    ],
+    process.env,
+  );
+  run("codesign", ["--verify", "--strict", binaryPath], process.env);
+}
+
+chmodSync(binaryPath, 0o755);
+writeFileSync(
+  join(binDirectory, "target.json"),
+  `${JSON.stringify({ target: target.name })}\n`,
+  { mode: 0o644 },
+);
+
+const hash = createHash("sha256")
+  .update(readFileSync(binaryPath))
+  .digest("hex");
+log(`Prepared ${target.name} bingo binary: ${hash}`);
+
+function run(command, args, env) {
+  const result = spawnSync(command, args, {
+    cwd: repositoryRoot,
+    env,
+    stdio: "inherit",
+  });
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} exited with status ${String(result.status)}`,
+    );
+  }
+}

--- a/editors/vscode/scripts/smoke-server.mjs
+++ b/editors/vscode/scripts/smoke-server.mjs
@@ -4,6 +4,8 @@ import {
   openSync,
   rmSync,
 } from "node:fs";
+import { Buffer } from "node:buffer";
+import { log } from "node:console";
 import { request } from "node:http";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
@@ -13,6 +15,8 @@ import { fileURLToPath, URL } from "node:url";
 import { spawn, spawnSync } from "node:child_process";
 
 import { currentTarget } from "./platform.mjs";
+import { terminateOwnedProcessGroup } from "./owned-process.mjs";
+import { withTimeout } from "./timing.mjs";
 
 const target = currentTarget();
 const vsix = fileURLToPath(
@@ -20,6 +24,10 @@ const vsix = fileURLToPath(
 );
 const extracted = mkdtempSync(join(tmpdir(), "bingo-smoke-"));
 const idleTimeoutMs = 2000;
+let child;
+let exit;
+let childExited = false;
+let failure;
 
 try {
   run("unzip", ["-q", vsix, "-d", extracted]);
@@ -27,7 +35,7 @@ try {
   const binary = join(extracted, "extension", "bin", "bingo");
   const logPath = join(extracted, "server.log");
   const logFD = openSync(logPath, "a", 0o600);
-  const child = spawn(
+  child = spawn(
     binary,
     [
       "-addr",
@@ -43,15 +51,20 @@ try {
       stdio: ["ignore", logFD, logFD],
     },
   );
-  closeSync(logFD);
-  child.unref();
-
-  const exit = new Promise((resolve, reject) => {
-    child.once("error", reject);
+  exit = new Promise((resolve, reject) => {
+    child.once("error", (error) => {
+      childExited = true;
+      reject(error);
+    });
     child.once("exit", (code, signal) => {
+      childExited = true;
       resolve({ code, signal });
     });
   });
+  closeSync(logFD);
+  child.unref();
+  // The harness must stay alive to observe server-owned exit without relying on a leaked timeout.
+  child.ref();
 
   const health = await pollHealth(managementPort, dapPort, exit);
   if (
@@ -79,8 +92,42 @@ try {
   log(
     `Packaged ${target} server became healthy and self-exited cleanly`,
   );
+} catch (error) {
+  failure = error;
 } finally {
-  rmSync(extracted, { force: true, recursive: true });
+  if (failure !== undefined && child !== undefined && !childExited) {
+    try {
+      if (child.pid !== undefined && exit !== undefined) {
+        child.ref();
+        await terminateOwnedProcessGroup(child.pid, exit);
+        childExited = true;
+      }
+    } catch (cleanupError) {
+      failure = new AggregateError(
+        [failure, cleanupError],
+        "packaged server smoke failed and emergency cleanup also failed",
+      );
+    }
+  }
+  if (child === undefined || childExited) {
+    try {
+      rmSync(extracted, { force: true, recursive: true });
+    } catch (cleanupError) {
+      failure =
+        failure === undefined
+          ? cleanupError
+          : new AggregateError(
+              [failure, cleanupError],
+              "packaged server smoke failed and extraction cleanup also failed",
+            );
+    }
+  } else {
+    log(`Preserved ${extracted}: test-owned server exit was not confirmed`);
+  }
+}
+
+if (failure !== undefined) {
+  throw failure;
 }
 
 async function unusedPorts(count) {
@@ -186,15 +233,6 @@ function getHealth(port) {
   });
 }
 
-function withTimeout(promise, milliseconds, message) {
-  return Promise.race([
-    promise,
-    new Promise((_, reject) => {
-      setTimeout(() => reject(new Error(message)), milliseconds);
-    }),
-  ]);
-}
-
 function run(command, args) {
   const result = spawnSync(command, args, { stdio: "inherit" });
   if (result.error !== undefined) {
@@ -206,5 +244,3 @@ function run(command, args) {
     );
   }
 }
-import { Buffer } from "node:buffer";
-import { log } from "node:console";

--- a/editors/vscode/scripts/smoke-server.mjs
+++ b/editors/vscode/scripts/smoke-server.mjs
@@ -1,0 +1,210 @@
+import {
+  closeSync,
+  mkdtempSync,
+  openSync,
+  rmSync,
+} from "node:fs";
+import { request } from "node:http";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout } from "node:timers";
+import { fileURLToPath, URL } from "node:url";
+import { spawn, spawnSync } from "node:child_process";
+
+import { currentTarget } from "./platform.mjs";
+
+const target = currentTarget();
+const vsix = fileURLToPath(
+  new URL(`../../../dist/bingo-${target}.vsix`, import.meta.url),
+);
+const extracted = mkdtempSync(join(tmpdir(), "bingo-smoke-"));
+const idleTimeoutMs = 2000;
+
+try {
+  run("unzip", ["-q", vsix, "-d", extracted]);
+  const [managementPort, dapPort] = await unusedPorts(2);
+  const binary = join(extracted, "extension", "bin", "bingo");
+  const logPath = join(extracted, "server.log");
+  const logFD = openSync(logPath, "a", 0o600);
+  const child = spawn(
+    binary,
+    [
+      "-addr",
+      `127.0.0.1:${String(managementPort)}`,
+      "-dap-addr",
+      `127.0.0.1:${String(dapPort)}`,
+      "-idle-timeout",
+      `${String(idleTimeoutMs)}ms`,
+    ],
+    {
+      detached: true,
+      shell: false,
+      stdio: ["ignore", logFD, logFD],
+    },
+  );
+  closeSync(logFD);
+  child.unref();
+
+  const exit = new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      resolve({ code, signal });
+    });
+  });
+
+  const health = await pollHealth(managementPort, dapPort, exit);
+  if (
+    health.service !== "bingo" ||
+    health.managementApiVersion !== 1 ||
+    health.wireProtocolVersion !== "1.2" ||
+    health.dap?.enabled !== true ||
+    health.dap.address !== `127.0.0.1:${String(dapPort)}` ||
+    health.managedIdleShutdown?.enabled !== true ||
+    health.managedIdleShutdown.timeoutMs !== idleTimeoutMs
+  ) {
+    throw new Error(`unexpected packaged server health: ${JSON.stringify(health)}`);
+  }
+
+  const outcome = await withTimeout(
+    exit,
+    idleTimeoutMs + 8000,
+    "packaged server did not self-exit after its idle grace",
+  );
+  if (outcome.code !== 0 || outcome.signal !== null) {
+    throw new Error(
+      `packaged server exited with code ${String(outcome.code)} signal ${String(outcome.signal)}`,
+    );
+  }
+  log(
+    `Packaged ${target} server became healthy and self-exited cleanly`,
+  );
+} finally {
+  rmSync(extracted, { force: true, recursive: true });
+}
+
+async function unusedPorts(count) {
+  const servers = Array.from({ length: count }, () => createServer());
+  try {
+    await Promise.all(
+      servers.map(
+        (server) =>
+          new Promise((resolve, reject) => {
+            server.once("error", reject);
+            server.listen(0, "127.0.0.1", resolve);
+          }),
+      ),
+    );
+    return servers.map((server) => {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        throw new Error("failed to reserve a loopback port");
+      }
+      return address.port;
+    });
+  } finally {
+    await Promise.all(
+      servers.map(
+        (server) =>
+          new Promise((resolve, reject) => {
+            if (!server.listening) {
+              resolve();
+              return;
+            }
+            server.close((error) => {
+              if (error === undefined) {
+                resolve();
+              } else {
+                reject(error);
+              }
+            });
+          }),
+      ),
+    );
+  }
+}
+
+async function pollHealth(managementPort, dapPort, exit) {
+  const deadline = Date.now() + 5000;
+  for (;;) {
+    const result = await Promise.race([
+      getHealth(managementPort),
+      exit.then((outcome) => {
+        throw new Error(
+          `packaged server exited before health readiness: ${JSON.stringify(outcome)}`,
+        );
+      }),
+    ]).catch((error) => {
+      if (error?.code === "ECONNREFUSED") {
+        return undefined;
+      }
+      throw error;
+    });
+    if (result !== undefined) {
+      if (result.dap?.address !== `127.0.0.1:${String(dapPort)}`) {
+        throw new Error(`packaged server advertised wrong DAP endpoint`);
+      }
+      return result;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error("packaged server did not become healthy within 5000ms");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+function getHealth(port) {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: "/api/health",
+        method: "GET",
+      },
+      (response) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => {
+          if (response.statusCode !== 200) {
+            reject(new Error(`health returned HTTP ${String(response.statusCode)}`));
+            return;
+          }
+          try {
+            resolve(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+          } catch (error) {
+            reject(error);
+          }
+        });
+      },
+    );
+    req.setTimeout(1000, () => {
+      req.destroy(new Error("health probe timed out"));
+    });
+    req.once("error", reject);
+    req.end();
+  });
+}
+
+function withTimeout(promise, milliseconds, message) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      setTimeout(() => reject(new Error(message)), milliseconds);
+    }),
+  ]);
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, { stdio: "inherit" });
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} exited with status ${String(result.status)}`,
+    );
+  }
+}
+import { Buffer } from "node:buffer";
+import { log } from "node:console";

--- a/editors/vscode/scripts/timing.d.mts
+++ b/editors/vscode/scripts/timing.d.mts
@@ -1,0 +1,15 @@
+export interface TimeoutHandle {
+  unref?(): void;
+}
+
+export interface TimeoutTimers {
+  set(milliseconds: number, callback: () => void): TimeoutHandle;
+  clear(timer: TimeoutHandle): void;
+}
+
+export function withTimeout<T>(
+  operation: Promise<T>,
+  milliseconds: number,
+  message: string,
+  timers?: TimeoutTimers,
+): Promise<T>;

--- a/editors/vscode/scripts/timing.mjs
+++ b/editors/vscode/scripts/timing.mjs
@@ -1,0 +1,32 @@
+import { clearTimeout, setTimeout } from "node:timers";
+
+const systemTimers = {
+  set(milliseconds, callback) {
+    return setTimeout(callback, milliseconds);
+  },
+  clear(timer) {
+    clearTimeout(timer);
+  },
+};
+
+export async function withTimeout(
+  operation,
+  milliseconds,
+  message,
+  timers = systemTimers,
+) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = timers.set(milliseconds, () => {
+      reject(new Error(message));
+    });
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([operation, timeout]);
+  } finally {
+    if (timer !== undefined) {
+      timers.clear(timer);
+    }
+  }
+}

--- a/editors/vscode/scripts/verify-package.mjs
+++ b/editors/vscode/scripts/verify-package.mjs
@@ -1,0 +1,129 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { log } from "node:console";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, URL } from "node:url";
+import { spawnSync } from "node:child_process";
+
+import { currentTarget } from "./platform.mjs";
+
+const target = currentTarget();
+const vsix = fileURLToPath(
+  new URL(`../../../dist/bingo-${target}.vsix`, import.meta.url),
+);
+const extracted = mkdtempSync(join(tmpdir(), "bingo-vsix-"));
+
+try {
+  run("unzip", ["-q", vsix, "-d", extracted]);
+  const entries = capture("unzip", ["-Z1", vsix])
+    .split("\n")
+    .filter((entry) => entry.length > 0);
+  const binaries = entries.filter((entry) => entry === "extension/bin/bingo");
+  if (binaries.length !== 1) {
+    throw new Error(
+      `expected exactly one extension/bin/bingo, found ${String(binaries.length)}`,
+    );
+  }
+  const binEntries = entries.filter((entry) =>
+    entry.startsWith("extension/bin/"),
+  );
+  if (
+    binEntries.length !== 2 ||
+    !binEntries.includes("extension/bin/target.json")
+  ) {
+    throw new Error(`unexpected bin contents: ${binEntries.join(", ")}`);
+  }
+
+  const forbidden = entries.filter(
+    (entry) =>
+      entry.endsWith(".map") ||
+      entry.includes("/src/") ||
+      entry.includes("/test/") ||
+      entry.includes("/scripts/") ||
+      /(^|\/)\.env($|\.)/.test(entry) ||
+      /\.(pem|key|p12|pfx)$/i.test(entry),
+  );
+  if (forbidden.length > 0) {
+    throw new Error(`forbidden VSIX contents: ${forbidden.join(", ")}`);
+  }
+
+  const marker = JSON.parse(
+    readFileSync(join(extracted, "extension", "bin", "target.json"), "utf8"),
+  );
+  if (marker.target !== target) {
+    throw new Error(
+      `package target marker is ${String(marker.target)}, expected ${target}`,
+    );
+  }
+  const manifest = readFileSync(
+    join(extracted, "extension.vsixmanifest"),
+    "utf8",
+  );
+  if (!manifest.includes(`TargetPlatform="${target}"`)) {
+    throw new Error(`VSIX manifest does not declare target ${target}`);
+  }
+
+  const binary = join(extracted, "extension", "bin", "bingo");
+  if ((statSync(binary).mode & 0o111) === 0) {
+    throw new Error("packaged bingo binary is not executable");
+  }
+  const fileOutput = capture("file", [binary]);
+  if (
+    target === "linux-x64" &&
+    !(fileOutput.includes("ELF 64-bit") && fileOutput.includes("x86-64"))
+  ) {
+    throw new Error(`unexpected linux binary: ${fileOutput}`);
+  }
+  if (
+    target === "darwin-arm64" &&
+    !(fileOutput.includes("Mach-O 64-bit") && fileOutput.includes("arm64"))
+  ) {
+    throw new Error(`unexpected Darwin binary: ${fileOutput}`);
+  }
+  if (target === "darwin-arm64") {
+    run("codesign", ["--verify", "--strict", binary]);
+    const entitlements = capture("codesign", [
+      "-d",
+      "--entitlements",
+      ":-",
+      binary,
+    ]);
+    if (!entitlements.includes("com.apple.security.cs.debugger")) {
+      throw new Error("packaged Darwin binary lacks debugger entitlement");
+    }
+  }
+
+  log(`Verified ${target} VSIX contents and binary`);
+} finally {
+  rmSync(extracted, { force: true, recursive: true });
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, { stdio: "inherit" });
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} exited with status ${String(result.status)}`,
+    );
+  }
+}
+
+function capture(command, args) {
+  const result = spawnSync(command, args, { encoding: "utf8" });
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} exited with status ${String(result.status)}: ${result.stderr}`,
+    );
+  }
+  return `${result.stdout}${result.stderr}`;
+}

--- a/editors/vscode/scripts/verify-reproducible.mjs
+++ b/editors/vscode/scripts/verify-reproducible.mjs
@@ -2,22 +2,41 @@ import { spawnSync } from "node:child_process";
 import { log } from "node:console";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import process from "node:process";
 import { fileURLToPath, URL } from "node:url";
+
+import { currentTarget } from "./platform.mjs";
 
 const packageScript = fileURLToPath(
   new URL("./package.mjs", import.meta.url),
 );
-const vsix = new URL("../../../dist/bingo.vsix", import.meta.url);
+const target = currentTarget();
+const vsix = fileURLToPath(
+  new URL(`../../../dist/bingo-${target}.vsix`, import.meta.url),
+);
+const binary = join(
+  fileURLToPath(new URL("../", import.meta.url)),
+  "bin",
+  "bingo",
+);
 
 const first = packageAndHash();
 const second = packageAndHash();
 
-if (first !== second) {
-  throw new Error(`VSIX is not reproducible: ${first} != ${second}`);
+if (first.vsix !== second.vsix) {
+  throw new Error(
+    `VSIX is not reproducible: ${first.vsix} != ${second.vsix}`,
+  );
+}
+if (first.binary !== second.binary) {
+  throw new Error(
+    `bundled binary is not reproducible: ${first.binary} != ${second.binary}`,
+  );
 }
 
-log(`Reproducible VSIX: ${first}`);
+log(`Reproducible binary (${target}): ${first.binary}`);
+log(`Reproducible VSIX (${target}): ${first.vsix}`);
 
 function packageAndHash() {
   const result = spawnSync(process.execPath, [packageScript], {
@@ -30,5 +49,12 @@ function packageAndHash() {
     throw new Error(`package script exited with status ${String(result.status)}`);
   }
 
-  return createHash("sha256").update(readFileSync(vsix)).digest("hex");
+  return {
+    vsix: hash(vsix),
+    binary: hash(binary),
+  };
+}
+
+function hash(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
 }

--- a/editors/vscode/src/binary.ts
+++ b/editors/vscode/src/binary.ts
@@ -1,0 +1,60 @@
+import {
+  chmod,
+  readFile,
+  stat,
+} from "node:fs/promises";
+import { join } from "node:path";
+
+import type { SupportedTarget } from "./platform.js";
+
+export async function resolveBundledBinary(
+  extensionPath: string,
+  expectedTarget: SupportedTarget,
+): Promise<string> {
+  const binaryPath = join(extensionPath, "bin", "bingo");
+  const markerPath = join(extensionPath, "bin", "target.json");
+
+  let marker: unknown;
+  try {
+    marker = JSON.parse(await readFile(markerPath, "utf8")) as unknown;
+  } catch (error: unknown) {
+    throw new Error(
+      `cannot read bundled bingo target marker ${markerPath}: ${errorMessage(error)}`,
+    );
+  }
+  const markerTarget =
+    typeof marker === "object" && marker !== null && "target" in marker
+      ? marker.target
+      : undefined;
+  if (markerTarget !== expectedTarget) {
+    throw new Error(
+      `bundled bingo target is ${JSON.stringify(markerTarget)}, expected ${expectedTarget}`,
+    );
+  }
+
+  let info;
+  try {
+    info = await stat(binaryPath);
+  } catch (error: unknown) {
+    throw new Error(
+      `cannot find bundled bingo executable ${binaryPath}: ${errorMessage(error)}`,
+    );
+  }
+  if (!info.isFile()) {
+    throw new Error(`bundled bingo executable is not a file: ${binaryPath}`);
+  }
+  if ((info.mode & 0o111) === 0) {
+    try {
+      await chmod(binaryPath, 0o755);
+    } catch (error: unknown) {
+      throw new Error(
+        `cannot make bundled bingo executable runnable ${binaryPath}: ${errorMessage(error)}`,
+      );
+    }
+  }
+  return binaryPath;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/editors/vscode/src/configuration.ts
+++ b/editors/vscode/src/configuration.ts
@@ -1,16 +1,32 @@
 export const defaultDapHost = "127.0.0.1";
 export const defaultDapPort = 4711;
+export const defaultManagementHost = "127.0.0.1";
+export const defaultManagementPort = 6060;
+export const defaultServerMode = "auto";
+export const defaultServerReadyTimeoutMs = 5000;
+export const defaultManagedIdleTimeoutMs = 30000;
 
 type JsonRecord = Record<string, unknown>;
+
+export type ServerMode = "auto" | "connectOnly";
 
 export interface BingoEndpoint {
   readonly host: string;
   readonly port: number;
 }
 
+export interface BingoServerConfiguration {
+  readonly mode: ServerMode;
+  readonly managementEndpoint: BingoEndpoint;
+  readonly dapEndpoint: BingoEndpoint;
+  readonly readyTimeoutMs: number;
+  readonly idleTimeoutMs: number;
+}
+
 export interface ValidatedBingoConfiguration {
   readonly endpoint: BingoEndpoint;
   readonly request: "attach" | "launch";
+  readonly server: BingoServerConfiguration;
 }
 
 export class ConfigurationError extends Error {
@@ -21,7 +37,8 @@ export function validateBingoConfiguration(
   value: unknown,
 ): ValidatedBingoConfiguration {
   const config = requireRecord(value, "debug configuration");
-  const endpoint = resolveEndpoint(config);
+  const server = resolveServerConfiguration(config);
+  const endpoint = server.dapEndpoint;
   const request = requireNonEmptyString(config, "request");
 
   validateOptionalBoolean(config, "stopOnEntry");
@@ -30,12 +47,12 @@ export function validateBingoConfiguration(
     requireNonEmptyString(config, "program");
     validateOptionalStringArray(config, "args");
     validateOptionalStringArray(config, "env");
-    return { endpoint, request };
+    return { endpoint, request, server };
   }
 
   if (request === "attach") {
     validateAttach(config);
-    return { endpoint, request };
+    return { endpoint, request, server };
   }
 
   throw new ConfigurationError(
@@ -45,15 +62,79 @@ export function validateBingoConfiguration(
 
 export function resolveEndpoint(value: unknown): BingoEndpoint {
   const config = requireRecord(value, "debug configuration");
-  const hostValue = config.dapHost;
-  const portValue = config.dapPort;
+  return resolveNamedEndpoint(
+    config,
+    "dapHost",
+    "dapPort",
+    defaultDapHost,
+    defaultDapPort,
+  );
+}
 
+export function resolveServerConfiguration(
+  value: unknown,
+): BingoServerConfiguration {
+  const config = requireRecord(value, "debug configuration");
+  const mode = resolveServerMode(config.serverMode);
+  const managementEndpoint = resolveNamedEndpoint(
+    config,
+    "managementHost",
+    "managementPort",
+    defaultManagementHost,
+    defaultManagementPort,
+  );
+  const dapEndpoint = resolveEndpoint(config);
+  const readyTimeoutMs = resolveBoundedInteger(
+    config.serverReadyTimeoutMs,
+    defaultServerReadyTimeoutMs,
+    "serverReadyTimeoutMs",
+    100,
+    120000,
+  );
+  const idleTimeoutMs = resolveBoundedInteger(
+    config.managedIdleTimeoutMs,
+    defaultManagedIdleTimeoutMs,
+    "managedIdleTimeoutMs",
+    1,
+    86400000,
+  );
+
+  return {
+    mode,
+    managementEndpoint,
+    dapEndpoint,
+    readyTimeoutMs,
+    idleTimeoutMs,
+  };
+}
+
+function resolveServerMode(value: unknown): ServerMode {
+  if (value === undefined) {
+    return defaultServerMode;
+  }
+  if (value === "auto" || value === "connectOnly") {
+    return value;
+  }
+  throw new ConfigurationError(
+    'bingo serverMode must be "auto" or "connectOnly"',
+  );
+}
+
+function resolveNamedEndpoint(
+  config: JsonRecord,
+  hostKey: string,
+  portKey: string,
+  defaultHost: string,
+  defaultPort: number,
+): BingoEndpoint {
   const host =
-    hostValue === undefined
-      ? defaultDapHost
-      : requireNonEmptyString(config, "dapHost");
-  const port = portValue === undefined ? defaultDapPort : requirePort(portValue);
-
+    config[hostKey] === undefined
+      ? defaultHost
+      : requireNonEmptyString(config, hostKey);
+  const port =
+    config[portKey] === undefined
+      ? defaultPort
+      : requirePort(config[portKey], portKey);
   return { host, port };
 }
 
@@ -102,7 +183,7 @@ function validateOptionalStringArray(config: JsonRecord, key: string): void {
   }
 }
 
-function requirePort(value: unknown): number {
+function requirePort(value: unknown, key: string): number {
   if (
     typeof value !== "number" ||
     !Number.isInteger(value) ||
@@ -110,7 +191,30 @@ function requirePort(value: unknown): number {
     value > 65535
   ) {
     throw new ConfigurationError(
-      "bingo dapPort must be an integer between 1 and 65535",
+      `bingo ${key} must be an integer between 1 and 65535`,
+    );
+  }
+  return value;
+}
+
+function resolveBoundedInteger(
+  value: unknown,
+  defaultValue: number,
+  key: string,
+  minimum: number,
+  maximum: number,
+): number {
+  if (value === undefined) {
+    return defaultValue;
+  }
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    value < minimum ||
+    value > maximum
+  ) {
+    throw new ConfigurationError(
+      `bingo ${key} must be an integer between ${String(minimum)} and ${String(maximum)}`,
     );
   }
   return value;

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,9 +1,20 @@
+import { join } from "node:path";
+import process from "node:process";
+
 import * as vscode from "vscode";
 
+import { resolveBundledBinary } from "./binary.js";
 import {
   ConfigurationError,
   validateBingoConfiguration,
 } from "./configuration.js";
+import { probeBingoHealth } from "./health.js";
+import {
+  defaultDelay,
+  ServerManager,
+  ServerManagerError,
+} from "./serverManager.js";
+import { spawnDetachedServer } from "./serverProcess.js";
 
 const debugType = "bingo";
 
@@ -18,8 +29,13 @@ class BingoDebugConfigurationProvider
       const validated = validateBingoConfiguration(config);
       return {
         ...config,
+        serverMode: validated.server.mode,
+        managementHost: validated.server.managementEndpoint.host,
+        managementPort: validated.server.managementEndpoint.port,
         dapHost: validated.endpoint.host,
         dapPort: validated.endpoint.port,
+        serverReadyTimeoutMs: validated.server.readyTimeoutMs,
+        managedIdleTimeoutMs: validated.server.idleTimeoutMs,
       };
     } catch (error: unknown) {
       const message =
@@ -35,23 +51,78 @@ class BingoDebugConfigurationProvider
 class BingoDebugAdapterDescriptorFactory
   implements vscode.DebugAdapterDescriptorFactory
 {
+  public constructor(
+    private readonly manager: ServerManager,
+    private readonly output: vscode.OutputChannel,
+  ) {}
+
   public createDebugAdapterDescriptor(
     session: vscode.DebugSession,
-  ): vscode.DebugAdapterDescriptor {
-    const { endpoint } = validateBingoConfiguration(session.configuration);
+  ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+    return this.createDescriptor(session);
+  }
+
+  private async createDescriptor(
+    session: vscode.DebugSession,
+  ): Promise<vscode.DebugAdapterDescriptor> {
+    const { endpoint, server } = validateBingoConfiguration(
+      session.configuration,
+    );
+    try {
+      await this.manager.ensureServer(server);
+    } catch (error: unknown) {
+      const message =
+        error instanceof ServerManagerError
+          ? error.message
+          : `cannot prepare bingo server: ${String(error)}`;
+      this.output.appendLine(message);
+      void vscode.window.showErrorMessage(message);
+      throw error;
+    }
     return new vscode.DebugAdapterServer(endpoint.port, endpoint.host);
   }
 }
 
 export function activate(context: vscode.ExtensionContext): void {
+  const output = vscode.window.createOutputChannel("bingo Server");
+  const manager = new ServerManager({
+    probe: probeBingoHealth,
+    resolveBinary: async (target) =>
+      resolveBundledBinary(context.extensionPath, target),
+    spawnServer: spawnDetachedServer,
+    delay: defaultDelay,
+    now: Date.now,
+    runtime: {
+      platform: process.platform,
+      arch: process.arch,
+    },
+    logPathFor: (endpoint) =>
+      Promise.resolve(
+        join(
+          context.globalStorageUri.fsPath,
+          "server-logs",
+          `bingo-${String(endpoint.port)}.log`,
+        ),
+      ),
+    log: (message) => {
+      output.appendLine(message);
+    },
+  });
+
   context.subscriptions.push(
+    output,
+    {
+      dispose(): void {
+        manager.dispose();
+      },
+    },
     vscode.debug.registerDebugConfigurationProvider(
       debugType,
       new BingoDebugConfigurationProvider(),
     ),
     vscode.debug.registerDebugAdapterDescriptorFactory(
       debugType,
-      new BingoDebugAdapterDescriptorFactory(),
+      new BingoDebugAdapterDescriptorFactory(manager, output),
     ),
   );
 }

--- a/editors/vscode/src/health.ts
+++ b/editors/vscode/src/health.ts
@@ -45,6 +45,9 @@ export async function probeBingoHealth(
     if (isErrorCode(error, "ECONNREFUSED")) {
       return { kind: "absent" };
     }
+    if (isAbortError(error)) {
+      throw error;
+    }
     return { kind: "transportError", error: toError(error) };
   }
 }
@@ -59,6 +62,28 @@ function getHealth(
       reject(abortError());
       return;
     }
+
+    let settled = false;
+    const finish = (
+      outcome:
+        | {
+            readonly kind: "resolve";
+            readonly value: { readonly statusCode: number; readonly body: string };
+          }
+        | { readonly kind: "reject"; readonly error: Error },
+    ): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(deadline);
+      signal.removeEventListener("abort", onAbort);
+      if (outcome.kind === "resolve") {
+        resolve(outcome.value);
+      } else {
+        reject(outcome.error);
+      }
+    };
 
     const req = request(
       {
@@ -77,33 +102,54 @@ function getHealth(
         response.on("data", (chunk: Buffer) => {
           size += chunk.length;
           if (size > maximumHealthBytes) {
-            req.destroy(new Error("bingo health response exceeded 64 KiB"));
+            finish({
+              kind: "reject",
+              error: new Error("bingo health response exceeded 64 KiB"),
+            });
+            req.destroy();
             return;
           }
           chunks.push(chunk);
         });
-        response.on("end", () => {
-          resolve({
-            statusCode: response.statusCode ?? 0,
-            body: Buffer.concat(chunks).toString("utf8"),
+        response.once("aborted", () => {
+          finish({
+            kind: "reject",
+            error: new Error("bingo health response was aborted before completion"),
+          });
+        });
+        response.once("error", (error) => {
+          finish({ kind: "reject", error });
+        });
+        response.once("end", () => {
+          finish({
+            kind: "resolve",
+            value: {
+              statusCode: response.statusCode ?? 0,
+              body: Buffer.concat(chunks).toString("utf8"),
+            },
           });
         });
       },
     );
 
     const onAbort = (): void => {
-      req.destroy(abortError());
+      finish({ kind: "reject", error: abortError() });
+      req.destroy();
     };
     signal.addEventListener("abort", onAbort, { once: true });
-    req.setTimeout(timeoutMs, () => {
-      req.destroy(
-        new Error(`bingo health request timed out after ${String(timeoutMs)}ms`),
-      );
+    const deadline = setTimeout(() => {
+      finish({
+        kind: "reject",
+        error: new Error(
+          `bingo health request timed out after ${String(timeoutMs)}ms`,
+        ),
+      });
+      req.destroy();
+    }, timeoutMs);
+    deadline.unref();
+    req.once("error", (error) => {
+      finish({ kind: "reject", error });
     });
-    req.once("close", () => {
-      signal.removeEventListener("abort", onAbort);
-    });
-    req.once("error", reject);
     req.end();
   });
 }
@@ -239,6 +285,10 @@ function isErrorCode(error: unknown, code: string): boolean {
 
 function toError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
 }
 
 function abortError(): Error {

--- a/editors/vscode/src/health.ts
+++ b/editors/vscode/src/health.ts
@@ -5,6 +5,7 @@ import type { BingoEndpoint } from "./configuration.js";
 export const bingoServiceIdentity = "bingo";
 export const managementApiVersion = 1;
 export const wireProtocolVersion = "1.2";
+export const minimumHealthProbeTimeoutMs = 25;
 
 const maximumHealthBytes = 64 * 1024;
 

--- a/editors/vscode/src/health.ts
+++ b/editors/vscode/src/health.ts
@@ -1,0 +1,248 @@
+import { request } from "node:http";
+
+import type { BingoEndpoint } from "./configuration.js";
+
+export const bingoServiceIdentity = "bingo";
+export const managementApiVersion = 1;
+export const wireProtocolVersion = "1.2";
+
+const maximumHealthBytes = 64 * 1024;
+
+export interface CompatibleHealth {
+  readonly instanceId: string;
+  readonly dapAddress: string;
+}
+
+export type HealthProbeResult =
+  | { readonly kind: "absent" }
+  | { readonly kind: "compatible"; readonly health: CompatibleHealth }
+  | { readonly kind: "incompatible"; readonly reason: string }
+  | { readonly kind: "transportError"; readonly error: Error };
+
+export interface HealthProbe {
+  (
+    managementEndpoint: BingoEndpoint,
+    dapEndpoint: BingoEndpoint,
+    timeoutMs: number,
+    signal: AbortSignal,
+  ): Promise<HealthProbeResult>;
+}
+
+export async function probeBingoHealth(
+  managementEndpoint: BingoEndpoint,
+  dapEndpoint: BingoEndpoint,
+  timeoutMs: number,
+  signal: AbortSignal,
+): Promise<HealthProbeResult> {
+  try {
+    const response = await getHealth(
+      managementEndpoint,
+      timeoutMs,
+      signal,
+    );
+    return validateHealthResponse(response.statusCode, response.body, dapEndpoint);
+  } catch (error: unknown) {
+    if (isErrorCode(error, "ECONNREFUSED")) {
+      return { kind: "absent" };
+    }
+    return { kind: "transportError", error: toError(error) };
+  }
+}
+
+function getHealth(
+  endpoint: BingoEndpoint,
+  timeoutMs: number,
+  signal: AbortSignal,
+): Promise<{ readonly statusCode: number; readonly body: string }> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(abortError());
+      return;
+    }
+
+    const req = request(
+      {
+        host: endpoint.host,
+        port: endpoint.port,
+        path: "/api/health",
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          "Cache-Control": "no-cache",
+        },
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        let size = 0;
+        response.on("data", (chunk: Buffer) => {
+          size += chunk.length;
+          if (size > maximumHealthBytes) {
+            req.destroy(new Error("bingo health response exceeded 64 KiB"));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        response.on("end", () => {
+          resolve({
+            statusCode: response.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString("utf8"),
+          });
+        });
+      },
+    );
+
+    const onAbort = (): void => {
+      req.destroy(abortError());
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(
+        new Error(`bingo health request timed out after ${String(timeoutMs)}ms`),
+      );
+    });
+    req.once("close", () => {
+      signal.removeEventListener("abort", onAbort);
+    });
+    req.once("error", reject);
+    req.end();
+  });
+}
+
+export function validateHealthResponse(
+  statusCode: number,
+  body: string,
+  expectedDAP: BingoEndpoint,
+): HealthProbeResult {
+  if (statusCode !== 200) {
+    return {
+      kind: "incompatible",
+      reason: `health endpoint returned HTTP ${String(statusCode)}`,
+    };
+  }
+
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(body) as unknown;
+  } catch {
+    return { kind: "incompatible", reason: "health endpoint did not return JSON" };
+  }
+  if (!isRecord(decoded)) {
+    return { kind: "incompatible", reason: "health response must be an object" };
+  }
+  if (decoded.service !== bingoServiceIdentity) {
+    return {
+      kind: "incompatible",
+      reason: `health service identity is ${JSON.stringify(decoded.service)}, expected "bingo"`,
+    };
+  }
+  if (decoded.managementApiVersion !== managementApiVersion) {
+    return {
+      kind: "incompatible",
+      reason: `management API version is ${JSON.stringify(decoded.managementApiVersion)}, expected ${String(managementApiVersion)}`,
+    };
+  }
+  if (decoded.wireProtocolVersion !== wireProtocolVersion) {
+    return {
+      kind: "incompatible",
+      reason: `wire protocol version is ${JSON.stringify(decoded.wireProtocolVersion)}, expected ${wireProtocolVersion}`,
+    };
+  }
+  if (typeof decoded.instanceId !== "string" || decoded.instanceId.length === 0) {
+    return {
+      kind: "incompatible",
+      reason: "health response has no instanceId",
+    };
+  }
+  if (!isRecord(decoded.dap) || decoded.dap.enabled !== true) {
+    return {
+      kind: "incompatible",
+      reason: "bingo DAP listener is not enabled",
+    };
+  }
+  if (typeof decoded.dap.address !== "string") {
+    return {
+      kind: "incompatible",
+      reason: "health response has no DAP address",
+    };
+  }
+
+  const advertised = parseAddress(decoded.dap.address);
+  if (advertised === undefined) {
+    return {
+      kind: "incompatible",
+      reason: `health DAP address is invalid: ${decoded.dap.address}`,
+    };
+  }
+  if (advertised.port !== expectedDAP.port) {
+    return {
+      kind: "incompatible",
+      reason: `health DAP port is ${String(advertised.port)}, expected ${String(expectedDAP.port)}`,
+    };
+  }
+  if (!isWildcardHost(advertised.host) && advertised.host !== expectedDAP.host) {
+    return {
+      kind: "incompatible",
+      reason: `health DAP host is ${advertised.host}, expected ${expectedDAP.host}`,
+    };
+  }
+
+  return {
+    kind: "compatible",
+    health: {
+      instanceId: decoded.instanceId,
+      dapAddress: decoded.dap.address,
+    },
+  };
+}
+
+function parseAddress(value: string): BingoEndpoint | undefined {
+  if (value.startsWith("[")) {
+    const close = value.indexOf("]");
+    if (close < 0 || value[close + 1] !== ":") {
+      return undefined;
+    }
+    return endpointFromParts(value.slice(1, close), value.slice(close + 2));
+  }
+  const colon = value.lastIndexOf(":");
+  if (colon < 0) {
+    return undefined;
+  }
+  return endpointFromParts(value.slice(0, colon), value.slice(colon + 1));
+}
+
+function endpointFromParts(
+  host: string,
+  portText: string,
+): BingoEndpoint | undefined {
+  const port = Number(portText);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    return undefined;
+  }
+  return { host, port };
+}
+
+function isWildcardHost(host: string): boolean {
+  return host === "" || host === "0.0.0.0" || host === "::";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isErrorCode(error: unknown, code: string): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as Error & { code?: unknown }).code === code
+  );
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function abortError(): Error {
+  const error = new Error("operation cancelled");
+  error.name = "AbortError";
+  return error;
+}

--- a/editors/vscode/src/platform.ts
+++ b/editors/vscode/src/platform.ts
@@ -1,0 +1,18 @@
+export type SupportedTarget = "darwin-arm64" | "linux-x64";
+
+export interface RuntimePlatform {
+  readonly platform: NodeJS.Platform;
+  readonly arch: string;
+}
+
+export function supportedTargetFor(
+  runtime: RuntimePlatform,
+): SupportedTarget | undefined {
+  if (runtime.platform === "darwin" && runtime.arch === "arm64") {
+    return "darwin-arm64";
+  }
+  if (runtime.platform === "linux" && runtime.arch === "x64") {
+    return "linux-x64";
+  }
+  return undefined;
+}

--- a/editors/vscode/src/serverManager.ts
+++ b/editors/vscode/src/serverManager.ts
@@ -1,0 +1,360 @@
+import type {
+  BingoEndpoint,
+  BingoServerConfiguration,
+} from "./configuration.js";
+import type {
+  HealthProbe,
+  HealthProbeResult,
+} from "./health.js";
+import {
+  supportedTargetFor,
+  type RuntimePlatform,
+  type SupportedTarget,
+} from "./platform.js";
+import type {
+  ServerProcessObservation,
+  ServerProcessOutcome,
+  ServerSpawner,
+} from "./serverProcess.js";
+
+export type ServerManagerErrorCode =
+  | "binaryUnavailable"
+  | "cancelled"
+  | "endpointOccupied"
+  | "healthProbeFailed"
+  | "invalidConfiguration"
+  | "readinessTimedOut"
+  | "spawnFailed"
+  | "unsupportedAutoStart";
+
+export class ServerManagerError extends Error {
+  public override readonly name = "ServerManagerError";
+
+  public constructor(
+    public readonly code: ServerManagerErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+  }
+}
+
+export interface ServerManagerDependencies {
+  readonly probe: HealthProbe;
+  readonly resolveBinary: (target: SupportedTarget) => Promise<string>;
+  readonly spawnServer: ServerSpawner;
+  readonly delay: (milliseconds: number, signal: AbortSignal) => Promise<void>;
+  readonly now: () => number;
+  readonly runtime: RuntimePlatform;
+  readonly logPathFor: (endpoint: BingoEndpoint) => Promise<string>;
+  readonly log: (message: string) => void;
+}
+
+const probeTimeoutMs = 1000;
+const pollIntervalMs = 100;
+
+export class ServerManager {
+  readonly #dependencies: ServerManagerDependencies;
+  readonly #inFlight = new Map<string, Promise<BingoEndpoint>>();
+  readonly #lifetime = new AbortController();
+  #disposed = false;
+
+  public constructor(dependencies: ServerManagerDependencies) {
+    this.#dependencies = dependencies;
+  }
+
+  public ensureServer(
+    config: BingoServerConfiguration,
+    signal?: AbortSignal,
+  ): Promise<BingoEndpoint> {
+    if (this.#disposed) {
+      return Promise.reject(cancelledError());
+    }
+    if (config.mode === "connectOnly") {
+      return awaitWithCancellation(
+        Promise.resolve(config.dapEndpoint),
+        signal,
+      );
+    }
+
+    this.#validateAutoConfiguration(config);
+    const key = endpointKey(config);
+    let ensured = this.#inFlight.get(key);
+    if (ensured === undefined) {
+      ensured = this.#ensureAuto(config);
+      this.#inFlight.set(key, ensured);
+      void ensured.finally(() => {
+        if (this.#inFlight.get(key) === ensured) {
+          this.#inFlight.delete(key);
+        }
+      }).catch(() => undefined);
+    }
+    return awaitWithCancellation(ensured, signal);
+  }
+
+  public dispose(): void {
+    if (this.#disposed) {
+      return;
+    }
+    this.#disposed = true;
+    this.#lifetime.abort();
+    this.#inFlight.clear();
+  }
+
+  async #ensureAuto(
+    config: BingoServerConfiguration,
+  ): Promise<BingoEndpoint> {
+    const target = supportedTargetFor(this.#dependencies.runtime);
+    if (target === undefined) {
+      throw unsupportedTargetError(this.#dependencies.runtime);
+    }
+
+    this.#dependencies.log(
+      `probing bingo management endpoint ${formatEndpoint(config.managementEndpoint)}`,
+    );
+    const initial = await this.#dependencies.probe(
+      config.managementEndpoint,
+      config.dapEndpoint,
+      Math.min(probeTimeoutMs, config.readyTimeoutMs),
+      this.#lifetime.signal,
+    );
+    if (initial.kind === "compatible") {
+      this.#dependencies.log(
+        `reusing compatible bingo instance ${initial.health.instanceId}`,
+      );
+      return config.dapEndpoint;
+    }
+    if (initial.kind === "incompatible") {
+      throw occupiedError(config, initial.reason);
+    }
+    if (initial.kind === "transportError") {
+      throw new ServerManagerError(
+        "healthProbeFailed",
+        `cannot probe bingo management endpoint ${formatEndpoint(config.managementEndpoint)}: ${initial.error.message}`,
+        { cause: initial.error },
+      );
+    }
+
+    let binaryPath: string;
+    try {
+      binaryPath = await this.#dependencies.resolveBinary(target);
+    } catch (error: unknown) {
+      throw new ServerManagerError(
+        "binaryUnavailable",
+        `cannot use the bundled ${target} bingo server: ${errorMessage(error)}`,
+        { cause: error },
+      );
+    }
+
+    const logPath = await this.#dependencies.logPathFor(
+      config.managementEndpoint,
+    );
+    const args = serverArguments(config);
+    this.#dependencies.log(
+      `starting bundled bingo server; logs: ${logPath}`,
+    );
+
+    let childOutcome: ServerProcessOutcome | undefined;
+    let observation: ServerProcessObservation;
+    try {
+      observation = this.#dependencies.spawnServer(
+        { binaryPath, args, logPath },
+        (outcome) => {
+          childOutcome = outcome;
+        },
+      );
+    } catch (error: unknown) {
+      throw new ServerManagerError(
+        "spawnFailed",
+        `cannot start bundled bingo server for ${formatEndpoint(config.managementEndpoint)}: ${errorMessage(error)}; logs: ${logPath}`,
+        { cause: error },
+      );
+    }
+
+    const deadline = this.#dependencies.now() + config.readyTimeoutMs;
+    let lastProbe: HealthProbeResult = initial;
+    try {
+      for (;;) {
+        const remaining = deadline - this.#dependencies.now();
+        if (remaining <= 0) {
+          break;
+        }
+        await this.#dependencies.delay(
+          Math.min(pollIntervalMs, remaining),
+          this.#lifetime.signal,
+        );
+        lastProbe = await this.#dependencies.probe(
+          config.managementEndpoint,
+          config.dapEndpoint,
+          Math.min(probeTimeoutMs, remaining),
+          this.#lifetime.signal,
+        );
+        if (lastProbe.kind === "compatible") {
+          this.#dependencies.log(
+            `bingo instance ${lastProbe.health.instanceId} is ready at ${formatEndpoint(config.dapEndpoint)}`,
+          );
+          return config.dapEndpoint;
+        }
+        if (lastProbe.kind === "incompatible") {
+          throw occupiedError(config, lastProbe.reason);
+        }
+      }
+    } catch (error: unknown) {
+      if (isAbortError(error)) {
+        throw cancelledError();
+      }
+      throw error;
+    } finally {
+      observation.stopObserving();
+    }
+
+    const outcome = describeOutcome(childOutcome);
+    const probe = describeProbe(lastProbe);
+    const message =
+      `bundled bingo server did not become ready at ${formatEndpoint(config.managementEndpoint)} ` +
+      `within ${String(config.readyTimeoutMs)}ms (${probe}; ${outcome}); ` +
+      `DAP ${formatEndpoint(config.dapEndpoint)}; logs: ${logPath}`;
+    throw new ServerManagerError(
+      childOutcome === undefined ? "readinessTimedOut" : "spawnFailed",
+      message,
+    );
+  }
+
+  #validateAutoConfiguration(config: BingoServerConfiguration): void {
+    if (
+      config.managementEndpoint.host !== "127.0.0.1" ||
+      config.dapEndpoint.host !== "127.0.0.1"
+    ) {
+      throw new ServerManagerError(
+        "invalidConfiguration",
+        'bingo serverMode "auto" requires managementHost and dapHost to be 127.0.0.1; use "connectOnly" for remote or custom endpoints',
+      );
+    }
+    const target = supportedTargetFor(this.#dependencies.runtime);
+    if (target === undefined) {
+      throw unsupportedTargetError(this.#dependencies.runtime);
+    }
+  }
+}
+
+function serverArguments(config: BingoServerConfiguration): string[] {
+  return [
+    "-addr",
+    formatEndpoint(config.managementEndpoint),
+    "-dap-addr",
+    formatEndpoint(config.dapEndpoint),
+    "-idle-timeout",
+    `${String(config.idleTimeoutMs)}ms`,
+  ];
+}
+
+function endpointKey(config: BingoServerConfiguration): string {
+  return `${formatEndpoint(config.managementEndpoint)}|${formatEndpoint(config.dapEndpoint)}`;
+}
+
+function formatEndpoint(endpoint: BingoEndpoint): string {
+  return `${endpoint.host}:${String(endpoint.port)}`;
+}
+
+function occupiedError(
+  config: BingoServerConfiguration,
+  reason: string,
+): ServerManagerError {
+  return new ServerManagerError(
+    "endpointOccupied",
+    `cannot use bingo management endpoint ${formatEndpoint(config.managementEndpoint)}: ${reason}; no server was started`,
+  );
+}
+
+function unsupportedTargetError(runtime: RuntimePlatform): ServerManagerError {
+  return new ServerManagerError(
+    "unsupportedAutoStart",
+    `bingo server autostart supports only linux/x64 and darwin/arm64, not ${runtime.platform}/${runtime.arch}; use serverMode "connectOnly" with an existing server`,
+  );
+}
+
+function describeOutcome(outcome: ServerProcessOutcome | undefined): string {
+  if (outcome === undefined) {
+    return "child is still running or produced no exit status";
+  }
+  if (outcome.kind === "error") {
+    return `child error: ${outcome.error.message}`;
+  }
+  return `child exited with code ${String(outcome.code)} signal ${String(outcome.signal)}`;
+}
+
+function describeProbe(probe: HealthProbeResult): string {
+  if (probe.kind === "transportError") {
+    return `last health error: ${probe.error.message}`;
+  }
+  if (probe.kind === "incompatible") {
+    return `last health response: ${probe.reason}`;
+  }
+  return `last health result: ${probe.kind}`;
+}
+
+function awaitWithCancellation<T>(
+  promise: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (signal === undefined) {
+    return promise;
+  }
+  if (signal.aborted) {
+    return Promise.reject(cancelledError());
+  }
+  return new Promise((resolve, reject) => {
+    const onAbort = (): void => {
+      reject(cancelledError());
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    void promise.then(resolve, reject).finally(() => {
+      signal.removeEventListener("abort", onAbort);
+    });
+  });
+}
+
+function cancelledError(): ServerManagerError {
+  return new ServerManagerError("cancelled", "bingo server startup was cancelled");
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function defaultDelay(
+  milliseconds: number,
+  signal: AbortSignal,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(abortException());
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, milliseconds);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      reject(abortException());
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    void Promise.resolve().then(() => {
+      if (signal.aborted) {
+        onAbort();
+      }
+    });
+  });
+}
+
+function abortException(): Error {
+  const error = new Error("operation cancelled");
+  error.name = "AbortError";
+  return error;
+}

--- a/editors/vscode/src/serverManager.ts
+++ b/editors/vscode/src/serverManager.ts
@@ -53,6 +53,7 @@ export interface ServerManagerDependencies {
 const probeTimeoutMs = 1000;
 const pollIntervalMs = 100;
 const finalProbeBudgetMs = 50;
+const minimumProbeBudgetMs = 1;
 
 export class ServerManager {
   readonly #dependencies: ServerManagerDependencies;
@@ -189,21 +190,23 @@ export class ServerManager {
         if (remaining <= 0) {
           break;
         }
+        if (remaining <= minimumProbeBudgetMs) {
+          await this.#dependencies.delay(remaining, this.#lifetime.signal);
+          break;
+        }
+        const reservedProbeBudget =
+          remaining > finalProbeBudgetMs
+            ? finalProbeBudgetMs
+            : minimumProbeBudgetMs;
         const delayMs = Math.min(
           pollIntervalMs,
-          Math.max(0, remaining - finalProbeBudgetMs),
+          remaining - reservedProbeBudget,
         );
-        if (delayMs > 0) {
-          await this.#dependencies.delay(
-            delayMs,
-            this.#lifetime.signal,
-          );
-        }
+        await this.#dependencies.delay(delayMs, this.#lifetime.signal);
         const probeRemaining = deadline - this.#dependencies.now();
         if (probeRemaining <= 0) {
           break;
         }
-        const finalAttempt = probeRemaining <= finalProbeBudgetMs;
         lastProbe = await this.#probe(
           config.managementEndpoint,
           config.dapEndpoint,
@@ -217,9 +220,6 @@ export class ServerManager {
         }
         if (lastProbe.kind === "incompatible") {
           throw occupiedError(config, lastProbe.reason);
-        }
-        if (finalAttempt) {
-          break;
         }
       }
     } catch (error: unknown) {

--- a/editors/vscode/src/serverManager.ts
+++ b/editors/vscode/src/serverManager.ts
@@ -112,11 +112,10 @@ export class ServerManager {
     this.#dependencies.log(
       `probing bingo management endpoint ${formatEndpoint(config.managementEndpoint)}`,
     );
-    const initial = await this.#dependencies.probe(
+    const initial = await this.#probe(
       config.managementEndpoint,
       config.dapEndpoint,
       Math.min(probeTimeoutMs, config.readyTimeoutMs),
-      this.#lifetime.signal,
     );
     if (initial.kind === "compatible") {
       this.#dependencies.log(
@@ -139,16 +138,25 @@ export class ServerManager {
     try {
       binaryPath = await this.#dependencies.resolveBinary(target);
     } catch (error: unknown) {
+      this.#throwIfCancelled(error);
       throw new ServerManagerError(
         "binaryUnavailable",
         `cannot use the bundled ${target} bingo server: ${errorMessage(error)}`,
         { cause: error },
       );
     }
+    this.#throwIfCancelled();
 
-    const logPath = await this.#dependencies.logPathFor(
-      config.managementEndpoint,
-    );
+    let logPath: string;
+    try {
+      logPath = await this.#dependencies.logPathFor(
+        config.managementEndpoint,
+      );
+    } catch (error: unknown) {
+      this.#throwIfCancelled(error);
+      throw error;
+    }
+    this.#throwIfCancelled();
     const args = serverArguments(config);
     this.#dependencies.log(
       `starting bundled bingo server; logs: ${logPath}`,
@@ -156,6 +164,7 @@ export class ServerManager {
 
     let childOutcome: ServerProcessOutcome | undefined;
     let observation: ServerProcessObservation;
+    this.#throwIfCancelled();
     try {
       observation = this.#dependencies.spawnServer(
         { binaryPath, args, logPath },
@@ -183,11 +192,14 @@ export class ServerManager {
           Math.min(pollIntervalMs, remaining),
           this.#lifetime.signal,
         );
-        lastProbe = await this.#dependencies.probe(
+        const probeRemaining = deadline - this.#dependencies.now();
+        if (probeRemaining <= 0) {
+          break;
+        }
+        lastProbe = await this.#probe(
           config.managementEndpoint,
           config.dapEndpoint,
-          Math.min(probeTimeoutMs, remaining),
-          this.#lifetime.signal,
+          Math.min(probeTimeoutMs, probeRemaining),
         );
         if (lastProbe.kind === "compatible") {
           this.#dependencies.log(
@@ -218,6 +230,34 @@ export class ServerManager {
       childOutcome === undefined ? "readinessTimedOut" : "spawnFailed",
       message,
     );
+  }
+
+  async #probe(
+    managementEndpoint: BingoEndpoint,
+    dapEndpoint: BingoEndpoint,
+    timeoutMs: number,
+  ): Promise<HealthProbeResult> {
+    try {
+      const result = await this.#dependencies.probe(
+        managementEndpoint,
+        dapEndpoint,
+        timeoutMs,
+        this.#lifetime.signal,
+      );
+      this.#throwIfCancelled(
+        result.kind === "transportError" ? result.error : undefined,
+      );
+      return result;
+    } catch (error: unknown) {
+      this.#throwIfCancelled(error);
+      throw error;
+    }
+  }
+
+  #throwIfCancelled(error?: unknown): void {
+    if (this.#lifetime.signal.aborted || isAbortError(error)) {
+      throw cancelledError();
+    }
   }
 
   #validateAutoConfiguration(config: BingoServerConfiguration): void {

--- a/editors/vscode/src/serverManager.ts
+++ b/editors/vscode/src/serverManager.ts
@@ -6,6 +6,7 @@ import type {
   HealthProbe,
   HealthProbeResult,
 } from "./health.js";
+import { minimumHealthProbeTimeoutMs } from "./health.js";
 import {
   supportedTargetFor,
   type RuntimePlatform,
@@ -52,8 +53,8 @@ export interface ServerManagerDependencies {
 
 const probeTimeoutMs = 1000;
 const pollIntervalMs = 100;
-const finalProbeBudgetMs = 50;
-const minimumProbeBudgetMs = 1;
+const finalWindowMs = 50;
+const finalPollIntervalMs = 10;
 
 export class ServerManager {
   readonly #dependencies: ServerManagerDependencies;
@@ -185,41 +186,61 @@ export class ServerManager {
     const deadline = this.#dependencies.now() + config.readyTimeoutMs;
     let lastProbe: HealthProbeResult = initial;
     try {
-      for (;;) {
-        const remaining = deadline - this.#dependencies.now();
-        if (remaining <= 0) {
-          break;
-        }
-        if (remaining <= minimumProbeBudgetMs) {
-          await this.#dependencies.delay(remaining, this.#lifetime.signal);
-          break;
-        }
-        const reservedProbeBudget =
-          remaining > finalProbeBudgetMs
-            ? finalProbeBudgetMs
-            : minimumProbeBudgetMs;
-        const delayMs = Math.min(
-          pollIntervalMs,
-          remaining - reservedProbeBudget,
-        );
-        await this.#dependencies.delay(delayMs, this.#lifetime.signal);
-        const probeRemaining = deadline - this.#dependencies.now();
-        if (probeRemaining <= 0) {
-          break;
-        }
+      const probeReady = async (timeoutMs: number): Promise<boolean> => {
         lastProbe = await this.#probe(
           config.managementEndpoint,
           config.dapEndpoint,
-          Math.min(probeTimeoutMs, probeRemaining),
+          Math.min(probeTimeoutMs, timeoutMs),
         );
         if (lastProbe.kind === "compatible") {
           this.#dependencies.log(
             `bingo instance ${lastProbe.health.instanceId} is ready at ${formatEndpoint(config.dapEndpoint)}`,
           );
-          return config.dapEndpoint;
+          return true;
         }
         if (lastProbe.kind === "incompatible") {
           throw occupiedError(config, lastProbe.reason);
+        }
+        return false;
+      };
+
+      const initialRemaining = deadline - this.#dependencies.now();
+      if (
+        initialRemaining >= minimumHealthProbeTimeoutMs &&
+        (await probeReady(initialRemaining))
+      ) {
+        return config.dapEndpoint;
+      }
+
+      for (;;) {
+        const remaining = deadline - this.#dependencies.now();
+        if (remaining <= 0) {
+          break;
+        }
+        if (remaining <= minimumHealthProbeTimeoutMs) {
+          await this.#dependencies.delay(remaining, this.#lifetime.signal);
+          break;
+        }
+        const delayMs =
+          remaining > finalWindowMs
+            ? Math.min(pollIntervalMs, remaining - finalWindowMs)
+            : Math.min(
+                finalPollIntervalMs,
+                remaining - minimumHealthProbeTimeoutMs,
+              );
+        await this.#dependencies.delay(delayMs, this.#lifetime.signal);
+        const probeRemaining = deadline - this.#dependencies.now();
+        if (probeRemaining < minimumHealthProbeTimeoutMs) {
+          if (probeRemaining > 0) {
+            await this.#dependencies.delay(
+              probeRemaining,
+              this.#lifetime.signal,
+            );
+          }
+          break;
+        }
+        if (await probeReady(probeRemaining)) {
+          return config.dapEndpoint;
         }
       }
     } catch (error: unknown) {

--- a/editors/vscode/src/serverManager.ts
+++ b/editors/vscode/src/serverManager.ts
@@ -52,6 +52,7 @@ export interface ServerManagerDependencies {
 
 const probeTimeoutMs = 1000;
 const pollIntervalMs = 100;
+const finalProbeBudgetMs = 50;
 
 export class ServerManager {
   readonly #dependencies: ServerManagerDependencies;
@@ -188,14 +189,21 @@ export class ServerManager {
         if (remaining <= 0) {
           break;
         }
-        await this.#dependencies.delay(
-          Math.min(pollIntervalMs, remaining),
-          this.#lifetime.signal,
+        const delayMs = Math.min(
+          pollIntervalMs,
+          Math.max(0, remaining - finalProbeBudgetMs),
         );
+        if (delayMs > 0) {
+          await this.#dependencies.delay(
+            delayMs,
+            this.#lifetime.signal,
+          );
+        }
         const probeRemaining = deadline - this.#dependencies.now();
         if (probeRemaining <= 0) {
           break;
         }
+        const finalAttempt = probeRemaining <= finalProbeBudgetMs;
         lastProbe = await this.#probe(
           config.managementEndpoint,
           config.dapEndpoint,
@@ -209,6 +217,9 @@ export class ServerManager {
         }
         if (lastProbe.kind === "incompatible") {
           throw occupiedError(config, lastProbe.reason);
+        }
+        if (finalAttempt) {
+          break;
         }
       }
     } catch (error: unknown) {

--- a/editors/vscode/src/serverProcess.ts
+++ b/editors/vscode/src/serverProcess.ts
@@ -1,0 +1,81 @@
+import {
+  closeSync,
+  mkdirSync,
+  openSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import {
+  spawn,
+  type ChildProcess,
+  type SpawnOptions,
+} from "node:child_process";
+
+export type ServerProcessOutcome =
+  | { readonly kind: "error"; readonly error: Error }
+  | {
+      readonly kind: "exit";
+      readonly code: number | null;
+      readonly signal: NodeJS.Signals | null;
+    };
+
+export interface SpawnServerRequest {
+  readonly binaryPath: string;
+  readonly args: readonly string[];
+  readonly logPath: string;
+}
+
+export interface ServerProcessObservation {
+  stopObserving(): void;
+}
+
+export interface ServerSpawner {
+  (
+    request: SpawnServerRequest,
+    onOutcome: (outcome: ServerProcessOutcome) => void,
+  ): ServerProcessObservation;
+}
+
+type SpawnFunction = (
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions,
+) => ChildProcess;
+
+export function spawnDetachedServer(
+  request: SpawnServerRequest,
+  onOutcome: (outcome: ServerProcessOutcome) => void,
+  spawnProcess: SpawnFunction = spawn,
+): ServerProcessObservation {
+  mkdirSync(dirname(request.logPath), { recursive: true });
+  const logFD = openSync(request.logPath, "a", 0o600);
+  let child: ChildProcess;
+  try {
+    child = spawnProcess(request.binaryPath, request.args, {
+      detached: true,
+      shell: false,
+      stdio: ["ignore", logFD, logFD],
+    });
+  } finally {
+    closeSync(logFD);
+  }
+
+  const handleError = (error: Error): void => {
+    onOutcome({ kind: "error", error });
+  };
+  const handleExit = (
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ): void => {
+    onOutcome({ kind: "exit", code, signal });
+  };
+  child.on("error", handleError);
+  child.on("exit", handleExit);
+  child.unref();
+
+  return {
+    stopObserving(): void {
+      child.off("error", handleError);
+      child.off("exit", handleExit);
+    },
+  };
+}

--- a/editors/vscode/test/binary.test.ts
+++ b/editors/vscode/test/binary.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import {
+  chmod,
+  mkdtemp,
+  mkdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import { resolveBundledBinary } from "../src/binary.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(async (directory) => {
+      await rm(directory, { force: true, recursive: true });
+    }),
+  );
+});
+
+async function extensionFixture(
+  target = "darwin-arm64",
+): Promise<{ readonly root: string; readonly binary: string }> {
+  const root = await mkdtemp(join(tmpdir(), "bingo-extension-"));
+  temporaryDirectories.push(root);
+  const bin = join(root, "bin");
+  await mkdir(bin);
+  await writeFile(join(bin, "target.json"), JSON.stringify({ target }));
+  const binary = join(bin, "bingo");
+  await writeFile(binary, "binary", { mode: 0o644 });
+  await chmod(binary, 0o644);
+  return { root, binary };
+}
+
+describe("bundled binary resolution", () => {
+  it("finds the extension-local binary and repairs executable mode", async () => {
+    const fixture = await extensionFixture();
+    assert.equal(
+      await resolveBundledBinary(fixture.root, "darwin-arm64"),
+      fixture.binary,
+    );
+    assert.notEqual((await stat(fixture.binary)).mode & 0o111, 0);
+  });
+
+  it("rejects the wrong package target", async () => {
+    const fixture = await extensionFixture("linux-x64");
+    await assert.rejects(
+      resolveBundledBinary(fixture.root, "darwin-arm64"),
+      /expected darwin-arm64/,
+    );
+  });
+
+  it("rejects a missing binary", async () => {
+    const fixture = await extensionFixture();
+    await rm(fixture.binary);
+    await assert.rejects(
+      resolveBundledBinary(fixture.root, "darwin-arm64"),
+      /cannot find/,
+    );
+  });
+
+  it("rejects a directory in place of the binary", async () => {
+    const fixture = await extensionFixture();
+    await rm(fixture.binary);
+    await mkdir(fixture.binary);
+    await assert.rejects(
+      resolveBundledBinary(fixture.root, "darwin-arm64"),
+      /not a file/,
+    );
+  });
+});

--- a/editors/vscode/test/configuration.test.ts
+++ b/editors/vscode/test/configuration.test.ts
@@ -5,7 +5,13 @@ import {
   ConfigurationError,
   defaultDapHost,
   defaultDapPort,
+  defaultManagedIdleTimeoutMs,
+  defaultManagementHost,
+  defaultManagementPort,
+  defaultServerMode,
+  defaultServerReadyTimeoutMs,
   resolveEndpoint,
+  resolveServerConfiguration,
   validateBingoConfiguration,
 } from "../src/configuration.js";
 
@@ -38,6 +44,68 @@ describe("bingo endpoint", () => {
   }
 });
 
+describe("bingo server configuration", () => {
+  it("uses managed local defaults", () => {
+    assert.deepEqual(resolveServerConfiguration({}), {
+      mode: defaultServerMode,
+      managementEndpoint: {
+        host: defaultManagementHost,
+        port: defaultManagementPort,
+      },
+      dapEndpoint: {
+        host: defaultDapHost,
+        port: defaultDapPort,
+      },
+      readyTimeoutMs: defaultServerReadyTimeoutMs,
+      idleTimeoutMs: defaultManagedIdleTimeoutMs,
+    });
+  });
+
+  it("accepts explicit connect-only endpoints and timing", () => {
+    assert.deepEqual(
+      resolveServerConfiguration({
+        serverMode: "connectOnly",
+        managementHost: "management.internal",
+        managementPort: 16060,
+        dapHost: "debug.internal",
+        dapPort: 14711,
+        serverReadyTimeoutMs: 10000,
+        managedIdleTimeoutMs: 60000,
+      }),
+      {
+        mode: "connectOnly",
+        managementEndpoint: {
+          host: "management.internal",
+          port: 16060,
+        },
+        dapEndpoint: {
+          host: "debug.internal",
+          port: 14711,
+        },
+        readyTimeoutMs: 10000,
+        idleTimeoutMs: 60000,
+      },
+    );
+  });
+
+  for (const [label, config] of [
+    ["unknown mode", { serverMode: "launch" }],
+    ["empty management host", { managementHost: "" }],
+    ["invalid management port", { managementPort: 0 }],
+    ["short readiness timeout", { serverReadyTimeoutMs: 99 }],
+    ["fractional readiness timeout", { serverReadyTimeoutMs: 100.5 }],
+    ["zero managed idle timeout", { managedIdleTimeoutMs: 0 }],
+    ["excessive managed idle timeout", { managedIdleTimeoutMs: 86400001 }],
+  ] as const) {
+    it(`rejects ${label}`, () => {
+      assert.throws(
+        () => resolveServerConfiguration(config),
+        ConfigurationError,
+      );
+    });
+  }
+});
+
 describe("bingo debug configuration", () => {
   it("accepts binary launch arguments", () => {
     const validated = validateBingoConfiguration({
@@ -49,6 +117,7 @@ describe("bingo debug configuration", () => {
     });
 
     assert.equal(validated.request, "launch");
+    assert.equal(validated.server.mode, "auto");
   });
 
   it("accepts existing-session join", () => {

--- a/editors/vscode/test/health.test.ts
+++ b/editors/vscode/test/health.test.ts
@@ -1,11 +1,15 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import type { RequestListener, Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import { resolve } from "node:path";
 import { describe, it } from "node:test";
 
 import {
   bingoServiceIdentity,
   managementApiVersion,
+  probeBingoHealth,
   validateHealthResponse,
   wireProtocolVersion,
 } from "../src/health.js";
@@ -46,6 +50,53 @@ describe("health compatibility", () => {
       );
       assert.equal(result.kind, "compatible");
     }
+  });
+
+  it("rejects a response that closes before its declared body completes", async () => {
+    await withHTTPServer((_request, response) => {
+      response.writeHead(200, {
+        "Content-Type": "application/json",
+        "Content-Length": "1024",
+      });
+      response.write('{"service":"bingo"');
+      setImmediate(() => {
+        response.destroy();
+      });
+    }, async (port) => {
+      const started = Date.now();
+      const result = await probeWithSafetyAbort(port, 2000);
+      assert.equal(result.kind, "transportError");
+      if (result.kind === "transportError") {
+        assert.match(result.error.message, /aborted|reset|closed/i);
+      }
+      assert.ok(
+        Date.now() - started < 750,
+        "partial response must fail without waiting for the request deadline",
+      );
+    });
+  });
+
+  it("enforces a wall-clock deadline against a slow-drip response", async () => {
+    await withHTTPServer((_request, response) => {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.write("{");
+      const interval = setInterval(() => {
+        response.write(" ");
+      }, 20);
+      response.once("close", () => {
+        clearInterval(interval);
+      });
+    }, async (port) => {
+      const started = Date.now();
+      const result = await probeWithSafetyAbort(port, 120);
+      const elapsed = Date.now() - started;
+      assert.equal(result.kind, "transportError");
+      if (result.kind === "transportError") {
+        assert.match(result.error.message, /timed out after 120ms/);
+      }
+      assert.ok(elapsed >= 80, `wall timeout fired too early after ${String(elapsed)}ms`);
+      assert.ok(elapsed < 750, `slow-drip probe took ${String(elapsed)}ms`);
+    });
   });
 
   for (const [label, body] of [
@@ -119,3 +170,63 @@ describe("health compatibility", () => {
     );
   });
 });
+
+async function probeWithSafetyAbort(
+  port: number,
+  timeoutMs: number,
+): ReturnType<typeof probeBingoHealth> {
+  const controller = new AbortController();
+  const safety = setTimeout(() => {
+    controller.abort();
+  }, 1000);
+  safety.unref();
+  try {
+    return await probeBingoHealth(
+      { host: "127.0.0.1", port },
+      expectedDAP,
+      timeoutMs,
+      controller.signal,
+    );
+  } finally {
+    clearTimeout(safety);
+  }
+}
+
+async function withHTTPServer(
+  handler: RequestListener,
+  run: (port: number) => Promise<void>,
+): Promise<void> {
+  const server = createServer(handler);
+  await listen(server);
+  try {
+    const address = server.address();
+    assert.notEqual(address, null);
+    assert.equal(typeof address, "object");
+    await run((address as AddressInfo).port);
+  } finally {
+    server.closeAllConnections();
+    await close(server);
+  }
+}
+
+function listen(server: Server): Promise<void> {
+  return new Promise((resolveListen, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      resolveListen();
+    });
+  });
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolveClose, reject) => {
+    server.close((error) => {
+      if (error === undefined) {
+        resolveClose();
+      } else {
+        reject(error);
+      }
+    });
+  });
+}

--- a/editors/vscode/test/health.test.ts
+++ b/editors/vscode/test/health.test.ts
@@ -9,6 +9,7 @@ import { describe, it } from "node:test";
 import {
   bingoServiceIdentity,
   managementApiVersion,
+  minimumHealthProbeTimeoutMs,
   probeBingoHealth,
   validateHealthResponse,
   wireProtocolVersion,
@@ -39,6 +40,19 @@ describe("health compatibility", () => {
   it("accepts the exact bingo contract", () => {
     const result = validateHealthResponse(200, health(), expectedDAP);
     assert.equal(result.kind, "compatible");
+  });
+
+  it("reads localhost health within the minimum practical probe budget", async () => {
+    await withHTTPServer((_request, response) => {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(health());
+    }, async (port) => {
+      const result = await probeWithSafetyAbort(
+        port,
+        minimumHealthProbeTimeoutMs,
+      );
+      assert.equal(result.kind, "compatible");
+    });
   });
 
   it("accepts a wildcard advertised host but keeps port compatibility", () => {

--- a/editors/vscode/test/health.test.ts
+++ b/editors/vscode/test/health.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+
+import {
+  bingoServiceIdentity,
+  managementApiVersion,
+  validateHealthResponse,
+  wireProtocolVersion,
+} from "../src/health.js";
+
+const expectedDAP = { host: "127.0.0.1", port: 4711 };
+
+function health(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    service: "bingo",
+    managementApiVersion: 1,
+    wireProtocolVersion: "1.2",
+    instanceId: "instance-1",
+    dap: {
+      enabled: true,
+      address: "127.0.0.1:4711",
+    },
+    managedIdleShutdown: {
+      enabled: true,
+      timeoutMs: 30000,
+    },
+    sessionCount: 0,
+    ...overrides,
+  });
+}
+
+describe("health compatibility", () => {
+  it("accepts the exact bingo contract", () => {
+    const result = validateHealthResponse(200, health(), expectedDAP);
+    assert.equal(result.kind, "compatible");
+  });
+
+  it("accepts a wildcard advertised host but keeps port compatibility", () => {
+    for (const address of ["0.0.0.0:4711", "[::]:4711", ":4711"]) {
+      const result = validateHealthResponse(
+        200,
+        health({ dap: { enabled: true, address } }),
+        expectedDAP,
+      );
+      assert.equal(result.kind, "compatible");
+    }
+  });
+
+  for (const [label, body] of [
+    ["HTTP occupant", { status: 404, body: "not found" }],
+    ["non-JSON occupant", { status: 200, body: "<html></html>" }],
+    ["wrong identity", { status: 200, body: health({ service: "other" }) }],
+    [
+      "wrong management API",
+      { status: 200, body: health({ managementApiVersion: 2 }) },
+    ],
+    [
+      "wrong wire protocol",
+      { status: 200, body: health({ wireProtocolVersion: "9" }) },
+    ],
+    [
+      "disabled DAP",
+      {
+        status: 200,
+        body: health({ dap: { enabled: false, address: "" } }),
+      },
+    ],
+    [
+      "wrong DAP port",
+      {
+        status: 200,
+        body: health({
+          dap: { enabled: true, address: "127.0.0.1:9999" },
+        }),
+      },
+    ],
+    [
+      "wrong concrete DAP host",
+      {
+        status: 200,
+        body: health({
+          dap: { enabled: true, address: "192.0.2.1:4711" },
+        }),
+      },
+    ],
+  ] as const) {
+    it(`rejects ${label}`, () => {
+      const result = validateHealthResponse(body.status, body.body, expectedDAP);
+      assert.equal(result.kind, "incompatible");
+    });
+  }
+
+  it("drift-checks extension constants against Go sources", () => {
+    const root = resolve(process.cwd(), "../..");
+    const handler = readFileSync(
+      resolve(root, "internal/server/handler.go"),
+      "utf8",
+    );
+    const protocol = readFileSync(
+      resolve(root, "pkg/protocol/protocol.go"),
+      "utf8",
+    );
+
+    assert.match(
+      handler,
+      new RegExp(`serviceIdentity\\s*=\\s*"${bingoServiceIdentity}"`),
+    );
+    assert.match(
+      handler,
+      new RegExp(
+        `ManagementAPIVersion\\s*=\\s*${String(managementApiVersion)}`,
+      ),
+    );
+    assert.match(
+      protocol,
+      new RegExp(`const Version\\s*=\\s*"${wireProtocolVersion}"`),
+    );
+  });
+});

--- a/editors/vscode/test/manifest.test.ts
+++ b/editors/vscode/test/manifest.test.ts
@@ -41,8 +41,7 @@ describe("extension manifest", () => {
     for (const request of ["launch", "attach"]) {
       const schema = requireRecord(attributes[request]);
       const properties = requireRecord(schema.properties);
-      assert.equal(requireRecord(properties.dapHost).default, "127.0.0.1");
-      assert.equal(requireRecord(properties.dapPort).default, 4711);
+      assertLifecycleDefaults(properties);
     }
 
     const initialConfigurations = requireArray(
@@ -50,8 +49,7 @@ describe("extension manifest", () => {
     ).map(requireRecord);
     assert.ok(initialConfigurations.length > 0);
     for (const configuration of initialConfigurations) {
-      assert.equal(configuration.dapHost, "127.0.0.1");
-      assert.equal(configuration.dapPort, 4711);
+      assertLifecycleDefaults(configuration);
     }
   });
 
@@ -61,8 +59,7 @@ describe("extension manifest", () => {
       requireRecord(requireRecord(snippet).body),
     );
     for (const body of bodies) {
-      assert.equal(body.dapHost, "127.0.0.1");
-      assert.equal(body.dapPort, 4711);
+      assertLifecycleDefaults(body);
     }
 
     assert.ok(
@@ -81,6 +78,22 @@ describe("extension manifest", () => {
       ),
     );
   });
+
+  function assertLifecycleDefaults(record: JsonRecord): void {
+    assert.equal(valueOrDefault(record.serverMode), "auto");
+    assert.equal(valueOrDefault(record.managementHost), "127.0.0.1");
+    assert.equal(valueOrDefault(record.managementPort), 6060);
+    assert.equal(valueOrDefault(record.dapHost), "127.0.0.1");
+    assert.equal(valueOrDefault(record.dapPort), 4711);
+    assert.equal(valueOrDefault(record.serverReadyTimeoutMs), 5000);
+    assert.equal(valueOrDefault(record.managedIdleTimeoutMs), 30000);
+  }
+
+  function valueOrDefault(value: unknown): unknown {
+    return typeof value === "object" && value !== null && "default" in value
+      ? value.default
+      : value;
+  }
 });
 
 function requireRecord(value: unknown): JsonRecord {

--- a/editors/vscode/test/owned-process.test.ts
+++ b/editors/vscode/test/owned-process.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  terminateOwnedProcessGroup,
+  type ProcessSignal,
+} from "../scripts/owned-process.mjs";
+
+describe("test-owned process cleanup", () => {
+  it("signals only the detached process group and waits for exit", async () => {
+    const calls: Array<{ readonly pid: number; readonly signal: NodeJS.Signals }> = [];
+    let finishExit: (() => void) | undefined;
+    const exit = new Promise<void>((resolve) => {
+      finishExit = resolve;
+    });
+    const signalProcess: ProcessSignal = (pid, signal) => {
+      calls.push({ pid, signal });
+      finishExit?.();
+      return true;
+    };
+
+    await terminateOwnedProcessGroup(4321, exit, signalProcess);
+    assert.deepEqual(calls, [{ pid: -4321, signal: "SIGKILL" }]);
+  });
+
+  it("tolerates an already-exited owned process group", async () => {
+    const signalProcess: ProcessSignal = () => {
+      const error = new Error("gone") as NodeJS.ErrnoException;
+      error.code = "ESRCH";
+      throw error;
+    };
+
+    await terminateOwnedProcessGroup(
+      4321,
+      Promise.resolve(),
+      signalProcess,
+    );
+  });
+
+  it("surfaces unexpected cleanup signal failures", async () => {
+    const signalProcess: ProcessSignal = () => {
+      const error = new Error("permission denied") as NodeJS.ErrnoException;
+      error.code = "EPERM";
+      throw error;
+    };
+
+    await assert.rejects(
+      terminateOwnedProcessGroup(4321, Promise.resolve(), signalProcess),
+      /permission denied/,
+    );
+  });
+});

--- a/editors/vscode/test/serverManager.test.ts
+++ b/editors/vscode/test/serverManager.test.ts
@@ -286,6 +286,19 @@ describe("server manager", () => {
     );
   });
 
+  it("passes the remaining readiness deadline to each health probe", async () => {
+    const timeouts: number[] = [];
+    const test = harness((_management, _dap, timeoutMs) => {
+      timeouts.push(timeoutMs);
+      return Promise.resolve(absent);
+    });
+    await assert.rejects(
+      test.manager.ensureServer(configuration({ readyTimeoutMs: 250 })),
+      hasCode("readinessTimedOut"),
+    );
+    assert.deepEqual(timeouts, [250, 150, 50]);
+  });
+
   it("fails safely on an incompatible endpoint without spawning", async () => {
     const test = harness(
       sequence({ kind: "incompatible", reason: "not bingo" }),
@@ -344,6 +357,89 @@ describe("server manager", () => {
     custom.dispose();
     await assert.rejects(ensured, hasCode("cancelled"));
   });
+
+  for (const phase of ["binary", "log"] as const) {
+    it(`dispose during ${phase} resolution prevents spawn`, async () => {
+      const gate = deferred<string>();
+      const entered = deferred<void>();
+      let spawns = 0;
+      const manager = new ServerManager({
+        probe: sequence(absent),
+        resolveBinary: () => {
+          if (phase === "binary") {
+            entered.resolve();
+            return gate.promise;
+          }
+          return Promise.resolve("/extension/bin/bingo");
+        },
+        spawnServer: () => {
+          spawns += 1;
+          return { stopObserving() {} };
+        },
+        delay: () => Promise.resolve(),
+        now: () => 0,
+        runtime: { platform: "darwin", arch: "arm64" },
+        logPathFor: () => {
+          if (phase === "log") {
+            entered.resolve();
+            return gate.promise;
+          }
+          return Promise.resolve("/logs/server.log");
+        },
+        log() {},
+      });
+
+      const ensured = manager.ensureServer(configuration());
+      await entered.promise;
+      manager.dispose();
+      gate.resolve(
+        phase === "binary"
+          ? "/extension/bin/bingo"
+          : "/logs/server.log",
+      );
+
+      await assert.rejects(ensured, hasCode("cancelled"));
+      assert.equal(spawns, 0);
+    });
+  }
+
+  it("classifies abort during the initial probe as cancellation", async () => {
+    const entered = deferred<void>();
+    let spawns = 0;
+    const manager = new ServerManager({
+      probe: (_management, _dap, _timeout, signal) =>
+        new Promise((_resolve, reject) => {
+          entered.resolve();
+          const rejectAbort = (): void => {
+            const error = new Error("operation cancelled");
+            error.name = "AbortError";
+            reject(error);
+          };
+          if (signal.aborted) {
+            rejectAbort();
+            return;
+          }
+          signal.addEventListener("abort", rejectAbort, { once: true });
+        }),
+      resolveBinary: () => Promise.resolve("/extension/bin/bingo"),
+      spawnServer: () => {
+        spawns += 1;
+        return { stopObserving() {} };
+      },
+      delay: () => Promise.resolve(),
+      now: () => 0,
+      runtime: { platform: "darwin", arch: "arm64" },
+      logPathFor: () => Promise.resolve("/logs/server.log"),
+      log() {},
+    });
+
+    const ensured = manager.ensureServer(configuration());
+    await entered.promise;
+    manager.dispose();
+
+    await assert.rejects(ensured, hasCode("cancelled"));
+    assert.equal(spawns, 0);
+  });
 });
 
 function hasCode(code: ServerManagerError["code"]) {
@@ -355,4 +451,21 @@ async function waitForSpawn(requests: SpawnServerRequest[]): Promise<void> {
   while (requests.length === 0) {
     await Promise.resolve();
   }
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve(value) {
+      assert.notEqual(resolvePromise, undefined);
+      resolvePromise?.(value);
+    },
+  };
 }

--- a/editors/vscode/test/serverManager.test.ts
+++ b/editors/vscode/test/serverManager.test.ts
@@ -42,6 +42,8 @@ interface Harness {
   readonly manager: ServerManager;
   readonly requests: SpawnServerRequest[];
   readonly logs: string[];
+  readonly delays: number[];
+  readonly now: () => number;
   readonly setProbe: (probe: HealthProbe) => void;
   readonly outcome: (outcome: ServerProcessOutcome) => void;
   readonly stoppedObserving: () => boolean;
@@ -54,6 +56,7 @@ function harness(initialProbe: HealthProbe): Harness {
   let observationStopped = false;
   const requests: SpawnServerRequest[] = [];
   const logs: string[] = [];
+  const delays: number[] = [];
   const dependencies: ServerManagerDependencies = {
     probe: (...args) => probe(...args),
     resolveBinary: () => Promise.resolve("/extension/bin/bingo"),
@@ -72,6 +75,7 @@ function harness(initialProbe: HealthProbe): Harness {
         error.name = "AbortError";
         return Promise.reject(error);
       }
+      delays.push(milliseconds);
       clock += milliseconds;
       return Promise.resolve();
     },
@@ -86,6 +90,8 @@ function harness(initialProbe: HealthProbe): Harness {
     manager: new ServerManager(dependencies),
     requests,
     logs,
+    delays,
+    now: () => clock,
     setProbe(next) {
       probe = next;
     },
@@ -286,20 +292,39 @@ describe("server manager", () => {
     );
   });
 
-  it("reserves a post-spawn probe at the minimum readiness timeout", async () => {
+  it("uses the full minimum readiness window for fast absent probes", async () => {
+    const timeouts: number[] = [];
+    const test = harness((_management, _dap, timeoutMs) => {
+      timeouts.push(timeoutMs);
+      return Promise.resolve(absent);
+    });
+
+    await assert.rejects(
+      test.manager.ensureServer(configuration({ readyTimeoutMs: 100 })),
+      hasCode("readinessTimedOut"),
+    );
+    assert.deepEqual(timeouts, [100, 50, 1]);
+    assert.deepEqual(test.delays, [50, 49, 1]);
+    assert.equal(test.now(), 100);
+    assert.equal(test.delays.every((delay) => delay > 0), true);
+    assert.equal(test.requests.length, 1);
+  });
+
+  it("accepts a server that becomes healthy just before the minimum deadline", async () => {
     const timeouts: number[] = [];
     const test = harness((_management, _dap, timeoutMs) => {
       timeouts.push(timeoutMs);
       return Promise.resolve(
-        timeouts.length === 1 ? absent : compatible,
+        timeouts.length === 3 ? compatible : absent,
       );
     });
 
     await test.manager.ensureServer(
       configuration({ readyTimeoutMs: 100 }),
     );
-    assert.deepEqual(timeouts, [100, 50]);
-    assert.equal(test.requests.length, 1);
+    assert.deepEqual(timeouts, [100, 50, 1]);
+    assert.deepEqual(test.delays, [50, 49]);
+    assert.equal(test.now(), 99);
   });
 
   it("passes the remaining readiness deadline to each health probe", async () => {
@@ -312,7 +337,54 @@ describe("server manager", () => {
       test.manager.ensureServer(configuration({ readyTimeoutMs: 250 })),
       hasCode("readinessTimedOut"),
     );
-    assert.deepEqual(timeouts, [250, 150, 50]);
+    assert.deepEqual(timeouts, [250, 150, 50, 1]);
+    assert.deepEqual(test.delays, [100, 100, 49, 1]);
+    assert.equal(test.now(), 250);
+  });
+
+  it("cancels promptly during the final-window delay", async () => {
+    let clock = 0;
+    let delayCalls = 0;
+    let markFinalDelayStarted: (() => void) | undefined;
+    const finalDelayStarted = new Promise<void>((resolve) => {
+      markFinalDelayStarted = resolve;
+    });
+    const delays: number[] = [];
+    const manager = new ServerManager({
+      probe: sequence(absent),
+      resolveBinary: () => Promise.resolve("/extension/bin/bingo"),
+      spawnServer: () => ({ stopObserving() {} }),
+      delay: (milliseconds, signal) => {
+        delays.push(milliseconds);
+        delayCalls += 1;
+        if (delayCalls === 1) {
+          clock += milliseconds;
+          return Promise.resolve();
+        }
+        return new Promise((_resolve, reject) => {
+          const rejectCancelled = (): void => {
+            const error = new Error("aborted");
+            error.name = "AbortError";
+            reject(error);
+          };
+          signal.addEventListener("abort", rejectCancelled, { once: true });
+          markFinalDelayStarted?.();
+        });
+      },
+      now: () => clock,
+      runtime: { platform: "darwin", arch: "arm64" },
+      logPathFor: () => Promise.resolve("/logs/bingo-6060.log"),
+      log: () => {},
+    });
+
+    const ensured = manager.ensureServer(
+      configuration({ readyTimeoutMs: 100 }),
+    );
+    await finalDelayStarted;
+    manager.dispose();
+
+    await assert.rejects(ensured, hasCode("cancelled"));
+    assert.deepEqual(delays, [50, 49]);
   });
 
   it("fails safely on an incompatible endpoint without spawning", async () => {

--- a/editors/vscode/test/serverManager.test.ts
+++ b/editors/vscode/test/serverManager.test.ts
@@ -44,24 +44,44 @@ interface Harness {
   readonly logs: string[];
   readonly delays: number[];
   readonly now: () => number;
+  readonly spawnedAt: () => number;
   readonly setProbe: (probe: HealthProbe) => void;
   readonly outcome: (outcome: ServerProcessOutcome) => void;
   readonly stoppedObserving: () => boolean;
 }
 
-function harness(initialProbe: HealthProbe): Harness {
+interface HarnessOptions {
+  readonly probeElapsedMs?: (
+    timeoutMs: number,
+    callIndex: number,
+  ) => number;
+}
+
+function harness(
+  initialProbe: HealthProbe,
+  options: HarnessOptions = {},
+): Harness {
   let clock = 0;
+  let probeCalls = 0;
   let probe = initialProbe;
   let reportOutcome: ((outcome: ServerProcessOutcome) => void) | undefined;
   let observationStopped = false;
+  let spawnTime = -1;
   const requests: SpawnServerRequest[] = [];
   const logs: string[] = [];
   const delays: number[] = [];
   const dependencies: ServerManagerDependencies = {
-    probe: (...args) => probe(...args),
+    probe: async (...args) => {
+      const result = await probe(...args);
+      const elapsed = options.probeElapsedMs?.(args[2], probeCalls) ?? 0;
+      probeCalls += 1;
+      clock += Math.min(args[2], Math.max(0, elapsed));
+      return result;
+    },
     resolveBinary: () => Promise.resolve("/extension/bin/bingo"),
     spawnServer: (request, onOutcome) => {
       requests.push(request);
+      spawnTime = clock;
       reportOutcome = onOutcome;
       return {
         stopObserving(): void {
@@ -92,6 +112,7 @@ function harness(initialProbe: HealthProbe): Harness {
     logs,
     delays,
     now: () => clock,
+    spawnedAt: () => spawnTime,
     setProbe(next) {
       probe = next;
     },
@@ -294,52 +315,85 @@ describe("server manager", () => {
 
   it("uses the full minimum readiness window for fast absent probes", async () => {
     const timeouts: number[] = [];
-    const test = harness((_management, _dap, timeoutMs) => {
-      timeouts.push(timeoutMs);
-      return Promise.resolve(absent);
-    });
+    const test = harness(
+      (_management, _dap, timeoutMs) => {
+        timeouts.push(timeoutMs);
+        return Promise.resolve(absent);
+      },
+      { probeElapsedMs: () => 5 },
+    );
 
     await assert.rejects(
       test.manager.ensureServer(configuration({ readyTimeoutMs: 100 })),
       hasCode("readinessTimedOut"),
     );
-    assert.deepEqual(timeouts, [100, 50, 1]);
-    assert.deepEqual(test.delays, [50, 49, 1]);
-    assert.equal(test.now(), 100);
+    assert.deepEqual(timeouts, [100, 100, 50, 35, 25]);
+    assert.deepEqual(test.delays, [45, 10, 5, 20]);
+    assert.equal(test.now() - test.spawnedAt(), 100);
+    assert.equal(timeouts.every((timeout) => timeout >= 25), true);
     assert.equal(test.delays.every((delay) => delay > 0), true);
+    assert.ok(timeouts.length <= 5);
     assert.equal(test.requests.length, 1);
   });
 
-  it("accepts a server that becomes healthy just before the minimum deadline", async () => {
+  it("accepts a server that becomes healthy during the final window", async () => {
     const timeouts: number[] = [];
-    const test = harness((_management, _dap, timeoutMs) => {
-      timeouts.push(timeoutMs);
-      return Promise.resolve(
-        timeouts.length === 3 ? compatible : absent,
-      );
-    });
+    const test = harness(
+      (_management, _dap, timeoutMs) => {
+        timeouts.push(timeoutMs);
+        return Promise.resolve(
+          timeouts.length === 4 ? compatible : absent,
+        );
+      },
+      { probeElapsedMs: () => 5 },
+    );
 
     await test.manager.ensureServer(
       configuration({ readyTimeoutMs: 100 }),
     );
-    assert.deepEqual(timeouts, [100, 50, 1]);
-    assert.deepEqual(test.delays, [50, 49]);
-    assert.equal(test.now(), 99);
+    assert.deepEqual(timeouts, [100, 100, 50, 35]);
+    assert.deepEqual(test.delays, [45, 10]);
+    assert.equal(test.now() - test.spawnedAt(), 70);
   });
 
   it("passes the remaining readiness deadline to each health probe", async () => {
     const timeouts: number[] = [];
-    const test = harness((_management, _dap, timeoutMs) => {
-      timeouts.push(timeoutMs);
-      return Promise.resolve(absent);
-    });
+    const test = harness(
+      (_management, _dap, timeoutMs) => {
+        timeouts.push(timeoutMs);
+        return Promise.resolve(absent);
+      },
+      { probeElapsedMs: () => 5 },
+    );
     await assert.rejects(
       test.manager.ensureServer(configuration({ readyTimeoutMs: 250 })),
       hasCode("readinessTimedOut"),
     );
-    assert.deepEqual(timeouts, [250, 150, 50, 1]);
-    assert.deepEqual(test.delays, [100, 100, 49, 1]);
-    assert.equal(test.now(), 250);
+    assert.deepEqual(timeouts, [250, 250, 145, 50, 35, 25]);
+    assert.deepEqual(test.delays, [100, 90, 10, 5, 20]);
+    assert.equal(test.now() - test.spawnedAt(), 250);
+  });
+
+  it("keeps a slow probe within the single readiness deadline", async () => {
+    const timeouts: number[] = [];
+    const test = harness(
+      (_management, _dap, timeoutMs) => {
+        timeouts.push(timeoutMs);
+        return Promise.resolve(absent);
+      },
+      {
+        probeElapsedMs: (timeoutMs, callIndex) =>
+          callIndex === 0 ? 5 : timeoutMs,
+      },
+    );
+
+    await assert.rejects(
+      test.manager.ensureServer(configuration({ readyTimeoutMs: 100 })),
+      hasCode("readinessTimedOut"),
+    );
+    assert.deepEqual(timeouts, [100, 100]);
+    assert.deepEqual(test.delays, []);
+    assert.equal(test.now() - test.spawnedAt(), 100);
   });
 
   it("cancels promptly during the final-window delay", async () => {
@@ -384,7 +438,7 @@ describe("server manager", () => {
     manager.dispose();
 
     await assert.rejects(ensured, hasCode("cancelled"));
-    assert.deepEqual(delays, [50, 49]);
+    assert.deepEqual(delays, [50, 10]);
   });
 
   it("fails safely on an incompatible endpoint without spawning", async () => {

--- a/editors/vscode/test/serverManager.test.ts
+++ b/editors/vscode/test/serverManager.test.ts
@@ -1,0 +1,358 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { BingoServerConfiguration } from "../src/configuration.js";
+import type {
+  HealthProbe,
+  HealthProbeResult,
+} from "../src/health.js";
+import {
+  ServerManager,
+  ServerManagerError,
+  type ServerManagerDependencies,
+} from "../src/serverManager.js";
+import type {
+  ServerProcessOutcome,
+  SpawnServerRequest,
+} from "../src/serverProcess.js";
+
+const compatible: HealthProbeResult = {
+  kind: "compatible",
+  health: {
+    instanceId: "winner",
+    dapAddress: "127.0.0.1:4711",
+  },
+};
+const absent: HealthProbeResult = { kind: "absent" };
+
+function configuration(
+  overrides: Partial<BingoServerConfiguration> = {},
+): BingoServerConfiguration {
+  return {
+    mode: "auto",
+    managementEndpoint: { host: "127.0.0.1", port: 6060 },
+    dapEndpoint: { host: "127.0.0.1", port: 4711 },
+    readyTimeoutMs: 5000,
+    idleTimeoutMs: 30000,
+    ...overrides,
+  };
+}
+
+interface Harness {
+  readonly manager: ServerManager;
+  readonly requests: SpawnServerRequest[];
+  readonly logs: string[];
+  readonly setProbe: (probe: HealthProbe) => void;
+  readonly outcome: (outcome: ServerProcessOutcome) => void;
+  readonly stoppedObserving: () => boolean;
+}
+
+function harness(initialProbe: HealthProbe): Harness {
+  let clock = 0;
+  let probe = initialProbe;
+  let reportOutcome: ((outcome: ServerProcessOutcome) => void) | undefined;
+  let observationStopped = false;
+  const requests: SpawnServerRequest[] = [];
+  const logs: string[] = [];
+  const dependencies: ServerManagerDependencies = {
+    probe: (...args) => probe(...args),
+    resolveBinary: () => Promise.resolve("/extension/bin/bingo"),
+    spawnServer: (request, onOutcome) => {
+      requests.push(request);
+      reportOutcome = onOutcome;
+      return {
+        stopObserving(): void {
+          observationStopped = true;
+        },
+      };
+    },
+    delay: (milliseconds, signal) => {
+      if (signal.aborted) {
+        const error = new Error("aborted");
+        error.name = "AbortError";
+        return Promise.reject(error);
+      }
+      clock += milliseconds;
+      return Promise.resolve();
+    },
+    now: () => clock,
+    runtime: { platform: "darwin", arch: "arm64" },
+    logPathFor: () => Promise.resolve("/logs/bingo-6060.log"),
+    log: (message) => {
+      logs.push(message);
+    },
+  };
+  return {
+    manager: new ServerManager(dependencies),
+    requests,
+    logs,
+    setProbe(next) {
+      probe = next;
+    },
+    outcome(value) {
+      assert.notEqual(reportOutcome, undefined);
+      reportOutcome?.(value);
+    },
+    stoppedObserving() {
+      return observationStopped;
+    },
+  };
+}
+
+function sequence(...results: HealthProbeResult[]): HealthProbe {
+  let index = 0;
+  return () => {
+    const result = results[Math.min(index, results.length - 1)];
+    index += 1;
+    assert.notEqual(result, undefined);
+    return Promise.resolve(result as HealthProbeResult);
+  };
+}
+
+describe("server manager", () => {
+  it("reuses a compatible server without spawning", async () => {
+    const test = harness(sequence(compatible));
+    assert.deepEqual(
+      await test.manager.ensureServer(configuration()),
+      { host: "127.0.0.1", port: 4711 },
+    );
+    assert.equal(test.requests.length, 0);
+  });
+
+  it("spawns an absent server with exact arguments and waits for readiness", async () => {
+    const test = harness(sequence(absent, compatible));
+    await test.manager.ensureServer(configuration());
+
+    assert.deepEqual(test.requests, [
+      {
+        binaryPath: "/extension/bin/bingo",
+        args: [
+          "-addr",
+          "127.0.0.1:6060",
+          "-dap-addr",
+          "127.0.0.1:4711",
+          "-idle-timeout",
+          "30000ms",
+        ],
+        logPath: "/logs/bingo-6060.log",
+      },
+    ]);
+    assert.equal(test.stoppedObserving(), true);
+  });
+
+  it("coalesces simultaneous ensures for one endpoint", async () => {
+    let release: ((result: HealthProbeResult) => void) | undefined;
+    let probes = 0;
+    const pending = new Promise<HealthProbeResult>((resolve) => {
+      release = resolve;
+    });
+    const test = harness(() => {
+      probes += 1;
+      return Promise.resolve(pending);
+    });
+
+    const first = test.manager.ensureServer(configuration());
+    const second = test.manager.ensureServer(configuration());
+    assert.equal(probes, 1);
+    release?.(compatible);
+    await Promise.all([first, second]);
+    assert.equal(probes, 1);
+  });
+
+  it("clears a failed ensure so a retry can succeed", async () => {
+    const test = harness(
+      sequence(
+        { kind: "incompatible", reason: "wrong service" },
+        compatible,
+      ),
+    );
+    await assert.rejects(
+      test.manager.ensureServer(configuration()),
+      hasCode("endpointOccupied"),
+    );
+    await test.manager.ensureServer(configuration());
+  });
+
+  it("rejects remote auto mode without probing or spawning", () => {
+    let probes = 0;
+    const test = harness(() => {
+      probes += 1;
+      return Promise.resolve(compatible);
+    });
+    assert.throws(
+      () => test.manager.ensureServer(
+        configuration({
+          managementEndpoint: { host: "remote.example", port: 6060 },
+        }),
+      ),
+      hasCode("invalidConfiguration"),
+    );
+    assert.equal(probes, 0);
+    assert.equal(test.requests.length, 0);
+  });
+
+  it("connect-only bypasses platform, probing, binary checks, and spawning", async () => {
+    const test = harness(() =>
+      Promise.reject(new Error("probe must not run")),
+    );
+    const config = configuration({
+      mode: "connectOnly",
+      managementEndpoint: { host: "remote.example", port: 16060 },
+      dapEndpoint: { host: "remote.example", port: 14711 },
+    });
+
+    assert.deepEqual(await test.manager.ensureServer(config), config.dapEndpoint);
+    assert.equal(test.requests.length, 0);
+  });
+
+  it("rejects unsupported local auto-start platforms directly", () => {
+    const manager = new ServerManager({
+      probe: () => Promise.reject(new Error("probe must not run")),
+      resolveBinary: () => Promise.reject(new Error("binary must not run")),
+      spawnServer: () => {
+        throw new Error("spawn must not run");
+      },
+      delay: () => Promise.reject(new Error("delay must not run")),
+      now: () => 0,
+      runtime: { platform: "win32", arch: "x64" },
+      logPathFor: () => Promise.reject(new Error("log must not run")),
+      log() {},
+    });
+
+    assert.throws(
+      () => manager.ensureServer(configuration()),
+      hasCode("unsupportedAutoStart"),
+    );
+  });
+
+  it("surfaces a missing bundled binary before spawning", async () => {
+    const manager = new ServerManager({
+      probe: sequence(absent),
+      resolveBinary: () => Promise.reject(new Error("missing binary")),
+      spawnServer: () => {
+        throw new Error("spawn must not run");
+      },
+      delay: () => Promise.resolve(),
+      now: () => 0,
+      runtime: { platform: "darwin", arch: "arm64" },
+      logPathFor: () => Promise.resolve("/logs/server.log"),
+      log() {},
+    });
+
+    await assert.rejects(
+      manager.ensureServer(configuration()),
+      (error: unknown) =>
+        error instanceof ServerManagerError &&
+        error.code === "binaryUnavailable" &&
+        /missing binary/.test(error.message),
+    );
+  });
+
+  it("accepts a healthy winner after this child loses the listener race", async () => {
+    const test = harness(sequence(absent, compatible));
+    const ensured = test.manager.ensureServer(configuration());
+    await waitForSpawn(test.requests);
+    test.outcome({ kind: "exit", code: 1, signal: null });
+    await ensured;
+  });
+
+  it("reports an early child failure if no winner becomes healthy", async () => {
+    const test = harness(sequence(absent));
+    const ensured = test.manager.ensureServer(
+      configuration({ readyTimeoutMs: 200 }),
+    );
+    await waitForSpawn(test.requests);
+    test.outcome({
+      kind: "error",
+      error: new Error("bind failed"),
+    });
+    await assert.rejects(
+      ensured,
+      (error: unknown) =>
+        error instanceof ServerManagerError &&
+        error.code === "spawnFailed" &&
+        /bind failed/.test(error.message) &&
+        /bingo-6060\.log/.test(error.message),
+    );
+  });
+
+  it("reports a bounded readiness timeout while a child remains alive", async () => {
+    const test = harness(sequence(absent));
+    await assert.rejects(
+      test.manager.ensureServer(
+        configuration({ readyTimeoutMs: 200 }),
+      ),
+      hasCode("readinessTimedOut"),
+    );
+  });
+
+  it("fails safely on an incompatible endpoint without spawning", async () => {
+    const test = harness(
+      sequence({ kind: "incompatible", reason: "not bingo" }),
+    );
+    await assert.rejects(
+      test.manager.ensureServer(configuration()),
+      hasCode("endpointOccupied"),
+    );
+    assert.equal(test.requests.length, 0);
+  });
+
+  it("fails safely on a non-refused transport error without spawning", async () => {
+    const test = harness(
+      sequence({
+        kind: "transportError",
+        error: new Error("request timed out"),
+      }),
+    );
+    await assert.rejects(
+      test.manager.ensureServer(configuration()),
+      hasCode("healthProbeFailed"),
+    );
+    assert.equal(test.requests.length, 0);
+  });
+
+  it("dispose cancels readiness and never exposes a kill operation", async () => {
+    let markDelayStarted: (() => void) | undefined;
+    const delayStarted = new Promise<void>((resolve) => {
+      markDelayStarted = resolve;
+    });
+    const custom = new ServerManager({
+      probe: sequence(absent),
+      resolveBinary: () => Promise.resolve("/extension/bin/bingo"),
+      spawnServer: () => ({ stopObserving() {} }),
+      delay: (_milliseconds, signal) =>
+        new Promise((_resolve, reject) => {
+          markDelayStarted?.();
+          const rejectCancelled = (): void => {
+            const error = new Error("aborted");
+            error.name = "AbortError";
+            reject(error);
+          };
+          if (signal.aborted) {
+            rejectCancelled();
+            return;
+          }
+          signal.addEventListener("abort", rejectCancelled, { once: true });
+        }),
+      now: () => 0,
+      runtime: { platform: "darwin", arch: "arm64" },
+      logPathFor: () => Promise.resolve("/logs/server.log"),
+      log() {},
+    });
+    const ensured = custom.ensureServer(configuration());
+    await delayStarted;
+    custom.dispose();
+    await assert.rejects(ensured, hasCode("cancelled"));
+  });
+});
+
+function hasCode(code: ServerManagerError["code"]) {
+  return (error: unknown): boolean =>
+    error instanceof ServerManagerError && error.code === code;
+}
+
+async function waitForSpawn(requests: SpawnServerRequest[]): Promise<void> {
+  while (requests.length === 0) {
+    await Promise.resolve();
+  }
+}

--- a/editors/vscode/test/serverManager.test.ts
+++ b/editors/vscode/test/serverManager.test.ts
@@ -286,6 +286,22 @@ describe("server manager", () => {
     );
   });
 
+  it("reserves a post-spawn probe at the minimum readiness timeout", async () => {
+    const timeouts: number[] = [];
+    const test = harness((_management, _dap, timeoutMs) => {
+      timeouts.push(timeoutMs);
+      return Promise.resolve(
+        timeouts.length === 1 ? absent : compatible,
+      );
+    });
+
+    await test.manager.ensureServer(
+      configuration({ readyTimeoutMs: 100 }),
+    );
+    assert.deepEqual(timeouts, [100, 50]);
+    assert.equal(test.requests.length, 1);
+  });
+
   it("passes the remaining readiness deadline to each health probe", async () => {
     const timeouts: number[] = [];
     const test = harness((_management, _dap, timeoutMs) => {

--- a/editors/vscode/test/serverProcess.test.ts
+++ b/editors/vscode/test/serverProcess.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import type {
+  ChildProcess,
+  SpawnOptions,
+} from "node:child_process";
+
+import { spawnDetachedServer } from "../src/serverProcess.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map(async (directory) => {
+      await rm(directory, { force: true, recursive: true });
+    }),
+  );
+});
+
+describe("detached server process", () => {
+  it("uses argv without a shell, detaches, logs through files, and only unrefs", async () => {
+    const root = await mkdtemp(join(tmpdir(), "bingo-process-"));
+    temporaryDirectories.push(root);
+    const child = new EventEmitter() as ChildProcess & {
+      unrefCalled?: boolean;
+    };
+    child.unref = () => {
+      child.unrefCalled = true;
+    };
+    let captured:
+      | {
+          readonly command: string;
+          readonly args: readonly string[];
+          readonly options: SpawnOptions;
+        }
+      | undefined;
+
+    const observation = spawnDetachedServer(
+      {
+        binaryPath: "/extension/bin/bingo",
+        args: ["-addr", "127.0.0.1:6060"],
+        logPath: join(root, "logs", "server.log"),
+      },
+      () => undefined,
+      (command, args, options) => {
+        captured = { command, args, options };
+        return child;
+      },
+    );
+
+    assert.equal(captured?.command, "/extension/bin/bingo");
+    assert.deepEqual(captured?.args, ["-addr", "127.0.0.1:6060"]);
+    assert.equal(captured?.options.detached, true);
+    assert.equal(captured?.options.shell, false);
+    const stdio = captured?.options.stdio;
+    assert.ok(Array.isArray(stdio));
+    assert.equal(stdio[0], "ignore");
+    assert.equal(typeof stdio[1], "number");
+    assert.equal(stdio[1], stdio[2]);
+    assert.equal(child.unrefCalled, true);
+    assert.equal("kill" in observation, false);
+    observation.stopObserving();
+  });
+});

--- a/editors/vscode/test/timing.test.ts
+++ b/editors/vscode/test/timing.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  withTimeout,
+  type TimeoutHandle,
+  type TimeoutTimers,
+} from "../scripts/timing.mjs";
+
+describe("script timeout", () => {
+  it("unrefs and clears the losing timer when the operation settles", async () => {
+    let unrefed = false;
+    let cleared: TimeoutHandle | undefined;
+    const handle: TimeoutHandle = {
+      unref(): void {
+        unrefed = true;
+      },
+    };
+    const timers: TimeoutTimers = {
+      set() {
+        return handle;
+      },
+      clear(timer) {
+        cleared = timer;
+      },
+    };
+
+    assert.equal(
+      await withTimeout(Promise.resolve("ready"), 10_000, "too slow", timers),
+      "ready",
+    );
+    assert.equal(unrefed, true);
+    assert.equal(cleared, handle);
+  });
+
+  it("clears the timer after a timeout rejection", async () => {
+    let fire: (() => void) | undefined;
+    let cleared = false;
+    const timers: TimeoutTimers = {
+      set(_milliseconds, callback) {
+        fire = callback;
+        return {};
+      },
+      clear() {
+        cleared = true;
+      },
+    };
+    const pending = new Promise<never>(() => undefined);
+    const result = withTimeout(pending, 100, "deadline reached", timers);
+
+    assert.notEqual(fire, undefined);
+    fire?.();
+    await assert.rejects(result, /deadline reached/);
+    assert.equal(cleared, true);
+  });
+});

--- a/editors/vscode/test/workspace.test.ts
+++ b/editors/vscode/test/workspace.test.ts
@@ -27,47 +27,94 @@ describe("repository VS Code integration", () => {
       JSON.stringify(requireRecord(manifest.scripts)),
       readText("editors/vscode/src/configuration.ts"),
       readText("editors/vscode/src/extension.ts"),
+      readText("editors/vscode/src/serverManager.ts"),
+      readText("editors/vscode/src/serverProcess.ts"),
       readText("editors/vscode/scripts/clean.mjs"),
       readText("editors/vscode/scripts/package.mjs"),
+      readText("editors/vscode/scripts/prepare-binary.mjs"),
       readText("editors/vscode/scripts/verify-reproducible.mjs"),
     ].join("\n");
 
     assert.doesNotMatch(sources, /\bdlv\b/i);
+    assert.doesNotMatch(sources, /getExtension\s*\(\s*["']golang\.go/);
+    assert.doesNotMatch(sources, /["']type["']\s*:\s*["']go["']/);
   });
 
-  it("uses only bingo launch configurations and builds spawntree before F5", () => {
+  it("uses only bingo product debugging and prepares extension development", () => {
     const launch = readJSON(".vscode/launch.json");
     const configurations = requireArray(launch.configurations).map(requireRecord);
 
     assert.ok(configurations.length > 0);
-    for (const configuration of configurations) {
+    assert.equal(
+      configurations.some((configuration) => configuration.type === "go"),
+      false,
+    );
+    const bingoConfigurations = configurations.filter(
+      (configuration) => configuration.type === "bingo",
+    );
+    assert.ok(bingoConfigurations.length > 0);
+    for (const configuration of bingoConfigurations) {
       assert.equal(configuration.type, "bingo");
       assert.equal("mode" in configuration, false);
       assert.equal("debugServer" in configuration, false);
-      assert.equal(configuration.dapHost, "127.0.0.1");
-      assert.equal(configuration.dapPort, 4711);
+      assertLifecycleDefaults(configuration);
     }
 
-    const binaryLaunch = configurations.find(
+    const binaryLaunch = bingoConfigurations.find(
       (configuration) => configuration.request === "launch",
     );
     assert.notEqual(binaryLaunch, undefined);
-    assert.equal(binaryLaunch?.preLaunchTask, "bingo: build spawntree");
+    assert.equal(binaryLaunch?.preLaunchTask, "bingo: prepare F5");
+
+    const extensionHost = configurations.find(
+      (configuration) => configuration.type === "extensionHost",
+    );
+    assert.notEqual(extensionHost, undefined);
+    assert.equal(extensionHost?.preLaunchTask, "bingo: prepare F5");
+    assert.deepEqual(extensionHost?.args, [
+      "--extensionDevelopmentPath=${workspaceFolder}/editors/vscode",
+    ]);
   });
 
-  it("defines the deterministic spawntree build task used by launch.json", () => {
+  it("defines the deterministic extension and target preparation task", () => {
     const tasksConfig = readJSON(".vscode/tasks.json");
     const tasks = requireArray(tasksConfig.tasks).map(requireRecord);
     const buildTask = tasks.find(
-      (task) => task.label === "bingo: build spawntree",
+      (task) => task.label === "bingo: prepare F5",
     );
 
     assert.notEqual(buildTask, undefined);
     assert.equal(buildTask?.type, "process");
     assert.equal(buildTask?.command, "just");
-    assert.deepEqual(buildTask?.args, ["build-spawntree"]);
+    assert.deepEqual(buildTask?.args, ["vscode-dev"]);
+  });
+
+  it("packages only the two supported native targets", () => {
+    const platform = readText("editors/vscode/scripts/platform.mjs");
+    const packageScript = readText("editors/vscode/scripts/package.mjs");
+    const prepareScript = readText(
+      "editors/vscode/scripts/prepare-binary.mjs",
+    );
+
+    assert.match(platform, /"linux-x64"/);
+    assert.match(platform, /"darwin-arm64"/);
+    assert.doesNotMatch(platform, /win32|ia32|linux-arm64|darwin-x64/);
+    assert.match(packageScript, /"--target"/);
+    assert.match(prepareScript, /"bingonative"/);
+    assert.match(prepareScript, /"codesign"/);
+    assert.match(prepareScript, /normalizeMachOUUID/);
   });
 });
+
+function assertLifecycleDefaults(record: JsonRecord): void {
+  assert.equal(record.serverMode, "auto");
+  assert.equal(record.managementHost, "127.0.0.1");
+  assert.equal(record.managementPort, 6060);
+  assert.equal(record.dapHost, "127.0.0.1");
+  assert.equal(record.dapPort, 4711);
+  assert.equal(record.serverReadyTimeoutMs, 5000);
+  assert.equal(record.managedIdleTimeoutMs, 30000);
+}
 
 function readJSON(path: string): JsonRecord {
   return requireRecord(

--- a/editors/vscode/test/workspace.test.ts
+++ b/editors/vscode/test/workspace.test.ts
@@ -38,6 +38,24 @@ describe("repository VS Code integration", () => {
     assert.doesNotMatch(sources, /\bdlv\b/i);
     assert.doesNotMatch(sources, /getExtension\s*\(\s*["']golang\.go/);
     assert.doesNotMatch(sources, /["']type["']\s*:\s*["']go["']/);
+
+    const productionProcessSources = [
+      readText("editors/vscode/src/extension.ts"),
+      readText("editors/vscode/src/serverManager.ts"),
+      readText("editors/vscode/src/serverProcess.ts"),
+    ].join("\n");
+    assert.doesNotMatch(productionProcessSources, /SIGKILL|process\.kill/);
+    assert.match(
+      readText("editors/vscode/scripts/owned-process.mjs"),
+      /signalProcess\(-pid, "SIGKILL"\)/,
+    );
+    const smoke = readText("editors/vscode/scripts/smoke-server.mjs");
+    assert.match(
+      smoke,
+      /failure !== undefined && child !== undefined && !childExited/,
+    );
+    assert.match(smoke, /terminateOwnedProcessGroup/);
+    assert.match(smoke, /if \(child === undefined \|\| childExited\)/);
   });
 
   it("keeps target and extension-development preparation separate", () => {
@@ -98,6 +116,19 @@ describe("repository VS Code integration", () => {
     assert.equal(targetTask?.type, "process");
     assert.equal(targetTask?.command, "just");
     assert.deepEqual(targetTask?.args, ["build-spawntree"]);
+
+    const justfile = readText("justfile");
+    const devStart = justfile.indexOf("vscode-dev:");
+    const devEnd = justfile.indexOf("\n# ARGS:", devStart);
+    const devRecipe = justfile.slice(devStart, devEnd);
+    const install = devRecipe.indexOf(
+      "npm --prefix editors/vscode ci --ignore-scripts",
+    );
+    const build = devRecipe.indexOf(
+      "npm --prefix editors/vscode run build",
+    );
+    assert.ok(install >= 0);
+    assert.ok(build > install);
   });
 
   it("packages only the two supported native targets", () => {
@@ -118,8 +149,10 @@ describe("repository VS Code integration", () => {
     assert.match(prepareScript, /"codesign"/);
     assert.match(prepareScript, /normalizeMachOUUID/);
     assert.match(workflow, /BINGO_VSCODE_TARGET: \$\{\{ matrix\.target \}\}/);
+    assert.match(workflow, /runner: macos-15/);
+    assert.doesNotMatch(workflow, /runner: macos-14(?:\s|$)/);
+    assert.match(workflow, /test "\$\(uname -m\)" = "\$\{\{ matrix\.unamearch \}\}"/);
     assert.match(workflow, /runner\.arch == 'ARM64'/);
-    assert.match(workflow, /runner\.arch != 'ARM64'/);
   });
 });
 

--- a/editors/vscode/test/workspace.test.ts
+++ b/editors/vscode/test/workspace.test.ts
@@ -40,7 +40,7 @@ describe("repository VS Code integration", () => {
     assert.doesNotMatch(sources, /["']type["']\s*:\s*["']go["']/);
   });
 
-  it("uses only bingo product debugging and prepares extension development", () => {
+  it("keeps target and extension-development preparation separate", () => {
     const launch = readJSON(".vscode/launch.json");
     const configurations = requireArray(launch.configurations).map(requireRecord);
 
@@ -64,29 +64,40 @@ describe("repository VS Code integration", () => {
       (configuration) => configuration.request === "launch",
     );
     assert.notEqual(binaryLaunch, undefined);
-    assert.equal(binaryLaunch?.preLaunchTask, "bingo: prepare F5");
+    assert.equal(binaryLaunch?.preLaunchTask, "bingo: build spawntree");
 
     const extensionHost = configurations.find(
       (configuration) => configuration.type === "extensionHost",
     );
     assert.notEqual(extensionHost, undefined);
-    assert.equal(extensionHost?.preLaunchTask, "bingo: prepare F5");
+    assert.equal(
+      extensionHost?.preLaunchTask,
+      "bingo: prepare extension host",
+    );
     assert.deepEqual(extensionHost?.args, [
       "--extensionDevelopmentPath=${workspaceFolder}/editors/vscode",
     ]);
   });
 
-  it("defines the deterministic extension and target preparation task", () => {
+  it("defines deterministic but independent extension and target tasks", () => {
     const tasksConfig = readJSON(".vscode/tasks.json");
     const tasks = requireArray(tasksConfig.tasks).map(requireRecord);
-    const buildTask = tasks.find(
-      (task) => task.label === "bingo: prepare F5",
+    const extensionTask = tasks.find(
+      (task) => task.label === "bingo: prepare extension host",
+    );
+    const targetTask = tasks.find(
+      (task) => task.label === "bingo: build spawntree",
     );
 
-    assert.notEqual(buildTask, undefined);
-    assert.equal(buildTask?.type, "process");
-    assert.equal(buildTask?.command, "just");
-    assert.deepEqual(buildTask?.args, ["vscode-dev"]);
+    assert.notEqual(extensionTask, undefined);
+    assert.equal(extensionTask?.type, "process");
+    assert.equal(extensionTask?.command, "just");
+    assert.deepEqual(extensionTask?.args, ["vscode-dev"]);
+
+    assert.notEqual(targetTask, undefined);
+    assert.equal(targetTask?.type, "process");
+    assert.equal(targetTask?.command, "just");
+    assert.deepEqual(targetTask?.args, ["build-spawntree"]);
   });
 
   it("packages only the two supported native targets", () => {
@@ -95,14 +106,20 @@ describe("repository VS Code integration", () => {
     const prepareScript = readText(
       "editors/vscode/scripts/prepare-binary.mjs",
     );
+    const workflow = readText(".github/workflows/vscode-extension.yml");
 
     assert.match(platform, /"linux-x64"/);
     assert.match(platform, /"darwin-arm64"/);
     assert.doesNotMatch(platform, /win32|ia32|linux-arm64|darwin-x64/);
+    assert.match(platform, /BINGO_VSCODE_TARGET/);
+    assert.match(platform, /darwinCrossBuild/);
     assert.match(packageScript, /"--target"/);
     assert.match(prepareScript, /"bingonative"/);
     assert.match(prepareScript, /"codesign"/);
     assert.match(prepareScript, /normalizeMachOUUID/);
+    assert.match(workflow, /BINGO_VSCODE_TARGET: \$\{\{ matrix\.target \}\}/);
+    assert.match(workflow, /runner\.arch == 'ARM64'/);
+    assert.match(workflow, /runner\.arch != 'ARM64'/);
   });
 });
 

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -277,10 +277,11 @@ func TestLaunchIgnoresVSCodeEndpointFields(t *testing.T) {
 	hh.sendReq("initialize", initArgs())
 	_ = recvType[*godap.InitializeResponse](hh)
 
-	// dapHost and dapPort select the socket before DAP starts, but VS Code also
-	// leaves them in launch arguments. They must not alter the bingo command.
+	// Endpoint and lifecycle fields select or start the server before DAP begins,
+	// but VS Code also leaves them in launch arguments. They must not alter the
+	// bingo command.
 	hh.sendReq("launch", &godap.LaunchRequest{Arguments: json.RawMessage(
-		`{"program":"/bin/x","args":["one"],"env":["BINGO_TEST=1"],"dapHost":"localhost","dapPort":4711}`,
+		`{"program":"/bin/x","args":["one"],"env":["BINGO_TEST=1"],"serverMode":"auto","managementHost":"127.0.0.1","managementPort":6060,"dapHost":"127.0.0.1","dapPort":4711,"serverReadyTimeoutMs":5000,"managedIdleTimeoutMs":30000}`,
 	)})
 
 	cmd := hh.cmds.waitForCommand(t, protocol.CmdLaunch)

--- a/justfile
+++ b/justfile
@@ -69,9 +69,8 @@ build-spawntree:
 vscode-prepare:
 	npm --prefix editors/vscode run binary:prepare
 
-# Prepare every artifact needed by the repository's bingo F5 configuration.
-# The extension performs connect-or-start, so this builds but never runs a
-# manually-owned server process.
+# Prepare source-extension and target artifacts for an Extension Development
+# Host. Normal target F5 uses the installed VSIX and only rebuilds spawntree.
 vscode-dev: build-spawntree vscode-prepare
 	npm --prefix editors/vscode run build
 

--- a/justfile
+++ b/justfile
@@ -72,6 +72,7 @@ vscode-prepare:
 # Prepare source-extension and target artifacts for an Extension Development
 # Host. Normal target F5 uses the installed VSIX and only rebuilds spawntree.
 vscode-dev: build-spawntree vscode-prepare
+	npm --prefix editors/vscode ci --ignore-scripts
 	npm --prefix editors/vscode run build
 
 # ARGS: -addr string    server address (default "localhost:6060")

--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@
 # positional args still override.
 os_name := if os() == "macos" { "darwin" } else { os() }
 arch_name := if arch() == "aarch64" { "arm64" } else if arch() == "x86_64" { "amd64" } else { arch() }
+vscode_target := if os_name + "/" + arch_name == "darwin/arm64" { "darwin-arm64" } else if os_name + "/" + arch_name == "linux/amd64" { "linux-x64" } else { "unsupported" }
 
 # Build the Target, build BinGo and run the Target
 default: build-target build run
@@ -63,6 +64,17 @@ build-spawntree:
 	mkdir -p ./build
 	go build -gcflags="all=-N -l" -o ./build/spawntree ./examples/spawntree
 
+# Build the native server into the extension-local layout used by both an
+# Extension Development Host and the platform-specific VSIX.
+vscode-prepare:
+	npm --prefix editors/vscode run binary:prepare
+
+# Prepare every artifact needed by the repository's bingo F5 configuration.
+# The extension performs connect-or-start, so this builds but never runs a
+# manually-owned server process.
+vscode-dev: build-spawntree vscode-prepare
+	npm --prefix editors/vscode run build
+
 # ARGS: -addr string    server address (default "localhost:6060")
 #	  	-session string session ID to join (omit to create a new session)
 # Build and run the interactive CLI client
@@ -88,11 +100,12 @@ vscode-check:
 vscode-package: vscode-check
 	mkdir -p ./dist
 	npm --prefix editors/vscode run package:reproducible
+	npm --prefix editors/vscode run package:verify
 
 # Explicit opt-in keeps packaging/CI from mutating a developer's normal VS Code
 # profile while still providing a one-command local install/update path.
 vscode-install: vscode-package
-	code --install-extension ./dist/bingo.vsix --force
+	code --install-extension ./dist/bingo-{{vscode_target}}.vsix --force
 
 # Run unit tests on the PKG (defaults to ./...)
 test PKG="./...":


### PR DESCRIPTION
Builds on #121 (merged)

## Summary

- make `bingosuite.bingo` health-check and reuse a compatible bingo server, or start its matching bundled server when the local management endpoint is absent
- bound health reads against truncated and slow-drip responses, probe immediately after spawn, and use a practical 25ms minimum request budget with bounded final-window polling under one absolute readiness deadline
- coalesce same-host descriptor requests, tolerate cross-process listener races, and keep the detached child shared: the extension never kills it; `-idle-timeout` is the only teardown owner
- add explicit `auto` / `connectOnly` lifecycle configuration while preserving launch, PID attach, and existing-session join
- package exactly one server per VSIX (`linux-x64` or codesigned `darwin-arm64`) with target/runtime checks, deterministic builds, exact content verification, and native health + idle-self-exit smoke coverage
- keep normal target F5 fast: it only rebuilds `spawntree` and uses the installed VSIX; a separate Extension Development Host task restores the lockfile and stages the source extension binary and bundle
- use the supported `macos-15` arm64 runner with explicit `uname -m` validation; failure-only smoke cleanup targets only the test-owned process group and never enters production

## Dependency

- base: `xsachax-managed-server-lifecycle`
- reviewed lower head: `debb7e8f99b6cd4f972bd1d3c5c22976623d86bc`
- this PR does not reimplement lower lifecycle behavior

## Defaults and process semantics

- `serverMode: "auto"`
- management: `127.0.0.1:6060`
- DAP: `127.0.0.1:4711`
- readiness: `5000ms`
- managed idle grace: `30000ms`
- remote/custom endpoints require `serverMode: "connectOnly"`, which bypasses health and spawn
- only connection refusal permits spawn; non-bingo/incompatible occupants fail safely
- child uses argv without a shell, detached/unref'd, ignored stdin, and persistent extension-storage logs
- production has no child kill path; deactivation aborts bounded work and cancellation is checked immediately before spawn

## Native artifact verification

Local Darwin/arm64 reproducibility was stress-run across three consecutive two-build cycles (six native builds). Final local Go 1.26.1 output:

- bundled binary SHA-256: `e7ca50ed079374b7c6d0000ba845e0038d8fdec7d62fa51edd97636be936853f`
- `bingo-darwin-arm64.vsix` SHA-256: `f4fd4342fd2021d0aa8691b8d1e4ddd3414a06054b92741bf4a6b6dfff4faa08`

Final uploaded CI artifacts built twice with Go 1.25.5:

| Target | Binary SHA-256 | VSIX SHA-256 |
| --- | --- | --- |
| `linux-x64` | `fc10c6c1f3386b54f45773bc4adf77c7e807672698cdbe9ce777f4ac5457fa08` | `395b82c74e69f27f70ecac51f6957de58ef976fd8b8e0eadbbd9c6e620cd462b` |
| `darwin-arm64` | `ca2c87e6b3ab085b31bbc21ecea5bab7e110183dc59bbdf5ce2edc5208e79ff0` | `4b98c34676adc2fdc43402e9626f096a934891057b7c333a4d27a99d1110d677` |

The Darwin build retains a deterministic content-derived `LC_UUID`, is codesigned with `entitlements.plist`, passes strict signature/entitlement checks, and runs successfully on Apple Silicon. The final `macos-15` job asserted `uname -m=arm64` and its packaged-server smoke passed. Linux built and smoked linux-x64 natively.

## Validation

- clean `npm ci --ignore-scripts`
- extension lint, strict typecheck, 79 tests, bundle, and package-list checks
- immediate post-spawn, practical-budget, final-window readiness, permanent-absence, bounded-count/no-spin, slow-probe deadline, and cancellation regressions with realistic fake response durations
- real localhost compatible-health request at the 25ms practical minimum (16ms in the final local full run)
- real HTTP tests for partial-close and slow-drip wall-clock deadlines
- disposal barriers during probe/binary/log resolution with zero post-abort spawns
- test-owned process-group cleanup and cleared/unref'd timeout helper tests
- `go vet -tags bingonative ./internal/dap/... ./internal/server/... ./cmd/bingo/...`
- `go test -tags bingonative ./internal/dap/... ./internal/server/... ./cmd/bingo/...`
- `just vscode-dev` from lockfile restoration through source bundle
- `just vscode-package`
- repeated binary + VSIX reproducibility
- exact VSIX content/target/architecture/executable-mode/signature/entitlement verification
- real packaged-server health readiness and clean idle self-exit locally and in both CI package jobs
- independent code review; all findings fixed and final re-review clean
- `git diff --check`
- all 10 reported PR checks green at final head

## Manual A-Z

Using the real extension manager and bundled Darwin server: auto-start reported compatible health, DAP launched `build/spawntree`, set and hit `examples/spawntree/main.go:27`, and `wsmon -once` joined the same session and rendered its goroutine tree/threads. After DAP and WS disconnected, the shared server self-exited at the configured idle grace; no kill signal was sent.

Native GitHub Stacks registration is intentionally not used because that API previously returned 404 for this repository; this is an ordinary dependent PR targeting the lower branch.