### PR TITLE
feat(examples): add progressive debugger suite

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,11 +2,11 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "bingo DAP: launch spawntree (stop on entry)",
+      "name": "bingo DAP: launch example (stop on entry)",
       "type": "bingo",
       "request": "launch",
-      "program": "${workspaceFolder}/build/spawntree",
-      "preLaunchTask": "bingo: build spawntree",
+      "program": "${workspaceFolder}/build/examples/${input:bingoExample}",
+      "preLaunchTask": "bingo: build examples",
       "stopOnEntry": true,
       "serverMode": "auto",
       "managementHost": "127.0.0.1",
@@ -31,6 +31,19 @@
     }
   ],
   "inputs": [
+    {
+      "id": "bingoExample",
+      "type": "pickString",
+      "description": "Progressive debugger example",
+      "options": [
+        "level1-loop",
+        "level2-channel",
+        "level3-worker-pool",
+        "level4-pipeline",
+        "level5-workflow"
+      ],
+      "default": "level1-loop"
+    },
     {
       "id": "bingoSession",
       "type": "promptString",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,11 +2,11 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "bingo: build spawntree",
+      "label": "bingo: build examples",
       "type": "process",
       "command": "just",
       "args": [
-        "build-spawntree"
+        "build-examples"
       ],
       "problemMatcher": []
     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ follow them so reviews stay about substance, not style.
 | [cmd/wsmon](cmd/wsmon/) | Read-only terminal telemetry observer. `-session`-joins a running session over WebSocket and live-renders the goroutine spawn tree + OS threads + created/exited lifecycle deltas from the `EventGoroutineSnapshot` stream. Never drives execution — the WS-observes half of the DAP-drives/WS-observes demo. |
 | [editors/vscode](editors/vscode/) | Platform-packaged TypeScript companion extension. Owns VS Code debugger type `bingo`, enables Go breakpoints, and reuses or starts a compatible shared bingo server before connecting the built-in Debug UI to DAP. |
 | [cmd/target](cmd/target/) | Trivial target program for manual testing. |
+| [examples/level1-loop](examples/level1-loop/) … [examples/level5-workflow](examples/level5-workflow/) | Progressive debugger targets, selected by the root VS Code launch picker and built together with `just build-examples` (see [examples/README.md](examples/README.md)). |
 | [examples/spawntree](examples/spawntree/) | Concurrency demo target: a deterministic main → supervisor → worker×N goroutine spawn tree for exercising the telemetry stream (see [docs/ConcurrencyTelemetry.md](docs/ConcurrencyTelemetry.md)). |
 | [cmd/githook](cmd/githook/) | Conventional-commits commitlint, wired via [lefthook.yml](lefthook.yml). |
 | [pkg/protocol](pkg/protocol/) | Wire types: `Event`, `Command`, payload structs, `EventKind`, `CommandKind`, `SessionState`. Single source of truth. |
@@ -916,8 +917,9 @@ or VS Code can retain an older bundle under the same identity. The manifest test
 and package verifier pin the current version (**0.2.0**) in source and VSIX
 metadata.
 The root Run and Debug dropdown exposes exactly two `"type":"bingo"` choices:
-launch spawntree and join a running session. Normal F5 uses the installed VSIX
-and only rebuilds the target; contributor source-extension development runs
+launch one of five progressive examples through a `pickString`, and join a
+running session. Normal F5 uses the installed VSIX and rebuilds the five targets
+with `just build-examples`; contributor source-extension development runs
 `just vscode-dev` and launches an Extension Development Host explicitly from
 the CLI with
 `code --new-window --extensionDevelopmentPath="$PWD/editors/vscode" "$PWD"`,
@@ -1384,9 +1386,10 @@ just build [linux amd64 | darwin arm64]   # produces ./build/bingo/...
 just test [PKG]                            # go test -v
 just coverage [PKG]                        # writes test/coverage.out
 just integration                           # ginkgo -r ./test/integration (no e2e tag)
-just build-spawntree                       # rebuilds the VS Code demo with -N -l
+just build-examples                        # build five progressive targets with -N -l
+just build-spawntree                       # build the dedicated telemetry demo with -N -l
 just vscode-prepare                        # stage the current native server inside the extension
-just vscode-dev                            # stage source extension + native server + spawntree for CLI-launched Extension Host
+just vscode-dev                            # stage source extension + native server + examples for CLI-launched Extension Host
 just vscode-check                          # lint, typecheck, test, bundle, package-list smoke
 just vscode-package                        # writes verified dist/bingo-<platform>.vsix
 just vscode-install                        # explicitly installs/updates bingosuite.bingo

--- a/README.md
+++ b/README.md
@@ -138,10 +138,11 @@ Lifecycle configuration is explicit per launch: `serverMode`,
 name the endpoint and persistent log path in the **bingo Server** output channel.
 
 Install the platform VSIX once (and update it when a newer version ships), then
-select **bingo DAP: launch spawntree (stop on entry)** from the repository's Run
-and Debug dropdown and press F5. The only other root choice is
-**bingo DAP: join running session**. The launch pre-task rebuilds only the demo
-with debugger-friendly compiler flags; the installed extension health-checks
+select **bingo DAP: launch example (stop on entry)** from the repository's Run
+and Debug dropdown, press F5, and choose one of the five
+[progressive examples](examples/README.md). The only other root choice is
+**bingo DAP: join running session**. The launch pre-task rebuilds all five
+targets with debugger-friendly compiler flags; the installed extension health-checks
 `127.0.0.1:6060`, reuses a compatible server or starts its bundled server, waits
 for DAP on `127.0.0.1:4711`, and connects. No manual `just server` or separate
 server-start/extension-host launch is required. The extension never kills the

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -47,15 +47,20 @@ architecture behind this.
   extension's `"go"` type. To update, rerun `just vscode-install`; uninstall with
   `code --uninstall-extension bingosuite.bingo`.
 
-## 1. Demo target
+## 1. Demo targets
 
-`examples/spawntree` is a deterministic **main → supervisor → worker×3** spawn
-tree that churns a fresh worker pool each round, so consecutive snapshots show
-workers appearing in the `created` delta and leaving in `exited`. The intended
-breakpoint is the `fmt.Printf` inside `worker` (`examples/spawntree/main.go:27`).
-There is no separate manual target build step: the normal workspace launch
-configuration runs **bingo: build spawntree** before F5. It uses the installed
-VSIX's bundled server and does not rebuild or codesign extension sources.
+The [progressive example suite](../examples/README.md) is available from the
+normal workspace launch picker. `level5-workflow` gives the richest hierarchy:
+**main → workflow×3 → stage×3**, including a deterministic canceled workflow.
+The intended telemetry breakpoint is the result send in `inventoryStage`
+(`examples/level5-workflow/main.go:83`). The workspace launch runs
+**bingo: build examples** before F5 and uses the installed VSIX's bundled
+server; it does not rebuild or codesign extension sources.
+
+`examples/spawntree` remains the dedicated long-running lifecycle demo. It
+churns a deterministic **main → supervisor → worker×3** tree so consecutive
+snapshots show workers appearing in `created` and leaving in `exited`. Build it
+with `just build-spawntree` and drive it with `cmd/dapcli` as shown below.
 Contributor source-extension work is a separate command-line path: run
 `just vscode-dev`, then
 `code --new-window --extensionDevelopmentPath="$PWD/editors/vscode" "$PWD"`.
@@ -64,16 +69,17 @@ It is intentionally absent from the root Run and Debug dropdown.
 ## 2. Drive with VS Code (DAP, automatic server)
 
 1. Open this repo in VS Code.
-2. Select **“bingo DAP: launch spawntree (stop on entry)”**. The only other root
+2. Select **“bingo DAP: launch example (stop on entry)”**. The only other root
    choice is **“bingo DAP: join running session”**.
-3. Press F5. VS Code runs **“bingo: build spawntree”**. The companion
+3. Press F5, choose **level5-workflow**, and let VS Code run
+   **“bingo: build examples”**. The companion
    health-checks `127.0.0.1:6060`,
    reuses a compatible server or starts its detached bundled server, waits up
    to `serverReadyTimeoutMs` (five seconds by default) for compatible readiness,
-   then connects to DAP at `127.0.0.1:4711`. bingo launches the rebuilt
-   `build/spawntree` and stops at entry.
-4. Set a breakpoint on `examples/spawntree/main.go:27` and **Continue** — the
-   tracee stops there with several worker goroutines alive.
+   then connects to DAP at `127.0.0.1:4711`. bingo launches
+   `build/examples/level5-workflow` and stops at entry.
+4. Set a breakpoint on `examples/level5-workflow/main.go:83` and **Continue** —
+   the tracee stops with several workflow and stage goroutines alive.
 5. Grab the **session id** so the observer can join: it is printed in the bingo
    DAP `console` output and is listed by
    `curl -s 127.0.0.1:6060/api/sessions`.
@@ -103,6 +109,7 @@ path in **bingo Server** rather than killing a potentially shared process.
 Equivalent driver in a terminal requires a manual server:
 
 ```sh
+just build-spawntree
 just server
 just dapcli            # or: go run -tags bingonative ./cmd/dapcli -addr localhost:4711
 # in the REPL:

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -35,10 +35,10 @@ binary and VSIX twice and requires both SHA-256 hashes to match.
 ## F5: connect or start
 
 Install the matching platform VSIX once, select
-**bingo DAP: launch spawntree (stop on entry)** (or
+**bingo DAP: launch example (stop on entry)** (or
 **bingo DAP: join running session**) from the repository's Run and Debug
-dropdown, and press F5. There is no separate server-start or extension-host
-choice. In the default `auto` mode the extension:
+dropdown, press F5, and choose one of the five progressive targets. There is no
+separate server-start or extension-host choice. In the default `auto` mode the extension:
 
 1. checks `http://127.0.0.1:6060/api/health`;
 2. reuses a compatible manual or managed bingo server;
@@ -175,14 +175,14 @@ just server
 ## Contributor extension development
 
 ```sh
-just vscode-dev       # build extension, native bundled server, and spawntree
+just vscode-dev       # build extension, native bundled server, and examples
 just vscode-check     # clean install, lint, typecheck, tests, bundle/list smoke
 just vscode-package   # native reproducible package + content verification
 ```
 
 `just vscode-dev` restores the exact npm lockfile with lifecycle scripts
 disabled, stages the source extension's native binary, builds its bundle, and
-rebuilds spawntree. It does not add contributor tooling to the root Run and
+rebuilds the progressive examples. It does not add contributor tooling to the root Run and
 Debug dropdown. To exercise the staged source extension, launch its Extension
 Development Host explicitly from a terminal:
 
@@ -190,9 +190,9 @@ Development Host explicitly from a terminal:
 code --new-window --extensionDevelopmentPath="$PWD/editors/vscode" "$PWD"
 ```
 
-Inside that window, select the normal spawntree configuration. Ordinary target
+Inside that window, select the normal example configuration. Ordinary target
 debugging instead uses the installed VSIX and runs only
-**bingo: build spawntree**, so F5 does not rebuild or codesign the
+**bingo: build examples**, so F5 does not rebuild or codesign the
 extension-local server.
 
 ## Troubleshooting

--- a/editors/vscode/test/workspace.test.ts
+++ b/editors/vscode/test/workspace.test.ts
@@ -67,7 +67,7 @@ describe("repository VS Code integration", () => {
     assert.deepEqual(
       configurations.map((configuration) => configuration.name),
       [
-        "bingo DAP: launch spawntree (stop on entry)",
+        "bingo DAP: launch example (stop on entry)",
         "bingo DAP: join running session",
       ],
     );
@@ -87,10 +87,28 @@ describe("repository VS Code integration", () => {
     assert.notEqual(binaryLaunch, undefined);
     assert.equal(
       binaryLaunch?.name,
-      "bingo DAP: launch spawntree (stop on entry)",
+      "bingo DAP: launch example (stop on entry)",
     );
-    assert.equal(binaryLaunch?.program, "${workspaceFolder}/build/spawntree");
-    assert.equal(binaryLaunch?.preLaunchTask, "bingo: build spawntree");
+    assert.equal(
+      binaryLaunch?.program,
+      "${workspaceFolder}/build/examples/${input:bingoExample}",
+    );
+    assert.equal(binaryLaunch?.preLaunchTask, "bingo: build examples");
+    assert.equal(binaryLaunch?.stopOnEntry, true);
+
+    const inputs = requireArray(launch.inputs).map(requireRecord);
+    assert.equal(inputs.length, 2);
+    const examplePicker = inputs.find((input) => input.id === "bingoExample");
+    assert.notEqual(examplePicker, undefined);
+    assert.equal(examplePicker?.type, "pickString");
+    assert.equal(examplePicker?.default, "level1-loop");
+    assert.deepEqual(examplePicker?.options, [
+      "level1-loop",
+      "level2-channel",
+      "level3-worker-pool",
+      "level4-pipeline",
+      "level5-workflow",
+    ]);
 
     const sessionJoin = configurations.find(
       (configuration) => configuration.request === "attach",
@@ -108,10 +126,10 @@ describe("repository VS Code integration", () => {
     assert.equal(tasks.length, 1);
     const [targetTask] = tasks;
     assert.notEqual(targetTask, undefined);
-    assert.equal(targetTask?.label, "bingo: build spawntree");
+    assert.equal(targetTask?.label, "bingo: build examples");
     assert.equal(targetTask?.type, "process");
     assert.equal(targetTask?.command, "just");
-    assert.deepEqual(targetTask?.args, ["build-spawntree"]);
+    assert.deepEqual(targetTask?.args, ["build-examples"]);
 
     const launch = readJSON(".vscode/launch.json");
     const configurations = requireArray(launch.configurations).map(requireRecord);

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,48 @@
+# Progressive debugger examples
+
+These five small targets introduce bingo one concept at a time. They are finite,
+self-contained, and built without compiler optimization so source stepping and
+locals remain easy to follow.
+
+| Level | Concepts | Expected application goroutines | Suggested breakpoint | Inspect in DAP and WS telemetry |
+| --- | --- | --- | --- | --- |
+| [`level1-loop`](level1-loop/) | Sequential loop, locals, continue, step-over | `main` only | `main.go:8`, the running-total update | `step` and `total`; a single application goroutine |
+| [`level2-channel`](level2-channel/) | First spawn, send/receive, close/range | `main` → producer | `main.go:14`, the channel send | producer creation and exit; channel value in each goroutine |
+| [`level3-worker-pool`](level3-worker-pool/) | Three siblings, jobs/results channels, `WaitGroup` | `main` → worker ×3 | `worker` at `main.go:20` | sibling workers, current worker/job, workers exiting after `jobs` closes |
+| [`level4-pipeline`](level4-pipeline/) | Owned channel closure, multi-stage pipeline, `select`, explicit cancellation | `main` → generate, square, retain | `retainEven` at `main.go:43` | stage fan-out, values moving between stages, all stages exiting after the third retained value cancels the context |
+| [`level5-workflow`](level5-workflow/) | Nested workflows, parallel stages, deterministic error cancellation, shared mutex-protected ledger | `main` → workflow ×3 → stage ×3 | `inventoryStage` at `main.go:83` or `processOrder` at `main.go:137` | parent/child hierarchy, overlapping workflow lifetimes, canceled stages for `order-202`, shared ledger state |
+
+## Build, run, and debug
+
+Build every target with debugger-friendly compiler flags:
+
+```sh
+just build-examples
+./build/examples/level1-loop
+go run -race ./examples/level5-workflow
+go test -race ./examples/...
+```
+
+In VS Code, install the bingo extension, choose **bingo DAP: launch example
+(stop on entry)**, press F5, and select a level from the picker. The pre-launch
+task rebuilds all five binaries in `build/examples/` with
+`-gcflags="all=-N -l"`. The only other root debug configuration joins an
+existing bingo session.
+
+For a terminal-only DAP session, start `just server`, run `just dapcli`, and
+launch a selected binary:
+
+```text
+launch ./build/examples/level3-worker-pool
+break examples/level3-worker-pool/main.go:20
+c
+```
+
+Join the reported session with `go run ./cmd/wsmon -session <id>` to watch
+goroutine snapshots while DAP drives execution. Concurrent worker and workflow
+status lines can interleave differently between runs, but every level's final
+summary is sorted or otherwise deterministic.
+
+[`spawntree`](spawntree/) remains the dedicated advanced hierarchy and lifecycle
+telemetry demo. Build it separately with `just build-spawntree` and follow
+[`docs/ConcurrencyTelemetry.md`](../docs/ConcurrencyTelemetry.md).

--- a/examples/level1-loop/main.go
+++ b/examples/level1-loop/main.go
@@ -1,0 +1,12 @@
+package main
+
+import "fmt"
+
+func main() {
+	total := 0
+	for step := 1; step <= 5; step++ {
+		total += step
+		fmt.Printf("step=%d total=%d\n", step, total)
+	}
+	fmt.Printf("summary total=%d\n", total)
+}

--- a/examples/level2-channel/main.go
+++ b/examples/level2-channel/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func produce(values []int) <-chan int {
+	output := make(chan int)
+	go func() {
+		defer close(output)
+		for _, value := range values {
+			time.Sleep(15 * time.Millisecond)
+			output <- value
+		}
+	}()
+	return output
+}
+
+func main() {
+	values := make([]int, 0, 4)
+	for value := range produce([]int{2, 4, 6, 8}) {
+		values = append(values, value)
+		fmt.Printf("received=%d square=%d\n", value, value*value)
+	}
+	fmt.Printf("summary values=%v\n", values)
+}

--- a/examples/level3-worker-pool/main.go
+++ b/examples/level3-worker-pool/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+type jobResult struct {
+	job    int
+	square int
+}
+
+func worker(id int, jobs <-chan int, results chan<- jobResult, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for job := range jobs {
+		time.Sleep(time.Duration(5+job) * time.Millisecond)
+		result := jobResult{job: job, square: job * job}
+		fmt.Printf("worker=%d job=%d square=%d\n", id, result.job, result.square)
+		results <- result
+	}
+}
+
+func main() {
+	const (
+		workerCount = 3
+		jobCount    = 6
+	)
+
+	jobs := make(chan int, jobCount)
+	results := make(chan jobResult, jobCount)
+	var workers sync.WaitGroup
+
+	for id := 1; id <= workerCount; id++ {
+		workers.Add(1)
+		go worker(id, jobs, results, &workers)
+	}
+	for job := 1; job <= jobCount; job++ {
+		jobs <- job
+	}
+	close(jobs)
+
+	workers.Wait()
+	close(results)
+
+	ordered := make([]jobResult, 0, jobCount)
+	for result := range results {
+		ordered = append(ordered, result)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		return ordered[i].job < ordered[j].job
+	})
+	for _, result := range ordered {
+		fmt.Printf("summary job=%d square=%d\n", result.job, result.square)
+	}
+}

--- a/examples/level4-pipeline/main.go
+++ b/examples/level4-pipeline/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+func generate(ctx context.Context, values []int, output chan<- int, stages *sync.WaitGroup) {
+	defer stages.Done()
+	defer close(output)
+	for _, value := range values {
+		select {
+		case output <- value:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func square(ctx context.Context, input <-chan int, output chan<- int, stages *sync.WaitGroup) {
+	defer stages.Done()
+	defer close(output)
+	for value := range input {
+		time.Sleep(10 * time.Millisecond)
+		select {
+		case output <- value * value:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func retainEven(ctx context.Context, input <-chan int, output chan<- int, stages *sync.WaitGroup) {
+	defer stages.Done()
+	defer close(output)
+	for value := range input {
+		if value%2 != 0 {
+			continue
+		}
+		select {
+		case output <- value:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	generated := make(chan int)
+	squared := make(chan int)
+	retained := make(chan int)
+	var stages sync.WaitGroup
+	stages.Add(3)
+	go generate(ctx, []int{1, 2, 3, 4, 5, 6, 7, 8}, generated, &stages)
+	go square(ctx, generated, squared, &stages)
+	go retainEven(ctx, squared, retained, &stages)
+
+	values := make([]int, 0, 3)
+	for value := range retained {
+		values = append(values, value)
+		fmt.Printf("retained=%d\n", value)
+		if len(values) == 3 {
+			cancel()
+			break
+		}
+	}
+	stages.Wait()
+	fmt.Printf("summary retained=%v canceled=%t\n", values, ctx.Err() != nil)
+}

--- a/examples/level5-workflow/main.go
+++ b/examples/level5-workflow/main.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+type order struct {
+	id              string
+	items           int
+	paymentRejected bool
+}
+
+type stageResult struct {
+	stage  string
+	amount int
+	err    error
+}
+
+type ledgerEntry struct {
+	orderID string
+	status  string
+	detail  string
+	total   int
+}
+
+type ledger struct {
+	mu        sync.Mutex
+	entries   []ledgerEntry
+	completed int
+	failed    int
+}
+
+func (l *ledger) record(entry ledgerEntry) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, entry)
+	if entry.status == "completed" {
+		l.completed++
+	} else {
+		l.failed++
+	}
+}
+
+func (l *ledger) report() ([]ledgerEntry, int, int) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	entries := append([]ledgerEntry(nil), l.entries...)
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].orderID < entries[j].orderID
+	})
+	return entries, l.completed, l.failed
+}
+
+func paymentStage(ctx context.Context, current order, approved chan<- struct{}, results chan<- stageResult, stages *sync.WaitGroup) {
+	defer stages.Done()
+	time.Sleep(10 * time.Millisecond)
+	if current.paymentRejected {
+		results <- stageResult{stage: "payment", err: errors.New("payment rejected")}
+		return
+	}
+	close(approved)
+	select {
+	case results <- stageResult{stage: "payment", amount: current.items * 10}:
+	case <-ctx.Done():
+	}
+}
+
+func inventoryStage(ctx context.Context, current order, approved <-chan struct{}, results chan<- stageResult, stages *sync.WaitGroup) {
+	defer stages.Done()
+	select {
+	case <-approved:
+	case <-ctx.Done():
+		results <- stageResult{stage: "inventory", err: ctx.Err()}
+		return
+	}
+	time.Sleep(15 * time.Millisecond)
+	select {
+	case results <- stageResult{stage: "inventory", amount: current.items}:
+	case <-ctx.Done():
+	}
+}
+
+func packingStage(ctx context.Context, current order, approved <-chan struct{}, results chan<- stageResult, stages *sync.WaitGroup) {
+	defer stages.Done()
+	select {
+	case <-approved:
+	case <-ctx.Done():
+		results <- stageResult{stage: "packing", err: ctx.Err()}
+		return
+	}
+	time.Sleep(20 * time.Millisecond)
+	select {
+	case results <- stageResult{stage: "packing", amount: current.items * 2}:
+	case <-ctx.Done():
+	}
+}
+
+func processOrder(current order, records *ledger, workflows *sync.WaitGroup) {
+	defer workflows.Done()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	approved := make(chan struct{})
+	results := make(chan stageResult, 3)
+	var stages sync.WaitGroup
+	stages.Add(3)
+	go paymentStage(ctx, current, approved, results, &stages)
+	go inventoryStage(ctx, current, approved, results, &stages)
+	go packingStage(ctx, current, approved, results, &stages)
+
+	collected := make([]stageResult, 0, 3)
+	for len(collected) < 3 {
+		result := <-results
+		collected = append(collected, result)
+		if result.err != nil && !errors.Is(result.err, context.Canceled) {
+			cancel()
+		}
+	}
+	stages.Wait()
+
+	sort.Slice(collected, func(i, j int) bool {
+		return collected[i].stage < collected[j].stage
+	})
+	total := 0
+	for _, result := range collected {
+		if result.err != nil && !errors.Is(result.err, context.Canceled) {
+			records.record(ledgerEntry{
+				orderID: current.id,
+				status:  "failed",
+				detail:  result.err.Error(),
+			})
+			fmt.Printf("workflow=%s status=failed stage=%s\n", current.id, result.stage)
+			return
+		}
+		total += result.amount
+	}
+
+	records.record(ledgerEntry{orderID: current.id, status: "completed", total: total})
+	fmt.Printf("workflow=%s status=completed\n", current.id)
+}
+
+func main() {
+	orders := []order{
+		{id: "order-101", items: 2},
+		{id: "order-202", items: 4, paymentRejected: true},
+		{id: "order-303", items: 3},
+	}
+
+	var records ledger
+	var workflows sync.WaitGroup
+	for _, current := range orders {
+		workflows.Add(1)
+		go processOrder(current, &records, &workflows)
+	}
+	workflows.Wait()
+
+	entries, completed, failed := records.report()
+	for _, entry := range entries {
+		if entry.status == "completed" {
+			fmt.Printf("ledger order=%s status=%s total=%d\n", entry.orderID, entry.status, entry.total)
+		} else {
+			fmt.Printf("ledger order=%s status=%s detail=%q\n", entry.orderID, entry.status, entry.detail)
+		}
+	}
+	fmt.Printf("summary completed=%d failed=%d\n", completed, failed)
+}

--- a/justfile
+++ b/justfile
@@ -58,8 +58,16 @@ build-target:
 	mkdir -p ./build/target
 	go build --gcflags="all=-N -l" -o ./build/target/target ./cmd/target
 
-# VS Code's pre-launch task rebuilds the telemetry demo without optimization so
-# source breakpoints and stepping stay aligned with the checked-out source.
+# The picker has one pre-launch task, so build every selectable target with
+# debugger-friendly code generation before resolving its chosen binary.
+build-examples:
+	mkdir -p ./build/examples
+	go build -gcflags="all=-N -l" -o ./build/examples/level1-loop ./examples/level1-loop
+	go build -gcflags="all=-N -l" -o ./build/examples/level2-channel ./examples/level2-channel
+	go build -gcflags="all=-N -l" -o ./build/examples/level3-worker-pool ./examples/level3-worker-pool
+	go build -gcflags="all=-N -l" -o ./build/examples/level4-pipeline ./examples/level4-pipeline
+	go build -gcflags="all=-N -l" -o ./build/examples/level5-workflow ./examples/level5-workflow
+
 build-spawntree:
 	mkdir -p ./build
 	go build -gcflags="all=-N -l" -o ./build/spawntree ./examples/spawntree
@@ -70,8 +78,8 @@ vscode-prepare:
 	npm --prefix editors/vscode run binary:prepare
 
 # Prepare source-extension and target artifacts for an Extension Development
-# Host. Normal target F5 uses the installed VSIX and only rebuilds spawntree.
-vscode-dev: build-spawntree vscode-prepare
+# Host. Normal target F5 uses the installed VSIX and only rebuilds the examples.
+vscode-dev: build-examples vscode-prepare
 	npm --prefix editors/vscode ci --ignore-scripts
 	npm --prefix editors/vscode run build
 


### PR DESCRIPTION
## Summary

Adds a five-level, finite debugger-target progression and makes it the repository's normal VS Code launch experience.

| Level | Target | Progression |
| --- | --- | --- |
| 1 | `level1-loop` | Sequential loop, locals, breakpoints, continue, step-over |
| 2 | `level2-channel` | Main plus one producer, channel close/range, first lifecycle |
| 3 | `level3-worker-pool` | Three sibling workers, jobs/results channels, WaitGroup, sorted results |
| 4 | `level4-pipeline` | Generator/transform/filter stages, channel ownership, select, explicit data-count cancellation |
| 5 | `level5-workflow` | Nested workflows and parallel stages, channels, WaitGroups, mutex ledger, deterministic rejected-payment cancellation |

`examples/spawntree` remains the separate advanced lifecycle telemetry demo.

## VS Code workspace proof

- Root Run and Debug contains exactly **2** configurations, both `type: "bingo"`:
  1. `bingo DAP: launch example (stop on entry)`
  2. `bingo DAP: join running session`
- The launch config uses a string-only `pickString` with exactly five options, defaults to `level1-loop`, and maps `${input:bingoExample}` to `${workspaceFolder}/build/examples/...`.
- Root tasks contains exactly **1** task: `bingo: build examples` → `just build-examples`.
- No root extension-host, server-start, `type: go`, `debugServer`, `mode`, or `dlv` entry was introduced.
- Extension runtime remains **0.2.0**; no package/version change.

## Validation

- `just build-examples` produced exactly five executable targets under `build/examples/` with `-gcflags="all=-N -l"`.
- Each binary exited 0 in normal runs; stable final invariants passed across three repeated runs:
  - L1: `summary total=15`
  - L2: `summary values=[2 4 6 8]`
  - L3: jobs 1–6 each summarized exactly once with squares 1–36
  - L4: `summary retained=[4 16 36] canceled=true`
  - L5: sorted ledger totals 26/39, deterministic `order-202` payment rejection, `summary completed=2 failed=1`
- `go run -race` succeeded for every target.
- `go test -race ./examples/...`
- `go vet -tags bingonative ./...`
- `go test -tags bingonative ./...`
- `npm --prefix editors/vscode ci --ignore-scripts`
- `npm --prefix editors/vscode run check` (80 tests, lint, typecheck, bundle/list smoke)
- `git diff --check`
- Independent code review: no high-confidence findings.

## Real native debugger proof

Used the actual codesigned darwin/arm64 bingo binary with the debugger entitlement, over TCP DAP plus a joined WebSocket client. Picker options were mechanically resolved to the five built binaries. Every target stopped at entry, verified/hit the documented source breakpoint, reported `reason=breakpoint`, continued through repeated hits, and exited 0.

| Level | Breakpoint | WS snapshot at stop (goroutines / parent links / threads) |
| --- | --- | --- |
| 1 | `level1-loop/main.go:9` | 6 / 5 / 5 |
| 2 | `level2-channel/main.go:14` | 7 / 6 / 5 |
| 3 | `level3-worker-pool/main.go:20` | 9 / 8 / 6 |
| 4 | `level4-pipeline/main.go:43` | 9 / 8 / 5 |
| 5 | `level5-workflow/main.go:83` | 12 / 11 / 6 |

Counts include Go runtime goroutines and are evidence only, not brittle assertions. After the final DAP/WS disconnect, the shared server logged `managed server idle timeout elapsed` and exited cleanly after its 15-second server-owned grace; it was not signaled or killed.

**VS Code UI boundary:** direct UI automation was unavailable, so the proof used the same bingo DAP wire path and independently parsed `.vscode/launch.json` to verify each picker option resolves to its exact built binary.

## CI

All hosted checks passed: build, unit tests, Linux ptrace, Darwin Mach exceptions, both full-stack jobs, both VS Code package jobs, Darwin verification gate, CodeQL, SonarCloud, and action/workflow analysis.