### PR TITLE
fix(vscode): restore installed debugging UX

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,18 +2,6 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Run bingo extension",
-      "type": "extensionHost",
-      "request": "launch",
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}/editors/vscode"
-      ],
-      "outFiles": [
-        "${workspaceFolder}/editors/vscode/dist/**/*.js"
-      ],
-      "preLaunchTask": "bingo: prepare extension host"
-    },
-    {
       "name": "bingo DAP: launch spawntree (stop on entry)",
       "type": "bingo",
       "request": "launch",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,15 +2,6 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "bingo: prepare extension host",
-      "type": "process",
-      "command": "just",
-      "args": [
-        "vscode-dev"
-      ],
-      "problemMatcher": []
-    },
-    {
       "label": "bingo: build spawntree",
       "type": "process",
       "command": "just",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -910,6 +910,11 @@ checks the target, and repairs executable mode if extraction lost it.
 Packaging rebuilds/signs twice and requires identical binary and VSIX hashes;
 tests drift-check service/API/wire constants against Go source and inspect exact
 archive contents, target metadata, architecture, mode, and entitlements.
+The extension package version is the installed-runtime upgrade boundary:
+material shipped behavior changes must bump both `package.json` and the lockfile
+or VS Code can retain an older bundle under the same identity. The manifest test
+and package verifier pin the current version (**0.2.0**) in source and VSIX
+metadata.
 The root Run and Debug dropdown exposes exactly two `"type":"bingo"` choices:
 launch spawntree and join a running session. Normal F5 uses the installed VSIX
 and only rebuilds the target; contributor source-extension development runs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -910,15 +910,19 @@ checks the target, and repairs executable mode if extraction lost it.
 Packaging rebuilds/signs twice and requires identical binary and VSIX hashes;
 tests drift-check service/API/wire constants against Go source and inspect exact
 archive contents, target metadata, architecture, mode, and entitlements.
-Normal repository `"type":"bingo"` F5 uses the installed VSIX and only rebuilds
-the target; source binary/build preparation belongs to the separate Extension
-Development Host task (`just vscode-dev`), which restores the exact npm lockfile
-with lifecycle scripts disabled before building. The macOS packaging job uses
-the supported `macos-15` arm64 image, asserts `uname -m`, and runs the real
-packaged-server smoke. That smoke observes server-owned idle exit on success;
-only its failure path may SIGKILL the exact detached process group it created,
-then it must await exit before deleting the extracted package. This cleanup
-helper is test-only and must never enter extension production code.
+The root Run and Debug dropdown exposes exactly two `"type":"bingo"` choices:
+launch spawntree and join a running session. Normal F5 uses the installed VSIX
+and only rebuilds the target; contributor source-extension development runs
+`just vscode-dev` and launches an Extension Development Host explicitly from
+the CLI with
+`code --new-window --extensionDevelopmentPath="$PWD/editors/vscode" "$PWD"`,
+outside the root launch configurations. The recipe restores the exact npm
+lockfile with lifecycle scripts disabled before building. The macOS packaging
+job uses the supported `macos-15` arm64 image, asserts `uname -m`, and runs the
+real packaged-server smoke. That smoke observes server-owned idle exit on
+success; only its failure path may SIGKILL the exact detached process group it
+created, then it must await exit before deleting the extracted package. This
+cleanup helper is test-only and must never enter extension production code.
 Apple's external linker can vary `LC_UUID` even for identical cgo inputs, but
 current dyld rejects binaries with `-no_uuid`; `normalize-mach-o-uuid.mjs`
 therefore derives a stable UUID from the unsigned Mach-O with its UUID and
@@ -1377,7 +1381,7 @@ just coverage [PKG]                        # writes test/coverage.out
 just integration                           # ginkgo -r ./test/integration (no e2e tag)
 just build-spawntree                       # rebuilds the VS Code demo with -N -l
 just vscode-prepare                        # stage the current native server inside the extension
-just vscode-dev                            # stage source extension + native server + spawntree for Extension Host F5
+just vscode-dev                            # stage source extension + native server + spawntree for CLI-launched Extension Host
 just vscode-check                          # lint, typecheck, test, bundle, package-list smoke
 just vscode-package                        # writes verified dist/bingo-<platform>.vsix
 just vscode-install                        # explicitly installs/updates bingosuite.bingo

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Build and install the repository's companion extension:
 just vscode-install
 ```
 
+The managed-server/autostart runtime requires extension version **0.2.0 or
+newer**. After installing or updating the VSIX, run **Developer: Reload Window**
+once so the current extension host activates the new bundle.
+
 It contributes debugger type `"bingo"` and connects VS Code's built-in Debug UI
 directly to bingo. In its default `auto` mode it health-checks
 `127.0.0.1:6060`, reuses a compatible server, or starts the matching bundled
@@ -133,9 +137,9 @@ Lifecycle configuration is explicit per launch: `serverMode`,
 `"serverMode": "connectOnly"`, which neither probes nor spawns. Startup failures
 name the endpoint and persistent log path in the **bingo Server** output channel.
 
-Install the platform VSIX once, then select
-**bingo DAP: launch spawntree (stop on entry)** from the repository's Run and
-Debug dropdown and press F5. The only other root choice is
+Install the platform VSIX once (and update it when a newer version ships), then
+select **bingo DAP: launch spawntree (stop on entry)** from the repository's Run
+and Debug dropdown and press F5. The only other root choice is
 **bingo DAP: join running session**. The launch pre-task rebuilds only the demo
 with debugger-friendly compiler flags; the installed extension health-checks
 `127.0.0.1:6060`, reuses a compatible server or starts its bundled server, waits

--- a/README.md
+++ b/README.md
@@ -133,13 +133,22 @@ Lifecycle configuration is explicit per launch: `serverMode`,
 `"serverMode": "connectOnly"`, which neither probes nor spawns. Startup failures
 name the endpoint and persistent log path in the **bingo Server** output channel.
 
-After installing, select the `"type": "bingo"` spawntree configuration from
-`.vscode/launch.json` and press F5. Its pre-launch task only rebuilds the demo
-with debugger-friendly compiler flags; the installed VSIX supplies the server,
-so target F5 stays fast and no manual `just server` is required. Use the
-separate **Run bingo extension** launch (or `just vscode-dev`) when changing the
-extension itself; that path stages the source extension binary and bundle.
-Manual servers remain supported and are reused when compatible.
+Install the platform VSIX once, then select
+**bingo DAP: launch spawntree (stop on entry)** from the repository's Run and
+Debug dropdown and press F5. The only other root choice is
+**bingo DAP: join running session**. The launch pre-task rebuilds only the demo
+with debugger-friendly compiler flags; the installed extension health-checks
+`127.0.0.1:6060`, reuses a compatible server or starts its bundled server, waits
+for DAP on `127.0.0.1:4711`, and connects. No manual `just server` or separate
+server-start/extension-host launch is required. The extension never kills the
+shared server; after every client disconnects, a managed server exits after its
+server-owned idle grace.
+
+Contributor development of the extension source is deliberately separate from
+normal target debugging. Run `just vscode-dev`, then launch VS Code explicitly
+from a terminal with
+`code --new-window --extensionDevelopmentPath="$PWD/editors/vscode" "$PWD"`.
+Compatible manually-started servers remain supported and are reused.
 
 Other DAP clients can point at `127.0.0.1:4711`. The DAP client creates a
 managed session on `launch`/`attach`; WebSocket observers join that same session

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -40,10 +40,11 @@ architecture behind this.
   just vscode-install
   ```
 
-  Reload the VS Code window after installation. The companion owns debugger type
-  `"bingo"` and connects directly to bingo's DAP listener; it neither invokes
-  nor validates `dlv`, and it does not replace the Go extension's `"go"` type.
-  To update, rerun `just vscode-install`; uninstall with
+  Managed server autostart requires **bingosuite.bingo 0.2.0 or newer**. Run
+  **Developer: Reload Window** once after installation or update. The companion
+  owns debugger type `"bingo"` and connects directly to bingo's DAP listener;
+  it neither invokes nor validates `dlv`, and it does not replace the Go
+  extension's `"go"` type. To update, rerun `just vscode-install`; uninstall with
   `code --uninstall-extension bingosuite.bingo`.
 
 ## 1. Demo target

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -34,7 +34,7 @@ architecture behind this.
   keeps its `go.buildTags: bingonative` settings for gopls, navigation,
   formatting, and tests.
 - For the VS Code debugger: bingo's separate companion extension. Build and
-  install it locally:
+  install the matching platform VSIX once:
 
   ```sh
   just vscode-install
@@ -55,20 +55,21 @@ breakpoint is the `fmt.Printf` inside `worker` (`examples/spawntree/main.go:27`)
 There is no separate manual target build step: the normal workspace launch
 configuration runs **bingo: build spawntree** before F5. It uses the installed
 VSIX's bundled server and does not rebuild or codesign extension sources.
-**Run bingo extension** separately runs **bingo: prepare extension host**
-(`just vscode-dev`) to stage the source extension binary and bundle.
+Contributor source-extension work is a separate command-line path: run
+`just vscode-dev`, then
+`code --new-window --extensionDevelopmentPath="$PWD/editors/vscode" "$PWD"`.
+It is intentionally absent from the root Run and Debug dropdown.
 
 ## 2. Drive with VS Code (DAP, automatic server)
 
 1. Open this repo in VS Code.
-2. For an installed package, select
-   **“bingo DAP: launch spawntree (stop on entry)”** directly. To exercise the
-   source extension, first run **“Run bingo extension”**, then select the
-   spawntree configuration in the Extension Development Host.
+2. Select **“bingo DAP: launch spawntree (stop on entry)”**. The only other root
+   choice is **“bingo DAP: join running session”**.
 3. Press F5. VS Code runs **“bingo: build spawntree”**. The companion
    health-checks `127.0.0.1:6060`,
-   reuses a compatible server or starts its detached bundled server, then
-   connects to DAP at `127.0.0.1:4711`. bingo launches the rebuilt
+   reuses a compatible server or starts its detached bundled server, waits up
+   to `serverReadyTimeoutMs` (five seconds by default) for compatible readiness,
+   then connects to DAP at `127.0.0.1:4711`. bingo launches the rebuilt
    `build/spawntree` and stops at entry.
 4. Set a breakpoint on `examples/spawntree/main.go:27` and **Continue** — the
    tracee stops there with several worker goroutines alive.
@@ -76,10 +77,11 @@ VSIX's bundled server and does not rebuild or codesign extension sources.
    DAP `console` output and is listed by
    `curl -s 127.0.0.1:6060/api/sessions`.
 
-The extension never kills the shared process. The default managed server exits
-only after its 30-second idle grace with no sessions. Open **bingo Server** for
-the persistent child log path. If another extension host starts concurrently,
-listener binding selects one server and both hosts reuse it.
+No manual `just server` is required. The extension never kills the shared
+process. The default managed server exits only after its 30-second idle grace
+with no sessions. Open **bingo Server** for the persistent child log path. If
+another extension host starts concurrently, listener binding selects one server
+and both hosts reuse it.
 
 The lifecycle fields are `serverMode`, management host/port, DAP host/port,
 `serverReadyTimeoutMs`, and `managedIdleTimeoutMs`; the checked-in launch file

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -32,8 +32,11 @@ binary and VSIX twice and requires both SHA-256 hashes to match.
 
 ## F5: connect or start
 
-Select a `bingo` configuration and press F5. In the default `auto` mode the
-extension:
+Install the matching platform VSIX once, select
+**bingo DAP: launch spawntree (stop on entry)** (or
+**bingo DAP: join running session**) from the repository's Run and Debug
+dropdown, and press F5. There is no separate server-start or extension-host
+choice. In the default `auto` mode the extension:
 
 1. checks `http://127.0.0.1:6060/api/health`;
 2. reuses a compatible manual or managed bingo server;
@@ -167,7 +170,7 @@ just server
 # persistent until interrupted; add -idle-timeout 30s for server-owned cleanup
 ```
 
-## Development
+## Contributor extension development
 
 ```sh
 just vscode-dev       # build extension, native bundled server, and spawntree
@@ -175,13 +178,20 @@ just vscode-check     # clean install, lint, typecheck, tests, bundle/list smoke
 just vscode-package   # native reproducible package + content verification
 ```
 
-The repository's **bingo: prepare extension host** task runs `just vscode-dev`
-before **Run bingo extension**, restoring the exact npm lockfile with lifecycle
-scripts disabled and then staging the source extension's binary and bundle.
-The normal spawntree F5 configuration uses the installed VSIX and runs only
-**bingo: build spawntree**, so target debugging does not rebuild or codesign the
-extension-local server. In the Extension Development Host, select the same
-spawntree configuration to exercise the already-staged source extension.
+`just vscode-dev` restores the exact npm lockfile with lifecycle scripts
+disabled, stages the source extension's native binary, builds its bundle, and
+rebuilds spawntree. It does not add contributor tooling to the root Run and
+Debug dropdown. To exercise the staged source extension, launch its Extension
+Development Host explicitly from a terminal:
+
+```sh
+code --new-window --extensionDevelopmentPath="$PWD/editors/vscode" "$PWD"
+```
+
+Inside that window, select the normal spawntree configuration. Ordinary target
+debugging instead uses the installed VSIX and runs only
+**bingo: build spawntree**, so F5 does not rebuild or codesign the
+extension-local server.
 
 ## Troubleshooting
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -19,9 +19,11 @@ From the repository root on a supported host:
 just vscode-install
 ```
 
-This builds, verifies, and installs `dist/bingo-<platform>.vsix`. Rerun the
-command to update. Package without installing with `just vscode-package`.
-Uninstall with:
+This builds, verifies, and installs `dist/bingo-<platform>.vsix`. Managed local
+server autostart first ships in **0.2.0**; older `0.1.0` installs are
+connect-only and must be upgraded. Rerun the command to update, then run
+**Developer: Reload Window** once so the active extension host loads the new
+bundle. Package without installing with `just vscode-package`. Uninstall with:
 
 ```sh
 code --uninstall-extension bingosuite.bingo

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bingo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bingo",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "9.39.5",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "bingo",
   "displayName": "bingo Debugger",
   "description": "Connect VS Code's Debug UI to bingo, reusing or starting a managed local server.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "publisher": "bingosuite",
   "license": "MIT",
   "private": true,

--- a/editors/vscode/scripts/verify-package.mjs
+++ b/editors/vscode/scripts/verify-package.mjs
@@ -13,6 +13,7 @@ import { spawnSync } from "node:child_process";
 import { currentTarget } from "./platform.mjs";
 
 const target = currentTarget();
+const expectedExtensionVersion = "0.2.0";
 const vsix = fileURLToPath(
   new URL(`../../../dist/bingo-${target}.vsix`, import.meta.url),
 );
@@ -66,6 +67,19 @@ try {
   );
   if (!manifest.includes(`TargetPlatform="${target}"`)) {
     throw new Error(`VSIX manifest does not declare target ${target}`);
+  }
+  if (!manifest.includes(`Version="${expectedExtensionVersion}"`)) {
+    throw new Error(
+      `VSIX manifest does not declare version ${expectedExtensionVersion}`,
+    );
+  }
+  const extensionPackage = JSON.parse(
+    readFileSync(join(extracted, "extension", "package.json"), "utf8"),
+  );
+  if (extensionPackage.version !== expectedExtensionVersion) {
+    throw new Error(
+      `packaged extension version is ${String(extensionPackage.version)}, expected ${expectedExtensionVersion}`,
+    );
   }
 
   const binary = join(extracted, "extension", "bin", "bingo");

--- a/editors/vscode/test/manifest.test.ts
+++ b/editors/vscode/test/manifest.test.ts
@@ -12,8 +12,25 @@ const manifest = requireRecord(
 const contributes = requireRecord(manifest.contributes);
 const debuggers = requireArray(contributes.debuggers);
 const debuggerContribution = requireRecord(debuggers[0]);
+const expectedExtensionVersion = "0.2.0";
 
 describe("extension manifest", () => {
+  it("versions the managed-server runtime as an installable upgrade", () => {
+    const lock = requireRecord(
+      JSON.parse(
+        readFileSync(resolve(process.cwd(), "package-lock.json"), "utf8"),
+      ) as unknown,
+    );
+    const packages = requireRecord(lock.packages);
+
+    assert.equal(manifest.version, expectedExtensionVersion);
+    assert.equal(lock.version, expectedExtensionVersion);
+    assert.equal(
+      requireRecord(packages[""]).version,
+      expectedExtensionVersion,
+    );
+  });
+
   it("owns only the bingo debugger type", () => {
     assert.equal(manifest.name, "bingo");
     assert.equal(manifest.publisher, "bingosuite");

--- a/editors/vscode/test/workspace.test.ts
+++ b/editors/vscode/test/workspace.test.ts
@@ -58,64 +58,67 @@ describe("repository VS Code integration", () => {
     assert.match(smoke, /if \(child === undefined \|\| childExited\)/);
   });
 
-  it("keeps target and extension-development preparation separate", () => {
+  it("exposes exactly the two normal bingo debug choices", () => {
     const launch = readJSON(".vscode/launch.json");
     const configurations = requireArray(launch.configurations).map(requireRecord);
+    const serialized = JSON.stringify(configurations);
 
-    assert.ok(configurations.length > 0);
-    assert.equal(
-      configurations.some((configuration) => configuration.type === "go"),
-      false,
+    assert.equal(configurations.length, 2);
+    assert.deepEqual(
+      configurations.map((configuration) => configuration.name),
+      [
+        "bingo DAP: launch spawntree (stop on entry)",
+        "bingo DAP: join running session",
+      ],
     );
-    const bingoConfigurations = configurations.filter(
-      (configuration) => configuration.type === "bingo",
-    );
-    assert.ok(bingoConfigurations.length > 0);
-    for (const configuration of bingoConfigurations) {
+    for (const configuration of configurations) {
       assert.equal(configuration.type, "bingo");
       assert.equal("mode" in configuration, false);
       assert.equal("debugServer" in configuration, false);
       assertLifecycleDefaults(configuration);
     }
+    assert.doesNotMatch(serialized, /extensionHost|Run bingo extension/);
+    assert.doesNotMatch(serialized, /"type":"go"/);
+    assert.doesNotMatch(serialized, /\bdlv\b/i);
 
-    const binaryLaunch = bingoConfigurations.find(
+    const binaryLaunch = configurations.find(
       (configuration) => configuration.request === "launch",
     );
     assert.notEqual(binaryLaunch, undefined);
+    assert.equal(
+      binaryLaunch?.name,
+      "bingo DAP: launch spawntree (stop on entry)",
+    );
+    assert.equal(binaryLaunch?.program, "${workspaceFolder}/build/spawntree");
     assert.equal(binaryLaunch?.preLaunchTask, "bingo: build spawntree");
 
-    const extensionHost = configurations.find(
-      (configuration) => configuration.type === "extensionHost",
+    const sessionJoin = configurations.find(
+      (configuration) => configuration.request === "attach",
     );
-    assert.notEqual(extensionHost, undefined);
-    assert.equal(
-      extensionHost?.preLaunchTask,
-      "bingo: prepare extension host",
-    );
-    assert.deepEqual(extensionHost?.args, [
-      "--extensionDevelopmentPath=${workspaceFolder}/editors/vscode",
-    ]);
+    assert.notEqual(sessionJoin, undefined);
+    assert.equal(sessionJoin?.name, "bingo DAP: join running session");
+    assert.equal(sessionJoin?.session, "${input:bingoSession}");
+    assert.equal("preLaunchTask" in (sessionJoin ?? {}), false);
   });
 
-  it("defines deterministic but independent extension and target tasks", () => {
+  it("defines only the fast target preparation task", () => {
     const tasksConfig = readJSON(".vscode/tasks.json");
     const tasks = requireArray(tasksConfig.tasks).map(requireRecord);
-    const extensionTask = tasks.find(
-      (task) => task.label === "bingo: prepare extension host",
-    );
-    const targetTask = tasks.find(
-      (task) => task.label === "bingo: build spawntree",
-    );
 
-    assert.notEqual(extensionTask, undefined);
-    assert.equal(extensionTask?.type, "process");
-    assert.equal(extensionTask?.command, "just");
-    assert.deepEqual(extensionTask?.args, ["vscode-dev"]);
-
+    assert.equal(tasks.length, 1);
+    const [targetTask] = tasks;
     assert.notEqual(targetTask, undefined);
+    assert.equal(targetTask?.label, "bingo: build spawntree");
     assert.equal(targetTask?.type, "process");
     assert.equal(targetTask?.command, "just");
     assert.deepEqual(targetTask?.args, ["build-spawntree"]);
+
+    const launch = readJSON(".vscode/launch.json");
+    const configurations = requireArray(launch.configurations).map(requireRecord);
+    const binaryLaunch = configurations.find(
+      (configuration) => configuration.request === "launch",
+    );
+    assert.equal(binaryLaunch?.preLaunchTask, targetTask?.label);
 
     const justfile = readText("justfile");
     const devStart = justfile.indexOf("vscode-dev:");


### PR DESCRIPTION
## Problem

PR #122 left two distinct user-facing failures:

1. It exposed contributor-only Extension Development Host tooling in the repository's normal Run and Debug dropdown. **Run bingo extension** opened an Extension Development Host; it was never a server-start command and should not be product debugging UX.
2. The managed-server/autostart runtime shipped under the existing extension version `0.1.0`. VS Code therefore had no upgrade boundary: an existing `bingosuite.bingo@0.1.0` install remained on PR #120's connect-only bundle, so normal Launch connected directly to absent DAP `:4711` and failed with `ECONNREFUSED`.

## Change

- remove the `extensionHost` launch and its `bingo: prepare extension host` task
- expose exactly two root choices, both `type: bingo`:
  - **bingo DAP: launch spawntree (stop on entry)**
  - **bingo DAP: join running session**
- keep only `bingo: build spawntree` as the launch pre-task
- retain contributor source-extension development as the explicit `just vscode-dev` + CLI-launched Extension Development Host workflow
- bump extension/package-lock metadata to `0.2.0`, pin it in manifest tests and extracted-VSIX verification, and document that material shipped runtime changes must advance the extension version
- tell users upgrading from `0.1.0` to run **Developer: Reload Window** once
- preserve schema/default, Go-extension separation, `connectOnly`, never-kill ownership, and idle-shutdown behavior

## A-F proof

**A — original state and process safety:** default `127.0.0.1:6060` and `:4711` were free. Normal profile reported `bingosuite.bingo@0.1.0` at `/Users/sacha/.vscode/extensions/bingosuite.bingo-0.1.0`; bundle SHA-256 `f5393be166040d14ac7a172698c0dd40b81af7168f515ab93a5d30d8938c1c34`. It contained one direct `DebugAdapterServer` marker and zero `/api/health`, `ensureServer`, or `ServerManager` markers; connecting to absent `:4711` reproduced `ECONNREFUSED`. No unknown process was signaled or killed.

**B — versioned package/install:** `just vscode-package` produced a reproducible `darwin-arm64` VSIX whose extracted package and VSIX manifest are both verified as `0.2.0`. VSIX SHA-256: `d97125e51076b9eb71ece44a8d43809f330b48691d349211cffa40d0377bf5e3`; bundled binary SHA-256: `e7ca50ed079374b7c6d0000ba845e0038d8fdec7d62fa51edd97636be936853f`; bundle SHA-256: `eaf66c3be3c046b0d2cb394bf36b24211adb1f72a07ad5d0c64e52f422546b42`. A fresh isolated profile reports `bingosuite.bingo@0.2.0` and its installed bundle contains `managedIdleTimeoutMs`, `serverMode`, `/api/health`, `ensureServer`, and `ServerManager` markers.

The same VSIX was explicitly installed with `code --install-extension ... --force` into the user's normal profile without changing other extensions/settings. Normal `code --list-extensions --show-versions` now reports `bingosuite.bingo@0.2.0`; `code --locate-extension` resolves `/Users/sacha/.vscode/extensions/bingosuite.bingo-0.2.0`, not the retained old folder. VS Code must **Reload Window once** so its already-running extension host activates `0.2.0`.

**C — cold autostart:** production `ServerManager` + real health probe/binary resolver/detached spawner targeted the isolated installed `0.2.0` binary on management `59928`, DAP `59929`. Initial health was `absent`; manager spawned exactly once and reached instance `408227f3-060e-40c2-bf76-54a9b8f81cc6`. A real DAP launch of `build/spawntree` stopped for `breakpoint` at `examples/spawntree/main.go:27`. After disconnect, exact listener PID `17610` disappeared after 3031 ms of a 3000 ms idle grace; log records idle timeout and shutdown. No signal or kill was used.

**D — compatible reuse:** prestarted the installed `0.2.0` packaged server on management `59945`, DAP `59946`; instance `8c18a3ff-4b3c-45b1-accb-fcb0d4206131` remained identical through the production ensure path, with zero spawn attempts and no listener conflict. A real DAP launch again stopped at `main.go:27`; PID `17761` exited naturally with code 0/no signal 3023 ms after final disconnect.

**E — root UI shape:** mechanical parsing of shipped workspace JSON reports exactly two configs (launch + join, both `bingo`) and one task (`bingo: build spawntree`), referenced by launch. Contract tests explicitly reject `extensionHost`, **Run bingo extension**, `go`, `debugServer`, `mode`, and `dlv`. VS Code CLI cannot enumerate/click Run and Debug choices, so no heavy UI framework was added; JSON contract tests plus installed production-manager/DAP flows cover the boundary.

**F — validation:** locked npm restore; ESLint; strict TypeScript; all 80 extension tests; focused manifest/workspace tests; bundle/package-list; two-build binary/VSIX reproducibility; extracted package target/version/content/signature verification; packaged-server clean idle smoke; targeted `go vet -tags bingonative` and `go test -tags bingonative` for DAP/server/cmd; `git diff --check`; two independent code reviews. Default ports remained untouched and both proof PIDs/listeners were absent afterward.