### PR TITLE
feat(vscode): add graphical concurrency view

### DIFF
--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -77,7 +77,11 @@ jobs:
         run: npm --prefix editors/vscode run package:verify
 
       - name: Build progressive concurrency targets
-        run: just build-examples
+        run: |
+          mkdir -p build/examples
+          for example in level1-loop level2-channel level3-worker-pool level4-pipeline level5-workflow; do
+            go build -gcflags="all=-N -l" -o "build/examples/${example}" "./examples/${example}"
+          done
 
       - name: Exercise packaged DAP and concurrency UI data path
         if: matrix.target == 'linux-x64' || runner.environment == 'self-hosted'

--- a/.github/workflows/vscode-extension.yml
+++ b/.github/workflows/vscode-extension.yml
@@ -12,7 +12,7 @@ jobs:
   package:
     name: Package ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 20
+    timeout-minutes: 35
     env:
       BINGO_VSCODE_TARGET: ${{ matrix.target }}
     strategy:
@@ -62,11 +62,30 @@ jobs:
       - name: Validate extension source
         run: npm --prefix editors/vscode run check
 
+      - name: Exercise activation, view, and custom-event acknowledgement
+        run: |
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            xvfb-run -a npm --prefix editors/vscode run test:integration
+          else
+            npm --prefix editors/vscode run test:integration
+          fi
+
       - name: Build reproducible native VSIX
         run: npm --prefix editors/vscode run package:reproducible
 
       - name: Verify exact package contents
         run: npm --prefix editors/vscode run package:verify
+
+      - name: Build progressive concurrency targets
+        run: just build-examples
+
+      - name: Exercise packaged DAP and concurrency UI data path
+        if: matrix.target == 'linux-x64' || runner.environment == 'self-hosted'
+        run: npm --prefix editors/vscode run e2e:packaged
+
+      - name: Explain hosted Darwin native-debug gate
+        if: matrix.target == 'darwin-arm64' && runner.environment != 'self-hosted'
+        run: echo "Packaged Darwin runtime execution requires a self-hosted Apple Silicon runner; compile, signature, entitlements, package, and Electron UI remain verified here."
 
       - name: Smoke packaged server health and idle exit
         if: matrix.target == 'linux-x64' || runner.arch == 'ARM64'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ follow them so reviews stay about substance, not style.
 | [internal/server](internal/server/) | HTTP/WebSocket entry. `Server`, `sessionStore`, `/api/sessions` and `/ws` handlers. |
 | [internal/hub](internal/hub/) | Per-session bridge between connected clients and one `Debugger`. |
 | [internal/dap](internal/dap/) | Debug Adapter Protocol translator. A `Handler` implements `hub.WSConn`, so a DAP/IDE client plugs into a hub session as just another client (ZERO hub changes). |
+| [internal/dapclient](internal/dapclient/) | Lightweight DAP decoder shared by in-repo clients so namespaced bingo events coexist with standard go-dap messages. |
 | [internal/debugger](internal/debugger/) | The actual debugger. Engine + per-platform Backend. |
 | [test/integration](test/integration/) | Ginkgo suite. Placeholder specs + the platform-split debugger E2E acceptance tests (`e2e` build tag). |
 
@@ -881,7 +882,8 @@ wire protocol or `launchConfig`.
 **VS Code connect-or-start invariants.** Default `serverMode:"auto"` is local
 only: management `127.0.0.1:6060`, DAP `127.0.0.1:4711`, readiness 5s, managed
 idle grace 30s. It health-checks before spawning and requires
-`service:"bingo"`, management API 1, the exact wire version, enabled DAP, and
+`service:"bingo"`, management API 1, the exact wire version, enabled DAP,
+`dap.sessionEventVersion:1`, and
 the expected DAP port/host (wildcard advertised hosts retain the configured
 connect host). Only connection refusal permits spawning; a non-bingo or
 incompatible occupant fails safely. `connectOnly` bypasses management and spawn
@@ -917,7 +919,7 @@ target metadata, architecture, mode, and entitlements.
 The extension package version is the installed-runtime upgrade boundary:
 material shipped behavior changes must bump both `package.json` and the lockfile
 or VS Code can retain an older bundle under the same identity. The manifest test
-and package verifier pin the current version (**0.3.0**) in source and VSIX
+and package verifier pin the current version (**0.3.1**) in source and VSIX
 metadata.
 The root Run and Debug dropdown exposes exactly two `"type":"bingo"` choices:
 launch one of five progressive examples through a `pickString`, and join a
@@ -977,7 +979,11 @@ the adapter emits exactly one custom DAP event named `bingo/session/v1` with
 body `{"version":1,"sessionId":"…"}` and preserves the console announcement.
 It emits neither event on create/join failure. `sessionAnnounced` is claimed
 under `mu`, but the event write occurs after unlocking, preserving the
-no-lock-across-socket-write invariant. The VS Code extension subscribes at
+no-lock-across-socket-write invariant. Go DAP clients must read through
+`internal/dapclient`, which recognizes this namespaced event before delegating
+standard messages to go-dap; `cmd/dapcli` and the native E2E client share that
+path. The VS
+Code extension subscribes at
 activation and keys observers by `DebugSession.id`, never
 `activeDebugSession`.
 
@@ -988,12 +994,18 @@ payload/string/count limits and seq gaps, and reconnects only while the DAP
 session lives. It sends `CmdGoroutineSnapshot` once after every successful
 WebSocket join and thereafter only for explicit Refresh—never run control.
 The recreatable webview receives validated view models through a
-ready/rendered-ack protocol. A fresh `ready` resets any in-flight revision
+ready/rendered-ack protocol. Every document has a generation token; async
+`postMessage` completions may mutate delivery state only while their captured
+view and generation are current, even when an old and new render share a
+revision. A fresh `ready` resets any in-flight revision
 because a hidden non-retained webview may have discarded its prior delivery;
 otherwise the host can wait forever for an acknowledgement from a dead document.
-Preserve the strict nonce CSP, `dist`-only
-`localResourceRoots`, DOM/textContent rendering, deterministic capped
-cycle-safe tree, bounded lifecycle history, and multi-session selector.
+Preserve the strict nonce CSP, `dist`-only `localResourceRoots`,
+DOM/textContent rendering, deterministic capped cycle-safe tree, bounded
+lifecycle history, and multi-session selector. Filtering re-lays out a bounded
+matching subtree (match plus at most four ancestors) and resets fit so a deep
+match cannot remain subpixel in the original 500-node viewBox. SVG treeitems
+carry `aria-level`, sibling position/size, selection, and parent context.
 
 ### Handshake (Delve-style, VS Code-compatible)
 
@@ -1138,7 +1150,10 @@ non-cacheable process-discovery endpoint frontends use for connect-or-start. Its
 explicit JSON response carries `service:"bingo"`, `managementApiVersion:1`, the
 independent `wireProtocolVersion` from `pkg/protocol.Version`, a per-process
 UUID `instanceId`, the enabled/resolved DAP listener address, managed-idle
-configuration in milliseconds, and the current session count. Management API
+configuration in milliseconds, and the current session count. The DAP object
+also advertises `sessionEventVersion:1`; graphical clients require it before
+reusing a managed server because older API-v1/wire-v1.2 servers do not emit the
+`bingo/session/v1` discovery event. Management API
 compatibility and WebSocket wire compatibility are separate checks: changing
 one does not implicitly version the other. A DAP bind to `:0` MUST publish the
 actual listener address, never the unresolved configured address. Health
@@ -1477,6 +1492,10 @@ through the justfile.
   of the wire protocol. Bump it for incompatible `/api/health` or management
   semantics, keep the response structs/tags and README example aligned, and
   preserve no-cache + GET-only behavior.
+- **DAP session discovery**: when the `bingo/session/v1` body contract changes,
+  bump `protocol.DAPSessionEventVersion`, the `dap.sessionEventVersion` health
+  capability, the extension compatibility check, and the shared
+  `internal/dapclient` decoder/tests together.
 - **Goroutine snapshot layout**: the reader resolves runtime struct offsets from
   DWARF **by name** (`goroutines.go`), never hardcoded. If you add a field, add
   it to `goLayout`/`resolveGoLayout`; a missing *required* offset invalidates the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ follow them so reviews stay about substance, not style.
 | [cmd/cli](cmd/cli/) | Interactive readline client. |
 | [cmd/dapcli](cmd/dapcli/) | Interactive readline client that drives a session over DAP (mirrors `cmd/cli`'s UX). Talks to the server's `-dap-addr` listener; can create a session or `-session` join an existing one. |
 | [cmd/wsmon](cmd/wsmon/) | Read-only terminal telemetry observer. `-session`-joins a running session over WebSocket and live-renders the goroutine spawn tree + OS threads + created/exited lifecycle deltas from the `EventGoroutineSnapshot` stream. Never drives execution — the WS-observes half of the DAP-drives/WS-observes demo. |
-| [editors/vscode](editors/vscode/) | Platform-packaged TypeScript companion extension. Owns VS Code debugger type `bingo`, enables Go breakpoints, and reuses or starts a compatible shared bingo server before connecting the built-in Debug UI to DAP. |
+| [editors/vscode](editors/vscode/) | Platform-packaged TypeScript companion extension. Owns debugger type `bingo`, manages the shared server, and hosts the read-only Bingo Concurrency Activity Bar WebSocket observer. |
 | [cmd/target](cmd/target/) | Trivial target program for manual testing. |
 | [examples/level1-loop](examples/level1-loop/) … [examples/level5-workflow](examples/level5-workflow/) | Progressive debugger targets, selected by the root VS Code launch picker and built together with `just build-examples` (see [examples/README.md](examples/README.md)). |
 | [examples/spawntree](examples/spawntree/) | Concurrency demo target: a deterministic main → supervisor → worker×N goroutine spawn tree for exercising the telemetry stream (see [docs/ConcurrencyTelemetry.md](docs/ConcurrencyTelemetry.md)). |
@@ -624,13 +624,15 @@ translating it would corrupt the FIFO that correlates a DAP `threads` request to
 clients get goroutine data from the `threads` request (`EventGoroutines`, which
 now returns the rich list); the snapshot stream is WebSocket-only.
 
-**Reference observer + runbook.** [cmd/wsmon](cmd/wsmon/) is the reference
-WebSocket telemetry consumer: it `-session`-joins read-only and live-renders the
-spawn tree / thread set / lifecycle deltas from this stream (a UI-agnostic view
-of exactly the data a spawn-hierarchy visualization needs). The end-to-end
+**Observers + runbook.** The VS Code extension's Bingo Concurrency view is the
+graphical consumer; it joins from the DAP discovery event without user input.
+[cmd/wsmon](cmd/wsmon/) is the terminal fallback and joins with `-session`.
+Both are read-only and render the spawn tree / thread set / lifecycle deltas
+from this stream (a UI-agnostic view of exactly the data a spawn-hierarchy
+visualization needs). The end-to-end
 DAP-drives + WS-observes walkthrough — server, VS Code (or `cmd/dapcli`) driver,
-and `wsmon` against the [examples/spawntree](examples/spawntree/) target — is in
-[docs/ConcurrencyTelemetry.md](docs/ConcurrencyTelemetry.md).
+and either observer against the [examples/spawntree](examples/spawntree/)
+target — is in [docs/ConcurrencyTelemetry.md](docs/ConcurrencyTelemetry.md).
 
 **Lifecycle deltas.** `engine.prevGoids` (loop-thread-only, no lock, like
 `manualStopPending`) remembers the previous live goid set; `diffGoids` returns
@@ -910,11 +912,12 @@ VSIXes are platform-specific: `linux-x64` contains only linux/amd64 bingo;
 checks the target, and repairs executable mode if extraction lost it.
 Packaging rebuilds/signs twice and requires identical binary and VSIX hashes;
 tests drift-check service/API/wire constants against Go source and inspect exact
-archive contents, target metadata, architecture, mode, and entitlements.
+archive contents (one native binary plus the two bundles and original icon),
+target metadata, architecture, mode, and entitlements.
 The extension package version is the installed-runtime upgrade boundary:
 material shipped behavior changes must bump both `package.json` and the lockfile
 or VS Code can retain an older bundle under the same identity. The manifest test
-and package verifier pin the current version (**0.2.0**) in source and VSIX
+and package verifier pin the current version (**0.3.0**) in source and VSIX
 metadata.
 The root Run and Debug dropdown exposes exactly two `"type":"bingo"` choices:
 launch one of five progressive examples through a `pickString`, and join a
@@ -926,10 +929,14 @@ the CLI with
 outside the root launch configurations. The recipe restores the exact npm
 lockfile with lifecycle scripts disabled before building. The macOS packaging
 job uses the supported `macos-15` arm64 image, asserts `uname -m`, and runs the
-real packaged-server smoke. That smoke observes server-owned idle exit on
-success; only its failure path may SIGKILL the exact detached process group it
-created, then it must await exit before deleting the extracted package. This
-cleanup helper is test-only and must never enter extension production code.
+real packaged-server smoke. Both package matrix legs run the pinned Electron
+activation/view/custom-event acknowledgement test; linux additionally runs the
+real packaged DAP→WebSocket graphical-model E2E. Darwin native-debug execution
+requires local/self-hosted Apple Silicon, where the same E2E covers all five
+examples. Both tests observe server-owned idle exit on success. On failure the
+smoke may SIGKILL only the detached process group it created; the packaged E2E
+may signal only its exact captured server PID. Cleanup is test-only and must
+never enter extension production code.
 Apple's external linker can vary `LC_UUID` even for identical cgo inputs, but
 current dyld rejects binaries with `-no_uuid`; `normalize-mach-o-uuid.mjs`
 therefore derives a stable UUID from the unsigned Mach-O with its UUID and
@@ -963,6 +970,30 @@ guards coordination state; `writeMu` serialises socket writes + the DAP `seq`.
 `mu`, then take `writeMu`). go-dap's `WriteProtocolMessage` does not set `Seq`,
 so `send` stamps it via reflection (`setSeqField` walks anonymous-embedded
 structs for the int `Seq`).
+
+**Managed-session discovery event.** Immediately after `startSession` has
+successfully attached the DAP handler to a created or joined managed session,
+the adapter emits exactly one custom DAP event named `bingo/session/v1` with
+body `{"version":1,"sessionId":"…"}` and preserves the console announcement.
+It emits neither event on create/join failure. `sessionAnnounced` is claimed
+under `mu`, but the event write occurs after unlocking, preserving the
+no-lock-across-socket-write invariant. The VS Code extension subscribes at
+activation and keys observers by `DebugSession.id`, never
+`activeDebugSession`.
+
+**Concurrency webview ownership/security.** The extension host, not the
+webview, owns one bounded WebSocket observer/model per live DAP session. It
+reuses the normalized management endpoint, validates protocol 1.2 envelopes,
+payload/string/count limits and seq gaps, and reconnects only while the DAP
+session lives. It sends `CmdGoroutineSnapshot` once after every successful
+WebSocket join and thereafter only for explicit Refresh—never run control.
+The recreatable webview receives validated view models through a
+ready/rendered-ack protocol. A fresh `ready` resets any in-flight revision
+because a hidden non-retained webview may have discarded its prior delivery;
+otherwise the host can wait forever for an acknowledgement from a dead document.
+Preserve the strict nonce CSP, `dist`-only
+`localResourceRoots`, DOM/textContent rendering, deterministic capped
+cycle-safe tree, bounded lifecycle history, and multi-session selector.
 
 ### Handshake (Delve-style, VS Code-compatible)
 
@@ -1239,8 +1270,13 @@ translator keeps DAP entirely outside the hub — a strictly additive package.
   `fullstack-*` jobs of
   [debugger-e2e.yml](.github/workflows/debugger-e2e.yml).
 - VS Code: [editors/vscode](editors/vscode/) uses strict TypeScript unit tests
-  for endpoint/request validation plus manifest tests that pin debugger ownership,
-  Go breakpoint support, endpoint defaults, and launch/join/PID snippets. The
+  for endpoint/request validation, telemetry codecs/observer/reconnect/session
+  registry, tree normalization/layout/lifecycle, a real lightweight DOM renderer,
+  webview security/messages, and manifest/workspace/package contracts; a pinned
+  `@vscode/test-electron` run activates the real extension/view and acknowledges
+  a fake adapter's namespaced custom event, while `packagedE2E.ts` drives the
+  actual native packaged server, DAP, WebSocket observer, and graphical model.
+  The
   dedicated [vscode-extension.yml](.github/workflows/vscode-extension.yml)
   workflow lints, typechecks, tests, bundles, and builds the local VSIX without
   changing the Go CI jobs.
@@ -1393,6 +1429,8 @@ just vscode-dev                            # stage source extension + native ser
 just vscode-check                          # lint, typecheck, test, bundle, package-list smoke
 just vscode-package                        # writes verified dist/bingo-<platform>.vsix
 just vscode-install                        # explicitly installs/updates bingosuite.bingo
+npm --prefix editors/vscode run test:integration # pinned Electron activation/view/custom-event test
+npm --prefix editors/vscode run e2e:packaged     # real native packaged DAP + graphical telemetry path
 just e2e-linux                             # native linux/amd64 ptrace E2E (all labels)
 just e2e-darwin                            # native darwin/arm64 Mach-exception E2E (codesigned; all labels)
 # Filter to one label, e.g. only the correctness gate (package path must come

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -997,7 +997,9 @@ The recreatable webview receives validated view models through a
 ready/rendered-ack protocol. Every document has a generation token; async
 `postMessage` completions may mutate delivery state only while their captured
 view and generation are current, even when an old and new render share a
-revision. A fresh `ready` resets any in-flight revision
+revision. Rendered acknowledgements echo both generation and revision, so a
+destroyed document cannot acknowledge its replacement. A fresh `ready` resets
+any in-flight revision
 because a hidden non-retained webview may have discarded its prior delivery;
 otherwise the host can wait forever for an acknowledgement from a dead document.
 Preserve the strict nonce CSP, `dist`-only `localResourceRoots`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1004,10 +1004,13 @@ because a hidden non-retained webview may have discarded its prior delivery;
 otherwise the host can wait forever for an acknowledgement from a dead document.
 Preserve the strict nonce CSP, `dist`-only `localResourceRoots`,
 DOM/textContent rendering, deterministic capped cycle-safe tree, bounded
-lifecycle history, and multi-session selector. Filtering re-lays out a bounded
-matching subtree (match plus at most four ancestors) and resets fit so a deep
-match cannot remain subpixel in the original 500-node viewBox. SVG treeitems
-carry `aria-level`, sibling position/size, selection, and parent context.
+lifecycle history, and multi-session selector. Filtering searches the full
+validated snapshot (up to the protocol's 5,000-goroutine bound) before applying
+the 500-node rendering cap, re-lays out each match with at most four ancestors,
+and resets fit so a deep or previously capped match cannot remain invisible.
+Empty results keep Fit/zoom callbacks safe even without an SVG scene. SVG
+treeitems carry `aria-level`, sibling position/size, selection, and parent
+context; arrow navigation moves DOM focus with selection.
 
 ### Handshake (Delve-style, VS Code-compatible)
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Build and install the repository's companion extension:
 just vscode-install
 ```
 
-The managed-server/autostart runtime requires extension version **0.2.0 or
+The graphical concurrency runtime requires extension version **0.3.0 or
 newer**. After installing or updating the VSIX, run **Developer: Reload Window**
 once so the current extension host activates the new bundle.
 
@@ -155,6 +155,13 @@ from a terminal with
 `code --new-window --extensionDevelopmentPath="$PWD/editors/vscode" "$PWD"`.
 Compatible manually-started servers remain supported and are reused.
 
+The **Bingo Concurrency** Activity Bar view is included in extension 0.3.0.
+Press F5, choose one of the five progressive examples, and the view
+automatically follows the exact DAP-created session over WebSocket—no session
+ID copy is needed. It visualizes the goroutine spawn tree, OS threads, current
+goroutine, source locations, and bounded created/exited timeline while keeping
+all run control in VS Code's Debug UI.
+
 Other DAP clients can point at `127.0.0.1:4711`. The DAP client creates a
 managed session on `launch`/`attach`; WebSocket observers join that same session
 via `/ws?session=<id>` (the id is discoverable through `/api/sessions`, and the
@@ -180,8 +187,8 @@ with the announced session id.
 Alongside the DAP debug loop, BinGo streams **concurrency telemetry** over its
 native WebSocket protocol — a goroutine spawn hierarchy (parent/child linkage),
 the live OS-thread set, and per-stop created/exited goroutine lifecycle deltas —
-so any UI can build a concurrency view on top of the data. `cmd/wsmon` is a
-read-only terminal observer that joins a session and live-renders these streams:
+so UIs can build concurrency views on top of the data. The VS Code extension
+joins automatically; `cmd/wsmon` remains the read-only terminal fallback:
 
 ```sh
 go run ./cmd/wsmon -session <id>  # connects to -addr localhost:6060 by default

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Frontends can identify and reuse a compatible bingo process through
   "instanceId": "4dd4dfdd-7f55-41a5-bd95-c086ce6f3c2a",
   "dap": {
     "enabled": true,
-    "address": "0.0.0.0:4711"
+    "address": "0.0.0.0:4711",
+    "sessionEventVersion": 1
   },
   "managedIdleShutdown": {
     "enabled": false,
@@ -78,7 +79,9 @@ Frontends can identify and reuse a compatible bingo process through
 The response is non-cacheable. `managementApiVersion` versions this HTTP
 contract independently of `wireProtocolVersion`; integrations should require
 management API v1 and separately check that they support the advertised bingo
-wire version. `instanceId` changes on every process start. The DAP address is the
+wire version. Graphical clients also require `dap.sessionEventVersion: 1`,
+which guarantees the server emits `bingo/session/v1` after managed session
+discovery. `instanceId` changes on every process start. The DAP address is the
 actual bound listener address, including the selected port when bingo was
 started with `-dap-addr ...:0`.
 
@@ -112,7 +115,7 @@ Build and install the repository's companion extension:
 just vscode-install
 ```
 
-The graphical concurrency runtime requires extension version **0.3.0 or
+The capability-safe graphical concurrency runtime requires extension version **0.3.1 or
 newer**. After installing or updating the VSIX, run **Developer: Reload Window**
 once so the current extension host activates the new bundle.
 
@@ -155,7 +158,8 @@ from a terminal with
 `code --new-window --extensionDevelopmentPath="$PWD/editors/vscode" "$PWD"`.
 Compatible manually-started servers remain supported and are reused.
 
-The **Bingo Concurrency** Activity Bar view is included in extension 0.3.0.
+The **Bingo Concurrency** Activity Bar view was introduced in 0.3.0; use 0.3.1
+or newer so managed-server reuse requires the session-discovery capability.
 Press F5, choose one of the five progressive examples, and the view
 automatically follows the exact DAP-created session over WebSocket—no session
 ID copy is needed. It visualizes the goroutine spawn tree, OS threads, current

--- a/cmd/dapcli/main.go
+++ b/cmd/dapcli/main.go
@@ -13,8 +13,8 @@
 //
 // Without -session the session is created lazily by the first `launch`/`attach`
 // command (the DAP model has no standalone "create empty session" request). The
-// adapter prints the new session id on an `output` event so other clients can
-// join it.
+// adapter publishes the new session id on `bingo/session/v1` (and preserves its
+// console output) so other clients can join it.
 package main
 
 import (
@@ -30,6 +30,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bingosuite/bingo/internal/dapclient"
+	"github.com/bingosuite/bingo/pkg/protocol"
 	"github.com/chzyer/readline"
 	godap "github.com/google/go-dap"
 )
@@ -279,7 +281,7 @@ func (h *dapCLI) dispatch(args []string) bool {
 // handshake-driven) until the connection closes.
 func (h *dapCLI) readLoop() {
 	for {
-		msg, err := godap.ReadProtocolMessage(h.reader)
+		msg, err := readDAPMessage(h.reader)
 		if err != nil {
 			h.failPending()
 			if !isClosed(err) {
@@ -296,6 +298,10 @@ func (h *dapCLI) readLoop() {
 			h.onEvent(m)
 		}
 	}
+}
+
+func readDAPMessage(reader *bufio.Reader) (godap.Message, error) {
+	return dapclient.ReadProtocolMessage(reader)
 }
 
 func (h *dapCLI) onResponse(rm godap.ResponseMessage, msg godap.Message) {
@@ -383,6 +389,12 @@ func (h *dapCLI) close() { _ = h.conn.Close() }
 
 func (h *dapCLI) onEvent(em godap.EventMessage) {
 	switch e := em.(type) {
+	case *dapclient.SessionEvent:
+		if e.Body.Version == protocol.DAPSessionEventVersion &&
+			e.Body.SessionID != "" {
+			h.setSessionID(e.Body.SessionID)
+			h.printAsync("[session] " + e.Body.SessionID)
+		}
 	case *godap.InitializedEvent:
 		h.printAsync("[initialized] session ready")
 		go h.onInitialized()

--- a/cmd/dapcli/main_test.go
+++ b/cmd/dapcli/main_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/bingosuite/bingo/internal/dapclient"
+	"github.com/bingosuite/bingo/pkg/protocol"
+	godap "github.com/google/go-dap"
+	. "github.com/onsi/gomega"
+)
+
+func TestReadDAPMessageAcceptsSessionAnnouncement(t *testing.T) {
+	g := NewWithT(t)
+	var stream bytes.Buffer
+	writeDAPFrame(&stream, fmt.Sprintf(
+		`{"seq":1,"type":"event","event":%q,"body":{"version":%d,"sessionId":"session-1"}}`,
+		protocol.DAPSessionEventName,
+		protocol.DAPSessionEventVersion,
+	))
+	writeDAPFrame(&stream, `{"seq":2,"type":"event","event":"initialized"}`)
+	reader := bufio.NewReader(&stream)
+
+	message, err := readDAPMessage(reader)
+	g.Expect(err).NotTo(HaveOccurred())
+	announcement, ok := message.(*dapclient.SessionEvent)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(announcement.Event.Event).To(Equal(protocol.DAPSessionEventName))
+	g.Expect(announcement.Body.Version).To(Equal(protocol.DAPSessionEventVersion))
+	g.Expect(announcement.Body.SessionID).To(Equal("session-1"))
+
+	message, err = readDAPMessage(reader)
+	g.Expect(err).NotTo(HaveOccurred())
+	_, ok = message.(*godap.InitializedEvent)
+	g.Expect(ok).To(BeTrue())
+}
+
+func TestReadLoopContinuesAfterSessionAnnouncement(t *testing.T) {
+	g := NewWithT(t)
+	server, client := net.Pipe()
+	t.Cleanup(func() {
+		_ = server.Close()
+		_ = client.Close()
+	})
+
+	response := make(chan godap.Message, 1)
+	h := &dapCLI{
+		conn:      client,
+		reader:    bufio.NewReader(client),
+		pending:   map[int]chan godap.Message{7: response},
+		bpsByFile: make(map[string][]breakpoint),
+	}
+	go h.readLoop()
+
+	go func() {
+		writeDAPFrameTo(server, fmt.Sprintf(
+			`{"seq":1,"type":"event","event":%q,"body":{"version":%d,"sessionId":"session-live"}}`,
+			protocol.DAPSessionEventName,
+			protocol.DAPSessionEventVersion,
+		))
+		_ = godap.WriteProtocolMessage(server, &godap.InitializeResponse{
+			Response: godap.Response{
+				ProtocolMessage: godap.ProtocolMessage{Seq: 2, Type: "response"},
+				RequestSeq:      7,
+				Success:         true,
+				Command:         "initialize",
+			},
+		})
+	}()
+
+	select {
+	case message := <-response:
+		_, ok := message.(*godap.InitializeResponse)
+		g.Expect(ok).To(BeTrue())
+	case <-time.After(time.Second):
+		t.Fatal("normal response was not delivered after custom event")
+	}
+	g.Eventually(func() string {
+		h.stateMu.Lock()
+		defer h.stateMu.Unlock()
+		return h.sessionID
+	}).WithTimeout(time.Second).Should(Equal("session-live"))
+}
+
+func writeDAPFrame(buffer *bytes.Buffer, content string) {
+	_, _ = fmt.Fprintf(buffer, "Content-Length: %d\r\n\r\n%s", len(content), content)
+}
+
+func writeDAPFrameTo(writer net.Conn, content string) {
+	_, _ = fmt.Fprintf(writer, "Content-Length: %d\r\n\r\n%s", len(content), content)
+}

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -10,14 +10,14 @@ bingo speaks two protocols against **one** debug session at the same time:
   the OS-thread set, and created/exited lifecycle deltas — streams here as
   `EventGoroutineSnapshot`.
 
-This runbook wires both together A–Z: a server, a **DAP driver** (VS Code or
-`cmd/dapcli`), and a terminal **WS observer** (`cmd/wsmon`) that live-renders the
-telemetry while the driver steps through a goroutine spawn tree.
+The VS Code 0.3.0 extension wires both together automatically: DAP drives while
+the **Bingo Concurrency** Activity Bar view observes the exact session over
+WebSocket. `cmd/wsmon` remains the terminal observer for non-VS Code workflows.
 
 ```
              drives (DAP :4711)                observes (WS :6060)
-  VS Code  ─────────────────────►  bingo server  ◄─────────────────  cmd/wsmon
-  / dapcli                          (one session)                    (spawn tree,
+  VS Code  ─────────────────────►  bingo server  ◄─────────────────  Concurrency view
+  / dapcli                          (one session)                    / cmd/wsmon
                                           │                            threads,
                                           ▼                            lifecycle)
                                     spawntree tracee
@@ -40,7 +40,7 @@ architecture behind this.
   just vscode-install
   ```
 
-  Managed server autostart requires **bingosuite.bingo 0.2.0 or newer**. Run
+  Automatic graphical telemetry requires **bingosuite.bingo 0.3.0 or newer**. Run
   **Developer: Reload Window** once after installation or update. The companion
   owns debugger type `"bingo"` and connects directly to bingo's DAP listener;
   it neither invokes nor validates `dlv`, and it does not replace the Go
@@ -80,9 +80,12 @@ It is intentionally absent from the root Run and Debug dropdown.
    `build/examples/level5-workflow` and stops at entry.
 4. Set a breakpoint on `examples/level5-workflow/main.go:83` and **Continue** —
    the tracee stops with several workflow and stage goroutines alive.
-5. Grab the **session id** so the observer can join: it is printed in the bingo
-   DAP `console` output and is listed by
-   `curl -s 127.0.0.1:6060/api/sessions`.
+5. Open **Bingo Concurrency** in the Activity Bar. The DAP adapter publishes the
+   versioned `bingo/session/v1` custom event after session attachment, and the
+   extension joins it automatically. No session-id copy is required.
+6. Search/select nodes, inspect current/start/creation locations and threads,
+   or use the title-bar Refresh/Fit actions. The first graphical session
+   auto-reveals unless `bingo.concurrency.autoReveal` is disabled.
 
 No manual `just server` is required. The extension never kills the shared
 process. The default managed server exits only after its 30-second idle grace
@@ -121,7 +124,7 @@ c                             # continue → hits the breakpoint
 `dapcli` prints the session id it created (also on the server console). Continue
 again to churn rounds; each stop pushes a fresh telemetry snapshot to observers.
 
-## 4. Observe the telemetry with cmd/wsmon
+## 4. Terminal fallback with cmd/wsmon
 
 In another terminal, join the **same session id** read-only and watch it update:
 
@@ -145,7 +148,10 @@ repaints with the new round's workers — the plumbing, end to end.
 
 - `wsmon` is a pure observer: it never sends run-control commands, so it cannot
   disturb the DAP driver. Many `wsmon` + DAP clients can share one session.
+- The graphical observer is also read-only. It sends exactly one on-demand
+  snapshot request after joining and on explicit Refresh only.
 - Snapshots stream on **breakpoint / pause / entry**, not per single-step (steps
   stay cheap). Use the driver's breakpoints/continue to advance between frames.
 - If the tracee is a stripped binary or stopped before runtime init, the snapshot
-  degrades to a single synthetic goroutine; `wsmon` renders whatever is present.
+  degrades to a single synthetic goroutine; both observers render the degraded
+  state rather than failing the debug session.

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -10,7 +10,7 @@ bingo speaks two protocols against **one** debug session at the same time:
   the OS-thread set, and created/exited lifecycle deltas — streams here as
   `EventGoroutineSnapshot`.
 
-The VS Code 0.3.0 extension wires both together automatically: DAP drives while
+The VS Code 0.3.1 extension wires both together automatically: DAP drives while
 the **Bingo Concurrency** Activity Bar view observes the exact session over
 WebSocket. `cmd/wsmon` remains the terminal observer for non-VS Code workflows.
 
@@ -40,7 +40,7 @@ architecture behind this.
   just vscode-install
   ```
 
-  Automatic graphical telemetry requires **bingosuite.bingo 0.3.0 or newer**. Run
+  Automatic graphical telemetry requires **bingosuite.bingo 0.3.1 or newer**. Run
   **Developer: Reload Window** once after installation or update. The companion
   owns debugger type `"bingo"` and connects directly to bingo's DAP listener;
   it neither invokes nor validates `dlv`, and it does not replace the Go

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -8,3 +8,4 @@ scripts/**
 tsconfig.json
 node_modules/**
 dist/**/*.map
+dist/test/**

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -77,7 +77,9 @@ in the selector; the status bar shows active goroutine/thread counts.
 
 - Pan, zoom, fit, search, and keyboard arrows navigate the deterministic spawn
   tree. Parent links, current state, status, and thread badges remain stable
-  across updates, including missing-parent and cyclic runtime data.
+  across updates, including missing-parent and cyclic runtime data. Search runs
+  against the full validated snapshot before the 500-node rendering cap, then
+  fits a bounded match/ancestor layout.
 - Selecting a goroutine shows wait reason, thread, and current/start/creation
   source locations. Thread cards and a bounded created/exited timeline provide
   physical and lifecycle context.
@@ -94,6 +96,8 @@ once. Disable it to keep the view in the background. Connection, degraded,
 empty, sequence-gap, and error states remain visible. Rendering uses a strict
 nonce CSP, local bundles only, DOM `textContent` for tracee strings, VS Code
 theme/high-contrast colors, labelled controls, and keyboard selection.
+Treeitems expose hierarchy level, parent context, sibling position, selection,
+and synchronized keyboard focus to assistive technology.
 
 ## Configurations
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -20,7 +20,8 @@ just vscode-install
 ```
 
 This builds, verifies, and installs `dist/bingo-<platform>.vsix`. The graphical
-concurrency view ships in **0.3.0**. Rerun the command to update, then run
+concurrency view debuted in 0.3.0; **0.3.1** adds capability-safe managed-server
+reuse and is the minimum supported version. Rerun the command to update, then run
 **Developer: Reload Window** once so the active extension host loads the new
 bundle. Package without installing with `just vscode-package`. Uninstall with:
 
@@ -47,6 +48,10 @@ separate server-start or extension-host choice. In the default `auto` mode the e
 4. waits up to five seconds for compatible health, then connects VS Code to DAP;
 5. receives the DAP adapter's `bingo/session/v1` event and automatically joins
    that exact managed session over WebSocket in **Bingo Concurrency**.
+
+Compatible health must advertise `dap.sessionEventVersion: 1`; an older server
+that lacks managed-session discovery is reported as incompatible and is never
+reused or replaced while it occupies the configured endpoint.
 
 Concurrent VS Code extension hosts may both try to start. Listener binding
 chooses the winner; a child that loses the race is harmless because both hosts

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -19,9 +19,8 @@ From the repository root on a supported host:
 just vscode-install
 ```
 
-This builds, verifies, and installs `dist/bingo-<platform>.vsix`. Managed local
-server autostart first ships in **0.2.0**; older `0.1.0` installs are
-connect-only and must be upgraded. Rerun the command to update, then run
+This builds, verifies, and installs `dist/bingo-<platform>.vsix`. The graphical
+concurrency view ships in **0.3.0**. Rerun the command to update, then run
 **Developer: Reload Window** once so the active extension host loads the new
 bundle. Package without installing with `just vscode-package`. Uninstall with:
 
@@ -45,7 +44,9 @@ separate server-start or extension-host choice. In the default `auto` mode the e
 3. if and only if the endpoint refuses the connection, starts its bundled
    server with management on `127.0.0.1:6060`, DAP on
    `127.0.0.1:4711`, and a 30-second server-owned idle grace;
-4. waits up to five seconds for compatible health, then connects VS Code to DAP.
+4. waits up to five seconds for compatible health, then connects VS Code to DAP;
+5. receives the DAP adapter's `bingo/session/v1` event and automatically joins
+   that exact managed session over WebSocket in **Bingo Concurrency**.
 
 Concurrent VS Code extension hosts may both try to start. Listener binding
 chooses the winner; a child that loses the race is harmless because both hosts
@@ -61,6 +62,33 @@ WebSocket clients can share the process safely.
 If the management port answers with non-bingo HTTP or an incompatible bingo,
 F5 fails without spawning over it. Errors include the endpoints and server log
 path.
+
+## Bingo Concurrency
+
+The Bingo Activity Bar icon opens a session-aware graphical observer. The
+extension host owns the WebSocket and validated model, so hiding or recreating
+the webview does not lose the latest snapshot. Multiple debug sessions appear
+in the selector; the status bar shows active goroutine/thread counts.
+
+- Pan, zoom, fit, search, and keyboard arrows navigate the deterministic spawn
+  tree. Parent links, current state, status, and thread badges remain stable
+  across updates, including missing-parent and cyclic runtime data.
+- Selecting a goroutine shows wait reason, thread, and current/start/creation
+  source locations. Thread cards and a bounded created/exited timeline provide
+  physical and lifecycle context.
+- Snapshots arrive at entry, breakpoints, and pauses—not per step. The view sends
+  one read-only `GoroutineSnapshot` request after joining and only sends another
+  when **Refresh** is explicit. It never sends run-control commands.
+- **Bingo: Copy Concurrency Snapshot** copies validated JSON. **Select
+  Concurrency Session**, **Refresh**, and **Fit** are available from the
+  Command Palette; the Activity Bar icon and status item focus the view through
+  VS Code's generated `bingo.concurrency.focus` command.
+
+`bingo.concurrency.autoReveal` defaults to `true` and reveals the first session
+once. Disable it to keep the view in the background. Connection, degraded,
+empty, sequence-gap, and error states remain visible. Rendering uses a strict
+nonce CSP, local bundles only, DOM `textContent` for tracee strings, VS Code
+theme/high-contrast colors, labelled controls, and keyboard selection.
 
 ## Configurations
 
@@ -159,8 +187,8 @@ or any custom host, explicitly select connect-only mode:
 
 Connect-only mode does not probe management health, inspect a bundled binary, or
 spawn. Start and secure the reachable bingo server through that environment's
-normal process manager. A future bingo UI can use the same management contract;
-no such UI is included in this extension.
+normal process manager. The concurrency observer uses the same configured
+management host/port for its WebSocket connection.
 
 ## Manual server option
 
@@ -178,6 +206,8 @@ just server
 just vscode-dev       # build extension, native bundled server, and examples
 just vscode-check     # clean install, lint, typecheck, tests, bundle/list smoke
 just vscode-package   # native reproducible package + content verification
+npm --prefix editors/vscode run test:integration # isolated Electron view/event acknowledgement
+npm --prefix editors/vscode run e2e:packaged     # actual packaged server + DAP + WS graphical model
 ```
 
 `just vscode-dev` restores the exact npm lockfile with lifecycle scripts
@@ -195,6 +225,12 @@ debugging instead uses the installed VSIX and runs only
 **bingo: build examples**, so F5 does not rebuild or codesign the
 extension-local server.
 
+The packaged E2E reserves unique loopback management/DAP ports, proves
+compatible-instance reuse without a competing spawn, drives levels 1–5 (with a
+nested level-5 tree), exercises select/filter/copy/refresh, and waits for the
+managed server to exit by its idle policy. It signals only its exact captured
+server PID, and only on failure.
+
 ## Troubleshooting
 
 - **Unsupported platform:** auto mode packages only linux/x64 and darwin/arm64.
@@ -206,3 +242,7 @@ extension-local server.
 - **Remote endpoint rejected:** set `"serverMode": "connectOnly"`.
 - **Server remains after VS Code closes:** expected while another session is
   active or during the idle grace. The extension never sends a kill signal.
+- **Concurrency view is empty:** stop at entry, a breakpoint, or Pause, then use
+  **Bingo: Refresh Concurrency Snapshot**. Stripped/pre-runtime targets can
+  degrade to a synthetic single goroutine. `cmd/wsmon` remains available as a
+  terminal observer.

--- a/editors/vscode/media/bingo-activity.svg
+++ b/editors/vscode/media/bingo-activity.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M4 5.5h5l3 4h8v9H4z" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"/>
+  <circle cx="8" cy="14" r="1.8" fill="currentColor"/>
+  <circle cx="16" cy="14" r="1.8" fill="currentColor"/>
+  <path d="M9.8 14h4.4M12 9.5V7" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/>
+</svg>

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,20 +1,26 @@
 {
   "name": "bingo",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bingo",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
+      "dependencies": {
+        "ws": "8.18.3"
+      },
       "devDependencies": {
         "@eslint/js": "9.39.5",
         "@types/node": "22.20.1",
         "@types/vscode": "1.85.0",
+        "@types/ws": "8.18.1",
+        "@vscode/test-electron": "3.1.0",
         "@vscode/vsce": "3.9.2",
         "esbuild": "0.28.1",
         "eslint": "9.39.5",
+        "linkedom": "0.18.12",
         "tsx": "4.23.9",
         "typescript": "5.9.3",
         "typescript-eslint": "8.66.0"
@@ -1328,6 +1334,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.66.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
@@ -1584,6 +1600,23 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@vscode/test-electron": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "jszip": "^3.10.1",
+        "ora": "^8.1.0",
+        "semver": "^7.6.2"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@vscode/vsce": {
@@ -2178,6 +2211,35 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cockatiel": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
@@ -2238,6 +2300,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2282,6 +2351,13 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3090,6 +3166,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3297,6 +3386,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
@@ -3403,6 +3499,13 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3448,8 +3551,7 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -3527,6 +3629,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3535,6 +3650,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-wsl": {
@@ -3552,6 +3680,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3685,6 +3820,52 @@
         "npm": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -3753,6 +3934,41 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/linkedom": {
+      "version": "0.18.12",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.12.tgz",
+      "integrity": "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.0.0",
+        "uhyphen": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": ">= 2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/linkify-it": {
@@ -3860,6 +4076,49 @@
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
+      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "is-unicode-supported": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -3977,6 +4236,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -4175,6 +4447,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/open": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
@@ -4210,6 +4498,68 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
+      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^2.9.2",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.0.0",
+        "log-symbols": "^6.0.0",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-limit": {
@@ -4256,6 +4606,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -4497,6 +4854,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -4690,6 +5054,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -4811,6 +5192,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4908,6 +5296,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/simple-concat": {
@@ -5025,6 +5426,19 @@
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -5473,6 +5887,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/underscore": {
       "version": "1.13.8",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
@@ -5542,8 +5963,7 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -5626,6 +6046,27 @@
       "dev": true,
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bingo",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bingo",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "ws": "8.18.3"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,8 +1,8 @@
 {
   "name": "bingo",
   "displayName": "bingo Debugger",
-  "description": "Connect VS Code's Debug UI to bingo, reusing or starting a managed local server.",
-  "version": "0.2.0",
+  "description": "Debug Go concurrency with bingo's DAP adapter and live goroutine visualization.",
+  "version": "0.3.0",
   "publisher": "bingosuite",
   "license": "MIT",
   "private": true,
@@ -30,7 +30,8 @@
   },
   "main": "./dist/extension.js",
   "activationEvents": [
-    "onDebugResolve:bingo"
+    "onDebug",
+    "onView:bingo.concurrency"
   ],
   "capabilities": {
     "untrustedWorkspaces": {
@@ -39,6 +40,69 @@
     }
   },
   "contributes": {
+    "commands": [
+      {
+        "command": "bingo.concurrency.refresh",
+        "title": "Bingo: Refresh Concurrency Snapshot",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "bingo.concurrency.selectSession",
+        "title": "Bingo: Select Concurrency Session"
+      },
+      {
+        "command": "bingo.concurrency.fit",
+        "title": "Bingo: Fit Concurrency Tree",
+        "icon": "$(screen-full)"
+      },
+      {
+        "command": "bingo.concurrency.copySnapshot",
+        "title": "Bingo: Copy Concurrency Snapshot"
+      }
+    ],
+    "configuration": {
+      "title": "Bingo",
+      "properties": {
+        "bingo.concurrency.autoReveal": {
+          "type": "boolean",
+          "default": true,
+          "description": "Reveal Bingo Concurrency when the first debug session publishes its telemetry session."
+        }
+      }
+    },
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "bingo",
+          "title": "Bingo",
+          "icon": "media/bingo-activity.svg"
+        }
+      ]
+    },
+    "views": {
+      "bingo": [
+        {
+          "id": "bingo.concurrency",
+          "name": "Bingo Concurrency",
+          "type": "webview",
+          "contextualTitle": "Bingo Concurrency"
+        }
+      ]
+    },
+    "menus": {
+      "view/title": [
+        {
+          "command": "bingo.concurrency.refresh",
+          "when": "view == bingo.concurrency",
+          "group": "navigation@1"
+        },
+        {
+          "command": "bingo.concurrency.fit",
+          "when": "view == bingo.concurrency",
+          "group": "navigation@2"
+        }
+      ]
+    },
     "breakpoints": [
       {
         "language": "go"
@@ -293,27 +357,37 @@
   },
   "scripts": {
     "binary:prepare": "node ./scripts/prepare-binary.mjs",
-    "build": "node ./scripts/clean.mjs && esbuild ./src/extension.ts --bundle --tsconfig=./tsconfig.json --external:vscode --format=cjs --platform=node --target=node18 --outfile=dist/extension.js",
+    "build": "node ./scripts/clean.mjs && esbuild ./src/extension.ts --bundle --tsconfig=./tsconfig.json --external:vscode --format=cjs --platform=node --target=node18 --outfile=dist/extension.js && esbuild ./src/webview.ts --bundle --tsconfig=./tsconfig.json --format=iife --platform=browser --target=es2022 --outfile=dist/webview.js && esbuild ./test/vscodeIntegration.ts --bundle --tsconfig=./tsconfig.json --external:vscode --format=cjs --platform=node --target=node18 --outfile=dist/test/vscodeIntegration.js",
     "check": "npm run lint && npm run typecheck && npm test && npm run build && npm run package:list",
+    "e2e:packaged": "tsx ./test/packagedE2E.ts",
     "lint": "eslint src test scripts",
     "package": "node ./scripts/package.mjs",
     "package:list": "vsce ls --tree",
     "package:reproducible": "node ./scripts/verify-reproducible.mjs",
     "package:verify": "node ./scripts/verify-package.mjs",
     "smoke:server": "node ./scripts/smoke-server.mjs",
-    "test": "tsx --test test/**/*.test.ts",
+    "test": "npm run test:unit",
+    "test:dom": "tsx --test ./test/webviewDom.test.ts",
+    "test:integration": "npm run build && node ./scripts/run-vscode-integration.mjs",
+    "test:unit": "tsx --test test/**/*.test.ts",
     "typecheck": "tsc --noEmit",
     "vscode:prepublish": "npm run build"
+  },
+  "dependencies": {
+    "ws": "8.18.3"
   },
   "devDependencies": {
     "@eslint/js": "9.39.5",
     "@types/node": "22.20.1",
     "@types/vscode": "1.85.0",
+    "@types/ws": "8.18.1",
+    "@vscode/test-electron": "3.1.0",
     "@vscode/vsce": "3.9.2",
     "esbuild": "0.28.1",
     "eslint": "9.39.5",
     "tsx": "4.23.9",
     "typescript": "5.9.3",
+    "linkedom": "0.18.12",
     "typescript-eslint": "8.66.0"
   },
   "packageManager": "npm@10.9.3"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "bingo",
   "displayName": "bingo Debugger",
   "description": "Debug Go concurrency with bingo's DAP adapter and live goroutine visualization.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "bingosuite",
   "license": "MIT",
   "private": true,

--- a/editors/vscode/scripts/package.mjs
+++ b/editors/vscode/scripts/package.mjs
@@ -13,30 +13,50 @@ const outputDirectory = fileURLToPath(
   new URL("../../../dist/", import.meta.url),
 );
 const outputPath = join(outputDirectory, `bingo-${target}.vsix`);
+const scratch = join(
+  outputDirectory,
+  `.package-bingo-${target}-${String(process.pid)}`,
+);
 mkdirSync(outputDirectory, { recursive: true });
 rmSync(outputPath, { force: true });
+rmSync(scratch, { force: true, recursive: true });
+mkdirSync(scratch, { recursive: true });
+const buildEnvironment = {
+  ...process.env,
+  TMPDIR: scratch,
+  TMP: scratch,
+  TEMP: scratch,
+};
 
-run(process.execPath, [fileURLToPath(new URL("./prepare-binary.mjs", import.meta.url))]);
+try {
+  run(
+    process.execPath,
+    [fileURLToPath(new URL("./prepare-binary.mjs", import.meta.url))],
+    buildEnvironment,
+  );
 
-const vsce = fileURLToPath(
-  new URL("../node_modules/@vscode/vsce/vsce", import.meta.url),
-);
-run(
-  process.execPath,
-  [
-    vsce,
-    "package",
-    "--no-dependencies",
-    "--target",
-    target,
-    "--out",
-    outputPath,
-  ],
-  {
-    ...process.env,
-    SOURCE_DATE_EPOCH: "946684800",
-  },
-);
+  const vsce = fileURLToPath(
+    new URL("../node_modules/@vscode/vsce/vsce", import.meta.url),
+  );
+  run(
+    process.execPath,
+    [
+      vsce,
+      "package",
+      "--no-dependencies",
+      "--target",
+      target,
+      "--out",
+      outputPath,
+    ],
+    {
+      ...buildEnvironment,
+      SOURCE_DATE_EPOCH: "946684800",
+    },
+  );
+} finally {
+  rmSync(scratch, { force: true, recursive: true });
+}
 
 log(`Packaged ${outputPath}`);
 

--- a/editors/vscode/scripts/platform.mjs
+++ b/editors/vscode/scripts/platform.mjs
@@ -53,9 +53,13 @@ function validateBuilder(target) {
     target === "darwin-arm64" &&
     process.platform === "darwin" &&
     process.arch === "x64";
-  if (!native && !darwinCrossBuild) {
+  const linuxCrossBuild =
+    target === "linux-x64" &&
+    process.platform === "darwin" &&
+    (process.arch === "arm64" || process.arch === "x64");
+  if (!native && !darwinCrossBuild && !linuxCrossBuild) {
     throw new Error(
-      `target ${target} requires ${details.platform}/${details.arch} or a darwin/x64 signing host, got ${process.platform}/${process.arch}`,
+      `target ${target} cannot be packaged from ${process.platform}/${process.arch}`,
     );
   }
 }

--- a/editors/vscode/scripts/run-vscode-integration.mjs
+++ b/editors/vscode/scripts/run-vscode-integration.mjs
@@ -1,0 +1,65 @@
+import { mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import process from "node:process";
+import { fileURLToPath, URL } from "node:url";
+
+import { runTests } from "@vscode/test-electron";
+
+const extensionRoot = fileURLToPath(new URL("../", import.meta.url));
+const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const scratch = join(
+  repositoryRoot,
+  "dist",
+  `.vscode-integration-${String(process.pid)}`,
+);
+const profile = join(
+  repositoryRoot,
+  "dist",
+  `.vu-${String(process.pid)}`,
+);
+const extensions = join(
+  repositoryRoot,
+  "dist",
+  `.ve-${String(process.pid)}`,
+);
+rmSync(scratch, { force: true, recursive: true });
+mkdirSync(scratch, { recursive: true });
+rmSync(profile, { force: true, recursive: true });
+rmSync(extensions, { force: true, recursive: true });
+mkdirSync(profile, { recursive: true });
+mkdirSync(extensions, { recursive: true });
+process.env.TMPDIR = scratch;
+process.env.TMP = scratch;
+process.env.TEMP = scratch;
+
+try {
+  await runTests({
+    version: "1.107.1",
+    cachePath: join(repositoryRoot, ".vscode-test"),
+    extensionDevelopmentPath: extensionRoot,
+    extensionTestsPath: join(
+      extensionRoot,
+      "dist",
+      "test",
+      "vscodeIntegration.js",
+    ),
+    launchArgs: [
+      repositoryRoot,
+      `--user-data-dir=${profile}`,
+      `--extensions-dir=${extensions}`,
+      "--disable-workspace-trust",
+      "--skip-release-notes",
+      "--skip-welcome",
+    ],
+    extensionTestsEnv: {
+      ...process.env,
+      TMPDIR: scratch,
+      TMP: scratch,
+      TEMP: scratch,
+    },
+  });
+} finally {
+  rmSync(scratch, { force: true, recursive: true });
+  rmSync(profile, { force: true, recursive: true });
+  rmSync(extensions, { force: true, recursive: true });
+}

--- a/editors/vscode/scripts/run-vscode-integration.mjs
+++ b/editors/vscode/scripts/run-vscode-integration.mjs
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import process from "node:process";
@@ -7,30 +8,32 @@ import { runTests } from "@vscode/test-electron";
 
 const extensionRoot = fileURLToPath(new URL("../", import.meta.url));
 const repositoryRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const runID = randomBytes(16).toString("hex");
 const scratch = join(
   repositoryRoot,
   "dist",
-  `.vscode-integration-${String(process.pid)}`,
+  `.vscode-integration-${runID}`,
 );
 const profile = join(
   repositoryRoot,
   "dist",
-  `.vu-${String(process.pid)}`,
+  `.vu-${runID}`,
 );
 const extensions = join(
   repositoryRoot,
   "dist",
-  `.ve-${String(process.pid)}`,
+  `.ve-${runID}`,
 );
 rmSync(scratch, { force: true, recursive: true });
-mkdirSync(scratch, { recursive: true });
+mkdirSync(scratch, { recursive: true, mode: 0o700 });
 rmSync(profile, { force: true, recursive: true });
 rmSync(extensions, { force: true, recursive: true });
-mkdirSync(profile, { recursive: true });
-mkdirSync(extensions, { recursive: true });
-process.env.TMPDIR = scratch;
-process.env.TMP = scratch;
-process.env.TEMP = scratch;
+mkdirSync(profile, { recursive: true, mode: 0o700 });
+mkdirSync(extensions, { recursive: true, mode: 0o700 });
+// The unpredictable, mode-0700 directory is private despite temp-variable heuristics.
+process.env.TMPDIR = scratch; // NOSONAR
+process.env.TMP = scratch; // NOSONAR
+process.env.TEMP = scratch; // NOSONAR
 
 try {
   await runTests({
@@ -53,9 +56,9 @@ try {
     ],
     extensionTestsEnv: {
       ...process.env,
-      TMPDIR: scratch,
-      TMP: scratch,
-      TEMP: scratch,
+      TMPDIR: scratch, // NOSONAR -- same private directory described above.
+      TMP: scratch, // NOSONAR
+      TEMP: scratch, // NOSONAR
     },
   });
 } finally {

--- a/editors/vscode/scripts/smoke-server.mjs
+++ b/editors/vscode/scripts/smoke-server.mjs
@@ -80,6 +80,7 @@ try {
     health.managementApiVersion !== 1 ||
     health.wireProtocolVersion !== "1.2" ||
     health.dap?.enabled !== true ||
+    health.dap.sessionEventVersion !== 1 ||
     health.dap.address !== `127.0.0.1:${String(dapPort)}` ||
     health.managedIdleShutdown?.enabled !== true ||
     health.managedIdleShutdown.timeoutMs !== idleTimeoutMs

--- a/editors/vscode/scripts/smoke-server.mjs
+++ b/editors/vscode/scripts/smoke-server.mjs
@@ -1,6 +1,6 @@
 import {
   closeSync,
-  mkdtempSync,
+  mkdirSync,
   openSync,
   rmSync,
 } from "node:fs";
@@ -8,8 +8,8 @@ import { Buffer } from "node:buffer";
 import { log } from "node:console";
 import { request } from "node:http";
 import { createServer } from "node:net";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import process from "node:process";
 import { setTimeout } from "node:timers";
 import { fileURLToPath, URL } from "node:url";
 import { spawn, spawnSync } from "node:child_process";
@@ -22,7 +22,15 @@ const target = currentTarget();
 const vsix = fileURLToPath(
   new URL(`../../../dist/bingo-${target}.vsix`, import.meta.url),
 );
-const extracted = mkdtempSync(join(tmpdir(), "bingo-smoke-"));
+const outputDirectory = fileURLToPath(
+  new URL("../../../dist/", import.meta.url),
+);
+const extracted = join(
+  outputDirectory,
+  `.smoke-bingo-${target}-${String(process.pid)}`,
+);
+rmSync(extracted, { force: true, recursive: true });
+mkdirSync(extracted, { recursive: true });
 const idleTimeoutMs = 2000;
 let child;
 let exit;

--- a/editors/vscode/scripts/verify-package.mjs
+++ b/editors/vscode/scripts/verify-package.mjs
@@ -13,7 +13,7 @@ import { spawnSync } from "node:child_process";
 import { currentTarget } from "./platform.mjs";
 
 const target = currentTarget();
-const expectedExtensionVersion = "0.3.0";
+const expectedExtensionVersion = "0.3.1";
 const vsix = fileURLToPath(
   new URL(`../../../dist/bingo-${target}.vsix`, import.meta.url),
 );

--- a/editors/vscode/scripts/verify-package.mjs
+++ b/editors/vscode/scripts/verify-package.mjs
@@ -1,34 +1,69 @@
 import {
-  mkdtempSync,
+  mkdirSync,
   readFileSync,
   rmSync,
   statSync,
 } from "node:fs";
 import { log } from "node:console";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
+import process from "node:process";
 import { fileURLToPath, URL } from "node:url";
 import { spawnSync } from "node:child_process";
 
 import { currentTarget } from "./platform.mjs";
 
 const target = currentTarget();
-const expectedExtensionVersion = "0.2.0";
+const expectedExtensionVersion = "0.3.0";
 const vsix = fileURLToPath(
   new URL(`../../../dist/bingo-${target}.vsix`, import.meta.url),
 );
-const extracted = mkdtempSync(join(tmpdir(), "bingo-vsix-"));
+const outputDirectory = fileURLToPath(
+  new URL("../../../dist/", import.meta.url),
+);
+const extracted = join(
+  outputDirectory,
+  `.verify-bingo-${target}-${String(process.pid)}`,
+);
+rmSync(extracted, { force: true, recursive: true });
+mkdirSync(extracted, { recursive: true });
 
 try {
   run("unzip", ["-q", vsix, "-d", extracted]);
   const entries = capture("unzip", ["-Z1", vsix])
     .split("\n")
     .filter((entry) => entry.length > 0);
+  const expectedEntries = [
+    "[Content_Types].xml",
+    "extension.vsixmanifest",
+    "extension/LICENSE.txt",
+    "extension/bin/bingo",
+    "extension/bin/target.json",
+    "extension/dist/extension.js",
+    "extension/dist/webview.js",
+    "extension/media/bingo-activity.svg",
+    "extension/package.json",
+    "extension/readme.md",
+  ].sort();
+  const sortedEntries = [...entries].sort();
+  if (JSON.stringify(sortedEntries) !== JSON.stringify(expectedEntries)) {
+    throw new Error(
+      `unexpected VSIX contents:\n${sortedEntries.join("\n")}`,
+    );
+  }
   const binaries = entries.filter((entry) => entry === "extension/bin/bingo");
   if (binaries.length !== 1) {
     throw new Error(
       `expected exactly one extension/bin/bingo, found ${String(binaries.length)}`,
     );
+  }
+  for (const required of [
+    "extension/dist/extension.js",
+    "extension/dist/webview.js",
+    "extension/media/bingo-activity.svg",
+  ]) {
+    if (!entries.includes(required)) {
+      throw new Error(`VSIX is missing required concurrency UI asset ${required}`);
+    }
   }
   const binEntries = entries.filter((entry) =>
     entry.startsWith("extension/bin/"),
@@ -85,6 +120,10 @@ try {
   const binary = join(extracted, "extension", "bin", "bingo");
   if ((statSync(binary).mode & 0o111) === 0) {
     throw new Error("packaged bingo binary is not executable");
+  }
+  const webviewBundle = join(extracted, "extension", "dist", "webview.js");
+  if (statSync(webviewBundle).size > 250 * 1024) {
+    throw new Error("packaged concurrency webview exceeds 250 KiB");
   }
   const fileOutput = capture("file", [binary]);
   if (

--- a/editors/vscode/scripts/verify-package.mjs
+++ b/editors/vscode/scripts/verify-package.mjs
@@ -43,8 +43,10 @@ try {
     "extension/media/bingo-activity.svg",
     "extension/package.json",
     "extension/readme.md",
-  ].sort();
-  const sortedEntries = [...entries].sort();
+  ].sort((left, right) => left.localeCompare(right));
+  const sortedEntries = [...entries].sort((left, right) =>
+    left.localeCompare(right),
+  );
   if (JSON.stringify(sortedEntries) !== JSON.stringify(expectedEntries)) {
     throw new Error(
       `unexpected VSIX contents:\n${sortedEntries.join("\n")}`,

--- a/editors/vscode/src/concurrencyView.ts
+++ b/editors/vscode/src/concurrencyView.ts
@@ -1,0 +1,268 @@
+import { randomBytes } from "node:crypto";
+
+import * as vscode from "vscode";
+
+import type { ConcurrencyViewModel } from "./model.js";
+import { decodeWebviewMessage } from "./messages.js";
+import type { SessionRegistry } from "./registry.js";
+
+export const concurrencyViewId = "bingo.concurrency";
+
+export class ConcurrencyViewProvider implements vscode.WebviewViewProvider {
+  #view: vscode.WebviewView | undefined;
+  #ready = false;
+  #lastRenderedRevision = -1;
+  #inFlightRevision = -1;
+  #fitPending = false;
+  #model: ConcurrencyViewModel;
+  readonly #unsubscribe: () => void;
+
+  public constructor(
+    private readonly extensionUri: vscode.Uri,
+    private readonly registry: SessionRegistry,
+  ) {
+    this.#model = registry.viewModel;
+    this.#unsubscribe = registry.onChange((model) => {
+      this.#model = model;
+      this.#render();
+    });
+  }
+
+  public resolveWebviewView(view: vscode.WebviewView): void {
+    this.#view = view;
+    this.#ready = false;
+    this.#lastRenderedRevision = -1;
+    this.#inFlightRevision = -1;
+    const dist = vscode.Uri.joinPath(this.extensionUri, "dist");
+    view.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [dist],
+    };
+    view.webview.html = this.#html(view.webview);
+    view.webview.onDidReceiveMessage((message: unknown) => {
+      this.#receive(message);
+    });
+    const visibility = view.onDidChangeVisibility(() => {
+      if (this.#view === view && !view.visible) {
+        this.#ready = false;
+        this.#inFlightRevision = -1;
+      }
+    });
+    view.onDidDispose(() => {
+      visibility.dispose();
+      if (this.#view === view) {
+        this.#view = undefined;
+        this.#ready = false;
+        this.#inFlightRevision = -1;
+      }
+    });
+  }
+
+  public fit(): void {
+    this.#fitPending = true;
+    this.#sendFit();
+  }
+
+  public get lastRenderedRevision(): number {
+    return this.#lastRenderedRevision;
+  }
+
+  public get status(): {
+    readonly resolved: boolean;
+    readonly ready: boolean;
+  } {
+    return {
+      resolved: this.#view !== undefined,
+      ready: this.#ready,
+    };
+  }
+
+  public dispose(): void {
+    this.#unsubscribe();
+  }
+
+  #receive(value: unknown): void {
+    let message;
+    try {
+      message = decodeWebviewMessage(value);
+    } catch {
+      return;
+    }
+    switch (message.type) {
+      case "ready":
+        this.#ready = true;
+        this.#lastRenderedRevision = -1;
+        this.#inFlightRevision = -1;
+        this.#render();
+        this.#sendFit();
+        break;
+      case "rendered":
+        if (
+          message.revision === this.#inFlightRevision
+        ) {
+          this.#lastRenderedRevision = message.revision;
+          this.#inFlightRevision = -1;
+          this.#render();
+        }
+        break;
+      case "refresh":
+        this.registry.refresh();
+        break;
+      case "selectSession":
+        this.registry.select(message.id);
+        break;
+      case "selectGoroutine":
+        this.registry.selectGoroutine(message.id);
+        break;
+      case "copySnapshot":
+        void copySnapshot(this.registry);
+        break;
+    }
+  }
+
+  #render(): void {
+    if (
+      !this.#ready ||
+      this.#view === undefined ||
+      this.#inFlightRevision >= 0 ||
+      this.#lastRenderedRevision === this.#model.revision
+    ) {
+      return;
+    }
+    this.#inFlightRevision = this.#model.revision;
+    const active = this.#model.sessions.find(
+      (session) =>
+        session.debugSessionId === this.#model.activeDebugSessionId,
+    );
+    this.#view.badge =
+      active?.snapshot === undefined
+        ? undefined
+        : {
+            value: active.snapshot.goroutines.length,
+            tooltip: `${String(active.snapshot.goroutines.length)} goroutines · ${String(active.snapshot.threads.length)} threads`,
+          };
+    const revision = this.#model.revision;
+    void this.#view.webview
+      .postMessage({
+        type: "render",
+        revision,
+        model: this.#model,
+      })
+      .then((delivered) => {
+        if (!delivered && this.#inFlightRevision === revision) {
+          this.#inFlightRevision = -1;
+          this.#ready = false;
+        }
+      }, () => {
+        this.#inFlightRevision = -1;
+        this.#ready = false;
+      });
+  }
+
+  #sendFit(): void {
+    if (!this.#fitPending || !this.#ready || this.#view === undefined) {
+      return;
+    }
+    void this.#view.webview
+      .postMessage({ type: "fit" })
+      .then((delivered) => {
+        if (delivered) {
+          this.#fitPending = false;
+        }
+      }, () => undefined);
+  }
+
+  #html(webview: vscode.Webview): string {
+    const nonce = randomBytes(18).toString("base64");
+    const script = webview.asWebviewUri(
+      vscode.Uri.joinPath(this.extensionUri, "dist", "webview.js"),
+    );
+    return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}';">
+  <style nonce="${nonce}">${styles}</style>
+  <title>Bingo Concurrency</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script nonce="${nonce}" src="${script.toString()}"></script>
+</body>
+</html>`;
+  }
+}
+
+export async function copySnapshot(registry: SessionRegistry): Promise<void> {
+  const snapshot = registry.activeSnapshotJSON();
+  if (snapshot === undefined) {
+    void vscode.window.showInformationMessage(
+      "Bingo Concurrency has no active snapshot to copy.",
+    );
+    return;
+  }
+  await vscode.env.clipboard.writeText(snapshot);
+  void vscode.window.setStatusBarMessage("Bingo concurrency snapshot copied", 2000);
+}
+
+export const styles = `
+:root { color-scheme: light dark; font-family: var(--vscode-font-family); color: var(--vscode-foreground); }
+* { box-sizing: border-box; }
+body { padding: 0; margin: 0; background: var(--vscode-sideBar-background); }
+button, input, select { font: inherit; color: inherit; }
+button, select, input { border: 1px solid var(--vscode-input-border, transparent); background: var(--vscode-input-background); border-radius: 5px; }
+button { cursor: pointer; padding: 5px 9px; }
+button:hover { background: var(--vscode-toolbar-hoverBackground); }
+button:focus-visible, input:focus-visible, select:focus-visible, .graph-viewport:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: 1px; }
+.app { min-height: 100vh; }
+.topbar { position: sticky; top: 0; z-index: 5; display: flex; align-items: center; gap: 12px; justify-content: space-between; padding: 12px; background: var(--vscode-sideBar-background); border-bottom: 1px solid var(--vscode-sideBarSectionHeader-border, transparent); }
+.brand { display: grid; gap: 2px; }
+.brand strong { font-size: 14px; }
+.brand span, .muted { color: var(--vscode-descriptionForeground); font-size: 11px; }
+.session-selector { min-width: 120px; max-width: 48%; padding: 4px; }
+.session { padding: 10px; display: grid; gap: 10px; }
+.cards { display: grid; grid-template-columns: repeat(4, minmax(58px, 1fr)); gap: 7px; }
+.card { display: grid; padding: 9px; border: 1px solid var(--vscode-widget-border); border-radius: 8px; background: var(--vscode-editorWidget-background); }
+.card strong { font-size: 18px; color: var(--vscode-charts-blue); }
+.card span { color: var(--vscode-descriptionForeground); font-size: 10px; text-transform: uppercase; }
+.last-stop { grid-column: 1 / -1; padding: 7px 9px; border-left: 3px solid var(--vscode-debugIcon-breakpointCurrentStackframeForeground); background: var(--vscode-textBlockQuote-background); overflow-wrap: anywhere; }
+.toolbar { display: flex; gap: 6px; }
+.toolbar input { flex: 1; min-width: 80px; padding: 6px 8px; }
+.workspace { display: grid; grid-template-columns: minmax(0, 2fr) minmax(175px, 1fr); gap: 10px; }
+.graph-panel, .inspector, .threads, .timeline { position: relative; min-width: 0; border: 1px solid var(--vscode-widget-border); border-radius: 9px; background: var(--vscode-editorWidget-background); overflow: hidden; }
+.graph-controls { position: absolute; right: 7px; top: 7px; z-index: 2; display: flex; gap: 4px; }
+.graph-viewport { height: 410px; overflow: hidden; touch-action: none; }
+.graph-viewport svg { width: 100%; height: 100%; }
+.tree-edge { fill: none; stroke: var(--vscode-editorIndentGuide-background); stroke-width: 1.5; }
+.tree-node { cursor: pointer; }
+.tree-node rect { fill: var(--vscode-editorWidget-background); stroke: var(--vscode-widget-border); stroke-width: 1.5; }
+.tree-node:hover rect, .tree-node.selected rect { stroke: var(--vscode-focusBorder); stroke-width: 2.5; }
+.tree-node.current rect { fill: var(--vscode-list-activeSelectionBackground); stroke: var(--vscode-debugIcon-breakpointCurrentStackframeForeground); }
+.tree-node text { fill: var(--vscode-foreground); pointer-events: none; }
+.node-id { font-size: 14px; font-weight: 700; }
+.node-status, .node-thread { font-size: 10px; fill: var(--vscode-descriptionForeground) !important; }
+.filtered { display: none; }
+.omitted { position: absolute; bottom: 2px; left: 8px; color: var(--vscode-descriptionForeground); font-size: 10px; }
+.inspector, .threads, .timeline { padding: 11px; }
+h2 { margin: 0 0 10px; font-size: 12px; text-transform: uppercase; color: var(--vscode-descriptionForeground); }
+.inspector-title { display: block; margin-bottom: 10px; font-size: 15px; }
+dl { margin: 0; display: grid; grid-template-columns: 58px 1fr; gap: 6px; }
+dt { color: var(--vscode-descriptionForeground); }
+dd { margin: 0; overflow-wrap: anywhere; }
+.thread-list { display: grid; grid-template-columns: repeat(auto-fill, minmax(105px, 1fr)); gap: 6px; }
+.thread { display: grid; padding: 7px; border: 1px solid var(--vscode-widget-border); border-radius: 6px; }
+.thread.current { border-color: var(--vscode-focusBorder); }
+.thread span { color: var(--vscode-descriptionForeground); font-size: 10px; }
+.timeline ol { display: flex; gap: 5px; padding: 0; margin: 0; list-style: none; overflow-x: auto; }
+.timeline li { white-space: nowrap; padding: 4px 6px; border-radius: 999px; background: var(--vscode-badge-background); color: var(--vscode-badge-foreground); }
+.timeline li.created { border-left: 3px solid var(--vscode-testing-iconPassed); }
+.timeline li.exited { border-left: 3px solid var(--vscode-testing-iconFailed); }
+.empty-state { min-height: 130px; display: grid; place-content: center; gap: 6px; padding: 18px; text-align: center; color: var(--vscode-descriptionForeground); }
+.empty-state strong { color: var(--vscode-foreground); }
+.callout { display: grid; gap: 3px; padding: 8px; border-radius: 6px; }
+.callout.error { border-left: 3px solid var(--vscode-errorForeground); background: var(--vscode-inputValidation-errorBackground); }
+.callout.warning { border-left: 3px solid var(--vscode-editorWarning-foreground); background: var(--vscode-inputValidation-warningBackground); }
+@media (max-width: 520px) { .workspace { grid-template-columns: 1fr; } .graph-viewport { height: 330px; } .cards { grid-template-columns: repeat(2, 1fr); } }
+@media (forced-colors: active) { .tree-node rect, .graph-panel, .inspector, .threads, .timeline, .card { border: 1px solid CanvasText; } }
+`;

--- a/editors/vscode/src/concurrencyView.ts
+++ b/editors/vscode/src/concurrencyView.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 
 import * as vscode from "vscode";
 
+import { WebviewDeliveryState } from "./documentGeneration.js";
 import type { ConcurrencyViewModel } from "./model.js";
 import { decodeWebviewMessage } from "./messages.js";
 import type { SessionRegistry } from "./registry.js";
@@ -10,10 +11,8 @@ export const concurrencyViewId = "bingo.concurrency";
 
 export class ConcurrencyViewProvider implements vscode.WebviewViewProvider {
   #view: vscode.WebviewView | undefined;
-  #ready = false;
-  #lastRenderedRevision = -1;
-  #inFlightRevision = -1;
   #fitPending = false;
+  readonly #delivery = new WebviewDeliveryState();
   #model: ConcurrencyViewModel;
   readonly #unsubscribe: () => void;
 
@@ -29,10 +28,8 @@ export class ConcurrencyViewProvider implements vscode.WebviewViewProvider {
   }
 
   public resolveWebviewView(view: vscode.WebviewView): void {
+    this.#delivery.beginDocument();
     this.#view = view;
-    this.#ready = false;
-    this.#lastRenderedRevision = -1;
-    this.#inFlightRevision = -1;
     const dist = vscode.Uri.joinPath(this.extensionUri, "dist");
     view.webview.options = {
       enableScripts: true,
@@ -40,20 +37,20 @@ export class ConcurrencyViewProvider implements vscode.WebviewViewProvider {
     };
     view.webview.html = this.#html(view.webview);
     view.webview.onDidReceiveMessage((message: unknown) => {
-      this.#receive(message);
+      if (this.#view === view && view.visible) {
+        this.#receive(message);
+      }
     });
     const visibility = view.onDidChangeVisibility(() => {
       if (this.#view === view && !view.visible) {
-        this.#ready = false;
-        this.#inFlightRevision = -1;
+        this.#delivery.markHidden();
       }
     });
     view.onDidDispose(() => {
       visibility.dispose();
       if (this.#view === view) {
+        this.#delivery.beginDocument();
         this.#view = undefined;
-        this.#ready = false;
-        this.#inFlightRevision = -1;
       }
     });
   }
@@ -64,7 +61,7 @@ export class ConcurrencyViewProvider implements vscode.WebviewViewProvider {
   }
 
   public get lastRenderedRevision(): number {
-    return this.#lastRenderedRevision;
+    return this.#delivery.lastRenderedRevision;
   }
 
   public get status(): {
@@ -73,7 +70,7 @@ export class ConcurrencyViewProvider implements vscode.WebviewViewProvider {
   } {
     return {
       resolved: this.#view !== undefined,
-      ready: this.#ready,
+      ready: this.#delivery.ready,
     };
   }
 
@@ -90,18 +87,12 @@ export class ConcurrencyViewProvider implements vscode.WebviewViewProvider {
     }
     switch (message.type) {
       case "ready":
-        this.#ready = true;
-        this.#lastRenderedRevision = -1;
-        this.#inFlightRevision = -1;
+        this.#delivery.markReady();
         this.#render();
         this.#sendFit();
         break;
       case "rendered":
-        if (
-          message.revision === this.#inFlightRevision
-        ) {
-          this.#lastRenderedRevision = message.revision;
-          this.#inFlightRevision = -1;
+        if (this.#delivery.acknowledge(message.revision)) {
           this.#render();
         }
         break;
@@ -121,15 +112,13 @@ export class ConcurrencyViewProvider implements vscode.WebviewViewProvider {
   }
 
   #render(): void {
-    if (
-      !this.#ready ||
-      this.#view === undefined ||
-      this.#inFlightRevision >= 0 ||
-      this.#lastRenderedRevision === this.#model.revision
-    ) {
+    if (this.#view === undefined) {
       return;
     }
-    this.#inFlightRevision = this.#model.revision;
+    const delivery = this.#delivery.beginDelivery(this.#model.revision);
+    if (delivery === undefined) {
+      return;
+    }
     const active = this.#model.sessions.find(
       (session) =>
         session.debugSessionId === this.#model.activeDebugSessionId,
@@ -142,34 +131,42 @@ export class ConcurrencyViewProvider implements vscode.WebviewViewProvider {
             tooltip: `${String(active.snapshot.goroutines.length)} goroutines · ${String(active.snapshot.threads.length)} threads`,
           };
     const revision = this.#model.revision;
-    void this.#view.webview
+    const view = this.#view;
+    void view.webview
       .postMessage({
         type: "render",
         revision,
         model: this.#model,
       })
-      .then((delivered) => {
-        if (!delivered && this.#inFlightRevision === revision) {
-          this.#inFlightRevision = -1;
-          this.#ready = false;
-        }
-      }, () => {
-        this.#inFlightRevision = -1;
-        this.#ready = false;
-      });
+      .then(
+        (delivered) => {
+          if (!delivered && this.#view === view) {
+            this.#delivery.rejectDelivery(delivery);
+          }
+        },
+        () => {
+          if (this.#view === view) {
+            this.#delivery.rejectDelivery(delivery);
+          }
+        },
+      );
   }
 
   #sendFit(): void {
-    if (!this.#fitPending || !this.#ready || this.#view === undefined) {
+    if (!this.#fitPending || !this.#delivery.ready || this.#view === undefined) {
       return;
     }
-    void this.#view.webview
-      .postMessage({ type: "fit" })
-      .then((delivered) => {
-        if (delivered) {
-          this.#fitPending = false;
-        }
-      }, () => undefined);
+    const view = this.#view;
+    const generation = this.#delivery.captureGeneration();
+    void view.webview.postMessage({ type: "fit" }).then((delivered) => {
+      if (
+        delivered &&
+        this.#view === view &&
+        this.#delivery.isCurrent(generation)
+      ) {
+        this.#fitPending = false;
+      }
+    }, () => undefined);
   }
 
   #html(webview: vscode.Webview): string {
@@ -242,7 +239,6 @@ button:focus-visible, input:focus-visible, select:focus-visible, .graph-viewport
 .tree-node text { fill: var(--vscode-foreground); pointer-events: none; }
 .node-id { font-size: 14px; font-weight: 700; }
 .node-status, .node-thread { font-size: 10px; fill: var(--vscode-descriptionForeground) !important; }
-.filtered { display: none; }
 .omitted { position: absolute; bottom: 2px; left: 8px; color: var(--vscode-descriptionForeground); font-size: 10px; }
 .inspector, .threads, .timeline { padding: 11px; }
 h2 { margin: 0 0 10px; font-size: 12px; text-transform: uppercase; color: var(--vscode-descriptionForeground); }

--- a/editors/vscode/src/concurrencyView.ts
+++ b/editors/vscode/src/concurrencyView.ts
@@ -92,7 +92,12 @@ export class ConcurrencyViewProvider implements vscode.WebviewViewProvider {
         this.#sendFit();
         break;
       case "rendered":
-        if (this.#delivery.acknowledge(message.revision)) {
+        if (
+          this.#delivery.acknowledge({
+            generation: message.generation,
+            revision: message.revision,
+          })
+        ) {
           this.#render();
         }
         break;
@@ -135,6 +140,7 @@ export class ConcurrencyViewProvider implements vscode.WebviewViewProvider {
     void view.webview
       .postMessage({
         type: "render",
+        generation: delivery.generation,
         revision,
         model: this.#model,
       })

--- a/editors/vscode/src/documentGeneration.ts
+++ b/editors/vscode/src/documentGeneration.ts
@@ -1,0 +1,84 @@
+export interface DeliveryToken {
+  readonly generation: number;
+  readonly revision: number;
+}
+
+export class WebviewDeliveryState {
+  #generation = 0;
+  #ready = false;
+  #lastRenderedRevision = -1;
+  #inFlightRevision = -1;
+
+  public beginDocument(): void {
+    this.#generation += 1;
+    this.#ready = false;
+    this.#lastRenderedRevision = -1;
+    this.#inFlightRevision = -1;
+  }
+
+  public markReady(): void {
+    this.#generation += 1;
+    this.#ready = true;
+    this.#lastRenderedRevision = -1;
+    this.#inFlightRevision = -1;
+  }
+
+  public markHidden(): void {
+    this.#generation += 1;
+    this.#ready = false;
+    this.#inFlightRevision = -1;
+  }
+
+  public beginDelivery(revision: number): DeliveryToken | undefined {
+    if (
+      !this.#ready ||
+      this.#inFlightRevision >= 0 ||
+      this.#lastRenderedRevision === revision
+    ) {
+      return undefined;
+    }
+    this.#inFlightRevision = revision;
+    return { generation: this.#generation, revision };
+  }
+
+  public rejectDelivery(token: DeliveryToken): boolean {
+    if (!this.#matches(token)) {
+      return false;
+    }
+    this.#inFlightRevision = -1;
+    this.#ready = false;
+    return true;
+  }
+
+  public acknowledge(revision: number): boolean {
+    if (revision !== this.#inFlightRevision) {
+      return false;
+    }
+    this.#lastRenderedRevision = revision;
+    this.#inFlightRevision = -1;
+    return true;
+  }
+
+  public captureGeneration(): number {
+    return this.#generation;
+  }
+
+  public isCurrent(generation: number): boolean {
+    return generation === this.#generation;
+  }
+
+  public get ready(): boolean {
+    return this.#ready;
+  }
+
+  public get lastRenderedRevision(): number {
+    return this.#lastRenderedRevision;
+  }
+
+  #matches(token: DeliveryToken): boolean {
+    return (
+      token.generation === this.#generation &&
+      token.revision === this.#inFlightRevision
+    );
+  }
+}

--- a/editors/vscode/src/documentGeneration.ts
+++ b/editors/vscode/src/documentGeneration.ts
@@ -50,11 +50,11 @@ export class WebviewDeliveryState {
     return true;
   }
 
-  public acknowledge(revision: number): boolean {
-    if (revision !== this.#inFlightRevision) {
+  public acknowledge(token: DeliveryToken): boolean {
+    if (!this.#matches(token)) {
       return false;
     }
-    this.#lastRenderedRevision = revision;
+    this.#lastRenderedRevision = token.revision;
     this.#inFlightRevision = -1;
     return true;
   }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -6,6 +6,7 @@ import * as vscode from "vscode";
 import { resolveBundledBinary } from "./binary.js";
 import {
   ConfigurationError,
+  resolveServerConfiguration,
   validateBingoConfiguration,
 } from "./configuration.js";
 import { probeBingoHealth } from "./health.js";
@@ -15,8 +16,26 @@ import {
   ServerManagerError,
 } from "./serverManager.js";
 import { spawnDetachedServer } from "./serverProcess.js";
+import {
+  concurrencyViewId,
+  ConcurrencyViewProvider,
+  copySnapshot,
+} from "./concurrencyView.js";
+import type { ConcurrencyViewModel } from "./model.js";
+import { SessionRegistry } from "./registry.js";
+import { decodeSessionAnnouncement } from "./sessionEvent.js";
 
 const debugType = "bingo";
+
+export interface BingoExtensionAPI {
+  readonly version: 1;
+  getConcurrencyState(): ConcurrencyViewModel;
+  getLastRenderedRevision(): number;
+  getConcurrencyViewStatus(): {
+    readonly resolved: boolean;
+    readonly ready: boolean;
+  };
+}
 
 class BingoDebugConfigurationProvider
   implements vscode.DebugConfigurationProvider
@@ -83,8 +102,33 @@ class BingoDebugAdapterDescriptorFactory
   }
 }
 
-export function activate(context: vscode.ExtensionContext): void {
+export function activate(context: vscode.ExtensionContext): BingoExtensionAPI {
   const output = vscode.window.createOutputChannel("bingo Server");
+  const registry = new SessionRegistry();
+  const concurrencyView = new ConcurrencyViewProvider(
+    context.extensionUri,
+    registry,
+  );
+  const status = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Left,
+    10,
+  );
+  status.command = "bingo.concurrency.focus";
+  status.name = "Bingo Concurrency";
+  let autoRevealed = false;
+  const updateStatus = (): void => {
+    const active = registry.activeModel();
+    if (active === undefined) {
+      status.hide();
+      return;
+    }
+    const goroutines = active.snapshot?.goroutines.length ?? 0;
+    const threads = active.snapshot?.threads.length ?? 0;
+    status.text = `$(type-hierarchy) Bingo ${String(goroutines)}g · ${String(threads)}t`;
+    status.tooltip = `${active.debugSessionName} · ${active.connection} · ${active.sessionState}`;
+    status.show();
+  };
+  const unsubscribeStatus = registry.onChange(updateStatus);
   const manager = new ServerManager({
     probe: probeBingoHealth,
     resolveBinary: async (target) =>
@@ -111,6 +155,10 @@ export function activate(context: vscode.ExtensionContext): void {
 
   context.subscriptions.push(
     output,
+    status,
+    registry,
+    concurrencyView,
+    { dispose: unsubscribeStatus },
     {
       dispose(): void {
         manager.dispose();
@@ -124,5 +172,100 @@ export function activate(context: vscode.ExtensionContext): void {
       debugType,
       new BingoDebugAdapterDescriptorFactory(manager, output),
     ),
+    vscode.window.registerWebviewViewProvider(
+      concurrencyViewId,
+      concurrencyView,
+      { webviewOptions: { retainContextWhenHidden: false } },
+    ),
+    vscode.debug.onDidStartDebugSession((session) => {
+      if (session.type === debugType) {
+        registry.select(session.id);
+      }
+    }),
+    vscode.debug.onDidReceiveDebugSessionCustomEvent((event) => {
+      let announcement;
+      try {
+        announcement = decodeSessionAnnouncement(event.event, event.body);
+      } catch (error: unknown) {
+        output.appendLine(
+          `ignored invalid bingo session event: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        return;
+      }
+      if (
+        event.session.type !== debugType ||
+        announcement === undefined
+      ) {
+        return;
+      }
+      let server;
+      try {
+        server = resolveServerConfiguration(event.session.configuration);
+      } catch (error: unknown) {
+        output.appendLine(
+          `cannot start concurrency observer: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        return;
+      }
+      const added = registry.add({
+        debugSessionId: event.session.id,
+        debugSessionName: event.session.name,
+        sessionId: announcement.sessionId,
+        managementEndpoint: server.managementEndpoint,
+      });
+      if (
+        added &&
+        !autoRevealed &&
+        vscode.workspace
+          .getConfiguration("bingo.concurrency")
+          .get<boolean>("autoReveal", true)
+      ) {
+        autoRevealed = true;
+        void vscode.commands.executeCommand(`${concurrencyViewId}.focus`);
+      }
+    }),
+    vscode.debug.onDidChangeActiveDebugSession((session) => {
+      if (session?.type === debugType) {
+        registry.select(session.id);
+      }
+    }),
+    vscode.debug.onDidTerminateDebugSession((session) => {
+      registry.remove(session.id);
+    }),
+    vscode.commands.registerCommand("bingo.concurrency.refresh", () => {
+      registry.refresh();
+    }),
+    vscode.commands.registerCommand("bingo.concurrency.selectSession", async () => {
+      const sessions = registry.viewModel.sessions;
+      const selected = await vscode.window.showQuickPick(
+        sessions.map((session) => ({
+          label: session.debugSessionName,
+          description: session.sessionId,
+          id: session.debugSessionId,
+        })),
+        { title: "Select Bingo Concurrency session" },
+      );
+      if (selected !== undefined) {
+        registry.select(selected.id);
+        await vscode.commands.executeCommand(`${concurrencyViewId}.focus`);
+      }
+    }),
+    vscode.commands.registerCommand("bingo.concurrency.fit", async () => {
+      await vscode.commands.executeCommand(`${concurrencyViewId}.focus`);
+      concurrencyView.fit();
+    }),
+    vscode.commands.registerCommand("bingo.concurrency.copySnapshot", () =>
+      copySnapshot(registry),
+    ),
   );
+  return {
+    version: 1,
+    getConcurrencyState: () => registry.viewModel,
+    getLastRenderedRevision: () => concurrencyView.lastRenderedRevision,
+    getConcurrencyViewStatus: () => concurrencyView.status,
+  };
 }

--- a/editors/vscode/src/health.ts
+++ b/editors/vscode/src/health.ts
@@ -1,10 +1,12 @@
 import { request } from "node:http";
 
 import type { BingoEndpoint } from "./configuration.js";
+import { sessionDAPEventVersion } from "./sessionEvent.js";
 
 export const bingoServiceIdentity = "bingo";
 export const managementApiVersion = 1;
 export const wireProtocolVersion = "1.2";
+export const dapSessionEventVersion = sessionDAPEventVersion;
 export const minimumHealthProbeTimeoutMs = 25;
 
 const maximumHealthBytes = 64 * 1024;
@@ -12,6 +14,7 @@ const maximumHealthBytes = 64 * 1024;
 export interface CompatibleHealth {
   readonly instanceId: string;
   readonly dapAddress: string;
+  readonly dapSessionEventVersion: number;
 }
 
 export type HealthProbeResult =
@@ -206,6 +209,12 @@ export function validateHealthResponse(
       reason: "bingo DAP listener is not enabled",
     };
   }
+  if (decoded.dap.sessionEventVersion !== dapSessionEventVersion) {
+    return {
+      kind: "incompatible",
+      reason: `DAP session event version is ${JSON.stringify(decoded.dap.sessionEventVersion)}, expected ${String(dapSessionEventVersion)}`,
+    };
+  }
   if (typeof decoded.dap.address !== "string") {
     return {
       kind: "incompatible",
@@ -238,6 +247,7 @@ export function validateHealthResponse(
     health: {
       instanceId: decoded.instanceId,
       dapAddress: decoded.dap.address,
+      dapSessionEventVersion,
     },
   };
 }

--- a/editors/vscode/src/messages.ts
+++ b/editors/vscode/src/messages.ts
@@ -1,0 +1,88 @@
+import type { ConcurrencyViewModel } from "./model.js";
+
+export type HostMessage =
+  | {
+      readonly type: "render";
+      readonly revision: number;
+      readonly model: ConcurrencyViewModel;
+    }
+  | { readonly type: "fit" };
+
+export type WebviewMessage =
+  | { readonly type: "ready" }
+  | { readonly type: "rendered"; readonly revision: number }
+  | { readonly type: "selectGoroutine"; readonly id: number }
+  | { readonly type: "selectSession"; readonly id: string }
+  | { readonly type: "refresh" }
+  | { readonly type: "fit" }
+  | { readonly type: "copySnapshot" };
+
+export function decodeWebviewMessage(value: unknown): WebviewMessage {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("webview message must be an object");
+  }
+  const message = value as Record<string, unknown>;
+  if (typeof message.type !== "string") {
+    throw new Error("webview message requires a type");
+  }
+  switch (message.type) {
+    case "ready":
+    case "refresh":
+    case "fit":
+    case "copySnapshot":
+      exactKeys(message, ["type"]);
+      return { type: message.type };
+    case "rendered":
+      exactKeys(message, ["type", "revision"]);
+      return {
+        type: "rendered",
+        revision: safeInteger(message.revision, "revision", 0),
+      };
+    case "selectGoroutine":
+      exactKeys(message, ["type", "id"]);
+      return {
+        type: "selectGoroutine",
+        id: safeInteger(message.id, "goroutine id", 1),
+      };
+    case "selectSession":
+      exactKeys(message, ["type", "id"]);
+      if (
+        typeof message.id !== "string" ||
+        message.id.length === 0 ||
+        message.id.length > 256
+      ) {
+        throw new Error("debug session id must be a bounded non-empty string");
+      }
+      return {
+        type: "selectSession",
+        id: message.id,
+      };
+    default:
+      throw new Error(`unknown webview message ${JSON.stringify(message.type)}`);
+  }
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+): void {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (
+    actual.length !== wanted.length ||
+    actual.some((key, index) => key !== wanted[index])
+  ) {
+    throw new Error("webview message has unexpected fields");
+  }
+}
+
+function safeInteger(value: unknown, label: string, minimum: number): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value < minimum
+  ) {
+    throw new Error(`${label} must be a safe integer >= ${String(minimum)}`);
+  }
+  return value;
+}

--- a/editors/vscode/src/messages.ts
+++ b/editors/vscode/src/messages.ts
@@ -3,6 +3,7 @@ import type { ConcurrencyViewModel } from "./model.js";
 export type HostMessage =
   | {
       readonly type: "render";
+      readonly generation: number;
       readonly revision: number;
       readonly model: ConcurrencyViewModel;
     }
@@ -10,7 +11,11 @@ export type HostMessage =
 
 export type WebviewMessage =
   | { readonly type: "ready" }
-  | { readonly type: "rendered"; readonly revision: number }
+  | {
+      readonly type: "rendered";
+      readonly generation: number;
+      readonly revision: number;
+    }
   | { readonly type: "selectGoroutine"; readonly id: number }
   | { readonly type: "selectSession"; readonly id: string }
   | { readonly type: "refresh" }
@@ -33,9 +38,10 @@ export function decodeWebviewMessage(value: unknown): WebviewMessage {
       exactKeys(message, ["type"]);
       return { type: message.type };
     case "rendered":
-      exactKeys(message, ["type", "revision"]);
+      exactKeys(message, ["type", "generation", "revision"]);
       return {
         type: "rendered",
+        generation: safeInteger(message.generation, "generation", 1),
         revision: safeInteger(message.revision, "revision", 0),
       };
     case "selectGoroutine":

--- a/editors/vscode/src/messages.ts
+++ b/editors/vscode/src/messages.ts
@@ -19,11 +19,11 @@ export type WebviewMessage =
 
 export function decodeWebviewMessage(value: unknown): WebviewMessage {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("webview message must be an object");
+    throw new TypeError("webview message must be an object");
   }
   const message = value as Record<string, unknown>;
   if (typeof message.type !== "string") {
-    throw new Error("webview message requires a type");
+    throw new TypeError("webview message requires a type");
   }
   switch (message.type) {
     case "ready":
@@ -51,14 +51,16 @@ export function decodeWebviewMessage(value: unknown): WebviewMessage {
         message.id.length === 0 ||
         message.id.length > 256
       ) {
-        throw new Error("debug session id must be a bounded non-empty string");
+        throw new TypeError("debug session id must be a bounded non-empty string");
       }
       return {
         type: "selectSession",
         id: message.id,
       };
     default:
-      throw new Error(`unknown webview message ${JSON.stringify(message.type)}`);
+      throw new TypeError(
+        `unknown webview message ${JSON.stringify(message.type)}`,
+      );
   }
 }
 
@@ -66,13 +68,17 @@ function exactKeys(
   value: Record<string, unknown>,
   expected: readonly string[],
 ): void {
-  const actual = Object.keys(value).sort();
-  const wanted = [...expected].sort();
+  const actual = Object.keys(value).sort((left, right) =>
+    left.localeCompare(right),
+  );
+  const wanted = [...expected].sort((left, right) =>
+    left.localeCompare(right),
+  );
   if (
     actual.length !== wanted.length ||
     actual.some((key, index) => key !== wanted[index])
   ) {
-    throw new Error("webview message has unexpected fields");
+    throw new TypeError("webview message has unexpected fields");
   }
 }
 
@@ -82,7 +88,9 @@ function safeInteger(value: unknown, label: string, minimum: number): number {
     !Number.isSafeInteger(value) ||
     value < minimum
   ) {
-    throw new Error(`${label} must be a safe integer >= ${String(minimum)}`);
+    throw new TypeError(
+      `${label} must be a safe integer >= ${String(minimum)}`,
+    );
   }
   return value;
 }

--- a/editors/vscode/src/model.ts
+++ b/editors/vscode/src/model.ts
@@ -1,0 +1,97 @@
+import type { Snapshot } from "./telemetry.js";
+import { layoutSpawnTree, type TreeLayout } from "./tree.js";
+
+export const maximumTimelineEntries = 100;
+
+export type ConnectionState =
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "closed"
+  | "error";
+
+export interface TimelineEntry {
+  readonly id: number;
+  readonly action: "created" | "exited";
+  readonly at: number;
+}
+
+export interface SessionModel {
+  readonly debugSessionId: string;
+  readonly debugSessionName: string;
+  readonly sessionId: string;
+  readonly connection: ConnectionState;
+  readonly sessionState: string;
+  readonly clients: number;
+  readonly lastStop: string;
+  readonly error: string;
+  readonly seqGap: string;
+  readonly lastSeq: number;
+  readonly snapshot: Snapshot | undefined;
+  readonly selectedGoroutine: number;
+  readonly timeline: readonly TimelineEntry[];
+}
+
+export interface SessionViewModel extends SessionModel {
+  readonly tree: TreeLayout;
+  readonly degraded: boolean;
+}
+
+export interface ConcurrencyViewModel {
+  readonly revision: number;
+  readonly activeDebugSessionId: string;
+  readonly sessions: readonly SessionViewModel[];
+}
+
+export function appendLifecycle(
+  existing: readonly TimelineEntry[],
+  snapshot: Snapshot,
+  now: number,
+): readonly TimelineEntry[] {
+  const additions: TimelineEntry[] = [
+    ...snapshot.created.map((id) => ({ id, action: "created" as const, at: now })),
+    ...snapshot.exited.map((id) => ({ id, action: "exited" as const, at: now })),
+  ];
+  return [...existing, ...additions].slice(-maximumTimelineEntries);
+}
+
+export function toSessionViewModel(model: SessionModel): SessionViewModel {
+  const snapshot = model.snapshot;
+  return {
+    ...model,
+    tree: layoutSpawnTree(snapshot?.goroutines ?? [], undefined, [
+      snapshot?.current ?? 0,
+      model.selectedGoroutine,
+    ]),
+    degraded: snapshot === undefined ? false : isDegraded(snapshot),
+  };
+}
+
+export function serializeSnapshot(model: SessionModel): string {
+  return JSON.stringify(
+    {
+      sessionId: model.sessionId,
+      debugSessionName: model.debugSessionName,
+      connection: model.connection,
+      state: model.sessionState,
+      seq: model.lastSeq,
+      snapshot: model.snapshot ?? null,
+      timeline: model.timeline,
+    },
+    undefined,
+    2,
+  );
+}
+
+function isDegraded(snapshot: Snapshot): boolean {
+  if (snapshot.goroutines.length !== 1 || snapshot.threads.length !== 0) {
+    return false;
+  }
+  const goroutine = snapshot.goroutines[0];
+  return (
+    goroutine !== undefined &&
+    goroutine.startLoc.file.length === 0 &&
+    goroutine.createdLoc.file.length === 0 &&
+    goroutine.currentLoc.file.length === 0
+  );
+}

--- a/editors/vscode/src/model.ts
+++ b/editors/vscode/src/model.ts
@@ -89,9 +89,8 @@ function isDegraded(snapshot: Snapshot): boolean {
   }
   const goroutine = snapshot.goroutines[0];
   return (
-    goroutine !== undefined &&
-    goroutine.startLoc.file.length === 0 &&
+    goroutine?.startLoc.file.length === 0 &&
     goroutine.createdLoc.file.length === 0 &&
     goroutine.currentLoc.file.length === 0
-  );
+  ) ?? false;
 }

--- a/editors/vscode/src/observer.ts
+++ b/editors/vscode/src/observer.ts
@@ -1,0 +1,436 @@
+import WebSocket from "ws";
+
+import type { BingoEndpoint } from "./configuration.js";
+import { appendLifecycle, type SessionModel } from "./model.js";
+import {
+  decodeEvent,
+  maximumEnvelopeBytes,
+  SequenceTracker,
+  snapshotCommand,
+  type TelemetryData,
+} from "./telemetry.js";
+
+const socketOpenState = 1;
+const reconnectDelays = [100, 250, 500, 1000, 2000, 4000] as const;
+
+export interface Socket {
+  readonly readyState: number;
+  onOpen(listener: () => void): void;
+  onMessage(listener: (data: TelemetryData) => void): void;
+  onClose(listener: () => void): void;
+  onError(listener: (error: Error) => void): void;
+  send(data: string): void;
+  close(): void;
+}
+
+export type SocketFactory = (url: string) => Socket;
+
+export interface ObserverDependencies {
+  readonly createSocket: SocketFactory;
+  readonly delay: (milliseconds: number, signal: AbortSignal) => Promise<void>;
+  readonly now: () => number;
+}
+
+export interface ObserverOptions {
+  readonly debugSessionId: string;
+  readonly debugSessionName: string;
+  readonly sessionId: string;
+  readonly managementEndpoint: BingoEndpoint;
+}
+
+export class TelemetryObserver {
+  readonly #dependencies: ObserverDependencies;
+  readonly #options: ObserverOptions;
+  readonly #lifetime = new AbortController();
+  readonly #sequence = new SequenceTracker();
+  readonly #listeners = new Set<(model: SessionModel) => void>();
+  #socket: Socket | undefined;
+  #connectionEpoch = 0;
+  #disposed = false;
+  #model: SessionModel;
+
+  public constructor(
+    options: ObserverOptions,
+    dependencies: ObserverDependencies = defaultDependencies,
+  ) {
+    this.#options = {
+      ...options,
+      managementEndpoint: normalizeManagementEndpoint(
+        options.managementEndpoint,
+      ),
+    };
+    this.#dependencies = dependencies;
+    this.#model = {
+      debugSessionId: options.debugSessionId,
+      debugSessionName: options.debugSessionName,
+      sessionId: options.sessionId,
+      connection: "connecting",
+      sessionState: "unknown",
+      clients: 0,
+      lastStop: "",
+      error: "",
+      seqGap: "",
+      lastSeq: 0,
+      snapshot: undefined,
+      selectedGoroutine: 0,
+      timeline: [],
+    };
+  }
+
+  public get model(): SessionModel {
+    return this.#model;
+  }
+
+  public onChange(listener: (model: SessionModel) => void): () => void {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  public start(): void {
+    if (this.#disposed || this.#socket !== undefined) {
+      return;
+    }
+    this.#connect(0);
+  }
+
+  public refresh(): void {
+    this.#sendSnapshot();
+  }
+
+  public selectGoroutine(id: number): void {
+    if (
+      this.#model.snapshot?.goroutines.some((goroutine) => goroutine.id === id) ===
+      true
+    ) {
+      this.#update({ selectedGoroutine: id });
+    }
+  }
+
+  public dispose(): void {
+    if (this.#disposed) {
+      return;
+    }
+    this.#disposed = true;
+    this.#lifetime.abort();
+    this.#connectionEpoch += 1;
+    const socket = this.#socket;
+    this.#socket = undefined;
+    socket?.close();
+    this.#update({ connection: "closed" });
+    this.#listeners.clear();
+  }
+
+  #connect(attempt: number): void {
+    if (this.#disposed) {
+      return;
+    }
+    const epoch = ++this.#connectionEpoch;
+    this.#sequence.reset();
+    this.#update({
+      connection: attempt === 0 ? "connecting" : "reconnecting",
+      error: "",
+      seqGap: "",
+      lastSeq: 0,
+    });
+
+    let socket: Socket;
+    try {
+      socket = this.#dependencies.createSocket(
+        telemetryURL(
+          this.#options.managementEndpoint,
+          this.#options.sessionId,
+        ),
+      );
+    } catch (error: unknown) {
+      this.#update({ error: errorMessage(error) });
+      void this.#reconnect(attempt + 1, epoch);
+      return;
+    }
+    this.#socket = socket;
+    socket.onOpen(() => {
+      if (!this.#isCurrent(epoch, socket)) {
+        return;
+      }
+      this.#update({ connection: "connected", error: "" });
+      this.#sendSnapshot();
+    });
+    socket.onMessage((data) => {
+      if (this.#isCurrent(epoch, socket)) {
+        this.#receive(data);
+      }
+    });
+    socket.onError((error) => {
+      if (!this.#isCurrent(epoch, socket)) {
+        return;
+      }
+      this.#update({ error: error.message });
+      socket.close();
+    });
+    socket.onClose(() => {
+      if (!this.#isCurrent(epoch, socket)) {
+        return;
+      }
+      this.#socket = undefined;
+      void this.#reconnect(attempt + 1, epoch);
+    });
+  }
+
+  async #reconnect(attempt: number, epoch: number): Promise<void> {
+    if (this.#disposed) {
+      return;
+    }
+    const wait = reconnectDelays[attempt - 1];
+    if (wait === undefined) {
+      const detail = this.#model.error;
+      this.#update({
+        connection: "error",
+        error:
+          detail.length === 0
+            ? "telemetry reconnect limit reached"
+            : `telemetry reconnect limit reached: ${detail}`,
+      });
+      return;
+    }
+    this.#update({ connection: "reconnecting" });
+    try {
+      await this.#dependencies.delay(wait, this.#lifetime.signal);
+    } catch {
+      return;
+    }
+    if (!this.#disposed && this.#connectionEpoch === epoch) {
+      this.#connect(attempt);
+    }
+  }
+
+  #sendSnapshot(): void {
+    const socket = this.#socket;
+    if (socket?.readyState !== socketOpenState) {
+      return;
+    }
+    try {
+      socket.send(snapshotCommand());
+    } catch (error: unknown) {
+      this.#update({ error: `cannot request snapshot: ${errorMessage(error)}` });
+      socket.close();
+    }
+  }
+
+  #receive(data: TelemetryData): void {
+    try {
+      const event = decodeEvent(data);
+      const sequence = this.#sequence.observe(event.seq);
+      if (!sequence.accept) {
+        this.#update({ seqGap: sequence.gap ?? "" });
+        return;
+      }
+      const sequencePatch = {
+        lastSeq: Math.max(this.#model.lastSeq, event.seq),
+        ...(sequence.gap === undefined ? {} : { seqGap: sequence.gap }),
+      };
+      if (event.snapshot !== undefined) {
+        const selected =
+          this.#model.selectedGoroutine !== 0 &&
+          event.snapshot.goroutines.some(
+            (goroutine) => goroutine.id === this.#model.selectedGoroutine,
+          )
+            ? this.#model.selectedGoroutine
+            : event.snapshot.current || event.snapshot.goroutines[0]?.id || 0;
+        this.#update({
+          ...sequencePatch,
+          error: "",
+          snapshot: event.snapshot,
+          selectedGoroutine: selected,
+          timeline: appendLifecycle(
+            this.#model.timeline,
+            event.snapshot,
+            this.#dependencies.now(),
+          ),
+        });
+        return;
+      }
+      this.#update(sequencePatch);
+      this.#applyEvent(event.kind, event.payload);
+    } catch (error: unknown) {
+      this.#update({ error: errorMessage(error) });
+      this.#socket?.close();
+    }
+  }
+
+  #applyEvent(kind: string, payload: Record<string, unknown>): void {
+    switch (kind) {
+      case "SessionState":
+        this.#update({
+          sessionState: String(payload.state),
+          clients: Number(payload.clients),
+        });
+        break;
+      case "BreakpointHit":
+        this.#update({ lastStop: describeStop("Breakpoint", payload) });
+        break;
+      case "Paused":
+        this.#update({ lastStop: describeStop("Paused", payload) });
+        break;
+      case "Stepped":
+        this.#update({ lastStop: describeStop("Stepped", payload) });
+        break;
+      case "Panic":
+        this.#update({ lastStop: `Panic: ${payloadText(payload.message, "")}` });
+        break;
+      case "Continued":
+        this.#update({ sessionState: "running", lastStop: "Continued" });
+        break;
+      case "ProcessExited":
+        this.#update({
+          sessionState: "exited",
+          lastStop: `Exited (${payloadText(payload.exitCode, "?")})`,
+        });
+        break;
+      case "Error":
+        this.#update({ error: payloadText(payload.message, "debugger error") });
+        break;
+    }
+  }
+
+  #isCurrent(epoch: number, socket: Socket): boolean {
+    return (
+      !this.#disposed &&
+      this.#connectionEpoch === epoch &&
+      this.#socket === socket
+    );
+  }
+
+  #update(patch: Partial<SessionModel>): void {
+    this.#model = { ...this.#model, ...patch };
+    for (const listener of this.#listeners) {
+      listener(this.#model);
+    }
+  }
+}
+
+export function normalizeManagementEndpoint(
+  endpoint: BingoEndpoint,
+): BingoEndpoint {
+  let host = endpoint.host.trim();
+  if (host.startsWith("[") && host.endsWith("]")) {
+    host = host.slice(1, -1);
+  }
+  host = host.toLocaleLowerCase();
+  if (
+    host.length === 0 ||
+    /[\s/?#@]/u.test(host) ||
+    !Number.isInteger(endpoint.port) ||
+    endpoint.port < 1 ||
+    endpoint.port > 65535
+  ) {
+    throw new Error("invalid bingo management endpoint");
+  }
+  return { host, port: endpoint.port };
+}
+
+export function telemetryURL(endpoint: BingoEndpoint, sessionId: string): string {
+  const normalized = normalizeManagementEndpoint(endpoint);
+  const host = normalized.host.includes(":")
+    ? `[${normalized.host}]`
+    : normalized.host;
+  return `ws://${host}:${String(normalized.port)}/ws?session=${encodeURIComponent(sessionId)}`;
+}
+
+function describeStop(
+  label: string,
+  payload: Record<string, unknown>,
+): string {
+  const location =
+    payload.location ??
+    (typeof payload.breakpoint === "object" &&
+    payload.breakpoint !== null &&
+    "location" in payload.breakpoint
+      ? (payload.breakpoint as { readonly location?: unknown }).location
+      : undefined);
+  if (typeof location !== "object" || location === null) {
+    return label;
+  }
+  const item = location as Record<string, unknown>;
+  const file = payloadText(item.file, "");
+  const line = Number(item.line ?? 0);
+  return file.length === 0 ? label : `${label} at ${file}:${String(line)}`;
+}
+
+function delay(milliseconds: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new Error("cancelled"));
+      return;
+    }
+    const finish = (): void => {
+      signal.removeEventListener("abort", abort);
+      resolve();
+    };
+    const timeout = setTimeout(finish, milliseconds);
+    const abort = (): void => {
+      clearTimeout(timeout);
+      signal.removeEventListener("abort", abort);
+      reject(new Error("cancelled"));
+    };
+    signal.addEventListener("abort", abort, { once: true });
+  });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+const defaultDependencies: ObserverDependencies = {
+  createSocket: (url) => new NodeSocket(url),
+  delay,
+  now: Date.now,
+};
+
+function payloadText(value: unknown, fallback: string): string {
+  return typeof value === "string" || typeof value === "number"
+    ? String(value)
+    : fallback;
+}
+
+class NodeSocket implements Socket {
+  readonly #socket: WebSocket;
+
+  public constructor(url: string) {
+    this.#socket = new WebSocket(url, {
+      handshakeTimeout: 5000,
+      maxPayload: maximumEnvelopeBytes,
+      perMessageDeflate: false,
+    });
+  }
+
+  public get readyState(): number {
+    return this.#socket.readyState;
+  }
+
+  public onOpen(listener: () => void): void {
+    this.#socket.on("open", listener);
+  }
+
+  public onMessage(listener: (data: TelemetryData) => void): void {
+    this.#socket.on("message", (data) => {
+      listener(data);
+    });
+  }
+
+  public onClose(listener: () => void): void {
+    this.#socket.on("close", listener);
+  }
+
+  public onError(listener: (error: Error) => void): void {
+    this.#socket.on("error", listener);
+  }
+
+  public send(data: string): void {
+    this.#socket.send(data);
+  }
+
+  public close(): void {
+    this.#socket.close();
+  }
+}

--- a/editors/vscode/src/registry.ts
+++ b/editors/vscode/src/registry.ts
@@ -1,0 +1,135 @@
+import type { BingoEndpoint } from "./configuration.js";
+import {
+  type ConcurrencyViewModel,
+  serializeSnapshot,
+  type SessionModel,
+  toSessionViewModel,
+} from "./model.js";
+import {
+  TelemetryObserver,
+  type ObserverDependencies,
+} from "./observer.js";
+
+export interface SessionRegistration {
+  readonly debugSessionId: string;
+  readonly debugSessionName: string;
+  readonly sessionId: string;
+  readonly managementEndpoint: BingoEndpoint;
+}
+
+export class SessionRegistry {
+  readonly #sessions = new Map<
+    string,
+    { readonly observer: TelemetryObserver; readonly unsubscribe: () => void }
+  >();
+  readonly #listeners = new Set<(model: ConcurrencyViewModel) => void>();
+  readonly #dependencies: ObserverDependencies | undefined;
+  #activeDebugSessionId = "";
+  #revision = 0;
+
+  public constructor(dependencies?: ObserverDependencies) {
+    this.#dependencies = dependencies;
+  }
+
+  public get viewModel(): ConcurrencyViewModel {
+    const sessions = [...this.#sessions.values()]
+      .map(({ observer }) => toSessionViewModel(observer.model))
+      .sort((left, right) =>
+        left.debugSessionName.localeCompare(right.debugSessionName) ||
+        left.debugSessionId.localeCompare(right.debugSessionId),
+      );
+    return {
+      revision: this.#revision,
+      activeDebugSessionId: this.#activeDebugSessionId,
+      sessions,
+    };
+  }
+
+  public onChange(listener: (model: ConcurrencyViewModel) => void): () => void {
+    this.#listeners.add(listener);
+    return () => {
+      this.#listeners.delete(listener);
+    };
+  }
+
+  public add(registration: SessionRegistration): boolean {
+    if (this.#sessions.has(registration.debugSessionId)) {
+      return false;
+    }
+    const observer =
+      this.#dependencies === undefined
+        ? new TelemetryObserver(registration)
+        : new TelemetryObserver(registration, this.#dependencies);
+    const unsubscribe = observer.onChange(() => {
+      this.#changed();
+    });
+    this.#sessions.set(registration.debugSessionId, { observer, unsubscribe });
+    this.#activeDebugSessionId = registration.debugSessionId;
+    observer.start();
+    this.#changed();
+    return true;
+  }
+
+  public remove(debugSessionId: string): void {
+    const entry = this.#sessions.get(debugSessionId);
+    if (entry === undefined) {
+      return;
+    }
+    entry.unsubscribe();
+    entry.observer.dispose();
+    this.#sessions.delete(debugSessionId);
+    if (this.#activeDebugSessionId === debugSessionId) {
+      this.#activeDebugSessionId = this.viewModel.sessions[0]?.debugSessionId ?? "";
+    }
+    this.#changed();
+  }
+
+  public select(debugSessionId: string): boolean {
+    if (!this.#sessions.has(debugSessionId)) {
+      return false;
+    }
+    this.#activeDebugSessionId = debugSessionId;
+    this.#changed();
+    return true;
+  }
+
+  public selectGoroutine(id: number): void {
+    this.#active()?.observer.selectGoroutine(id);
+  }
+
+  public refresh(): void {
+    this.#active()?.observer.refresh();
+  }
+
+  public activeSnapshotJSON(): string | undefined {
+    const model = this.#active()?.observer.model;
+    return model === undefined ? undefined : serializeSnapshot(model);
+  }
+
+  public activeModel(): SessionModel | undefined {
+    return this.#active()?.observer.model;
+  }
+
+  public dispose(): void {
+    for (const { observer, unsubscribe } of this.#sessions.values()) {
+      unsubscribe();
+      observer.dispose();
+    }
+    this.#sessions.clear();
+    this.#changed();
+  }
+
+  #active():
+    | { readonly observer: TelemetryObserver; readonly unsubscribe: () => void }
+    | undefined {
+    return this.#sessions.get(this.#activeDebugSessionId);
+  }
+
+  #changed(): void {
+    this.#revision += 1;
+    const model = this.viewModel;
+    for (const listener of this.#listeners) {
+      listener(model);
+    }
+  }
+}

--- a/editors/vscode/src/sessionEvent.ts
+++ b/editors/vscode/src/sessionEvent.ts
@@ -13,12 +13,14 @@ export function decodeSessionAnnouncement(
     return undefined;
   }
   if (body === null || typeof body !== "object" || Array.isArray(body)) {
-    throw new Error("bingo session event body must be an object");
+    throw new TypeError("bingo session event body must be an object");
   }
   const value = body as Record<string, unknown>;
-  const keys = Object.keys(value).sort();
+  const keys = Object.keys(value).sort((left, right) =>
+    left.localeCompare(right),
+  );
   if (keys.length !== 2 || keys[0] !== "sessionId" || keys[1] !== "version") {
-    throw new Error("bingo session event body has unexpected fields");
+    throw new TypeError("bingo session event body has unexpected fields");
   }
   if (value.version !== sessionDAPEventVersion) {
     throw new Error(
@@ -31,7 +33,7 @@ export function decodeSessionAnnouncement(
     value.sessionId.length > 128 ||
     !/^[A-Za-z0-9][A-Za-z0-9._-]*$/u.test(value.sessionId)
   ) {
-    throw new Error("bingo session event has an invalid sessionId");
+    throw new TypeError("bingo session event has an invalid sessionId");
   }
   return { sessionId: value.sessionId };
 }

--- a/editors/vscode/src/sessionEvent.ts
+++ b/editors/vscode/src/sessionEvent.ts
@@ -1,0 +1,37 @@
+export const sessionDAPEventName = "bingo/session/v1";
+export const sessionDAPEventVersion = 1;
+
+export interface SessionAnnouncement {
+  readonly sessionId: string;
+}
+
+export function decodeSessionAnnouncement(
+  eventName: string,
+  body: unknown,
+): SessionAnnouncement | undefined {
+  if (eventName !== sessionDAPEventName) {
+    return undefined;
+  }
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    throw new Error("bingo session event body must be an object");
+  }
+  const value = body as Record<string, unknown>;
+  const keys = Object.keys(value).sort();
+  if (keys.length !== 2 || keys[0] !== "sessionId" || keys[1] !== "version") {
+    throw new Error("bingo session event body has unexpected fields");
+  }
+  if (value.version !== sessionDAPEventVersion) {
+    throw new Error(
+      `unsupported bingo session event version ${JSON.stringify(value.version)}`,
+    );
+  }
+  if (
+    typeof value.sessionId !== "string" ||
+    value.sessionId.length === 0 ||
+    value.sessionId.length > 128 ||
+    !/^[A-Za-z0-9][A-Za-z0-9._-]*$/u.test(value.sessionId)
+  ) {
+    throw new Error("bingo session event has an invalid sessionId");
+  }
+  return { sessionId: value.sessionId };
+}

--- a/editors/vscode/src/telemetry.ts
+++ b/editors/vscode/src/telemetry.ts
@@ -1,0 +1,468 @@
+import { TextDecoder } from "node:util";
+
+export const wireProtocolVersion = "1.2";
+export const snapshotCommandKind = "GoroutineSnapshot";
+export const maximumEnvelopeBytes = 2 * 1024 * 1024;
+export const maximumGoroutines = 5000;
+export const maximumThreads = 2048;
+export const maximumStringLength = 4096;
+
+const maximumPayloadNodes = 20_000;
+const utf8 = new TextDecoder("utf-8", { fatal: true });
+
+const eventKinds = new Set([
+  "BreakpointHit",
+  "Panic",
+  "Stepped",
+  "Paused",
+  "Output",
+  "ProcessExited",
+  "BreakpointSet",
+  "BreakpointCleared",
+  "Continued",
+  "Locals",
+  "Frames",
+  "Goroutines",
+  "Evaluate",
+  "GoroutineSnapshot",
+  "SessionState",
+  "Error",
+  "Restarted",
+]);
+
+export interface Location {
+  readonly file: string;
+  readonly line: number;
+  readonly function: string;
+}
+
+export interface Goroutine {
+  readonly id: number;
+  readonly parentId: number;
+  readonly status: string;
+  readonly waitReason: string;
+  readonly currentLoc: Location;
+  readonly startLoc: Location;
+  readonly createdLoc: Location;
+  readonly threadId: number;
+  readonly current: boolean;
+}
+
+export interface Thread {
+  readonly id: number;
+  readonly mid: number;
+  readonly goid: number;
+  readonly spinning: boolean;
+  readonly currentLoc: Location;
+  readonly current: boolean;
+}
+
+export interface Snapshot {
+  readonly goroutines: readonly Goroutine[];
+  readonly threads: readonly Thread[];
+  readonly current: number;
+  readonly created: readonly number[];
+  readonly exited: readonly number[];
+}
+
+export interface DecodedEvent {
+  readonly kind: string;
+  readonly seq: number;
+  readonly payload: Record<string, unknown>;
+  readonly snapshot?: Snapshot;
+}
+
+export interface SequenceResult {
+  readonly accept: boolean;
+  readonly gap?: string;
+}
+
+export type TelemetryData =
+  | string
+  | Buffer
+  | ArrayBuffer
+  | readonly Buffer[];
+
+export class SequenceTracker {
+  #last = 0;
+  readonly #seen = new Set<number>();
+  readonly #recent: number[] = [];
+
+  public reset(): void {
+    this.#last = 0;
+    this.#seen.clear();
+    this.#recent.length = 0;
+  }
+
+  public observe(seq: number): SequenceResult {
+    if (!Number.isSafeInteger(seq) || seq < 1) {
+      return { accept: false, gap: `invalid event sequence ${String(seq)}` };
+    }
+    if (this.#seen.has(seq)) {
+      return {
+        accept: false,
+        gap: `duplicate event ${String(seq)}`,
+      };
+    }
+    this.#seen.add(seq);
+    this.#recent.push(seq);
+    if (this.#recent.length > 4096) {
+      const oldest = this.#recent.shift();
+      if (oldest !== undefined) {
+        this.#seen.delete(oldest);
+      }
+    }
+    if (seq < this.#last) {
+      return {
+        accept: true,
+        gap: `out-of-order event ${String(seq)} after ${String(this.#last)}`,
+      };
+    }
+    const gap =
+      this.#last > 0 && seq > this.#last + 1
+        ? `missed events ${String(this.#last + 1)}-${String(seq - 1)}`
+        : undefined;
+    this.#last = seq;
+    return gap === undefined ? { accept: true } : { accept: true, gap };
+  }
+}
+
+export function snapshotCommand(): string {
+  return JSON.stringify({
+    v: wireProtocolVersion,
+    kind: snapshotCommandKind,
+    payload: {},
+  });
+}
+
+export function decodeEvent(data: TelemetryData): DecodedEvent {
+  const text = decodeText(data);
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(text) as unknown;
+  } catch {
+    throw new Error("telemetry event is not valid JSON");
+  }
+  const envelope = record(decoded, "telemetry event");
+  exactKeys(envelope, ["v", "kind", "seq", "payload"], [], "telemetry event");
+  if (envelope.v !== wireProtocolVersion) {
+    throw new Error(
+      `telemetry protocol ${JSON.stringify(envelope.v)} is incompatible with ${wireProtocolVersion}`,
+    );
+  }
+  const kind = boundedString(envelope.kind, "event kind");
+  if (!eventKinds.has(kind)) {
+    throw new Error(`unknown telemetry event kind ${JSON.stringify(kind)}`);
+  }
+  const seq = integer(envelope.seq, "event seq", 1);
+  const payload = record(envelope.payload, "event payload");
+  if (kind === snapshotCommandKind) {
+    return { kind, seq, payload, snapshot: decodeSnapshot(payload) };
+  }
+  validatePayload(kind, payload);
+  return { kind, seq, payload };
+}
+
+function decodeText(data: TelemetryData): string {
+  const bytes = dataBytes(data);
+  if (bytes > maximumEnvelopeBytes) {
+    throw new Error("telemetry event exceeds 2 MiB");
+  }
+  if (typeof data === "string") {
+    return data;
+  }
+  try {
+    if (isBufferList(data)) {
+      return utf8.decode(Buffer.concat(data));
+    }
+    return utf8.decode(data);
+  } catch {
+    throw new Error("telemetry event is not valid UTF-8");
+  }
+}
+
+function dataBytes(data: TelemetryData): number {
+  if (typeof data === "string") {
+    return Buffer.byteLength(data);
+  }
+  if (isBufferList(data)) {
+    let size = 0;
+    for (const part of data) {
+      size += part.length;
+      if (size > maximumEnvelopeBytes) {
+        return size;
+      }
+    }
+    return size;
+  }
+  return data.byteLength;
+}
+
+function isBufferList(data: TelemetryData): data is readonly Buffer[] {
+  return Array.isArray(data);
+}
+
+function decodeSnapshot(payload: Record<string, unknown>): Snapshot {
+  exactKeys(
+    payload,
+    ["goroutines", "threads"],
+    ["current", "created", "exited"],
+    "snapshot",
+  );
+  const rawGoroutines = protocolArray(
+    payload.goroutines,
+    "goroutines",
+    maximumGoroutines,
+  );
+  const rawThreads = protocolArray(payload.threads, "threads", maximumThreads);
+  const goroutines = rawGoroutines.map((value, index) =>
+    decodeGoroutine(value, `goroutines[${String(index)}]`),
+  );
+  const ids = new Set<number>();
+  for (const goroutine of goroutines) {
+    if (ids.has(goroutine.id)) {
+      throw new Error(`duplicate goroutine id ${String(goroutine.id)}`);
+    }
+
+    ids.add(goroutine.id);
+  }
+  return {
+    goroutines,
+    threads: rawThreads.map((value, index) =>
+      decodeThread(value, `threads[${String(index)}]`),
+    ),
+    current: optionalInteger(payload.current, "current"),
+    created: decodeIDs(payload.created, "created"),
+    exited: decodeIDs(payload.exited, "exited"),
+  };
+}
+
+function protocolArray(
+  value: unknown,
+  label: string,
+  maximum: number,
+): readonly unknown[] {
+  // Go's encoding/json represents a nil slice as null; on an early degraded
+  // stop that is the protocol's empty collection rather than malformed input.
+  return value === null ? [] : boundedArray(value, label, maximum);
+}
+
+function decodeGoroutine(value: unknown, label: string): Goroutine {
+  const item = record(value, label);
+  exactKeys(
+    item,
+    ["id", "status", "currentLoc"],
+    [
+      "parentId",
+      "waitReason",
+      "startLoc",
+      "createdLoc",
+      "threadId",
+      "current",
+    ],
+    label,
+  );
+  return {
+    id: integer(item.id, `${label}.id`, 1),
+    parentId: optionalInteger(item.parentId, `${label}.parentId`),
+    status: boundedString(item.status, `${label}.status`),
+    waitReason: optionalString(item.waitReason, `${label}.waitReason`),
+    currentLoc: decodeLocation(item.currentLoc, `${label}.currentLoc`),
+    startLoc: decodeLocation(item.startLoc, `${label}.startLoc`, true),
+    createdLoc: decodeLocation(item.createdLoc, `${label}.createdLoc`, true),
+    threadId: optionalInteger(item.threadId, `${label}.threadId`),
+    current: optionalBoolean(item.current, `${label}.current`),
+  };
+}
+
+function decodeThread(value: unknown, label: string): Thread {
+  const item = record(value, label);
+  exactKeys(
+    item,
+    ["id"],
+    ["mid", "goid", "spinning", "currentLoc", "current"],
+    label,
+  );
+  return {
+    id: integer(item.id, `${label}.id`, 0),
+    mid: optionalInteger(item.mid, `${label}.mid`),
+    goid: optionalInteger(item.goid, `${label}.goid`),
+    spinning: optionalBoolean(item.spinning, `${label}.spinning`),
+    currentLoc: decodeLocation(item.currentLoc, `${label}.currentLoc`, true),
+    current: optionalBoolean(item.current, `${label}.current`),
+  };
+}
+
+function decodeLocation(
+  value: unknown,
+  label: string,
+  optional = false,
+): Location {
+  if (value === undefined && optional) {
+    return { file: "", line: 0, function: "" };
+  }
+  const item = record(value, label);
+  exactKeys(item, ["file", "line"], ["function"], label);
+  return {
+    file: boundedString(item.file, `${label}.file`),
+    line: integer(item.line, `${label}.line`, 0),
+    function: optionalString(item.function, `${label}.function`),
+  };
+}
+
+function validatePayload(
+  kind: string,
+  payload: Record<string, unknown>,
+): void {
+  if (kind === "SessionState") {
+    exactKeys(payload, ["sessionID", "state", "clients"], [], "SessionState");
+    boundedString(payload.sessionID, "sessionID");
+    const state = boundedString(payload.state, "session state");
+    if (!["idle", "running", "suspended", "exited"].includes(state)) {
+      throw new Error(`unknown session state ${JSON.stringify(state)}`);
+    }
+    integer(payload.clients, "session clients", 0);
+    return;
+  }
+  const budget = { remaining: maximumPayloadNodes };
+  validatePayloadValue(payload, kind, 0, budget);
+}
+
+function validatePayloadValue(
+  value: unknown,
+  label: string,
+  depth: number,
+  budget: { remaining: number },
+): void {
+  budget.remaining -= 1;
+  if (budget.remaining < 0) {
+    throw new Error(`${label} payload is too large`);
+  }
+  if (depth > 12) {
+    throw new Error(`${label} payload nesting is too deep`);
+  }
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    (typeof value === "number" && Number.isSafeInteger(value))
+  ) {
+    return;
+  }
+  if (typeof value === "string") {
+    boundedString(value, label);
+    return;
+  }
+  if (Array.isArray(value)) {
+    if (value.length > maximumGoroutines) {
+      throw new Error(`${label} payload array is too large`);
+    }
+    for (const item of value) {
+      validatePayloadValue(item, label, depth + 1, budget);
+    }
+    return;
+  }
+  if (value !== null && typeof value === "object") {
+    const entries = Object.entries(value);
+    if (entries.length > 128) {
+      throw new Error(`${label} payload object has too many fields`);
+    }
+    for (const [key, item] of entries) {
+      boundedString(key, `${label} field name`);
+      validatePayloadValue(item, label, depth + 1, budget);
+    }
+    return;
+  }
+  throw new Error(`${label} payload contains an unsupported value`);
+}
+
+function decodeIDs(value: unknown, label: string): readonly number[] {
+  if (value === undefined) {
+    return [];
+  }
+  const result = boundedArray(value, label, maximumGoroutines).map(
+    (item, index) => integer(item, `${label}[${String(index)}]`, 1),
+  );
+  if (new Set(result).size !== result.length) {
+    throw new Error(`${label} contains duplicate goroutine ids`);
+  }
+  return result;
+}
+
+function exactKeys(
+  value: Record<string, unknown>,
+  required: readonly string[],
+  optional: readonly string[],
+  label: string,
+): void {
+  const allowed = new Set([...required, ...optional]);
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) {
+      throw new Error(`${label} has unknown field ${JSON.stringify(key)}`);
+    }
+  }
+  for (const key of required) {
+    if (!Object.hasOwn(value, key)) {
+      throw new Error(`${label} is missing ${JSON.stringify(key)}`);
+    }
+  }
+}
+
+function boundedArray(
+  value: unknown,
+  label: string,
+  maximum: number,
+): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array`);
+  }
+  if (value.length > maximum) {
+    throw new Error(`${label} exceeds the ${String(maximum)} item limit`);
+  }
+  return value;
+}
+
+function boundedString(value: unknown, label: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string`);
+  }
+  if (value.length > maximumStringLength) {
+    throw new Error(`${label} exceeds ${String(maximumStringLength)} characters`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown, label: string): string {
+  return value === undefined ? "" : boundedString(value, label);
+}
+
+function integer(value: unknown, label: string, minimum: number): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isSafeInteger(value) ||
+    value < minimum
+  ) {
+    throw new Error(`${label} must be a safe integer >= ${String(minimum)}`);
+  }
+  return value;
+}
+
+function optionalInteger(value: unknown, label: string): number {
+  return value === undefined ? 0 : integer(value, label, 0);
+}
+
+function optionalBoolean(value: unknown, label: string): boolean {
+  if (value === undefined) {
+    return false;
+  }
+  if (typeof value !== "boolean") {
+    throw new Error(`${label} must be a boolean`);
+  }
+  return value;
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}

--- a/editors/vscode/src/telemetry.ts
+++ b/editors/vscode/src/telemetry.ts
@@ -353,26 +353,44 @@ function validatePayloadValue(
     return;
   }
   if (Array.isArray(value)) {
-    if (value.length > maximumGoroutines) {
-      throw new Error(`${label} payload array is too large`);
-    }
-    for (const item of value) {
-      validatePayloadValue(item, label, depth + 1, budget);
-    }
+    validatePayloadArray(value, label, depth, budget);
     return;
   }
   if (value !== null && typeof value === "object") {
-    const entries = Object.entries(value);
-    if (entries.length > 128) {
-      throw new Error(`${label} payload object has too many fields`);
-    }
-    for (const [key, item] of entries) {
-      boundedString(key, `${label} field name`);
-      validatePayloadValue(item, label, depth + 1, budget);
-    }
+    validatePayloadObject(value, label, depth, budget);
     return;
   }
-  throw new Error(`${label} payload contains an unsupported value`);
+  throw new TypeError(`${label} payload contains an unsupported value`);
+}
+
+function validatePayloadArray(
+  value: readonly unknown[],
+  label: string,
+  depth: number,
+  budget: { remaining: number },
+): void {
+  if (value.length > maximumGoroutines) {
+    throw new Error(`${label} payload array is too large`);
+  }
+  for (const item of value) {
+    validatePayloadValue(item, label, depth + 1, budget);
+  }
+}
+
+function validatePayloadObject(
+  value: object,
+  label: string,
+  depth: number,
+  budget: { remaining: number },
+): void {
+  const entries = Object.entries(value);
+  if (entries.length > 128) {
+    throw new Error(`${label} payload object has too many fields`);
+  }
+  for (const [key, item] of entries) {
+    boundedString(key, `${label} field name`);
+    validatePayloadValue(item, label, depth + 1, budget);
+  }
 }
 
 function decodeIDs(value: unknown, label: string): readonly number[] {
@@ -413,7 +431,7 @@ function boundedArray(
   maximum: number,
 ): unknown[] {
   if (!Array.isArray(value)) {
-    throw new Error(`${label} must be an array`);
+    throw new TypeError(`${label} must be an array`);
   }
   if (value.length > maximum) {
     throw new Error(`${label} exceeds the ${String(maximum)} item limit`);
@@ -423,7 +441,7 @@ function boundedArray(
 
 function boundedString(value: unknown, label: string): string {
   if (typeof value !== "string") {
-    throw new Error(`${label} must be a string`);
+    throw new TypeError(`${label} must be a string`);
   }
   if (value.length > maximumStringLength) {
     throw new Error(`${label} exceeds ${String(maximumStringLength)} characters`);
@@ -441,7 +459,9 @@ function integer(value: unknown, label: string, minimum: number): number {
     !Number.isSafeInteger(value) ||
     value < minimum
   ) {
-    throw new Error(`${label} must be a safe integer >= ${String(minimum)}`);
+    throw new TypeError(
+      `${label} must be a safe integer >= ${String(minimum)}`,
+    );
   }
   return value;
 }
@@ -455,14 +475,14 @@ function optionalBoolean(value: unknown, label: string): boolean {
     return false;
   }
   if (typeof value !== "boolean") {
-    throw new Error(`${label} must be a boolean`);
+    throw new TypeError(`${label} must be a boolean`);
   }
   return value;
 }
 
 function record(value: unknown, label: string): Record<string, unknown> {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`${label} must be an object`);
+    throw new TypeError(`${label} must be an object`);
   }
   return value as Record<string, unknown>;
 }

--- a/editors/vscode/src/tree.ts
+++ b/editors/vscode/src/tree.ts
@@ -30,53 +30,12 @@ export function layoutSpawnTree(
   preferredIDs: readonly number[] = [],
 ): TreeLayout {
   const limit = Math.max(1, Math.min(maximumRenderedGoroutines, Math.trunc(cap)));
-  const unique = new Map<number, Goroutine>();
-  for (const goroutine of [...goroutines].sort(compareGoroutines)) {
-    if (!unique.has(goroutine.id)) {
-      unique.set(goroutine.id, goroutine);
-    }
-  }
-
-  const selectedIDs = new Set<number>();
-  for (const id of preferredIDs) {
-    if (unique.has(id) && selectedIDs.size < limit) {
-      selectedIDs.add(id);
-    }
-  }
-  for (const item of unique.values()) {
-    if (selectedIDs.size >= limit) {
-      break;
-    }
-    selectedIDs.add(item.id);
-  }
-  const selected = [...selectedIDs]
-    .map((id) => unique.get(id))
-    .filter((item): item is Goroutine => item !== undefined)
-    .sort(compareGoroutines);
-
-  const parent = new Map<number, number>();
-  for (const item of selected) {
-    parent.set(
-      item.id,
-      item.parentId !== item.id && selectedIDs.has(item.parentId)
-        ? item.parentId
-        : 0,
-    );
-  }
+  const unique = uniqueGoroutines(goroutines);
+  const selected = selectGoroutines(unique, preferredIDs, limit);
+  const selectedIDs = new Set(selected.map((item) => item.id));
+  const parent = parentTable(selected, selectedIDs);
   breakCycles(parent);
-
-  const children = new Map<number, number[]>();
-  for (const item of selected) {
-    const parentID = parent.get(item.id) ?? 0;
-    const group = children.get(parentID) ?? [];
-    group.push(item.id);
-    children.set(parentID, group);
-  }
-  for (const group of children.values()) {
-    group.sort((left, right) =>
-      compareGoroutines(unique.get(left) as Goroutine, unique.get(right) as Goroutine),
-    );
-  }
+  const children = childrenTable(selected, parent);
 
   const nodes: TreeNode[] = [];
   const edges: TreeEdge[] = [];
@@ -123,6 +82,72 @@ export function layoutSpawnTree(
     width: Math.max(420, 310 + maxDepth * 208),
     height: Math.max(240, 86 + nodes.length * 82),
   };
+}
+
+function uniqueGoroutines(
+  goroutines: readonly Goroutine[],
+): Map<number, Goroutine> {
+  const unique = new Map<number, Goroutine>();
+  for (const goroutine of [...goroutines].sort(compareGoroutines)) {
+    if (!unique.has(goroutine.id)) {
+      unique.set(goroutine.id, goroutine);
+    }
+  }
+  return unique;
+}
+
+function selectGoroutines(
+  unique: ReadonlyMap<number, Goroutine>,
+  preferredIDs: readonly number[],
+  limit: number,
+): readonly Goroutine[] {
+  const selectedIDs = new Set<number>();
+  for (const id of preferredIDs) {
+    if (unique.has(id) && selectedIDs.size < limit) {
+      selectedIDs.add(id);
+    }
+  }
+  for (const item of unique.values()) {
+    if (selectedIDs.size >= limit) {
+      break;
+    }
+    selectedIDs.add(item.id);
+  }
+  return [...selectedIDs]
+    .map((id) => unique.get(id))
+    .filter((item): item is Goroutine => item !== undefined)
+    .sort(compareGoroutines);
+}
+
+function parentTable(
+  selected: readonly Goroutine[],
+  selectedIDs: ReadonlySet<number>,
+): Map<number, number> {
+  return new Map(
+    selected.map((item) => [
+      item.id,
+      item.parentId !== item.id && selectedIDs.has(item.parentId)
+        ? item.parentId
+        : 0,
+    ]),
+  );
+}
+
+function childrenTable(
+  selected: readonly Goroutine[],
+  parent: ReadonlyMap<number, number>,
+): Map<number, number[]> {
+  const children = new Map<number, number[]>();
+  for (const item of selected) {
+    const parentID = parent.get(item.id) ?? 0;
+    const group = children.get(parentID) ?? [];
+    group.push(item.id);
+    children.set(parentID, group);
+  }
+  for (const group of children.values()) {
+    group.sort((left, right) => left - right);
+  }
+  return children;
 }
 
 export function filterTree(layout: TreeLayout, query: string): TreeLayout {

--- a/editors/vscode/src/tree.ts
+++ b/editors/vscode/src/tree.ts
@@ -1,6 +1,7 @@
 import type { Goroutine } from "./telemetry.js";
 
 export const maximumRenderedGoroutines = 500;
+export const maximumFilterAncestorDepth = 4;
 
 export interface TreeNode {
   readonly goroutine: Goroutine;
@@ -164,9 +165,15 @@ export function filterTree(layout: TreeLayout, query: string): TreeLayout {
       continue;
     }
     let current: TreeNode | undefined = node;
-    while (current !== undefined && !visible.has(current.goroutine.id)) {
+    let ancestors = 0;
+    while (
+      current !== undefined &&
+      !visible.has(current.goroutine.id) &&
+      ancestors <= maximumFilterAncestorDepth
+    ) {
       visible.add(current.goroutine.id);
       current = byID.get(current.parentId);
+      ancestors += 1;
     }
   }
   const goroutines = layout.nodes

--- a/editors/vscode/src/tree.ts
+++ b/editors/vscode/src/tree.ts
@@ -152,38 +152,73 @@ function childrenTable(
 }
 
 export function filterTree(layout: TreeLayout, query: string): TreeLayout {
+  return filterFullTree(
+    layout,
+    query,
+    layout.nodes.map((node) => node.goroutine),
+  );
+}
+
+export function filterFullTree(
+  layout: TreeLayout,
+  query: string,
+  goroutines: readonly Goroutine[],
+): TreeLayout {
   const normalized = query.trim().toLocaleLowerCase();
   if (normalized.length === 0) {
     return layout;
   }
-  const byID = new Map(
-    layout.nodes.map((node) => [node.goroutine.id, node] as const),
+  const unique = uniqueGoroutines(goroutines);
+  const matches = [...unique.values()].filter((goroutine) =>
+    searchText(goroutine).includes(normalized),
   );
   const visible = new Set<number>();
-  for (const node of layout.nodes) {
-    if (!searchText(node.goroutine).includes(normalized)) {
-      continue;
+  for (const match of matches) {
+    if (visible.size >= maximumRenderedGoroutines) {
+      break;
     }
-    let current: TreeNode | undefined = node;
-    let ancestors = 0;
-    while (
-      current !== undefined &&
-      !visible.has(current.goroutine.id) &&
-      ancestors <= maximumFilterAncestorDepth
-    ) {
-      visible.add(current.goroutine.id);
-      current = byID.get(current.parentId);
-      ancestors += 1;
+    const chain = boundedAncestorChain(match, unique);
+    const additions = chain.filter((goroutine) => !visible.has(goroutine.id));
+    const remaining = maximumRenderedGoroutines - visible.size;
+    for (const goroutine of additions.slice(-remaining)) {
+      visible.add(goroutine.id);
     }
   }
-  const goroutines = layout.nodes
-    .filter((node) => visible.has(node.goroutine.id))
-    .map((node) => node.goroutine);
-  const filtered = layoutSpawnTree(goroutines, Math.max(1, goroutines.length));
+  const selected = [...visible]
+    .map((id) => unique.get(id))
+    .filter((goroutine): goroutine is Goroutine => goroutine !== undefined);
+  const filtered = layoutSpawnTree(selected, maximumRenderedGoroutines);
   return {
     ...filtered,
-    omitted: layout.omitted + layout.nodes.length - goroutines.length,
+    omitted: Math.max(0, unique.size - filtered.nodes.length),
   };
+}
+
+function boundedAncestorChain(
+  match: Goroutine,
+  byID: ReadonlyMap<number, Goroutine>,
+): readonly Goroutine[] {
+  const chain = [match];
+  const seen = new Set<number>([match.id]);
+  let current = match;
+  for (
+    let ancestors = 0;
+    ancestors < maximumFilterAncestorDepth;
+    ancestors += 1
+  ) {
+    const parent = byID.get(current.parentId);
+    if (
+      parent === undefined ||
+      parent.id === current.id ||
+      seen.has(parent.id)
+    ) {
+      break;
+    }
+    chain.push(parent);
+    seen.add(parent.id);
+    current = parent;
+  }
+  return chain.reverse();
 }
 
 function searchText(goroutine: Goroutine): string {

--- a/editors/vscode/src/tree.ts
+++ b/editors/vscode/src/tree.ts
@@ -1,0 +1,201 @@
+import type { Goroutine } from "./telemetry.js";
+
+export const maximumRenderedGoroutines = 500;
+
+export interface TreeNode {
+  readonly goroutine: Goroutine;
+  readonly parentId: number;
+  readonly depth: number;
+  readonly order: number;
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface TreeEdge {
+  readonly from: number;
+  readonly to: number;
+}
+
+export interface TreeLayout {
+  readonly nodes: readonly TreeNode[];
+  readonly edges: readonly TreeEdge[];
+  readonly omitted: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+export function layoutSpawnTree(
+  goroutines: readonly Goroutine[],
+  cap = maximumRenderedGoroutines,
+  preferredIDs: readonly number[] = [],
+): TreeLayout {
+  const limit = Math.max(1, Math.min(maximumRenderedGoroutines, Math.trunc(cap)));
+  const unique = new Map<number, Goroutine>();
+  for (const goroutine of [...goroutines].sort(compareGoroutines)) {
+    if (!unique.has(goroutine.id)) {
+      unique.set(goroutine.id, goroutine);
+    }
+  }
+
+  const selectedIDs = new Set<number>();
+  for (const id of preferredIDs) {
+    if (unique.has(id) && selectedIDs.size < limit) {
+      selectedIDs.add(id);
+    }
+  }
+  for (const item of unique.values()) {
+    if (selectedIDs.size >= limit) {
+      break;
+    }
+    selectedIDs.add(item.id);
+  }
+  const selected = [...selectedIDs]
+    .map((id) => unique.get(id))
+    .filter((item): item is Goroutine => item !== undefined)
+    .sort(compareGoroutines);
+
+  const parent = new Map<number, number>();
+  for (const item of selected) {
+    parent.set(
+      item.id,
+      item.parentId !== item.id && selectedIDs.has(item.parentId)
+        ? item.parentId
+        : 0,
+    );
+  }
+  breakCycles(parent);
+
+  const children = new Map<number, number[]>();
+  for (const item of selected) {
+    const parentID = parent.get(item.id) ?? 0;
+    const group = children.get(parentID) ?? [];
+    group.push(item.id);
+    children.set(parentID, group);
+  }
+  for (const group of children.values()) {
+    group.sort((left, right) =>
+      compareGoroutines(unique.get(left) as Goroutine, unique.get(right) as Goroutine),
+    );
+  }
+
+  const nodes: TreeNode[] = [];
+  const edges: TreeEdge[] = [];
+  const visited = new Set<number>();
+  let row = 0;
+  const visit = (id: number, depth: number): void => {
+    const goroutine = unique.get(id);
+    if (goroutine === undefined || visited.has(id)) {
+      return;
+    }
+    visited.add(id);
+    const parentId = parent.get(id) ?? 0;
+    nodes.push({
+      goroutine,
+      parentId,
+      depth,
+      order: row,
+      x: 42 + depth * 208,
+      y: 42 + row * 82,
+    });
+    row += 1;
+    if (parentId !== 0) {
+      edges.push({ from: parentId, to: id });
+    }
+    for (const child of children.get(id) ?? []) {
+      visit(child, depth + 1);
+    }
+  };
+  for (const root of children.get(0) ?? []) {
+    visit(root, 0);
+  }
+  for (const item of selected) {
+    visit(item.id, 0);
+  }
+
+  const maxDepth = nodes.reduce(
+    (result, node) => Math.max(result, node.depth),
+    0,
+  );
+  return {
+    nodes,
+    edges,
+    omitted: Math.max(0, unique.size - selected.length),
+    width: Math.max(420, 310 + maxDepth * 208),
+    height: Math.max(240, 86 + nodes.length * 82),
+  };
+}
+
+export function filterTree(layout: TreeLayout, query: string): TreeLayout {
+  const normalized = query.trim().toLocaleLowerCase();
+  if (normalized.length === 0) {
+    return layout;
+  }
+  const byID = new Map(
+    layout.nodes.map((node) => [node.goroutine.id, node] as const),
+  );
+  const visible = new Set<number>();
+  for (const node of layout.nodes) {
+    if (!searchText(node.goroutine).includes(normalized)) {
+      continue;
+    }
+    let current: TreeNode | undefined = node;
+    while (current !== undefined && !visible.has(current.goroutine.id)) {
+      visible.add(current.goroutine.id);
+      current = byID.get(current.parentId);
+    }
+  }
+  const goroutines = layout.nodes
+    .filter((node) => visible.has(node.goroutine.id))
+    .map((node) => node.goroutine);
+  const filtered = layoutSpawnTree(goroutines, Math.max(1, goroutines.length));
+  return {
+    ...filtered,
+    omitted: layout.omitted + layout.nodes.length - goroutines.length,
+  };
+}
+
+function searchText(goroutine: Goroutine): string {
+  return [
+    String(goroutine.id),
+    String(goroutine.parentId),
+    String(goroutine.threadId),
+    goroutine.status,
+    goroutine.waitReason,
+    locationText(goroutine.currentLoc),
+    locationText(goroutine.startLoc),
+    locationText(goroutine.createdLoc),
+  ]
+    .join(" ")
+    .toLocaleLowerCase();
+}
+
+function locationText(location: Goroutine["currentLoc"]): string {
+  return `${location.function} ${location.file} ${String(location.line)}`;
+}
+
+function breakCycles(parent: Map<number, number>): void {
+  for (const start of parent.keys()) {
+    const path: number[] = [];
+    const positions = new Map<number, number>();
+    let current = start;
+    while (current !== 0) {
+      const position = positions.get(current);
+      if (position !== undefined) {
+        const promoted = path
+          .slice(position)
+          .sort((left, right) => left - right)[0];
+        if (promoted !== undefined) {
+          parent.set(promoted, 0);
+        }
+        break;
+      }
+      positions.set(current, path.length);
+      path.push(current);
+      current = parent.get(current) ?? 0;
+    }
+  }
+}
+
+function compareGoroutines(left: Goroutine, right: Goroutine): number {
+  return left.id - right.id;
+}

--- a/editors/vscode/src/webview.ts
+++ b/editors/vscode/src/webview.ts
@@ -9,6 +9,9 @@ const vscode = acquireVsCodeApi();
 const render = mountConcurrencyView(document, vscode);
 
 window.addEventListener("message", (event: MessageEvent<unknown>) => {
+  if (event.origin !== window.location.origin) {
+    return;
+  }
   if (isFitMessage(event.data)) {
     document.querySelector<HTMLButtonElement>(".graph-controls button")?.click();
     return;

--- a/editors/vscode/src/webview.ts
+++ b/editors/vscode/src/webview.ts
@@ -22,7 +22,7 @@ window.addEventListener("message", (event: MessageEvent<unknown>) => {
   if (event.data.revision !== event.data.model.revision) {
     return;
   }
-  render(event.data.model);
+  render(event.data.model, event.data.generation);
 });
 vscode.postMessage({ type: "ready" });
 
@@ -30,6 +30,7 @@ function isRenderMessage(
   value: unknown,
 ): value is {
   readonly type: "render";
+  readonly generation: number;
   readonly revision: number;
   readonly model: ConcurrencyViewModel;
 } {
@@ -38,12 +39,16 @@ function isRenderMessage(
     value !== null &&
     "type" in value &&
     value.type === "render" &&
+    "generation" in value &&
+    typeof value.generation === "number" &&
+    Number.isSafeInteger(value.generation) &&
+    value.generation > 0 &&
     "revision" in value &&
     Number.isSafeInteger(value.revision) &&
     "model" in value &&
     typeof value.model === "object" &&
     value.model !== null &&
-    Object.keys(value).length === 3
+    Object.keys(value).length === 4
   );
 }
 

--- a/editors/vscode/src/webview.ts
+++ b/editors/vscode/src/webview.ts
@@ -1,0 +1,54 @@
+import type { ConcurrencyViewModel } from "./model.js";
+import { mountConcurrencyView } from "./webviewApp.js";
+
+declare function acquireVsCodeApi(): {
+  postMessage(message: Record<string, unknown>): void;
+};
+
+const vscode = acquireVsCodeApi();
+const render = mountConcurrencyView(document, vscode);
+
+window.addEventListener("message", (event: MessageEvent<unknown>) => {
+  if (isFitMessage(event.data)) {
+    document.querySelector<HTMLButtonElement>(".graph-controls button")?.click();
+    return;
+  }
+  if (!isRenderMessage(event.data)) {
+    return;
+  }
+  if (event.data.revision !== event.data.model.revision) {
+    return;
+  }
+  render(event.data.model);
+});
+vscode.postMessage({ type: "ready" });
+
+function isRenderMessage(
+  value: unknown,
+): value is {
+  readonly type: "render";
+  readonly revision: number;
+  readonly model: ConcurrencyViewModel;
+} {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    value.type === "render" &&
+    "revision" in value &&
+    Number.isSafeInteger(value.revision) &&
+    "model" in value &&
+    typeof value.model === "object" &&
+    value.model !== null &&
+    Object.keys(value).length === 3
+  );
+}
+
+function isFitMessage(value: unknown): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    value.type === "fit"
+  );
+}

--- a/editors/vscode/src/webviewApp.ts
+++ b/editors/vscode/src/webviewApp.ts
@@ -2,7 +2,7 @@ import type {
   ConcurrencyViewModel,
   SessionViewModel,
 } from "./model.js";
-import { filterTree, type TreeNode } from "./tree.js";
+import { filterFullTree, type TreeNode } from "./tree.js";
 
 export interface WebviewHost {
   postMessage(message: Record<string, unknown>): void;
@@ -228,6 +228,8 @@ function renderGraph(
   const panel = document.createElement("section");
   panel.className = "graph-panel";
   panel.setAttribute("aria-label", "Goroutine spawn tree");
+  let currentTransform = state.transform;
+  const scene = document.createElementNS(svgNamespace, "g");
   const controls = document.createElement("div");
   controls.className = "graph-controls";
   const fit = button(document, "Fit", () => {
@@ -261,9 +263,8 @@ function renderGraph(
   svg.setAttribute("viewBox", `0 0 ${String(session.tree.width)} ${String(session.tree.height)}`);
   svg.setAttribute("role", "tree");
   svg.setAttribute("aria-label", "Goroutine spawn hierarchy");
-  const scene = document.createElementNS(svgNamespace, "g");
-  let currentTransform = state.transform;
-  svg.append(scene);
+  const activeScene = scene;
+  svg.append(activeScene);
   const byID = new Map(
     session.tree.nodes.map((node) => [node.goroutine.id, node]),
   );
@@ -286,7 +287,7 @@ function renderGraph(
     path.setAttribute("class", "tree-edge");
     path.dataset.from = String(edge.from);
     path.dataset.to = String(edge.to);
-    scene.append(path);
+    activeScene.append(path);
   }
   const siblings = new Map<number, TreeNode[]>();
   for (const node of session.tree.nodes) {
@@ -296,7 +297,7 @@ function renderGraph(
   }
   for (const node of session.tree.nodes) {
     const group = siblings.get(node.parentId) ?? [];
-    scene.append(
+    activeScene.append(
       renderNode(
         document,
         node,
@@ -353,7 +354,7 @@ function renderGraph(
     }
     event.preventDefault();
     const visible = session.tree.nodes.filter((node) => {
-      const element = scene.querySelector<SVGGElement>(
+      const element = activeScene.querySelector<SVGGElement>(
         `[data-goid="${String(node.goroutine.id)}"]`,
       );
       return element?.classList.contains("filtered") !== true;
@@ -364,7 +365,7 @@ function renderGraph(
     const direction = event.key === "ArrowDown" || event.key === "ArrowRight" ? 1 : -1;
     const next = visible[(current + direction + visible.length) % visible.length];
     if (next !== undefined) {
-      scene
+      activeScene
         .querySelector<SVGGElement>(
           `[data-goid="${String(next.goroutine.id)}"]`,
         )
@@ -511,7 +512,11 @@ function filteredSession(
 ): SessionViewModel {
   return {
     ...session,
-    tree: filterTree(session.tree, query),
+    tree: filterFullTree(
+      session.tree,
+      query,
+      session.snapshot?.goroutines ?? [],
+    ),
   };
 }
 

--- a/editors/vscode/src/webviewApp.ts
+++ b/editors/vscode/src/webviewApp.ts
@@ -364,6 +364,11 @@ function renderGraph(
     const direction = event.key === "ArrowDown" || event.key === "ArrowRight" ? 1 : -1;
     const next = visible[(current + direction + visible.length) % visible.length];
     if (next !== undefined) {
+      scene
+        .querySelector<SVGGElement>(
+          `[data-goid="${String(next.goroutine.id)}"]`,
+        )
+        ?.focus();
       host.postMessage({ type: "selectGoroutine", id: next.goroutine.id });
     }
   });

--- a/editors/vscode/src/webviewApp.ts
+++ b/editors/vscode/src/webviewApp.ts
@@ -449,8 +449,7 @@ function applyGraphFilter(panel: HTMLElement, value: string): void {
     if (matched && node.dataset.goid !== undefined) {
       let current: SVGGElement | undefined = node;
       while (
-        current !== undefined &&
-        current.dataset.goid !== undefined &&
+        current?.dataset.goid !== undefined &&
         !visible.has(current.dataset.goid)
       ) {
         visible.add(current.dataset.goid);
@@ -528,10 +527,10 @@ function renderThreads(
     const label = document.createElement("strong");
     label.textContent = `t${String(thread.id)}`;
     const detail = document.createElement("span");
-    detail.textContent =
-      thread.goid > 0
-        ? `g${String(thread.goid)}${thread.spinning ? " · spinning" : ""}`
-        : `idle${thread.spinning ? " · spinning" : ""}`;
+    const scheduled =
+      thread.goid > 0 ? `g${String(thread.goid)}` : "idle";
+    const schedulerState = thread.spinning ? " · spinning" : "";
+    detail.textContent = scheduled + schedulerState;
     item.append(label, detail);
     list.append(item);
   }
@@ -621,10 +620,10 @@ function locationText(location: {
   if (location.file.length === 0 && location.function.length === 0) {
     return "unknown";
   }
-  const source =
-    location.file.length === 0
-      ? ""
-      : `${location.file}${location.line > 0 ? `:${String(location.line)}` : ""}`;
+  let source = location.file;
+  if (source.length > 0 && location.line > 0) {
+    source += `:${String(location.line)}`;
+  }
   return [location.function, source].filter((item) => item.length > 0).join(" · ");
 }
 
@@ -660,8 +659,8 @@ function focusIdentity(element: Element | null | undefined): string {
   if (element.id.length > 0) {
     return `#${element.id}`;
   }
-  const goid = element.getAttribute("data-goid");
-  if (goid !== null) {
+  const goid = (element as HTMLElement | SVGElement).dataset.goid;
+  if (goid !== undefined) {
     return `[data-goid="${goid}"]`;
   }
   return "";

--- a/editors/vscode/src/webviewApp.ts
+++ b/editors/vscode/src/webviewApp.ts
@@ -2,7 +2,7 @@ import type {
   ConcurrencyViewModel,
   SessionViewModel,
 } from "./model.js";
-import type { TreeNode } from "./tree.js";
+import { filterTree, type TreeNode } from "./tree.js";
 
 export interface WebviewHost {
   postMessage(message: Record<string, unknown>): void;
@@ -158,16 +158,29 @@ function renderSession(
 
   const workspace = document.createElement("div");
   workspace.className = "workspace";
-  const graph = renderGraph(document, session, host, state);
+  let graph = renderGraph(
+    document,
+    filteredSession(session, state.query),
+    host,
+    state,
+  );
   const side = renderInspector(document, session);
   workspace.append(graph, side);
   main.append(workspace, renderThreads(document, session), renderTimeline(document, session));
 
   search.addEventListener("input", () => {
     state.setQuery(search.value);
-    applyGraphFilter(graph, search.value);
+    const fitted = { x: 20, y: 20, scale: 1 };
+    state.setTransform(fitted);
+    const replacement = renderGraph(
+      document,
+      filteredSession(session, search.value),
+      host,
+      { ...state, query: search.value, transform: fitted },
+    );
+    graph.replaceWith(replacement);
+    graph = replacement;
   });
-  applyGraphFilter(graph, state.query);
   return main;
 }
 
@@ -271,13 +284,30 @@ function renderGraph(
     path.dataset.to = String(edge.to);
     scene.append(path);
   }
+  const siblings = new Map<number, TreeNode[]>();
   for (const node of session.tree.nodes) {
-    scene.append(renderNode(document, node, session.selectedGoroutine, host));
+    const group = siblings.get(node.parentId) ?? [];
+    group.push(node);
+    siblings.set(node.parentId, group);
+  }
+  for (const node of session.tree.nodes) {
+    const group = siblings.get(node.parentId) ?? [];
+    scene.append(
+      renderNode(
+        document,
+        node,
+        session.selectedGoroutine,
+        host,
+        group.indexOf(node) + 1,
+        group.length,
+        byID.has(node.goroutine.parentId),
+      ),
+    );
   }
   if (session.tree.omitted > 0) {
     const note = document.createElement("p");
     note.className = "omitted";
-    note.textContent = `${String(session.tree.omitted)} additional goroutines omitted from the visual cap`;
+    note.textContent = `${String(session.tree.omitted)} additional goroutines omitted by the filter or visual cap`;
     panel.append(note);
   }
   viewport.append(svg);
@@ -383,6 +413,9 @@ function renderNode(
   node: TreeNode,
   selected: number,
   host: WebviewHost,
+  position: number,
+  siblingCount: number,
+  reportedParentDisplayed: boolean,
 ): SVGGElement {
   const group = document.createElementNS(svgNamespace, "g");
   group.setAttribute("transform", `translate(${String(node.x)} ${String(node.y)})`);
@@ -391,7 +424,14 @@ function renderNode(
     `tree-node${node.goroutine.current ? " current" : ""}${node.goroutine.id === selected ? " selected" : ""}`,
   );
   group.setAttribute("role", "treeitem");
-  group.setAttribute("aria-label", goroutineLabel(node.goroutine));
+  group.setAttribute(
+    "aria-label",
+    `${goroutineLabel(node.goroutine)}, ${hierarchyLabel(node, reportedParentDisplayed)}`,
+  );
+  group.setAttribute("aria-level", String(node.depth + 1));
+  group.setAttribute("aria-posinset", String(position));
+  group.setAttribute("aria-setsize", String(siblingCount));
+  group.setAttribute("aria-selected", String(node.goroutine.id === selected));
   group.dataset.goid = String(node.goroutine.id);
   group.dataset.parent = String(node.parentId);
   group.dataset.search = goroutineLabel(node.goroutine).toLocaleLowerCase();
@@ -437,38 +477,33 @@ function renderNode(
   return group;
 }
 
-function applyGraphFilter(panel: HTMLElement, value: string): void {
-  const query = value.trim().toLocaleLowerCase();
-  const visible = new Set<string>();
-  const nodes = [...panel.querySelectorAll<SVGGElement>(".tree-node")];
-  const byID = new Map(
-    nodes.map((node) => [node.dataset.goid ?? "", node] as const),
-  );
-  for (const node of nodes) {
-    const matched = query.length === 0 || node.dataset.search?.includes(query) === true;
-    if (matched && node.dataset.goid !== undefined) {
-      let current: SVGGElement | undefined = node;
-      while (
-        current?.dataset.goid !== undefined &&
-        !visible.has(current.dataset.goid)
-      ) {
-        visible.add(current.dataset.goid);
-        current = byID.get(current.dataset.parent ?? "");
-      }
+function hierarchyLabel(
+  node: TreeNode,
+  reportedParentDisplayed: boolean,
+): string {
+  if (node.parentId !== 0) {
+    return `child of goroutine ${String(node.parentId)}`;
+  }
+  if (
+    node.goroutine.parentId > 0 &&
+    node.goroutine.parentId !== node.goroutine.id
+  ) {
+    if (reportedParentDisplayed) {
+      return `displayed root after cycle normalization, reported parent goroutine ${String(node.goroutine.parentId)}`;
     }
+    return `displayed root, reported parent goroutine ${String(node.goroutine.parentId)} is not displayed`;
   }
-  for (const node of nodes) {
-    node.classList.toggle(
-      "filtered",
-      !visible.has(node.dataset.goid ?? ""),
-    );
-  }
-  for (const edge of panel.querySelectorAll<SVGPathElement>(".tree-edge")) {
-    edge.classList.toggle(
-      "filtered",
-      !visible.has(edge.dataset.from ?? "") || !visible.has(edge.dataset.to ?? ""),
-    );
-  }
+  return "root goroutine";
+}
+
+function filteredSession(
+  session: SessionViewModel,
+  query: string,
+): SessionViewModel {
+  return {
+    ...session,
+    tree: filterTree(session.tree, query),
+  };
 }
 
 function renderInspector(

--- a/editors/vscode/src/webviewApp.ts
+++ b/editors/vscode/src/webviewApp.ts
@@ -13,7 +13,7 @@ const svgNamespace = "http://www.w3.org/2000/svg";
 export function mountConcurrencyView(
   document: Document,
   host: WebviewHost,
-): (model: ConcurrencyViewModel) => void {
+): (model: ConcurrencyViewModel, generation?: number) => void {
   const root = document.getElementById("app");
   if (root === null) {
     throw new Error("Bingo Concurrency root is missing");
@@ -21,7 +21,7 @@ export function mountConcurrencyView(
   let query = "";
   let transform = { x: 20, y: 20, scale: 1 };
 
-  return (model) => {
+  return (model, generation = 1) => {
     const focused = focusIdentity(document.activeElement);
     root.replaceChildren();
     root.className = "app";
@@ -50,7 +50,11 @@ export function mountConcurrencyView(
           }),
     );
     restoreFocus(root, focused);
-    host.postMessage({ type: "rendered", revision: model.revision });
+    host.postMessage({
+      type: "rendered",
+      generation,
+      revision: model.revision,
+    });
   };
 }
 

--- a/editors/vscode/src/webviewApp.ts
+++ b/editors/vscode/src/webviewApp.ts
@@ -1,0 +1,674 @@
+import type {
+  ConcurrencyViewModel,
+  SessionViewModel,
+} from "./model.js";
+import type { TreeNode } from "./tree.js";
+
+export interface WebviewHost {
+  postMessage(message: Record<string, unknown>): void;
+}
+
+const svgNamespace = "http://www.w3.org/2000/svg";
+
+export function mountConcurrencyView(
+  document: Document,
+  host: WebviewHost,
+): (model: ConcurrencyViewModel) => void {
+  const root = document.getElementById("app");
+  if (root === null) {
+    throw new Error("Bingo Concurrency root is missing");
+  }
+  let query = "";
+  let transform = { x: 20, y: 20, scale: 1 };
+
+  return (model) => {
+    const focused = focusIdentity(document.activeElement);
+    root.replaceChildren();
+    root.className = "app";
+    root.setAttribute("aria-live", "polite");
+    const session =
+      model.sessions.find(
+        (item) => item.debugSessionId === model.activeDebugSessionId,
+      ) ?? model.sessions[0];
+    root.append(
+      header(document, model, session, host),
+      session === undefined
+        ? emptyState(
+            document,
+            "Start a bingo debug session",
+            "Press F5 and choose a progressive example. This view joins automatically.",
+          )
+        : renderSession(document, session, host, {
+            query,
+            setQuery(value) {
+              query = value;
+            },
+            transform,
+            setTransform(value) {
+              transform = value;
+            },
+          }),
+    );
+    restoreFocus(root, focused);
+    host.postMessage({ type: "rendered", revision: model.revision });
+  };
+}
+
+function header(
+  document: Document,
+  model: ConcurrencyViewModel,
+  session: SessionViewModel | undefined,
+  host: WebviewHost,
+): HTMLElement {
+  const element = document.createElement("header");
+  element.className = "topbar";
+  const brand = document.createElement("div");
+  brand.className = "brand";
+  const title = document.createElement("strong");
+  title.textContent = "Bingo Concurrency";
+  const subtitle = document.createElement("span");
+  subtitle.textContent =
+    session === undefined
+      ? "Waiting for a debug session"
+      : `${session.connection} · ${session.sessionState} · seq ${String(session.lastSeq)}`;
+  brand.append(title, subtitle);
+  element.append(brand);
+  if (model.sessions.length > 0) {
+    const selector = document.createElement("select");
+    selector.className = "session-selector";
+    selector.setAttribute("aria-label", "Active bingo debug session");
+    for (const item of model.sessions) {
+      const option = document.createElement("option");
+      option.value = item.debugSessionId;
+      option.textContent = item.debugSessionName;
+      option.selected = item.debugSessionId === session?.debugSessionId;
+      selector.append(option);
+    }
+    selector.addEventListener("change", () => {
+      host.postMessage({ type: "selectSession", id: selector.value });
+    });
+    element.append(selector);
+  }
+  return element;
+}
+
+interface RenderState {
+  readonly query: string;
+  readonly setQuery: (value: string) => void;
+  readonly transform: { readonly x: number; readonly y: number; readonly scale: number };
+  readonly setTransform: (value: {
+    readonly x: number;
+    readonly y: number;
+    readonly scale: number;
+  }) => void;
+}
+
+function renderSession(
+  document: Document,
+  session: SessionViewModel,
+  host: WebviewHost,
+  state: RenderState,
+): HTMLElement {
+  const main = document.createElement("main");
+  main.className = "session";
+  main.append(summaryCards(document, session));
+  if (session.error.length > 0) {
+    main.append(callout(document, "error", "Telemetry error", session.error));
+  } else if (session.seqGap.length > 0) {
+    main.append(callout(document, "warning", "Sequence gap", session.seqGap));
+  } else if (session.degraded) {
+    main.append(
+      callout(
+        document,
+        "warning",
+        "Degraded runtime snapshot",
+        "DWARF or runtime data was unavailable; showing the synthetic fallback.",
+      ),
+    );
+  }
+  if (session.snapshot === undefined) {
+    main.append(
+      emptyState(
+        document,
+        session.connection === "connected"
+          ? "Waiting for a suspended snapshot"
+          : "Connecting to telemetry",
+        "Snapshots arrive at entry, breakpoints, pauses, and explicit refreshes.",
+      ),
+    );
+    return main;
+  }
+
+  const toolbar = document.createElement("div");
+  toolbar.className = "toolbar";
+  const search = document.createElement("input");
+  search.type = "search";
+  search.id = "bingo-goroutine-filter";
+  search.placeholder = "Filter goroutines";
+  search.value = state.query;
+  search.setAttribute("aria-label", "Filter goroutines");
+  const refresh = button(document, "Refresh", () => {
+    host.postMessage({ type: "refresh" });
+  });
+  const copy = button(document, "Copy snapshot", () => {
+    host.postMessage({ type: "copySnapshot" });
+  });
+  toolbar.append(search, refresh, copy);
+  main.append(toolbar);
+
+  const workspace = document.createElement("div");
+  workspace.className = "workspace";
+  const graph = renderGraph(document, session, host, state);
+  const side = renderInspector(document, session);
+  workspace.append(graph, side);
+  main.append(workspace, renderThreads(document, session), renderTimeline(document, session));
+
+  search.addEventListener("input", () => {
+    state.setQuery(search.value);
+    applyGraphFilter(graph, search.value);
+  });
+  applyGraphFilter(graph, state.query);
+  return main;
+}
+
+function summaryCards(
+  document: Document,
+  session: SessionViewModel,
+): HTMLElement {
+  const cards = document.createElement("section");
+  cards.className = "cards";
+  cards.setAttribute("aria-label", "Concurrency summary");
+  const values = [
+    ["Goroutines", session.snapshot?.goroutines.length ?? 0],
+    ["Threads", session.snapshot?.threads.length ?? 0],
+    ["Clients", session.clients],
+    ["Current", session.snapshot?.current || "—"],
+  ] as const;
+  for (const [label, value] of values) {
+    const card = document.createElement("div");
+    card.className = "card";
+    const number = document.createElement("strong");
+    number.textContent = String(value);
+    const caption = document.createElement("span");
+    caption.textContent = label;
+    card.append(number, caption);
+    cards.append(card);
+  }
+  const status = document.createElement("div");
+  status.className = "last-stop";
+  status.textContent =
+    session.lastStop.length > 0 ? session.lastStop : "Awaiting first stop";
+  cards.append(status);
+  return cards;
+}
+
+function renderGraph(
+  document: Document,
+  session: SessionViewModel,
+  host: WebviewHost,
+  state: RenderState,
+): HTMLElement {
+  const panel = document.createElement("section");
+  panel.className = "graph-panel";
+  panel.setAttribute("aria-label", "Goroutine spawn tree");
+  const controls = document.createElement("div");
+  controls.className = "graph-controls";
+  const fit = button(document, "Fit", () => {
+    currentTransform = { x: 20, y: 20, scale: 1 };
+    state.setTransform(currentTransform);
+    updateTransform();
+  });
+  const zoomIn = button(document, "+", () => zoom(1.15));
+  zoomIn.setAttribute("aria-label", "Zoom in");
+  const zoomOut = button(document, "−", () => zoom(0.85));
+  zoomOut.setAttribute("aria-label", "Zoom out");
+  controls.append(fit, zoomOut, zoomIn);
+  panel.append(controls);
+
+  if (session.tree.nodes.length === 0) {
+    panel.append(
+      emptyState(
+        document,
+        "No goroutines in this snapshot",
+        "The target may be exiting or runtime inspection degraded.",
+      ),
+    );
+    return panel;
+  }
+
+  const viewport = document.createElement("div");
+  viewport.className = "graph-viewport";
+  viewport.id = "concurrency-tree";
+  viewport.tabIndex = 0;
+  const svg = document.createElementNS(svgNamespace, "svg");
+  svg.setAttribute("viewBox", `0 0 ${String(session.tree.width)} ${String(session.tree.height)}`);
+  svg.setAttribute("role", "tree");
+  svg.setAttribute("aria-label", "Goroutine spawn hierarchy");
+  const scene = document.createElementNS(svgNamespace, "g");
+  let currentTransform = state.transform;
+  svg.append(scene);
+  const byID = new Map(
+    session.tree.nodes.map((node) => [node.goroutine.id, node]),
+  );
+  for (const edge of session.tree.edges) {
+    const from = byID.get(edge.from);
+    const to = byID.get(edge.to);
+    if (from === undefined || to === undefined) {
+      continue;
+    }
+    const path = document.createElementNS(svgNamespace, "path");
+    const startX = from.x + 150;
+    const startY = from.y + 24;
+    const endX = to.x;
+    const endY = to.y + 24;
+    const bend = startX + (endX - startX) / 2;
+    path.setAttribute(
+      "d",
+      `M ${String(startX)} ${String(startY)} C ${String(bend)} ${String(startY)}, ${String(bend)} ${String(endY)}, ${String(endX)} ${String(endY)}`,
+    );
+    path.setAttribute("class", "tree-edge");
+    path.dataset.from = String(edge.from);
+    path.dataset.to = String(edge.to);
+    scene.append(path);
+  }
+  for (const node of session.tree.nodes) {
+    scene.append(renderNode(document, node, session.selectedGoroutine, host));
+  }
+  if (session.tree.omitted > 0) {
+    const note = document.createElement("p");
+    note.className = "omitted";
+    note.textContent = `${String(session.tree.omitted)} additional goroutines omitted from the visual cap`;
+    panel.append(note);
+  }
+  viewport.append(svg);
+  panel.append(viewport);
+
+  let dragging: { readonly x: number; readonly y: number } | undefined;
+  viewport.addEventListener("wheel", (event) => {
+    event.preventDefault();
+    zoom(event.deltaY < 0 ? 1.1 : 0.9);
+  });
+  viewport.addEventListener("pointerdown", (event) => {
+    dragging = pointerPosition(event.clientX, event.clientY);
+    viewport.setPointerCapture(event.pointerId);
+  });
+  viewport.addEventListener("pointermove", (event) => {
+    if (dragging === undefined) {
+      return;
+    }
+    const pointer = pointerPosition(event.clientX, event.clientY);
+    state.setTransform({
+      ...currentTransform,
+      x: currentTransform.x + pointer.x - dragging.x,
+      y: currentTransform.y + pointer.y - dragging.y,
+    });
+    currentTransform = {
+      ...currentTransform,
+      x: currentTransform.x + pointer.x - dragging.x,
+      y: currentTransform.y + pointer.y - dragging.y,
+    };
+    dragging = pointer;
+    updateTransform();
+  });
+  viewport.addEventListener("pointerup", () => {
+    dragging = undefined;
+  });
+  viewport.addEventListener("keydown", (event) => {
+    if (!["ArrowDown", "ArrowRight", "ArrowUp", "ArrowLeft"].includes(event.key)) {
+      return;
+    }
+    event.preventDefault();
+    const visible = session.tree.nodes.filter((node) => {
+      const element = scene.querySelector<SVGGElement>(
+        `[data-goid="${String(node.goroutine.id)}"]`,
+      );
+      return element?.classList.contains("filtered") !== true;
+    });
+    const current = visible.findIndex(
+      (node) => node.goroutine.id === session.selectedGoroutine,
+    );
+    const direction = event.key === "ArrowDown" || event.key === "ArrowRight" ? 1 : -1;
+    const next = visible[(current + direction + visible.length) % visible.length];
+    if (next !== undefined) {
+      host.postMessage({ type: "selectGoroutine", id: next.goroutine.id });
+    }
+  });
+  updateTransform();
+  return panel;
+
+  function zoom(factor: number): void {
+    state.setTransform({
+      ...currentTransform,
+      scale: Math.min(3, Math.max(0.25, currentTransform.scale * factor)),
+    });
+    currentTransform = {
+      ...currentTransform,
+      scale: Math.min(3, Math.max(0.25, currentTransform.scale * factor)),
+    };
+    updateTransform();
+  }
+
+  function updateTransform(): void {
+    scene.setAttribute(
+      "transform",
+      `translate(${String(currentTransform.x)} ${String(currentTransform.y)}) scale(${String(currentTransform.scale)})`,
+    );
+  }
+
+  function pointerPosition(clientX: number, clientY: number): {
+    readonly x: number;
+    readonly y: number;
+  } {
+    const matrix = svg.getScreenCTM();
+    if (matrix !== null) {
+      const point = new DOMPoint(clientX, clientY).matrixTransform(
+        matrix.inverse(),
+      );
+      return { x: point.x, y: point.y };
+    }
+    const bounds = svg.getBoundingClientRect();
+    const unitsPerPixel = Math.max(
+      session.tree.width / Math.max(bounds.width, 1),
+      session.tree.height / Math.max(bounds.height, 1),
+    );
+    return {
+      x: (clientX - bounds.left) * unitsPerPixel,
+      y: (clientY - bounds.top) * unitsPerPixel,
+    };
+  }
+}
+
+function renderNode(
+  document: Document,
+  node: TreeNode,
+  selected: number,
+  host: WebviewHost,
+): SVGGElement {
+  const group = document.createElementNS(svgNamespace, "g");
+  group.setAttribute("transform", `translate(${String(node.x)} ${String(node.y)})`);
+  group.setAttribute(
+    "class",
+    `tree-node${node.goroutine.current ? " current" : ""}${node.goroutine.id === selected ? " selected" : ""}`,
+  );
+  group.setAttribute("role", "treeitem");
+  group.setAttribute("aria-label", goroutineLabel(node.goroutine));
+  group.dataset.goid = String(node.goroutine.id);
+  group.dataset.parent = String(node.parentId);
+  group.dataset.search = goroutineLabel(node.goroutine).toLocaleLowerCase();
+  group.tabIndex = node.goroutine.id === selected ? 0 : -1;
+
+  const body = document.createElementNS(svgNamespace, "rect");
+  body.setAttribute("width", "150");
+  body.setAttribute("height", "50");
+  body.setAttribute("rx", "11");
+  const id = document.createElementNS(svgNamespace, "text");
+  id.setAttribute("x", "12");
+  id.setAttribute("y", "21");
+  id.setAttribute("class", "node-id");
+  id.textContent = `g${String(node.goroutine.id)}`;
+  const status = document.createElementNS(svgNamespace, "text");
+  status.setAttribute("x", "12");
+  status.setAttribute("y", "39");
+  status.setAttribute("class", "node-status");
+  status.textContent = node.goroutine.status;
+  group.append(body, id, status);
+  if (node.goroutine.threadId > 0) {
+    const badge = document.createElementNS(svgNamespace, "text");
+    badge.setAttribute("x", "138");
+    badge.setAttribute("y", "21");
+    badge.setAttribute("text-anchor", "end");
+    badge.setAttribute("class", "node-thread");
+    badge.textContent = `t${String(node.goroutine.threadId)}`;
+    group.append(badge);
+  }
+  if (node.goroutine.current) {
+    const current = document.createElementNS(svgNamespace, "text");
+    current.setAttribute("x", "138");
+    current.setAttribute("y", "39");
+    current.setAttribute("text-anchor", "end");
+    current.setAttribute("class", "node-thread");
+    current.textContent = "current";
+    group.append(current);
+  }
+  group.addEventListener("click", () => {
+    group.focus();
+    host.postMessage({ type: "selectGoroutine", id: node.goroutine.id });
+  });
+  return group;
+}
+
+function applyGraphFilter(panel: HTMLElement, value: string): void {
+  const query = value.trim().toLocaleLowerCase();
+  const visible = new Set<string>();
+  const nodes = [...panel.querySelectorAll<SVGGElement>(".tree-node")];
+  const byID = new Map(
+    nodes.map((node) => [node.dataset.goid ?? "", node] as const),
+  );
+  for (const node of nodes) {
+    const matched = query.length === 0 || node.dataset.search?.includes(query) === true;
+    if (matched && node.dataset.goid !== undefined) {
+      let current: SVGGElement | undefined = node;
+      while (
+        current !== undefined &&
+        current.dataset.goid !== undefined &&
+        !visible.has(current.dataset.goid)
+      ) {
+        visible.add(current.dataset.goid);
+        current = byID.get(current.dataset.parent ?? "");
+      }
+    }
+  }
+  for (const node of nodes) {
+    node.classList.toggle(
+      "filtered",
+      !visible.has(node.dataset.goid ?? ""),
+    );
+  }
+  for (const edge of panel.querySelectorAll<SVGPathElement>(".tree-edge")) {
+    edge.classList.toggle(
+      "filtered",
+      !visible.has(edge.dataset.from ?? "") || !visible.has(edge.dataset.to ?? ""),
+    );
+  }
+}
+
+function renderInspector(
+  document: Document,
+  session: SessionViewModel,
+): HTMLElement {
+  const panel = document.createElement("aside");
+  panel.className = "inspector";
+  const heading = document.createElement("h2");
+  heading.textContent = "Selected goroutine";
+  panel.append(heading);
+  const goroutine = session.snapshot?.goroutines.find(
+    (item) => item.id === session.selectedGoroutine,
+  );
+  if (goroutine === undefined) {
+    panel.append(emptyState(document, "Nothing selected", "Choose a goroutine node."));
+    return panel;
+  }
+  const title = document.createElement("strong");
+  title.className = "inspector-title";
+  title.textContent = `g${String(goroutine.id)} · ${goroutine.status}`;
+  panel.append(title);
+  const list = document.createElement("dl");
+  const values: readonly [string, string][] = [
+    ["Wait", goroutine.waitReason || "—"],
+    ["Thread", goroutine.threadId > 0 ? `t${String(goroutine.threadId)}` : "not scheduled"],
+    ["Current", locationText(goroutine.currentLoc)],
+    ["Started", locationText(goroutine.startLoc)],
+    ["Created", locationText(goroutine.createdLoc)],
+  ];
+  for (const [term, value] of values) {
+    const dt = document.createElement("dt");
+    dt.textContent = term;
+    const dd = document.createElement("dd");
+    dd.textContent = value;
+    list.append(dt, dd);
+  }
+  panel.append(list);
+  return panel;
+}
+
+function renderThreads(
+  document: Document,
+  session: SessionViewModel,
+): HTMLElement {
+  const panel = document.createElement("section");
+  panel.className = "threads";
+  const heading = document.createElement("h2");
+  heading.textContent = "OS threads";
+  panel.append(heading);
+  const list = document.createElement("div");
+  list.className = "thread-list";
+  for (const thread of session.snapshot?.threads ?? []) {
+    const item = document.createElement("div");
+    item.className = `thread${thread.current ? " current" : ""}`;
+    const label = document.createElement("strong");
+    label.textContent = `t${String(thread.id)}`;
+    const detail = document.createElement("span");
+    detail.textContent =
+      thread.goid > 0
+        ? `g${String(thread.goid)}${thread.spinning ? " · spinning" : ""}`
+        : `idle${thread.spinning ? " · spinning" : ""}`;
+    item.append(label, detail);
+    list.append(item);
+  }
+  if (list.childElementCount === 0) {
+    list.append(emptyState(document, "No thread data", "Runtime thread inspection was unavailable."));
+  }
+  panel.append(list);
+  return panel;
+}
+
+function renderTimeline(
+  document: Document,
+  session: SessionViewModel,
+): HTMLElement {
+  const panel = document.createElement("section");
+  panel.className = "timeline";
+  const heading = document.createElement("h2");
+  heading.textContent = "Lifecycle";
+  panel.append(heading);
+  const list = document.createElement("ol");
+  for (const entry of [...session.timeline].reverse()) {
+    const item = document.createElement("li");
+    item.className = entry.action;
+    item.textContent = `${entry.action === "created" ? "+" : "−"} g${String(entry.id)}`;
+    list.append(item);
+  }
+  if (list.childElementCount === 0) {
+    const empty = document.createElement("p");
+    empty.className = "muted";
+    empty.textContent = "Created and exited goroutines will appear here.";
+    panel.append(empty);
+  } else {
+    panel.append(list);
+  }
+  return panel;
+}
+
+function emptyState(
+  document: Document,
+  titleText: string,
+  detailText: string,
+): HTMLElement {
+  const state = document.createElement("div");
+  state.className = "empty-state";
+  const title = document.createElement("strong");
+  title.textContent = titleText;
+  const detail = document.createElement("span");
+  detail.textContent = detailText;
+  state.append(title, detail);
+  return state;
+}
+
+function callout(
+  document: Document,
+  level: "error" | "warning",
+  titleText: string,
+  detailText: string,
+): HTMLElement {
+  const item = document.createElement("div");
+  item.className = `callout ${level}`;
+  item.setAttribute("role", level === "error" ? "alert" : "status");
+  const title = document.createElement("strong");
+  title.textContent = titleText;
+  const detail = document.createElement("span");
+  detail.textContent = detailText;
+  item.append(title, detail);
+  return item;
+}
+
+function button(
+  document: Document,
+  label: string,
+  action: () => void,
+): HTMLButtonElement {
+  const element = document.createElement("button");
+  element.type = "button";
+  element.textContent = label;
+  element.addEventListener("click", action);
+  return element;
+}
+
+function locationText(location: {
+  readonly file: string;
+  readonly line: number;
+  readonly function: string;
+}): string {
+  if (location.file.length === 0 && location.function.length === 0) {
+    return "unknown";
+  }
+  const source =
+    location.file.length === 0
+      ? ""
+      : `${location.file}${location.line > 0 ? `:${String(location.line)}` : ""}`;
+  return [location.function, source].filter((item) => item.length > 0).join(" · ");
+}
+
+function goroutineLabel(goroutine: {
+  readonly id: number;
+  readonly status: string;
+  readonly waitReason: string;
+  readonly current: boolean;
+  readonly currentLoc: { readonly function: string; readonly file: string };
+  readonly startLoc: { readonly function: string; readonly file: string };
+  readonly createdLoc: { readonly function: string; readonly file: string };
+}): string {
+  return [
+    `goroutine ${String(goroutine.id)}`,
+    goroutine.current ? "current" : "",
+    goroutine.status,
+    goroutine.waitReason,
+    goroutine.currentLoc.function,
+    goroutine.currentLoc.file,
+    goroutine.startLoc.function,
+    goroutine.startLoc.file,
+    goroutine.createdLoc.function,
+    goroutine.createdLoc.file,
+  ]
+    .filter((item) => item.length > 0)
+    .join(" ");
+}
+
+function focusIdentity(element: Element | null | undefined): string {
+  if (element === null || element === undefined) {
+    return "";
+  }
+  if (element.id.length > 0) {
+    return `#${element.id}`;
+  }
+  const goid = element.getAttribute("data-goid");
+  if (goid !== null) {
+    return `[data-goid="${goid}"]`;
+  }
+  return "";
+}
+
+function restoreFocus(root: HTMLElement, identity: string): void {
+  if (identity.length > 0) {
+    root.querySelector<HTMLElement | SVGElement>(identity)?.focus();
+  }
+}

--- a/editors/vscode/test/binary.test.ts
+++ b/editors/vscode/test/binary.test.ts
@@ -1,14 +1,13 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
 import {
   chmod,
-  mkdtemp,
   mkdir,
   rm,
   stat,
   writeFile,
 } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, describe, it } from "node:test";
 
 import { resolveBundledBinary } from "../src/binary.js";
@@ -26,7 +25,13 @@ afterEach(async () => {
 async function extensionFixture(
   target = "darwin-arm64",
 ): Promise<{ readonly root: string; readonly binary: string }> {
-  const root = await mkdtemp(join(tmpdir(), "bingo-extension-"));
+  const root = resolve(
+    process.cwd(),
+    "dist",
+    "test-artifacts",
+    `bingo-extension-${randomUUID()}`,
+  );
+  await mkdir(root, { recursive: true });
   temporaryDirectories.push(root);
   const bin = join(root, "bin");
   await mkdir(bin);

--- a/editors/vscode/test/documentGeneration.test.ts
+++ b/editors/vscode/test/documentGeneration.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { WebviewDeliveryState } from "../src/documentGeneration.js";
+
+describe("webview document generations", () => {
+  it("ignores an old failure after the same revision starts in a recreated document", () => {
+    const delivery = new WebviewDeliveryState();
+    delivery.beginDocument();
+    delivery.markReady();
+    const stale = delivery.beginDelivery(7)!;
+
+    delivery.markHidden();
+    delivery.markReady();
+    const current = delivery.beginDelivery(7)!;
+
+    assert.equal(delivery.rejectDelivery(stale), false);
+    assert.equal(delivery.ready, true);
+    assert.equal(delivery.acknowledge(current.revision), true);
+    assert.equal(delivery.lastRenderedRevision, 7);
+  });
+});

--- a/editors/vscode/test/documentGeneration.test.ts
+++ b/editors/vscode/test/documentGeneration.test.ts
@@ -15,8 +15,9 @@ describe("webview document generations", () => {
     const current = delivery.beginDelivery(7)!;
 
     assert.equal(delivery.rejectDelivery(stale), false);
+    assert.equal(delivery.acknowledge(stale), false);
     assert.equal(delivery.ready, true);
-    assert.equal(delivery.acknowledge(current.revision), true);
+    assert.equal(delivery.acknowledge(current), true);
     assert.equal(delivery.lastRenderedRevision, 7);
   });
 });

--- a/editors/vscode/test/fixtures.ts
+++ b/editors/vscode/test/fixtures.ts
@@ -1,0 +1,66 @@
+import type {
+  Goroutine,
+  Location,
+  Snapshot,
+  Thread,
+} from "../src/telemetry.js";
+
+export const location: Location = {
+  file: "/workspace/main.go",
+  line: 12,
+  function: "main.worker",
+};
+
+export function goroutine(
+  id: number,
+  parentId = 0,
+  overrides: Partial<Goroutine> = {},
+): Goroutine {
+  return {
+    id,
+    parentId,
+    status: "waiting",
+    waitReason: "chan receive",
+    currentLoc: location,
+    startLoc: location,
+    createdLoc: location,
+    threadId: 0,
+    current: false,
+    ...overrides,
+  };
+}
+
+export function thread(id: number, goid = 0): Thread {
+  return {
+    id,
+    mid: id,
+    goid,
+    spinning: false,
+    currentLoc: location,
+    current: false,
+  };
+}
+
+export function snapshot(
+  goroutines: readonly Goroutine[] = [goroutine(1, 0, { current: true })],
+  threads: readonly Thread[] = [thread(10, 1)],
+): Snapshot {
+  return {
+    goroutines,
+    threads,
+    current: goroutines[0]?.id ?? 0,
+    created: [],
+    exited: [],
+  };
+}
+
+export function envelope(
+  seq: number,
+  kind: string,
+  payload: unknown,
+): Buffer {
+  return Buffer.from(
+    JSON.stringify({ v: "1.2", kind, seq, payload }),
+    "utf8",
+  );
+}

--- a/editors/vscode/test/health.test.ts
+++ b/editors/vscode/test/health.test.ts
@@ -50,14 +50,14 @@ describe("health compatibility", () => {
     }
   });
 
-  it("reads localhost health within the minimum practical probe budget", async () => {
+  it("reads localhost health within a bounded practical probe budget", async () => {
     await withHTTPServer((_request, response) => {
       response.writeHead(200, { "Content-Type": "application/json" });
       response.end(health());
     }, async (port) => {
       const result = await probeWithSafetyAbort(
         port,
-        minimumHealthProbeTimeoutMs,
+        minimumHealthProbeTimeoutMs * 4,
       );
       assert.equal(result.kind, "compatible");
     });

--- a/editors/vscode/test/health.test.ts
+++ b/editors/vscode/test/health.test.ts
@@ -8,6 +8,7 @@ import { describe, it } from "node:test";
 
 import {
   bingoServiceIdentity,
+  dapSessionEventVersion,
   managementApiVersion,
   minimumHealthProbeTimeoutMs,
   probeBingoHealth,
@@ -26,6 +27,7 @@ function health(overrides: Record<string, unknown> = {}): string {
     dap: {
       enabled: true,
       address: "127.0.0.1:4711",
+      sessionEventVersion: 1,
     },
     managedIdleShutdown: {
       enabled: true,
@@ -40,6 +42,12 @@ describe("health compatibility", () => {
   it("accepts the exact bingo contract", () => {
     const result = validateHealthResponse(200, health(), expectedDAP);
     assert.equal(result.kind, "compatible");
+    if (result.kind === "compatible") {
+      assert.equal(
+        result.health.dapSessionEventVersion,
+        dapSessionEventVersion,
+      );
+    }
   });
 
   it("reads localhost health within the minimum practical probe budget", async () => {
@@ -59,7 +67,9 @@ describe("health compatibility", () => {
     for (const address of ["0.0.0.0:4711", "[::]:4711", ":4711"]) {
       const result = validateHealthResponse(
         200,
-        health({ dap: { enabled: true, address } }),
+        health({
+          dap: { enabled: true, address, sessionEventVersion: 1 },
+        }),
         expectedDAP,
       );
       assert.equal(result.kind, "compatible");
@@ -126,10 +136,34 @@ describe("health compatibility", () => {
       { status: 200, body: health({ wireProtocolVersion: "9" }) },
     ],
     [
+      "older bingo without DAP session discovery",
+      {
+        status: 200,
+        body: health({
+          dap: { enabled: true, address: "127.0.0.1:4711" },
+        }),
+      },
+    ],
+    [
+      "wrong DAP session event version",
+      {
+        status: 200,
+        body: health({
+          dap: {
+            enabled: true,
+            address: "127.0.0.1:4711",
+            sessionEventVersion: 2,
+          },
+        }),
+      },
+    ],
+    [
       "disabled DAP",
       {
         status: 200,
-        body: health({ dap: { enabled: false, address: "" } }),
+        body: health({
+          dap: { enabled: false, address: "", sessionEventVersion: 1 },
+        }),
       },
     ],
     [
@@ -137,7 +171,11 @@ describe("health compatibility", () => {
       {
         status: 200,
         body: health({
-          dap: { enabled: true, address: "127.0.0.1:9999" },
+          dap: {
+            enabled: true,
+            address: "127.0.0.1:9999",
+            sessionEventVersion: 1,
+          },
         }),
       },
     ],
@@ -146,7 +184,11 @@ describe("health compatibility", () => {
       {
         status: 200,
         body: health({
-          dap: { enabled: true, address: "192.0.2.1:4711" },
+          dap: {
+            enabled: true,
+            address: "192.0.2.1:4711",
+            sessionEventVersion: 1,
+          },
         }),
       },
     ],
@@ -167,6 +209,10 @@ describe("health compatibility", () => {
       resolve(root, "pkg/protocol/protocol.go"),
       "utf8",
     );
+    const dapProtocol = readFileSync(
+      resolve(root, "pkg/protocol/dap.go"),
+      "utf8",
+    );
 
     assert.match(
       handler,
@@ -181,6 +227,12 @@ describe("health compatibility", () => {
     assert.match(
       protocol,
       new RegExp(`const Version\\s*=\\s*"${wireProtocolVersion}"`),
+    );
+    assert.match(
+      dapProtocol,
+      new RegExp(
+        `DAPSessionEventVersion\\s*=\\s*${String(dapSessionEventVersion)}`,
+      ),
     );
   });
 });

--- a/editors/vscode/test/manifest.test.ts
+++ b/editors/vscode/test/manifest.test.ts
@@ -12,7 +12,7 @@ const manifest = requireRecord(
 const contributes = requireRecord(manifest.contributes);
 const debuggers = requireArray(contributes.debuggers);
 const debuggerContribution = requireRecord(debuggers[0]);
-const expectedExtensionVersion = "0.2.0";
+const expectedExtensionVersion = "0.3.0";
 
 describe("extension manifest", () => {
   it("versions the managed-server runtime as an installable upgrade", () => {
@@ -49,6 +49,39 @@ describe("extension manifest", () => {
     const breakpoints = requireArray(contributes.breakpoints);
     assert.deepEqual(breakpoints, [{ language: "go" }]);
     assert.deepEqual(debuggerContribution.languages, ["go"]);
+  });
+
+  it("contributes the concurrency Activity Bar view and controls", () => {
+    const containers = requireRecord(contributes.viewsContainers);
+    const activity = requireArray(requireRecord(containers).activitybar).map(requireRecord);
+    assert.deepEqual(
+      activity.map((item) => item.id),
+      ["bingo"],
+    );
+    assert.equal(activity[0]?.icon, "media/bingo-activity.svg");
+    const views = requireArray(requireRecord(contributes.views).bingo).map(requireRecord);
+    assert.equal(views.length, 1);
+    assert.equal(views[0]?.id, "bingo.concurrency");
+    assert.equal(views[0]?.type, "webview");
+
+    const commands = requireArray(contributes.commands)
+      .map(requireRecord)
+      .map((command) => command.command);
+    for (const command of [
+      "bingo.concurrency.refresh",
+      "bingo.concurrency.selectSession",
+      "bingo.concurrency.fit",
+      "bingo.concurrency.copySnapshot",
+    ]) {
+      assert.ok(commands.includes(command));
+    }
+    assert.equal(commands.includes("bingo.concurrency.focus"), false);
+    const properties = requireRecord(requireRecord(contributes.configuration).properties);
+    assert.equal(
+      requireRecord(properties["bingo.concurrency.autoReveal"]).default,
+      true,
+    );
+    assert.ok(requireArray(manifest.activationEvents).includes("onDebug"));
   });
 
   it("declares bingo endpoint defaults", () => {

--- a/editors/vscode/test/manifest.test.ts
+++ b/editors/vscode/test/manifest.test.ts
@@ -12,7 +12,7 @@ const manifest = requireRecord(
 const contributes = requireRecord(manifest.contributes);
 const debuggers = requireArray(contributes.debuggers);
 const debuggerContribution = requireRecord(debuggers[0]);
-const expectedExtensionVersion = "0.3.0";
+const expectedExtensionVersion = "0.3.1";
 
 describe("extension manifest", () => {
   it("versions the managed-server runtime as an installable upgrade", () => {

--- a/editors/vscode/test/messages.test.ts
+++ b/editors/vscode/test/messages.test.ts
@@ -14,6 +14,14 @@ describe("webview message codec", () => {
       decodeWebviewMessage({ type: "selectGoroutine", id: 42 }),
       { type: "selectGoroutine", id: 42 },
     );
+    assert.deepEqual(
+      decodeWebviewMessage({
+        type: "rendered",
+        generation: 3,
+        revision: 42,
+      }),
+      { type: "rendered", generation: 3, revision: 42 },
+    );
   });
 
   it("rejects unknown commands, extra fields, and invalid identifiers", () => {
@@ -25,6 +33,10 @@ describe("webview message codec", () => {
     assert.throws(
       () => decodeWebviewMessage({ type: "selectGoroutine", id: -1 }),
       /safe integer/,
+    );
+    assert.throws(
+      () => decodeWebviewMessage({ type: "rendered", revision: 1 }),
+      /unexpected fields/,
     );
   });
 });

--- a/editors/vscode/test/messages.test.ts
+++ b/editors/vscode/test/messages.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { decodeWebviewMessage } from "../src/messages.js";
+
+describe("webview message codec", () => {
+  it("accepts the bounded command surface", () => {
+    assert.deepEqual(decodeWebviewMessage({ type: "ready" }), { type: "ready" });
+    assert.deepEqual(
+      decodeWebviewMessage({ type: "selectSession", id: "debug-1" }),
+      { type: "selectSession", id: "debug-1" },
+    );
+    assert.deepEqual(
+      decodeWebviewMessage({ type: "selectGoroutine", id: 42 }),
+      { type: "selectGoroutine", id: 42 },
+    );
+  });
+
+  it("rejects unknown commands, extra fields, and invalid identifiers", () => {
+    assert.throws(() => decodeWebviewMessage({ type: "continue" }), /unknown/);
+    assert.throws(
+      () => decodeWebviewMessage({ type: "refresh", command: "Continue" }),
+      /unexpected fields/,
+    );
+    assert.throws(
+      () => decodeWebviewMessage({ type: "selectGoroutine", id: -1 }),
+      /safe integer/,
+    );
+  });
+});

--- a/editors/vscode/test/model.test.ts
+++ b/editors/vscode/test/model.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  appendLifecycle,
+  maximumTimelineEntries,
+  serializeSnapshot,
+  type SessionModel,
+} from "../src/model.js";
+import { snapshot } from "./fixtures.js";
+
+describe("concurrency model", () => {
+  it("retains only the bounded lifecycle tail", () => {
+    let timeline = appendLifecycle(
+      [],
+      { ...snapshot(), created: Array.from({ length: 80 }, (_, index) => index + 1) },
+      1,
+    );
+    timeline = appendLifecycle(
+      timeline,
+      { ...snapshot(), exited: Array.from({ length: 80 }, (_, index) => index + 1) },
+      2,
+    );
+    assert.equal(timeline.length, maximumTimelineEntries);
+    assert.equal(timeline.at(-1)?.action, "exited");
+  });
+
+  it("serializes hostile tracee strings as inert JSON", () => {
+    const model: SessionModel = {
+      debugSessionId: "debug",
+      debugSessionName: "<script>alert(1)</script>",
+      sessionId: "session",
+      connection: "connected",
+      sessionState: "suspended",
+      clients: 2,
+      lastStop: "",
+      error: "",
+      seqGap: "",
+      lastSeq: 1,
+      snapshot: {
+        ...snapshot(),
+        goroutines: [
+          {
+            ...snapshot().goroutines[0]!,
+            waitReason: "</script><img src=x onerror=alert(1)>",
+          },
+        ],
+      },
+      selectedGoroutine: 1,
+      timeline: [],
+    };
+    const serialized = serializeSnapshot(model);
+    const decoded = JSON.parse(serialized) as {
+      readonly snapshot: {
+        readonly goroutines: readonly [{ readonly waitReason: string }];
+      };
+    };
+    assert.equal(decoded.snapshot.goroutines[0].waitReason, "</script><img src=x onerror=alert(1)>");
+  });
+});

--- a/editors/vscode/test/observer.test.ts
+++ b/editors/vscode/test/observer.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { describe, it } from "node:test";
+
+import {
+  TelemetryObserver,
+  telemetryURL,
+  type ObserverDependencies,
+  type Socket,
+} from "../src/observer.js";
+import { envelope, snapshot } from "./fixtures.js";
+
+class FakeSocket extends EventEmitter implements Socket {
+  public readyState = 0;
+  public readonly sent: string[] = [];
+  public closed = false;
+
+  public onOpen(listener: () => void): void {
+    this.on("open", listener);
+  }
+
+  public onMessage(listener: (data: Buffer) => void): void {
+    this.on("message", listener);
+  }
+
+  public onClose(listener: () => void): void {
+    this.on("close", listener);
+  }
+
+  public onError(listener: (error: Error) => void): void {
+    this.on("error", listener);
+  }
+
+  public send(data: string): void {
+    this.sent.push(data);
+  }
+
+  public close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.readyState = 3;
+    this.emit("close");
+  }
+
+  public open(): void {
+    this.readyState = 1;
+    this.emit("open");
+  }
+}
+
+function setup(): {
+  readonly observer: TelemetryObserver;
+  readonly sockets: FakeSocket[];
+  readonly delays: { resolve: () => void }[];
+} {
+  const sockets: FakeSocket[] = [];
+  const delays: { resolve: () => void }[] = [];
+  const dependencies: ObserverDependencies = {
+    createSocket() {
+      const socket = new FakeSocket();
+      sockets.push(socket);
+      return socket;
+    },
+    delay(_milliseconds, signal) {
+      return new Promise((resolve, reject) => {
+        const delay = { resolve };
+        delays.push(delay);
+        signal.addEventListener("abort", () => {
+          reject(new Error("cancelled"));
+        });
+      });
+    },
+    now: () => 123,
+  };
+  return {
+    observer: new TelemetryObserver(
+      {
+        debugSessionId: "debug-1",
+        debugSessionName: "level5",
+        sessionId: "session/a",
+        managementEndpoint: { host: "127.0.0.1", port: 6060 },
+      },
+      dependencies,
+    ),
+    sockets,
+    delays,
+  };
+}
+
+describe("telemetry observer", () => {
+  it("builds encoded WS URLs including IPv6 hosts", () => {
+    assert.equal(
+      telemetryURL({ host: "::1", port: 6060 }, "id/a"),
+      "ws://[::1]:6060/ws?session=id%2Fa",
+    );
+  });
+
+  it("requests exactly one join snapshot and explicit refreshes only", () => {
+    const { observer, sockets } = setup();
+    observer.start();
+    const socket = sockets[0]!;
+    socket.open();
+    assert.equal(socket.sent.length, 1);
+    assert.deepEqual(JSON.parse(socket.sent[0]!), {
+      v: "1.2",
+      kind: "GoroutineSnapshot",
+      payload: {},
+    });
+    socket.emit("message", envelope(1, "GoroutineSnapshot", snapshot()));
+    socket.emit("message", envelope(2, "BreakpointHit", { breakpoint: { location: { file: "main.go", line: 4 } } }));
+    assert.equal(socket.sent.length, 1);
+    observer.refresh();
+    assert.equal(socket.sent.length, 2);
+    assert.ok(
+      socket.sent.every(
+        (item) =>
+          (JSON.parse(item) as { readonly kind?: unknown }).kind ===
+          "GoroutineSnapshot",
+      ),
+    );
+    observer.dispose();
+  });
+
+  it("tracks gaps, rejects duplicates, and preserves selection across snapshots", () => {
+    const { observer, sockets } = setup();
+    observer.start();
+    const socket = sockets[0]!;
+    socket.open();
+    socket.emit("message", envelope(1, "GoroutineSnapshot", snapshot()));
+    observer.selectGoroutine(1);
+    socket.emit("message", envelope(3, "GoroutineSnapshot", snapshot()));
+    assert.equal(observer.model.seqGap, "missed events 2-2");
+    assert.equal(observer.model.selectedGoroutine, 1);
+    socket.emit("message", envelope(3, "ProcessExited", { exitCode: 0 }));
+    assert.notEqual(observer.model.sessionState, "exited");
+    socket.emit("message", envelope(2, "ProcessExited", { exitCode: 0 }));
+    assert.equal(observer.model.sessionState, "exited");
+    assert.equal(observer.model.seqGap, "out-of-order event 2 after 3");
+    assert.equal(observer.model.lastSeq, 3);
+    observer.dispose();
+  });
+
+  it("reconnects only while live and cancels pending reconnect on dispose", async () => {
+    const { observer, sockets, delays } = setup();
+    observer.start();
+    sockets[0]!.open();
+    sockets[0]!.close();
+    assert.equal(observer.model.connection, "reconnecting");
+    delays[0]!.resolve();
+    await Promise.resolve();
+    assert.equal(sockets.length, 2);
+    sockets[1]!.close();
+    observer.dispose();
+    delays[1]!.resolve();
+    await Promise.resolve();
+    assert.equal(sockets.length, 2);
+  });
+
+  it("bounds repeated reconnects even when every short-lived socket opens", async () => {
+    const { observer, sockets, delays } = setup();
+    observer.start();
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+      const socket = sockets[attempt]!;
+      socket.open();
+      socket.close();
+      delays[attempt]!.resolve();
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    assert.equal(sockets.length, 7);
+    sockets[6]!.open();
+    sockets[6]!.close();
+    assert.equal(observer.model.connection, "error");
+    assert.match(observer.model.error, /reconnect limit/);
+    observer.dispose();
+  });
+
+  it("closes a malformed stream instead of accepting unvalidated data", () => {
+    const { observer, sockets } = setup();
+    observer.start();
+    const socket = sockets[0]!;
+    socket.open();
+    socket.emit(
+      "message",
+      Buffer.from('{"v":"9","kind":"Continued","seq":1,"payload":{}}'),
+    );
+    assert.equal(socket.closed, true);
+    assert.match(observer.model.error, /incompatible/);
+    observer.dispose();
+  });
+});

--- a/editors/vscode/test/packagedE2E.ts
+++ b/editors/vscode/test/packagedE2E.ts
@@ -1,0 +1,555 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { EventEmitter, once } from "node:events";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { createServer, connect, type Socket } from "node:net";
+import { basename, join, resolve } from "node:path";
+
+import type { BingoServerConfiguration } from "../src/configuration.js";
+import { probeBingoHealth } from "../src/health.js";
+import type { SessionModel } from "../src/model.js";
+import { filterTree } from "../src/tree.js";
+import { SessionRegistry } from "../src/registry.js";
+import { defaultDelay, ServerManager } from "../src/serverManager.js";
+import { spawnDetachedServer } from "../src/serverProcess.js";
+import {
+  decodeSessionAnnouncement,
+  sessionDAPEventName,
+} from "../src/sessionEvent.js";
+
+const repositoryRoot = resolve(process.cwd(), "../..");
+const target =
+  process.platform === "darwin" && process.arch === "arm64"
+    ? "darwin-arm64"
+    : process.platform === "linux" && process.arch === "x64"
+      ? "linux-x64"
+      : undefined;
+if (target === undefined) {
+  throw new Error(`unsupported packaged E2E host ${process.platform}/${process.arch}`);
+}
+
+const examples = [
+  { name: "level1-loop", line: 8, minimumDepth: 0 },
+  { name: "level2-channel", line: 14, minimumDepth: 1 },
+  { name: "level3-worker-pool", line: 20, minimumDepth: 1 },
+  { name: "level4-pipeline", line: 43, minimumDepth: 1 },
+  { name: "level5-workflow", line: 83, minimumDepth: 2 },
+] as const;
+
+void main().catch((error: unknown) => {
+  process.stderr.write(
+    `packaged concurrency E2E failed: ${
+      error instanceof Error ? error.stack : String(error)
+    }\n`,
+  );
+  process.exitCode = 1;
+});
+
+async function main(): Promise<void> {
+  const scratch = resolve(
+    repositoryRoot,
+    "dist",
+    `.concurrency-e2e-${target}-${String(process.pid)}`,
+  );
+  rmSync(scratch, { force: true, recursive: true });
+  mkdirSync(scratch, { recursive: true });
+  let child: ChildProcess | undefined;
+  let manager: ServerManager | undefined;
+  let succeeded = false;
+  try {
+    const vsix = resolve(repositoryRoot, "dist", `bingo-${target}.vsix`);
+    const extracted = join(scratch, "vsix");
+    mkdirSync(extracted);
+    run("unzip", ["-q", vsix, "-d", extracted]);
+    const binary = join(extracted, "extension", "bin", "bingo");
+    if (process.platform === "darwin") {
+      run("codesign", ["--verify", "--strict", binary]);
+    }
+
+    const managementPort = await freePort();
+    const dapPort = await freePort();
+    const config: BingoServerConfiguration = {
+      mode: "auto",
+      managementEndpoint: { host: "127.0.0.1", port: managementPort },
+      dapEndpoint: { host: "127.0.0.1", port: dapPort },
+      readyTimeoutMs: 10_000,
+      idleTimeoutMs: 1500,
+    };
+    let spawns = 0;
+    manager = new ServerManager({
+      probe: probeBingoHealth,
+      resolveBinary: () => Promise.resolve(binary),
+      spawnServer(request, onOutcome) {
+        spawns += 1;
+        return spawnDetachedServer(request, onOutcome, (command, args, options) => {
+          child = spawn(command, args, options);
+          return child;
+        });
+      },
+      delay: defaultDelay,
+      now: Date.now,
+      runtime: { platform: process.platform, arch: process.arch },
+      logPathFor: () => Promise.resolve(join(scratch, "server.log")),
+      log: (message) => {
+        process.stdout.write(`[manager] ${message}\n`);
+      },
+    });
+    await manager.ensureServer(config);
+    const firstHealth = await health(config.managementEndpoint);
+    await new Promise((resolveReady) => setImmediate(resolveReady));
+    await manager.ensureServer(config);
+    const reusedHealth = await health(config.managementEndpoint);
+    assert.equal(
+      spawns,
+      1,
+      "compatible server must be reused without a competing spawn",
+    );
+    assert.equal(reusedHealth.instanceId, firstHealth.instanceId);
+
+    const observedDepths: number[] = [];
+    for (const [index, example] of examples.entries()) {
+      const result = await runExample(
+        config,
+        example.name,
+        example.line,
+        `debug-${String(index + 1)}`,
+      );
+      observedDepths.push(result.depth);
+      assert.ok(
+        result.depth >= example.minimumDepth,
+        `${example.name} hierarchy depth ${String(result.depth)} is below ${String(example.minimumDepth)}`,
+      );
+      assert.ok(
+        result.threads > 0,
+        `${example.name} snapshot has no runtime threads`,
+      );
+      process.stdout.write(
+        `[snapshot] ${example.name}: session=${result.sessionId} goroutines=${String(result.goroutines)} threads=${String(result.threads)} depth=${String(result.depth)} seq=${String(result.seq)}\n`,
+      );
+    }
+    const firstDepth = observedDepths[0];
+    const lastDepth = observedDepths.at(-1);
+    if (firstDepth === undefined || lastDepth === undefined) {
+      throw new Error("progressive examples produced no hierarchy results");
+    }
+    assert.ok(firstDepth <= lastDepth);
+
+    manager.dispose();
+    if (child === undefined) {
+      throw new Error("managed server was not spawned");
+    }
+    await waitForExit(child, config.idleTimeoutMs + 10_000);
+    assert.equal(
+      child.exitCode,
+      0,
+      "managed server must self-exit cleanly after idle",
+    );
+    process.stdout.write(
+      `[idle] instance=${firstHealth.instanceId} self-exited after all sessions closed\n`,
+    );
+    succeeded = true;
+  } finally {
+    if (!succeeded) {
+      manager?.dispose();
+    }
+    const serverLog = join(scratch, "server.log");
+    if (!succeeded && existsSync(serverLog)) {
+      process.stderr.write(`[server log]\n${readFileSync(serverLog, "utf8")}\n`);
+    }
+    if (!succeeded && child?.pid !== undefined && child.exitCode === null) {
+      try {
+        process.kill(-child.pid, "SIGKILL");
+      } catch {
+        // The exact test-owned process group may already have exited.
+      }
+      await Promise.race([once(child, "exit"), delay(3000)]);
+    }
+    rmSync(scratch, { force: true, recursive: true });
+  }
+}
+
+async function runExample(
+  config: BingoServerConfiguration,
+  name: string,
+  line: number,
+  debugSessionId: string,
+): Promise<{
+  readonly sessionId: string;
+  readonly goroutines: number;
+  readonly threads: number;
+  readonly depth: number;
+  readonly seq: number;
+}> {
+  const client = await DAPClient.open(config.dapEndpoint.host, config.dapEndpoint.port);
+  const initialize = client.request("initialize", {
+    adapterID: "bingo",
+    linesStartAt1: true,
+    columnsStartAt1: true,
+  });
+  await client.response(initialize);
+  const program = resolve(repositoryRoot, "build", "examples", name);
+  const launch = client.request("launch", { program, stopOnEntry: true });
+  const custom = await client.message(
+    (message) =>
+      message.type === "event" && message.event === sessionDAPEventName,
+  );
+  const announcement = decodeSessionAnnouncement(
+    String(custom.event),
+    custom.body,
+  );
+  assert.notEqual(announcement, undefined);
+  const sessionId = announcement!.sessionId;
+  await client.message(
+    (message) => message.type === "event" && message.event === "initialized",
+  );
+
+  const registry = new SessionRegistry();
+  assert.equal(
+    registry.add({
+      debugSessionId,
+      debugSessionName: name,
+      sessionId,
+      managementEndpoint: config.managementEndpoint,
+    }),
+    true,
+  );
+  const initial = await waitForModel(
+    registry,
+    `${name} initial snapshot`,
+    (model) => model.snapshot !== undefined,
+    10_000,
+  );
+
+  const breakpoint = client.request("setBreakpoints", {
+    source: {
+      name: basename(program),
+      path: resolve(repositoryRoot, "examples", name, "main.go"),
+    },
+    breakpoints: [{ line }],
+    sourceModified: false,
+  });
+  const breakpointResponse = await client.response(breakpoint);
+  assert.equal(
+    ((breakpointResponse.body as { readonly breakpoints?: readonly { verified?: boolean }[] })
+      .breakpoints?.[0]?.verified),
+    true,
+  );
+  const configured = client.request("configurationDone", {});
+  await Promise.all([client.response(configured), client.response(launch)]);
+  await client.message(
+    (message) =>
+      message.type === "event" &&
+      message.event === "stopped" &&
+      (message.body as { readonly reason?: unknown } | undefined)?.reason ===
+        "entry",
+  );
+  const continued = client.request("continue", { threadId: 1 });
+  await client.response(continued);
+  await client.message(
+    (message) =>
+      message.type === "event" &&
+      message.event === "stopped" &&
+      (message.body as { readonly reason?: unknown } | undefined)?.reason ===
+        "breakpoint",
+    30_000,
+  );
+
+  const previousSeq = initial.lastSeq;
+  registry.refresh();
+  const stopped = await waitForModel(
+    registry,
+    `${name} breakpoint snapshot`,
+    (model) =>
+      model.snapshot !== undefined &&
+      model.snapshot !== initial.snapshot &&
+      model.lastSeq > previousSeq,
+    20_000,
+  );
+  const snapshot = stopped.snapshot!;
+  const depth = applicationDepth(snapshot, name);
+  if (name === "level5-workflow") {
+    assert.ok(snapshot.goroutines.some((goroutine) => goroutine.parentId > 0));
+    const selected = snapshot.goroutines.find((goroutine) => goroutine.parentId > 0)!;
+    registry.selectGoroutine(selected.id);
+    assert.equal(registry.activeModel()?.selectedGoroutine, selected.id);
+    assert.ok(filterTree(stopped.tree, "inventory").nodes.length > 0);
+    assert.match(registry.activeSnapshotJSON() ?? "", /"goroutines"/);
+    const beforeRefresh = registry.activeModel()?.snapshot;
+    registry.refresh();
+    await waitForModel(
+      registry,
+      `${name} explicit refresh`,
+      (model) => model.snapshot !== undefined && model.snapshot !== beforeRefresh,
+      10_000,
+    );
+  }
+
+  function applicationDepth(
+    snapshot: NonNullable<SessionModel["snapshot"]>,
+    example: string,
+  ): number {
+    const byID = new Map(snapshot.goroutines.map((goroutine) => [goroutine.id, goroutine]));
+    const source = `/examples/${example}/`;
+    let maximum = 0;
+    for (const goroutine of snapshot.goroutines) {
+      const locations = [
+        goroutine.currentLoc.file,
+        goroutine.startLoc.file,
+        goroutine.createdLoc.file,
+      ];
+      if (!locations.some((file) => file.replaceAll("\\", "/").includes(source))) {
+        continue;
+      }
+      let depth = 0;
+      let current = goroutine;
+      const seen = new Set<number>([current.id]);
+      while (current.parentId > 0) {
+        const parent = byID.get(current.parentId);
+        if (parent === undefined || seen.has(parent.id)) {
+          break;
+        }
+        seen.add(parent.id);
+        depth += 1;
+        current = parent;
+      }
+      maximum = Math.max(maximum, depth);
+    }
+    return maximum;
+  }
+
+  const disconnect = client.request("disconnect", { terminateDebuggee: true });
+  await client.response(disconnect);
+  client.close();
+  registry.remove(debugSessionId);
+  registry.dispose();
+  return {
+    sessionId,
+    goroutines: snapshot.goroutines.length,
+    threads: snapshot.threads.length,
+    depth,
+    seq: stopped.lastSeq,
+  };
+}
+
+interface DAPMessage {
+  readonly type?: unknown;
+  readonly event?: unknown;
+  readonly command?: unknown;
+  readonly request_seq?: unknown;
+  readonly body?: unknown;
+  readonly [key: string]: unknown;
+}
+
+class DAPClient {
+  readonly #events = new EventEmitter();
+  readonly #messages: DAPMessage[] = [];
+  #buffer = Buffer.alloc(0);
+  #seq = 1;
+
+  private constructor(private readonly socket: Socket) {
+    socket.on("data", (chunk: Buffer) => {
+      this.#buffer = Buffer.concat([this.#buffer, chunk]);
+      this.#parse();
+    });
+  }
+
+  public static async open(host: string, port: number): Promise<DAPClient> {
+    const socket = connect({ host, port });
+    await once(socket, "connect");
+    return new DAPClient(socket);
+  }
+
+  public request(command: string, args: Record<string, unknown>): number {
+    const seq = this.#seq++;
+    const body = Buffer.from(
+      JSON.stringify({ seq, type: "request", command, arguments: args }),
+    );
+    this.socket.write(
+      Buffer.concat([
+        Buffer.from(`Content-Length: ${String(body.length)}\r\n\r\n`),
+        body,
+      ]),
+    );
+    return seq;
+  }
+
+  public response(requestSeq: number): Promise<DAPMessage> {
+    return this.message(
+      (message) =>
+        message.type === "response" && message.request_seq === requestSeq,
+    );
+  }
+
+  public async message(
+    predicate: (message: DAPMessage) => boolean,
+    timeoutMs = 15_000,
+  ): Promise<DAPMessage> {
+    const existing = this.#messages.findIndex(predicate);
+    if (existing >= 0) {
+      return this.#messages.splice(existing, 1)[0]!;
+    }
+    return new Promise((resolveMessage, reject) => {
+      const timeout = setTimeout(() => {
+        this.#events.off("message", receive);
+        reject(new Error("timed out waiting for DAP message"));
+      }, timeoutMs);
+      const receive = (message: DAPMessage): void => {
+        if (!predicate(message)) {
+          return;
+        }
+        clearTimeout(timeout);
+        this.#events.off("message", receive);
+        const index = this.#messages.indexOf(message);
+        if (index >= 0) {
+          this.#messages.splice(index, 1);
+        }
+        resolveMessage(message);
+      };
+      this.#events.on("message", receive);
+    });
+  }
+
+  public close(): void {
+    this.socket.end();
+    this.socket.destroy();
+  }
+
+  #parse(): void {
+    for (;;) {
+      const headerEnd = this.#buffer.indexOf("\r\n\r\n");
+      if (headerEnd < 0) {
+        return;
+      }
+      const header = this.#buffer.subarray(0, headerEnd).toString("ascii");
+      const match = /(?:^|\r\n)Content-Length: (\d+)(?:\r\n|$)/iu.exec(header);
+      if (match?.[1] === undefined) {
+        throw new Error("DAP response omitted Content-Length");
+      }
+      const length = Number(match[1]);
+      const bodyStart = headerEnd + 4;
+      if (this.#buffer.length < bodyStart + length) {
+        return;
+      }
+      const raw = this.#buffer.subarray(bodyStart, bodyStart + length);
+      this.#buffer = this.#buffer.subarray(bodyStart + length);
+      const message = JSON.parse(raw.toString("utf8")) as DAPMessage;
+      this.#messages.push(message);
+      this.#events.emit("message", message);
+    }
+  }
+}
+
+async function waitForModel(
+  registry: SessionRegistry,
+  phase: string,
+  predicate: (model: ReturnType<SessionRegistry["activeModel"]> & {}) => boolean,
+  timeoutMs: number,
+) {
+  const current = registry.activeModel();
+  if (current !== undefined && predicate(current)) {
+    return {
+      ...current,
+      tree: registry.viewModel.sessions.find(
+        (session) => session.debugSessionId === current.debugSessionId,
+      )!.tree,
+    };
+  }
+  return new Promise<
+    ReturnType<typeof registry.activeModel> & { readonly tree: ReturnType<typeof filterTree> }
+  >((resolveModel, reject) => {
+    const timeout = setTimeout(() => {
+      unsubscribe();
+      reject(
+        new Error(
+          `timed out waiting for ${phase}: ${JSON.stringify(registry.activeModel())}`,
+        ),
+      );
+    }, timeoutMs);
+    const unsubscribe = registry.onChange(() => {
+      const model = registry.activeModel();
+      const view = registry.viewModel.sessions.find(
+        (session) => session.debugSessionId === model?.debugSessionId,
+      );
+      if (model === undefined || view === undefined || !predicate(model)) {
+        return;
+      }
+      clearTimeout(timeout);
+      unsubscribe();
+      resolveModel({ ...model, tree: view.tree });
+    });
+  });
+}
+
+async function health(endpoint: {
+  readonly host: string;
+  readonly port: number;
+}): Promise<{ readonly instanceId: string }> {
+  const controller = new AbortController();
+  const result = await probeBingoHealth(
+    endpoint,
+    { host: "127.0.0.1", port: await configuredDAPPort(endpoint) },
+    2000,
+    controller.signal,
+  );
+  if (result.kind !== "compatible") {
+    throw new Error(`server health is ${result.kind}`);
+  }
+  return { instanceId: result.health.instanceId };
+}
+
+async function configuredDAPPort(endpoint: {
+  readonly host: string;
+  readonly port: number;
+}): Promise<number> {
+  const response = await fetch(`http://${endpoint.host}:${String(endpoint.port)}/api/health`);
+  const decoded = (await response.json()) as {
+    readonly dap: { readonly address: string };
+  };
+  return Number(decoded.dap.address.slice(decoded.dap.address.lastIndexOf(":") + 1));
+}
+
+async function freePort(): Promise<number> {
+  const server = createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  assert.notEqual(address, null);
+  assert.equal(typeof address, "object");
+  const port = (address as { readonly port: number }).port;
+  server.close();
+  await once(server, "close");
+  return port;
+}
+
+async function waitForExit(process: ChildProcess, timeoutMs: number): Promise<void> {
+  if (process.exitCode !== null) {
+    return;
+  }
+  await Promise.race([
+    once(process, "exit").then(() => undefined),
+    delay(timeoutMs).then(() => {
+      throw new Error("managed server did not self-exit");
+    }),
+  ]);
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolveDelay) => {
+    setTimeout(resolveDelay, milliseconds);
+  });
+}
+
+function run(command: string, args: readonly string[]): void {
+  const result = spawnSync(command, args, { stdio: "inherit" });
+  if (result.error !== undefined) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`${command} exited with ${String(result.status)}`);
+  }
+}

--- a/editors/vscode/test/packagedE2E.ts
+++ b/editors/vscode/test/packagedE2E.ts
@@ -29,11 +29,11 @@ if (target === undefined) {
 }
 
 const examples = [
-  { name: "level1-loop", line: 8, minimumDepth: 0, stop: "breakpoint" },
-  { name: "level2-channel", line: undefined, minimumDepth: 1, stop: "pause" },
-  { name: "level3-worker-pool", line: undefined, minimumDepth: 1, stop: "pause" },
-  { name: "level4-pipeline", line: undefined, minimumDepth: 1, stop: "pause" },
-  { name: "level5-workflow", line: 83, minimumDepth: 2, stop: "breakpoint" },
+  { name: "level1-loop", line: 8, minimumDepth: 0 },
+  { name: "level2-channel", line: 23, minimumDepth: 1 },
+  { name: "level3-worker-pool", line: 44, minimumDepth: 1 },
+  { name: "level4-pipeline", line: 65, minimumDepth: 1 },
+  { name: "level5-workflow", line: 83, minimumDepth: 2 },
 ] as const;
 
 function packageTarget(): "darwin-arm64" | "linux-x64" | undefined {
@@ -122,7 +122,6 @@ async function main(): Promise<void> {
         config,
         example.name,
         example.line,
-        example.stop,
         `debug-${String(index + 1)}`,
       );
       observedDepths.push(result.depth);
@@ -182,8 +181,7 @@ async function main(): Promise<void> {
 async function runExample(
   config: BingoServerConfiguration,
   name: string,
-  line: number | undefined,
-  stop: "breakpoint" | "pause",
+  line: number,
   debugSessionId: string,
 ): Promise<{
   readonly sessionId: string;
@@ -232,23 +230,20 @@ async function runExample(
     10_000,
   );
 
-  if (stop === "breakpoint") {
-    assert.notEqual(line, undefined);
-    const breakpoint = client.request("setBreakpoints", {
-      source: {
-        name: basename(program),
-        path: resolve(repositoryRoot, "examples", name, "main.go"),
-      },
-      breakpoints: [{ line }],
-      sourceModified: false,
-    });
-    const breakpointResponse = await client.response(breakpoint);
-    assert.equal(
-      ((breakpointResponse.body as { readonly breakpoints?: readonly { verified?: boolean }[] })
-        .breakpoints?.[0]?.verified),
-      true,
-    );
-  }
+  const breakpoint = client.request("setBreakpoints", {
+    source: {
+      name: basename(program),
+      path: resolve(repositoryRoot, "examples", name, "main.go"),
+    },
+    breakpoints: [{ line }],
+    sourceModified: false,
+  });
+  const breakpointResponse = await client.response(breakpoint);
+  assert.equal(
+    ((breakpointResponse.body as { readonly breakpoints?: readonly { verified?: boolean }[] })
+      .breakpoints?.[0]?.verified),
+    true,
+  );
   const configured = client.request("configurationDone", {});
   await Promise.all([client.response(configured), client.response(launch)]);
   await client.message(
@@ -260,17 +255,12 @@ async function runExample(
   );
   const continued = client.request("continue", { threadId: 1 });
   await client.response(continued);
-  if (stop === "pause") {
-    await delay(10);
-    const pause = client.request("pause", { threadId: 1 });
-    await client.response(pause);
-  }
   await client.message(
     (message) =>
       message.type === "event" &&
       message.event === "stopped" &&
       (message.body as { readonly reason?: unknown } | undefined)?.reason ===
-        stop,
+        "breakpoint",
     30_000,
   );
 

--- a/editors/vscode/test/packagedE2E.ts
+++ b/editors/vscode/test/packagedE2E.ts
@@ -29,11 +29,11 @@ if (target === undefined) {
 }
 
 const examples = [
-  { name: "level1-loop", line: 8, minimumDepth: 0 },
-  { name: "level2-channel", line: 23, minimumDepth: 1 },
-  { name: "level3-worker-pool", line: 44, minimumDepth: 1 },
-  { name: "level4-pipeline", line: 65, minimumDepth: 1 },
-  { name: "level5-workflow", line: 83, minimumDepth: 2 },
+  { name: "level1-loop", line: 8, minimumDepth: 0, stop: "breakpoint" },
+  { name: "level2-channel", line: undefined, minimumDepth: 1, stop: "pause" },
+  { name: "level3-worker-pool", line: undefined, minimumDepth: 1, stop: "pause" },
+  { name: "level4-pipeline", line: undefined, minimumDepth: 1, stop: "pause" },
+  { name: "level5-workflow", line: 83, minimumDepth: 2, stop: "breakpoint" },
 ] as const;
 
 function packageTarget(): "darwin-arm64" | "linux-x64" | undefined {
@@ -122,6 +122,7 @@ async function main(): Promise<void> {
         config,
         example.name,
         example.line,
+        example.stop,
         `debug-${String(index + 1)}`,
       );
       observedDepths.push(result.depth);
@@ -181,7 +182,8 @@ async function main(): Promise<void> {
 async function runExample(
   config: BingoServerConfiguration,
   name: string,
-  line: number,
+  line: number | undefined,
+  stop: "breakpoint" | "pause",
   debugSessionId: string,
 ): Promise<{
   readonly sessionId: string;
@@ -230,20 +232,23 @@ async function runExample(
     10_000,
   );
 
-  const breakpoint = client.request("setBreakpoints", {
-    source: {
-      name: basename(program),
-      path: resolve(repositoryRoot, "examples", name, "main.go"),
-    },
-    breakpoints: [{ line }],
-    sourceModified: false,
-  });
-  const breakpointResponse = await client.response(breakpoint);
-  assert.equal(
-    ((breakpointResponse.body as { readonly breakpoints?: readonly { verified?: boolean }[] })
-      .breakpoints?.[0]?.verified),
-    true,
-  );
+  if (stop === "breakpoint") {
+    assert.notEqual(line, undefined);
+    const breakpoint = client.request("setBreakpoints", {
+      source: {
+        name: basename(program),
+        path: resolve(repositoryRoot, "examples", name, "main.go"),
+      },
+      breakpoints: [{ line }],
+      sourceModified: false,
+    });
+    const breakpointResponse = await client.response(breakpoint);
+    assert.equal(
+      ((breakpointResponse.body as { readonly breakpoints?: readonly { verified?: boolean }[] })
+        .breakpoints?.[0]?.verified),
+      true,
+    );
+  }
   const configured = client.request("configurationDone", {});
   await Promise.all([client.response(configured), client.response(launch)]);
   await client.message(
@@ -255,12 +260,17 @@ async function runExample(
   );
   const continued = client.request("continue", { threadId: 1 });
   await client.response(continued);
+  if (stop === "pause") {
+    await delay(10);
+    const pause = client.request("pause", { threadId: 1 });
+    await client.response(pause);
+  }
   await client.message(
     (message) =>
       message.type === "event" &&
       message.event === "stopped" &&
       (message.body as { readonly reason?: unknown } | undefined)?.reason ===
-        "breakpoint",
+        stop,
     30_000,
   );
 

--- a/editors/vscode/test/packagedE2E.ts
+++ b/editors/vscode/test/packagedE2E.ts
@@ -332,6 +332,7 @@ async function runExample(
   client.close();
   registry.remove(debugSessionId);
   registry.dispose();
+  await waitForNoSessions(config.managementEndpoint, 10_000);
   return {
     sessionId,
     goroutines: snapshot.goroutines.length,
@@ -339,6 +340,25 @@ async function runExample(
     depth,
     seq: stopped.lastSeq,
   };
+}
+
+async function waitForNoSessions(
+  endpoint: { readonly host: string; readonly port: number },
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const response = await fetch(
+      `http://${endpoint.host}:${String(endpoint.port)}/api/health`,
+      { headers: { "Cache-Control": "no-cache" } },
+    );
+    const decoded = (await response.json()) as { readonly sessionCount?: unknown };
+    if (decoded.sessionCount === 0) {
+      return;
+    }
+    await delay(20);
+  }
+  throw new Error("timed out waiting for the previous managed session to close");
 }
 
 interface DAPMessage {

--- a/editors/vscode/test/packagedE2E.ts
+++ b/editors/vscode/test/packagedE2E.ts
@@ -30,9 +30,9 @@ if (target === undefined) {
 
 const examples = [
   { name: "level1-loop", line: 8, minimumDepth: 0 },
-  { name: "level2-channel", line: 23, minimumDepth: 1 },
-  { name: "level3-worker-pool", line: 44, minimumDepth: 1 },
-  { name: "level4-pipeline", line: 65, minimumDepth: 1 },
+  { name: "level2-channel", line: 22, minimumDepth: 1 },
+  { name: "level3-worker-pool", line: 39, minimumDepth: 1 },
+  { name: "level4-pipeline", line: 63, minimumDepth: 1 },
   { name: "level5-workflow", line: 83, minimumDepth: 2 },
 ] as const;
 

--- a/editors/vscode/test/packagedE2E.ts
+++ b/editors/vscode/test/packagedE2E.ts
@@ -163,9 +163,9 @@ async function main(): Promise<void> {
     }
     if (!succeeded && child?.pid !== undefined && child.exitCode === null) {
       try {
-        process.kill(-child.pid, "SIGKILL");
+        process.kill(child.pid, "SIGKILL");
       } catch {
-        // The exact test-owned process group may already have exited.
+        // The exact test-owned server may already have exited.
       }
       await Promise.race([once(child, "exit"), delay(3000)]);
     }

--- a/editors/vscode/test/packagedE2E.ts
+++ b/editors/vscode/test/packagedE2E.ts
@@ -23,12 +23,7 @@ import {
 } from "../src/sessionEvent.js";
 
 const repositoryRoot = resolve(process.cwd(), "../..");
-const target =
-  process.platform === "darwin" && process.arch === "arm64"
-    ? "darwin-arm64"
-    : process.platform === "linux" && process.arch === "x64"
-      ? "linux-x64"
-      : undefined;
+const target = packageTarget();
 if (target === undefined) {
   throw new Error(`unsupported packaged E2E host ${process.platform}/${process.arch}`);
 }
@@ -40,6 +35,16 @@ const examples = [
   { name: "level4-pipeline", line: 43, minimumDepth: 1 },
   { name: "level5-workflow", line: 83, minimumDepth: 2 },
 ] as const;
+
+function packageTarget(): "darwin-arm64" | "linux-x64" | undefined {
+  if (process.platform === "darwin" && process.arch === "arm64") {
+    return "darwin-arm64";
+  }
+  if (process.platform === "linux" && process.arch === "x64") {
+    return "linux-x64";
+  }
+  return undefined;
+}
 
 void main().catch((error: unknown) => {
   process.stderr.write(

--- a/editors/vscode/test/packagedE2E.ts
+++ b/editors/vscode/test/packagedE2E.ts
@@ -30,9 +30,9 @@ if (target === undefined) {
 
 const examples = [
   { name: "level1-loop", line: 8, minimumDepth: 0 },
-  { name: "level2-channel", line: 14, minimumDepth: 1 },
-  { name: "level3-worker-pool", line: 20, minimumDepth: 1 },
-  { name: "level4-pipeline", line: 43, minimumDepth: 1 },
+  { name: "level2-channel", line: 23, minimumDepth: 1 },
+  { name: "level3-worker-pool", line: 44, minimumDepth: 1 },
+  { name: "level4-pipeline", line: 65, minimumDepth: 1 },
   { name: "level5-workflow", line: 83, minimumDepth: 2 },
 ] as const;
 

--- a/editors/vscode/test/registry.test.ts
+++ b/editors/vscode/test/registry.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { describe, it } from "node:test";
+
+import type { ObserverDependencies, Socket } from "../src/observer.js";
+import { SessionRegistry } from "../src/registry.js";
+
+class SocketStub extends EventEmitter implements Socket {
+  public readyState = 0;
+  public closed = false;
+  public onOpen(listener: () => void): void {
+    this.on("open", listener);
+  }
+  public onMessage(listener: (data: Buffer) => void): void {
+    this.on("message", listener);
+  }
+  public onClose(listener: () => void): void {
+    this.on("close", listener);
+  }
+  public onError(listener: (error: Error) => void): void {
+    this.on("error", listener);
+  }
+  public send(): void {}
+  public close(): void {
+    this.closed = true;
+  }
+}
+
+describe("session registry", () => {
+  it("supports multiple debug sessions, active selection, deduplication, and teardown", () => {
+    const sockets: SocketStub[] = [];
+    const dependencies: ObserverDependencies = {
+      createSocket() {
+        const socket = new SocketStub();
+        sockets.push(socket);
+        return socket;
+      },
+      delay: () => Promise.resolve(),
+      now: () => 0,
+    };
+    const registry = new SessionRegistry(dependencies);
+    const base = {
+      debugSessionName: "session",
+      managementEndpoint: { host: "127.0.0.1", port: 6060 },
+    };
+    assert.equal(registry.add({ ...base, debugSessionId: "a", sessionId: "one" }), true);
+    assert.equal(registry.add({ ...base, debugSessionId: "a", sessionId: "duplicate" }), false);
+    assert.equal(registry.add({ ...base, debugSessionId: "b", sessionId: "two" }), true);
+    assert.equal(registry.viewModel.sessions.length, 2);
+    assert.equal(registry.viewModel.activeDebugSessionId, "b");
+    assert.equal(registry.select("a"), true);
+    assert.equal(registry.viewModel.activeDebugSessionId, "a");
+    registry.remove("a");
+    assert.equal(sockets[0]?.closed, true);
+    assert.equal(registry.viewModel.activeDebugSessionId, "b");
+    registry.dispose();
+    assert.equal(sockets[1]?.closed, true);
+  });
+});

--- a/editors/vscode/test/serverManager.test.ts
+++ b/editors/vscode/test/serverManager.test.ts
@@ -21,6 +21,7 @@ const compatible: HealthProbeResult = {
   health: {
     instanceId: "winner",
     dapAddress: "127.0.0.1:4711",
+    dapSessionEventVersion: 1,
   },
 };
 const absent: HealthProbeResult = { kind: "absent" };
@@ -137,7 +138,7 @@ function sequence(...results: HealthProbeResult[]): HealthProbe {
 }
 
 describe("server manager", () => {
-  it("reuses a compatible server without spawning", async () => {
+  it("reuses a session-discovery-compatible server without spawning", async () => {
     const test = harness(sequence(compatible));
     assert.deepEqual(
       await test.manager.ensureServer(configuration()),
@@ -441,13 +442,19 @@ describe("server manager", () => {
     assert.deepEqual(delays, [50, 10]);
   });
 
-  it("fails safely on an incompatible endpoint without spawning", async () => {
+  it("treats an older server as an occupied endpoint without spawning", async () => {
     const test = harness(
-      sequence({ kind: "incompatible", reason: "not bingo" }),
+      sequence({
+        kind: "incompatible",
+        reason: "DAP session event version is undefined, expected 1",
+      }),
     );
     await assert.rejects(
       test.manager.ensureServer(configuration()),
-      hasCode("endpointOccupied"),
+      (error: unknown) =>
+        error instanceof ServerManagerError &&
+        error.code === "endpointOccupied" &&
+        /DAP session event version is undefined, expected 1/.test(error.message),
     );
     assert.equal(test.requests.length, 0);
   });

--- a/editors/vscode/test/serverProcess.test.ts
+++ b/editors/vscode/test/serverProcess.test.ts
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { mkdir, rm } from "node:fs/promises";
+import { join, resolve } from "node:path";
 import { afterEach, describe, it } from "node:test";
 import type {
   ChildProcess,
@@ -23,7 +23,13 @@ afterEach(async () => {
 
 describe("detached server process", () => {
   it("uses argv without a shell, detaches, logs through files, and only unrefs", async () => {
-    const root = await mkdtemp(join(tmpdir(), "bingo-process-"));
+    const root = resolve(
+      process.cwd(),
+      "dist",
+      "test-artifacts",
+      `bingo-process-${randomUUID()}`,
+    );
+    await mkdir(root, { recursive: true });
     temporaryDirectories.push(root);
     const child = new EventEmitter() as ChildProcess & {
       unrefCalled?: boolean;

--- a/editors/vscode/test/sessionEvent.test.ts
+++ b/editors/vscode/test/sessionEvent.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  decodeSessionAnnouncement,
+  sessionDAPEventName,
+} from "../src/sessionEvent.js";
+
+describe("DAP session discovery", () => {
+  it("accepts only the versioned namespaced event body", () => {
+    assert.equal(
+      decodeSessionAnnouncement(sessionDAPEventName, {
+        version: 1,
+        sessionId: "session-1",
+      })?.sessionId,
+      "session-1",
+    );
+    assert.equal(
+      decodeSessionAnnouncement("output", { version: 1, sessionId: "x" }),
+      undefined,
+    );
+    assert.throws(
+      () => decodeSessionAnnouncement(sessionDAPEventName, {
+        version: 2,
+        sessionId: "x",
+      }),
+      /unsupported/,
+    );
+    assert.throws(
+      () => decodeSessionAnnouncement(sessionDAPEventName, {
+        version: 1,
+        sessionId: "",
+      }),
+      /invalid sessionId/,
+    );
+  });
+});

--- a/editors/vscode/test/telemetry.test.ts
+++ b/editors/vscode/test/telemetry.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  decodeEvent,
+  maximumEnvelopeBytes,
+  maximumGoroutines,
+  SequenceTracker,
+  snapshotCommand,
+} from "../src/telemetry.js";
+import { envelope, goroutine, snapshot } from "./fixtures.js";
+
+describe("telemetry codec", () => {
+  it("decodes protocol 1.2 snapshots and emits only the read-only command", () => {
+    const decoded = decodeEvent(envelope(1, "GoroutineSnapshot", snapshot()));
+    assert.equal(decoded.kind, "GoroutineSnapshot");
+    assert.equal(decoded.snapshot?.goroutines[0]?.id, 1);
+    assert.deepEqual(JSON.parse(snapshotCommand()), {
+      v: "1.2",
+      kind: "GoroutineSnapshot",
+      payload: {},
+    });
+  });
+
+  it("accepts nil Go slices as empty snapshot collections", () => {
+    const decoded = decodeEvent(
+      envelope(1, "GoroutineSnapshot", {
+        goroutines: null,
+        threads: null,
+      }),
+    );
+    assert.deepEqual(decoded.snapshot?.goroutines, []);
+    assert.deepEqual(decoded.snapshot?.threads, []);
+  });
+
+  it("rejects malformed, incompatible, oversized, and hostile payloads", () => {
+    assert.throws(() => decodeEvent("{"), /valid JSON/);
+    assert.throws(
+      () => decodeEvent(JSON.stringify({ v: "9", kind: "Continued", seq: 1, payload: {} })),
+      /incompatible/,
+    );
+    assert.throws(
+      () => decodeEvent("x".repeat(maximumEnvelopeBytes + 1)),
+      /exceeds 2 MiB/,
+    );
+    assert.throws(
+      () =>
+        decodeEvent(
+          envelope(1, "GoroutineSnapshot", {
+            ...snapshot(),
+            goroutines: Array.from(
+              { length: maximumGoroutines + 1 },
+              (_, index) => goroutine(index + 1),
+            ),
+          }),
+        ),
+      /item limit/,
+    );
+    assert.throws(
+      () =>
+        decodeEvent(
+          envelope(1, "SessionState", {
+            sessionID: "<img onerror=alert(1)>",
+            state: "x".repeat(5000),
+            clients: 1,
+          }),
+        ),
+      /characters/,
+    );
+    assert.throws(
+      () =>
+        decodeEvent(
+          Buffer.from([
+            0x7b, 0x22, 0x76, 0x22, 0x3a, 0x22, 0xff, 0x22, 0x7d,
+          ]),
+        ),
+      /UTF-8/,
+    );
+    assert.throws(
+      () =>
+        decodeEvent(
+          JSON.stringify({
+            v: "1.2",
+            kind: "Continued",
+            seq: 1,
+            payload: {},
+            unexpected: true,
+          }),
+        ),
+      /unknown field/,
+    );
+    assert.throws(
+      () =>
+        decodeEvent(
+          JSON.stringify({
+            v: "1.2",
+            kind: "FutureEvent",
+            seq: 1,
+            payload: {},
+          }),
+        ),
+      /unknown telemetry event kind/,
+    );
+    assert.throws(
+      () =>
+        decodeEvent(
+          envelope(1, "GoroutineSnapshot", {
+            ...snapshot(),
+            goroutines: [goroutine(1), goroutine(1)],
+          }),
+        ),
+      /duplicate goroutine id/,
+    );
+  });
+
+  it("detects duplicates and gaps without accepting duplicates", () => {
+    const tracker = new SequenceTracker();
+    assert.deepEqual(tracker.observe(1), { accept: true });
+    assert.deepEqual(tracker.observe(1), {
+      accept: false,
+      gap: "duplicate event 1",
+    });
+    assert.deepEqual(tracker.observe(4), {
+      accept: true,
+      gap: "missed events 2-3",
+    });
+    assert.deepEqual(tracker.observe(2), {
+      accept: true,
+      gap: "out-of-order event 2 after 4",
+    });
+    tracker.reset();
+    assert.deepEqual(tracker.observe(2), { accept: true });
+  });
+});

--- a/editors/vscode/test/tree.test.ts
+++ b/editors/vscode/test/tree.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  filterFullTree,
   filterTree,
   layoutSpawnTree,
   maximumFilterAncestorDepth,
@@ -78,5 +79,23 @@ describe("spawn tree", () => {
     );
     assert.equal(filtered.width, 1142);
     assert.equal(filtered.height, 496);
+  });
+
+  it("finds matches beyond the rendering cap from the full snapshot", () => {
+    const input = Array.from({ length: 1000 }, (_, index) =>
+      goroutine(index + 1, index, {
+        waitReason: index === 999 ? "needle" : "waiting",
+      }),
+    );
+    const capped = layoutSpawnTree(input);
+    assert.equal(capped.nodes.some((node) => node.goroutine.id === 1000), false);
+
+    const filtered = filterFullTree(capped, "needle", input);
+    assert.deepEqual(
+      filtered.nodes.map((node) => node.goroutine.id),
+      [996, 997, 998, 999, 1000],
+    );
+    assert.equal(filtered.nodes.at(-1)?.goroutine.waitReason, "needle");
+    assert.equal(filtered.omitted, 995);
   });
 });

--- a/editors/vscode/test/tree.test.ts
+++ b/editors/vscode/test/tree.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { filterTree, layoutSpawnTree } from "../src/tree.js";
+import { goroutine } from "./fixtures.js";
+
+describe("spawn tree", () => {
+  it("normalizes missing parents, multiple roots, cycles, and stable ordering", () => {
+    const input = [
+      goroutine(8, 7),
+      goroutine(2, 3),
+      goroutine(5, 99),
+      goroutine(3, 2),
+      goroutine(1),
+      goroutine(7, 1),
+    ];
+    const first = layoutSpawnTree(input);
+    const second = layoutSpawnTree([...input].reverse());
+    assert.deepEqual(first, second);
+    assert.equal(first.nodes.length, input.length);
+    assert.equal(new Set(first.nodes.map((node) => node.goroutine.id)).size, input.length);
+    assert.ok(first.nodes.some((node) => node.goroutine.id === 5 && node.parentId === 0));
+    assert.ok(
+      first.nodes.some(
+        (node) => (node.goroutine.id === 2 || node.goroutine.id === 3) && node.parentId === 0,
+      ),
+    );
+  });
+
+  it("caps huge inputs and produces deterministic coordinates", () => {
+    const input = Array.from({ length: 1000 }, (_, index) =>
+      goroutine(index + 1, index),
+    );
+    const layout = layoutSpawnTree(input, 120);
+    assert.equal(layout.nodes.length, 120);
+    assert.equal(layout.omitted, 880);
+    assert.deepEqual(layout.nodes[0]?.x, 42);
+    assert.deepEqual(layout.nodes[0]?.y, 42);
+    assert.ok(layout.width > 0);
+    assert.ok(layout.height > 0);
+  });
+
+  it("retains preferred selections beyond the cap and filters with ancestors", () => {
+    const input = Array.from({ length: 20 }, (_, index) =>
+      goroutine(index + 1, index, {
+        status: index === 19 ? "needle" : "waiting",
+      }),
+    );
+    const layout = layoutSpawnTree(input, 5, [20]);
+    assert.ok(layout.nodes.some((node) => node.goroutine.id === 20));
+    const full = layoutSpawnTree(input);
+    const filtered = filterTree(full, "needle");
+    assert.deepEqual(
+      filtered.nodes.map((node) => node.goroutine.id),
+      input.map((item) => item.id),
+    );
+  });
+});

--- a/editors/vscode/test/tree.test.ts
+++ b/editors/vscode/test/tree.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { filterTree, layoutSpawnTree } from "../src/tree.js";
+import {
+  filterTree,
+  layoutSpawnTree,
+  maximumFilterAncestorDepth,
+} from "../src/tree.js";
 import { goroutine } from "./fixtures.js";
 
 describe("spawn tree", () => {
@@ -52,7 +56,27 @@ describe("spawn tree", () => {
     const filtered = filterTree(full, "needle");
     assert.deepEqual(
       filtered.nodes.map((node) => node.goroutine.id),
-      input.map((item) => item.id),
+      [16, 17, 18, 19, 20],
     );
+    assert.equal(maximumFilterAncestorDepth, 4);
+  });
+
+  it("bounds ancestor context and relayouts a 500-node filtered chain", () => {
+    const input = Array.from({ length: 500 }, (_, index) =>
+      goroutine(index + 1, index, {
+        waitReason: index === 499 ? "needle" : "waiting",
+      }),
+    );
+    const filtered = filterTree(layoutSpawnTree(input), "needle");
+    assert.deepEqual(
+      filtered.nodes.map((node) => node.goroutine.id),
+      [496, 497, 498, 499, 500],
+    );
+    assert.deepEqual(
+      filtered.nodes.map((node) => node.depth),
+      [0, 1, 2, 3, 4],
+    );
+    assert.equal(filtered.width, 1142);
+    assert.equal(filtered.height, 496);
   });
 });

--- a/editors/vscode/test/vscodeIntegration.ts
+++ b/editors/vscode/test/vscodeIntegration.ts
@@ -161,10 +161,7 @@ class FakeDAPServer {
   }
 
   public get port(): number {
-    const address = this.#server.address();
-    assert.notEqual(address, null);
-    assert.equal(typeof address, "object");
-    return (address as { readonly port: number }).port;
+    return listeningPort(this.#server.address());
   }
 
   public static async start(): Promise<FakeDAPServer> {
@@ -344,10 +341,7 @@ class FakeTelemetryServer {
   }
 
   public get port(): number {
-    const address = this.#server.address();
-    assert.notEqual(address, null);
-    assert.equal(typeof address, "object");
-    return (address as { readonly port: number }).port;
+    return listeningPort(this.#server.address());
   }
 
   public static async start(): Promise<FakeTelemetryServer> {
@@ -395,6 +389,14 @@ class FakeTelemetryServer {
 interface DAPRequest {
   readonly seq: number;
   readonly command: string;
+}
+
+function listeningPort(
+  address: string | { readonly port: number } | null,
+): number {
+  assert.notEqual(address, null);
+  assert.equal(typeof address, "object");
+  return (address as { readonly port: number }).port;
 }
 
 function snapshotPayload(): Record<string, unknown> {

--- a/editors/vscode/test/vscodeIntegration.ts
+++ b/editors/vscode/test/vscodeIntegration.ts
@@ -1,0 +1,464 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { createServer, type Server, type Socket } from "node:net";
+
+import * as vscode from "vscode";
+import {
+  WebSocketServer,
+  type WebSocket,
+} from "ws";
+
+import type { BingoExtensionAPI } from "../src/extension.js";
+import { sessionDAPEventName } from "../src/sessionEvent.js";
+
+const extensionID = "bingosuite.bingo";
+const debugSessionName = "Bingo concurrency integration";
+const managedSessionID = "integration-session";
+
+export async function run(): Promise<void> {
+  const dap = await FakeDAPServer.start();
+  const telemetry = await FakeTelemetryServer.start();
+  let session: vscode.DebugSession | undefined;
+  try {
+    const extension =
+      vscode.extensions.getExtension<BingoExtensionAPI>(extensionID);
+    assert.notEqual(extension, undefined, `${extensionID} is not installed`);
+    const api = await extension!.activate();
+    assert.equal(api.version, 1);
+
+    await vscode.commands.executeCommand("workbench.view.extension.bingo");
+    await vscode.commands.executeCommand("bingo.concurrency.focus");
+    await waitFor(
+      () =>
+        api.getConcurrencyViewStatus().ready ? true : undefined,
+      10_000,
+      "Bingo Concurrency webview activation",
+    );
+    let observedStart: vscode.DebugSession | undefined;
+    const startSubscription = vscode.debug.onDidStartDebugSession(
+      (candidate) => {
+        if (candidate.name === debugSessionName) {
+          observedStart = candidate;
+        }
+      },
+    );
+    const started = await vscode.debug.startDebugging(undefined, {
+      type: "bingo",
+      request: "launch",
+      name: debugSessionName,
+      program: "/integration/fake-target",
+      stopOnEntry: true,
+      serverMode: "connectOnly",
+      managementHost: "127.0.0.1",
+      managementPort: telemetry.port,
+      dapHost: "127.0.0.1",
+      dapPort: dap.port,
+    });
+    assert.equal(started, true);
+    session = await waitFor(
+      () => observedStart,
+      10_000,
+      "debug session start",
+    );
+    startSubscription.dispose();
+
+    const model = await waitFor(
+      () => {
+        const current = api.getConcurrencyState();
+        const observed = current.sessions[0];
+        return observed?.sessionId === managedSessionID &&
+          observed.snapshot?.goroutines.length === 2
+          ? current
+          : undefined;
+      },
+      10_000,
+      "custom session event and telemetry snapshot",
+    );
+    assert.equal(model.sessions[0]?.tree.edges.length, 1);
+    await vscode.commands.executeCommand("bingo.concurrency.focus");
+    await waitFor(
+      () =>
+        api.getConcurrencyViewStatus().ready ? true : undefined,
+      5000,
+      "focused concurrency webview",
+    );
+    await waitFor(
+      () =>
+        api.getLastRenderedRevision() ===
+        api.getConcurrencyState().revision
+          ? true
+          : undefined,
+      10_000,
+      "webview rendered acknowledgement",
+    );
+
+    const requestsBefore = telemetry.snapshotRequests;
+    await vscode.commands.executeCommand("bingo.concurrency.refresh");
+    await waitFor(
+      () =>
+        telemetry.snapshotRequests > requestsBefore ? true : undefined,
+      5000,
+      "explicit snapshot refresh",
+    );
+
+    await vscode.debug.stopDebugging(session);
+    await waitFor(
+      () =>
+        api.getConcurrencyState().sessions.length === 0 ? true : undefined,
+      10_000,
+      "debug-session teardown",
+    );
+    session = undefined;
+  } finally {
+    if (session !== undefined) {
+      await vscode.debug.stopDebugging(session);
+    }
+    await Promise.all([dap.close(), telemetry.close()]);
+  }
+}
+
+class FakeDAPServer {
+  readonly #server: Server;
+  readonly #sockets = new Set<Socket>();
+  #sequence = 1;
+  #launchRequest = 0;
+
+  private constructor(server: Server) {
+    this.#server = server;
+    server.on("connection", (socket) => {
+      this.#sockets.add(socket);
+      socket.once("close", () => {
+        this.#sockets.delete(socket);
+      });
+      let buffer = Buffer.alloc(0);
+      socket.on("data", (chunk: Buffer) => {
+        buffer = Buffer.concat([buffer, chunk]);
+        for (;;) {
+          const headerEnd = buffer.indexOf("\r\n\r\n");
+          if (headerEnd < 0) {
+            return;
+          }
+          const header = buffer.subarray(0, headerEnd).toString("ascii");
+          const match = /(?:^|\r\n)Content-Length: (\d+)(?:\r\n|$)/iu.exec(
+            header,
+          );
+          assert.notEqual(match?.[1], undefined);
+          const length = Number(match![1]);
+          const bodyStart = headerEnd + 4;
+          if (buffer.length < bodyStart + length) {
+            return;
+          }
+          const request = JSON.parse(
+            buffer
+              .subarray(bodyStart, bodyStart + length)
+              .toString("utf8"),
+          ) as DAPRequest;
+          buffer = buffer.subarray(bodyStart + length);
+          this.#request(socket, request);
+        }
+      });
+    });
+  }
+
+  public get port(): number {
+    const address = this.#server.address();
+    assert.notEqual(address, null);
+    assert.equal(typeof address, "object");
+    return (address as { readonly port: number }).port;
+  }
+
+  public static async start(): Promise<FakeDAPServer> {
+    const server = createServer();
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    return new FakeDAPServer(server);
+  }
+
+  public async close(): Promise<void> {
+    for (const socket of this.#sockets) {
+      socket.destroy();
+    }
+    if (!this.#server.listening) {
+      return;
+    }
+    this.#server.close();
+    await once(this.#server, "close");
+  }
+
+  #request(socket: Socket, request: DAPRequest): void {
+    const command = request.command;
+    switch (command) {
+      case "initialize":
+        this.#respond(socket, request, {
+          supportsConfigurationDoneRequest: true,
+          supportsTerminateRequest: true,
+        });
+        break;
+      case "launch":
+        this.#launchRequest = request.seq;
+        this.#event(socket, sessionDAPEventName, {
+          version: 1,
+          sessionId: managedSessionID,
+        });
+        this.#event(socket, "initialized", {});
+        break;
+      case "setBreakpoints":
+        this.#respond(socket, request, { breakpoints: [] });
+        break;
+      case "setFunctionBreakpoints":
+      case "setInstructionBreakpoints":
+        this.#respond(socket, request, { breakpoints: [] });
+        break;
+      case "setExceptionBreakpoints":
+        this.#respond(socket, request, {});
+        break;
+      case "configurationDone":
+        this.#respond(socket, request, {});
+        this.#write(socket, {
+          seq: this.#sequence++,
+          type: "response",
+          request_seq: this.#launchRequest,
+          success: true,
+          command: "launch",
+        });
+        this.#event(socket, "stopped", {
+          reason: "entry",
+          threadId: 1,
+          allThreadsStopped: true,
+        });
+        break;
+      case "threads":
+        this.#respond(socket, request, {
+          threads: [{ id: 1, name: "main" }],
+        });
+        break;
+      case "stackTrace":
+        this.#respond(socket, request, {
+          stackFrames: [],
+          totalFrames: 0,
+        });
+        break;
+      case "scopes":
+        this.#respond(socket, request, { scopes: [] });
+        break;
+      case "variables":
+        this.#respond(socket, request, { variables: [] });
+        break;
+      case "loadedSources":
+        this.#respond(socket, request, { sources: [] });
+        break;
+      case "terminate":
+        this.#respond(socket, request, {});
+        this.#event(socket, "terminated", {});
+        setTimeout(() => {
+          socket.end();
+        }, 25);
+        break;
+      case "disconnect":
+        this.#respond(socket, request, {});
+        socket.end();
+        break;
+      default:
+        this.#respond(socket, request, {});
+        break;
+    }
+  }
+
+  #respond(
+    socket: Socket,
+    request: DAPRequest,
+    body: Record<string, unknown>,
+  ): void {
+    this.#write(socket, {
+      seq: this.#sequence++,
+      type: "response",
+      request_seq: request.seq,
+      success: true,
+      command: request.command,
+      body,
+    });
+  }
+
+  #event(
+    socket: Socket,
+    event: string,
+    body: Record<string, unknown>,
+  ): void {
+    this.#write(socket, {
+      seq: this.#sequence++,
+      type: "event",
+      event,
+      body,
+    });
+  }
+
+  #write(socket: Socket, message: Record<string, unknown>): void {
+    const body = Buffer.from(JSON.stringify(message));
+    socket.write(
+      Buffer.concat([
+        Buffer.from(`Content-Length: ${String(body.length)}\r\n\r\n`),
+        body,
+      ]),
+    );
+  }
+}
+
+class FakeTelemetryServer {
+  readonly #server: WebSocketServer;
+  readonly #sockets = new Set<WebSocket>();
+  #sequence = 0;
+  public snapshotRequests = 0;
+
+  private constructor(server: WebSocketServer) {
+    this.#server = server;
+    server.on("connection", (socket, request) => {
+      assert.equal(
+        request.url,
+        `/ws?session=${encodeURIComponent(managedSessionID)}`,
+      );
+      this.#sockets.add(socket);
+      socket.once("close", () => {
+        this.#sockets.delete(socket);
+      });
+      this.#send(socket, "SessionState", {
+        sessionID: managedSessionID,
+        state: "suspended",
+        clients: 2,
+      });
+      socket.on("message", (raw) => {
+        assert.ok(Buffer.isBuffer(raw), "telemetry command must be a text buffer");
+        const command = JSON.parse(raw.toString("utf8")) as {
+          readonly v?: unknown;
+          readonly kind?: unknown;
+          readonly payload?: unknown;
+        };
+        assert.deepEqual(command, {
+          v: "1.2",
+          kind: "GoroutineSnapshot",
+          payload: {},
+        });
+        this.snapshotRequests += 1;
+        this.#send(socket, "GoroutineSnapshot", snapshotPayload());
+      });
+    });
+  }
+
+  public get port(): number {
+    const address = this.#server.address();
+    assert.notEqual(address, null);
+    assert.equal(typeof address, "object");
+    return (address as { readonly port: number }).port;
+  }
+
+  public static async start(): Promise<FakeTelemetryServer> {
+    const server = new WebSocketServer({
+      host: "127.0.0.1",
+      port: 0,
+      perMessageDeflate: false,
+    });
+    await once(server, "listening");
+    return new FakeTelemetryServer(server);
+  }
+
+  public async close(): Promise<void> {
+    for (const socket of this.#sockets) {
+      socket.close();
+    }
+    await new Promise<void>((resolveClose, reject) => {
+      this.#server.close((error) => {
+        if (error === undefined) {
+          resolveClose();
+        } else {
+          reject(error);
+        }
+      });
+    });
+  }
+
+  #send(
+    socket: WebSocket,
+    kind: string,
+    payload: Record<string, unknown>,
+  ): void {
+    this.#sequence += 1;
+    socket.send(
+      JSON.stringify({
+        v: "1.2",
+        kind,
+        seq: this.#sequence,
+        payload,
+      }),
+    );
+  }
+}
+
+interface DAPRequest {
+  readonly seq: number;
+  readonly command: string;
+}
+
+function snapshotPayload(): Record<string, unknown> {
+  const location = {
+    file: "/workspace/main.go",
+    line: 42,
+    function: "main.worker",
+  };
+  return {
+    goroutines: [
+      {
+        id: 1,
+        status: "waiting",
+        waitReason: "sync.WaitGroup.Wait",
+        currentLoc: location,
+        startLoc: location,
+        createdLoc: location,
+        current: true,
+        threadId: 101,
+      },
+      {
+        id: 2,
+        parentId: 1,
+        status: "running",
+        currentLoc: location,
+        startLoc: location,
+        createdLoc: location,
+        threadId: 102,
+      },
+    ],
+    threads: [
+      {
+        id: 101,
+        mid: 1,
+        goid: 1,
+        currentLoc: location,
+        current: true,
+      },
+      {
+        id: 102,
+        mid: 2,
+        goid: 2,
+        currentLoc: location,
+      },
+    ],
+    current: 1,
+    created: [2],
+  };
+}
+
+async function waitFor<T>(
+  probe: () => T | undefined,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = probe();
+    if (result !== undefined) {
+      return result;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`timed out waiting for ${label}`);
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+  }
+}

--- a/editors/vscode/test/webviewDom.test.ts
+++ b/editors/vscode/test/webviewDom.test.ts
@@ -159,12 +159,12 @@ describe("concurrency webview DOM", () => {
     assert.doesNotMatch(label, /not displayed/);
   });
 
-  it("compacts and fits a large tree around filtered matches", () => {
+  it("finds, compacts, and fits matches beyond the rendering cap", () => {
     const { document, window } = parseHTML("<html><body><div id=app></div></body></html>");
     const goroutines = [goroutine(1, 0, { current: true })];
-    for (let id = 2; id <= 500; id += 1) {
+    for (let id = 2; id <= 1000; id += 1) {
       goroutines.push(
-        goroutine(id, id - 1, id === 500 ? { waitReason: "needle" } : {}),
+        goroutine(id, id - 1, id === 1000 ? { waitReason: "needle" } : {}),
       );
     }
     mountConcurrencyView(document, { postMessage() {} })(
@@ -182,12 +182,12 @@ describe("concurrency webview DOM", () => {
       "0 0 1142 496",
     );
     assert.match(
-      document.querySelector('[data-goid="496"]')?.getAttribute("aria-label") ??
+      document.querySelector('[data-goid="996"]')?.getAttribute("aria-label") ??
         "",
-      /displayed root, reported parent goroutine 495 is not displayed/,
+      /displayed root, reported parent goroutine 995 is not displayed/,
     );
     assert.equal(
-      document.querySelector('[data-goid="500"]')?.getAttribute("transform"),
+      document.querySelector('[data-goid="1000"]')?.getAttribute("transform"),
       "translate(874 370)",
     );
 
@@ -195,6 +195,39 @@ describe("concurrency webview DOM", () => {
     search.dispatchEvent(new window.Event("input"));
     assert.equal(document.querySelectorAll(".tree-node").length, 500);
     assert.match(document.querySelector("svg")?.getAttribute("viewBox") ?? "", /41086$/);
+  });
+
+  it("keeps fit and zoom controls safe for an empty filter result", () => {
+    const { document, window } = parseHTML(
+      "<html><body><div id=app></div></body></html>",
+    );
+    mountConcurrencyView(document, { postMessage() {} })(model());
+    const search = document.querySelector<HTMLInputElement>(
+      'input[type="search"]',
+    )!;
+    search.value = "no-such-goroutine";
+    search.dispatchEvent(new window.Event("input"));
+
+    assert.equal(document.querySelectorAll(".tree-node").length, 0);
+    assert.match(
+      document.querySelector(".graph-panel")?.textContent ?? "",
+      /No goroutines in this snapshot/,
+    );
+    const controls = [
+      ...document.querySelectorAll<HTMLButtonElement>(
+        ".graph-controls button",
+      ),
+    ];
+    assert.deepEqual(
+      controls.map((control) => control.textContent),
+      ["Fit", "−", "+"],
+    );
+    assert.doesNotThrow(() => {
+      for (const control of controls) {
+        control.click();
+      }
+    });
+    assert.equal(document.querySelectorAll(".tree-node").length, 0);
   });
 
   it("renders empty and error states", () => {

--- a/editors/vscode/test/webviewDom.test.ts
+++ b/editors/vscode/test/webviewDom.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseHTML } from "linkedom";
+
+import type { ConcurrencyViewModel, SessionModel } from "../src/model.js";
+import { toSessionViewModel } from "../src/model.js";
+import { mountConcurrencyView } from "../src/webviewApp.js";
+import { goroutine, snapshot, thread } from "./fixtures.js";
+
+function model(
+  patch: Partial<SessionModel> = {},
+): ConcurrencyViewModel {
+  const session: SessionModel = {
+    debugSessionId: "debug",
+    debugSessionName: "Level 5",
+    sessionId: "session",
+    connection: "connected",
+    sessionState: "suspended",
+    clients: 2,
+    lastStop: "Breakpoint at inventory.go:42",
+    error: "",
+    seqGap: "",
+    lastSeq: 1,
+    snapshot: snapshot(
+      [
+        goroutine(1, 0, { current: true, threadId: 10 }),
+        goroutine(2, 1, { status: "running", waitReason: "" }),
+      ],
+      [thread(10, 1), thread(11)],
+    ),
+    selectedGoroutine: 1,
+    timeline: [{ id: 2, action: "created", at: 1 }],
+    ...patch,
+  };
+  return {
+    revision: 1,
+    activeDebugSessionId: "debug",
+    sessions: [toSessionViewModel(session)],
+  };
+}
+
+describe("concurrency webview DOM", () => {
+  it("renders nodes, edges, threads, inspector, lifecycle, and accessibility", () => {
+    const { document } = parseHTML("<html><body><div id=app></div></body></html>");
+    const messages: Record<string, unknown>[] = [];
+    const render = mountConcurrencyView(document, {
+      postMessage(message) {
+        messages.push(message);
+      },
+    });
+    render(model());
+    assert.equal(document.querySelectorAll(".tree-node").length, 2);
+    assert.equal(document.querySelectorAll(".tree-edge").length, 1);
+    assert.equal(document.querySelectorAll(".thread").length, 2);
+    assert.match(document.querySelector(".inspector")?.textContent ?? "", /main\.worker/);
+    assert.match(document.querySelector(".timeline")?.textContent ?? "", /\+ g2/);
+    assert.equal(document.querySelector("svg")?.getAttribute("role"), "tree");
+    assert.equal(document.querySelector(".graph-viewport")?.getAttribute("tabindex"), "0");
+    assert.equal(document.querySelector(".graph-viewport")?.id, "concurrency-tree");
+    assert.deepEqual(messages.at(-1), { type: "rendered", revision: 1 });
+  });
+
+  it("filters and selects through DOM events", () => {
+    const { document, window } = parseHTML("<html><body><div id=app></div></body></html>");
+    const messages: Record<string, unknown>[] = [];
+    mountConcurrencyView(document, { postMessage: (message) => messages.push(message) })(model());
+    const search = document.querySelector<HTMLInputElement>('input[type="search"]')!;
+    search.value = "running";
+    search.dispatchEvent(new window.Event("input"));
+    assert.equal(document.querySelectorAll(".tree-node.filtered").length, 0);
+    document.querySelectorAll<SVGGElement>(".tree-node")[1]?.dispatchEvent(new window.Event("click"));
+    assert.deepEqual(messages.at(-1), { type: "selectGoroutine", id: 2 });
+  });
+
+  it("keeps matching descendants connected to visible ancestors", () => {
+    const { document, window } = parseHTML("<html><body><div id=app></div></body></html>");
+    const nested = snapshot([
+      goroutine(1, 0, { current: true }),
+      goroutine(2, 1),
+      goroutine(3, 2, { waitReason: "needle" }),
+    ]);
+    mountConcurrencyView(document, { postMessage() {} })(
+      model({ snapshot: nested }),
+    );
+    const search = document.querySelector<HTMLInputElement>('input[type="search"]')!;
+    search.value = "needle";
+    search.dispatchEvent(new window.Event("input"));
+    assert.equal(document.querySelectorAll(".tree-node.filtered").length, 0);
+    assert.equal(document.querySelectorAll(".tree-edge.filtered").length, 0);
+  });
+
+  it("renders empty and error states", () => {
+    const { document } = parseHTML("<html><body><div id=app></div></body></html>");
+    const render = mountConcurrencyView(document, { postMessage() {} });
+    render({ revision: 1, activeDebugSessionId: "", sessions: [] });
+    assert.match(document.body.textContent, /Start a bingo debug session/);
+    render(model({ error: "socket rejected", snapshot: undefined }));
+    assert.equal(document.querySelector(".callout.error")?.getAttribute("role"), "alert");
+    assert.match(document.body.textContent, /socket rejected/);
+  });
+
+  it("keeps hostile tracee strings inert", () => {
+    const { document } = parseHTML("<html><body><div id=app></div></body></html>");
+    const hostile = '<img src=x onerror="globalThis.pwned=true">';
+    const snap = snapshot([goroutine(1, 0, { waitReason: hostile, current: true })]);
+    mountConcurrencyView(document, { postMessage() {} })(
+      model({ snapshot: snap, selectedGoroutine: 1 }),
+    );
+    assert.equal(document.querySelector("img"), null);
+    assert.match(document.body.textContent, /<img src=x/);
+  });
+});

--- a/editors/vscode/test/webviewDom.test.ts
+++ b/editors/vscode/test/webviewDom.test.ts
@@ -55,6 +55,18 @@ describe("concurrency webview DOM", () => {
     assert.match(document.querySelector(".inspector")?.textContent ?? "", /main\.worker/);
     assert.match(document.querySelector(".timeline")?.textContent ?? "", /\+ g2/);
     assert.equal(document.querySelector("svg")?.getAttribute("role"), "tree");
+    const treeItems = document.querySelectorAll(".tree-node");
+    assert.equal(treeItems[0]?.getAttribute("aria-level"), "1");
+    assert.match(treeItems[0]?.getAttribute("aria-label") ?? "", /root goroutine/);
+    assert.equal(treeItems[0]?.getAttribute("aria-selected"), "true");
+    assert.equal(treeItems[1]?.getAttribute("aria-level"), "2");
+    assert.match(
+      treeItems[1]?.getAttribute("aria-label") ?? "",
+      /child of goroutine 1/,
+    );
+    assert.equal(treeItems[1]?.getAttribute("aria-selected"), "false");
+    assert.equal(treeItems[1]?.getAttribute("aria-posinset"), "1");
+    assert.equal(treeItems[1]?.getAttribute("aria-setsize"), "1");
     assert.equal(document.querySelector(".graph-viewport")?.getAttribute("tabindex"), "0");
     assert.equal(document.querySelector(".graph-viewport")?.id, "concurrency-tree");
     assert.deepEqual(messages.at(-1), { type: "rendered", revision: 1 });
@@ -87,6 +99,62 @@ describe("concurrency webview DOM", () => {
     search.dispatchEvent(new window.Event("input"));
     assert.equal(document.querySelectorAll(".tree-node.filtered").length, 0);
     assert.equal(document.querySelectorAll(".tree-edge.filtered").length, 0);
+  });
+
+  it("describes cycle-normalized roots without claiming their parent is absent", () => {
+    const { document } = parseHTML("<html><body><div id=app></div></body></html>");
+    mountConcurrencyView(document, { postMessage() {} })(
+      model({
+        snapshot: snapshot([
+          goroutine(1, 2, { current: true }),
+          goroutine(2, 1),
+        ]),
+      }),
+    );
+
+    const label =
+      document.querySelector('[data-goid="1"]')?.getAttribute("aria-label") ?? "";
+    assert.match(label, /displayed root after cycle normalization/);
+    assert.match(label, /reported parent goroutine 2/);
+    assert.doesNotMatch(label, /not displayed/);
+  });
+
+  it("compacts and fits a large tree around filtered matches", () => {
+    const { document, window } = parseHTML("<html><body><div id=app></div></body></html>");
+    const goroutines = [goroutine(1, 0, { current: true })];
+    for (let id = 2; id <= 500; id += 1) {
+      goroutines.push(
+        goroutine(id, id - 1, id === 500 ? { waitReason: "needle" } : {}),
+      );
+    }
+    mountConcurrencyView(document, { postMessage() {} })(
+      model({ snapshot: snapshot(goroutines), selectedGoroutine: 1 }),
+    );
+    assert.match(document.querySelector("svg")?.getAttribute("viewBox") ?? "", /41086$/);
+
+    const search = document.querySelector<HTMLInputElement>('input[type="search"]')!;
+    search.value = "needle";
+    search.dispatchEvent(new window.Event("input"));
+
+    assert.equal(document.querySelectorAll(".tree-node").length, 5);
+    assert.equal(
+      document.querySelector("svg")?.getAttribute("viewBox"),
+      "0 0 1142 496",
+    );
+    assert.match(
+      document.querySelector('[data-goid="496"]')?.getAttribute("aria-label") ??
+        "",
+      /displayed root, reported parent goroutine 495 is not displayed/,
+    );
+    assert.equal(
+      document.querySelector('[data-goid="500"]')?.getAttribute("transform"),
+      "translate(874 370)",
+    );
+
+    search.value = "";
+    search.dispatchEvent(new window.Event("input"));
+    assert.equal(document.querySelectorAll(".tree-node").length, 500);
+    assert.match(document.querySelector("svg")?.getAttribute("viewBox") ?? "", /41086$/);
   });
 
   it("renders empty and error states", () => {

--- a/editors/vscode/test/webviewDom.test.ts
+++ b/editors/vscode/test/webviewDom.test.ts
@@ -69,7 +69,11 @@ describe("concurrency webview DOM", () => {
     assert.equal(treeItems[1]?.getAttribute("aria-setsize"), "1");
     assert.equal(document.querySelector(".graph-viewport")?.getAttribute("tabindex"), "0");
     assert.equal(document.querySelector(".graph-viewport")?.id, "concurrency-tree");
-    assert.deepEqual(messages.at(-1), { type: "rendered", revision: 1 });
+    assert.deepEqual(messages.at(-1), {
+      type: "rendered",
+      generation: 1,
+      revision: 1,
+    });
   });
 
   it("filters and selects through DOM events", () => {

--- a/editors/vscode/test/webviewDom.test.ts
+++ b/editors/vscode/test/webviewDom.test.ts
@@ -88,6 +88,42 @@ describe("concurrency webview DOM", () => {
     assert.deepEqual(messages.at(-1), { type: "selectGoroutine", id: 2 });
   });
 
+  it("moves DOM focus with keyboard tree selection", () => {
+    const { document, window } = parseHTML(
+      "<html><body><div id=app></div></body></html>",
+    );
+    const messages: Record<string, unknown>[] = [];
+    mountConcurrencyView(document, {
+      postMessage: (message) => messages.push(message),
+    })(model());
+    const first = document.querySelector<SVGGElement>('[data-goid="1"]')!;
+    const second = document.querySelector<SVGGElement>('[data-goid="2"]')!;
+    let focused = "";
+    Object.defineProperty(first, "focus", {
+      value: () => {
+        focused = "1";
+      },
+    });
+    Object.defineProperty(second, "focus", {
+      value: () => {
+        focused = "2";
+      },
+    });
+    first.focus();
+    const event = new window.Event("keydown", {
+      bubbles: true,
+      cancelable: true,
+    });
+    Object.defineProperty(event, "key", { value: "ArrowDown" });
+    first.dispatchEvent(event);
+
+    assert.equal(focused, "2");
+    assert.deepEqual(messages.at(-1), {
+      type: "selectGoroutine",
+      id: 2,
+    });
+  });
+
   it("keeps matching descendants connected to visible ancestors", () => {
     const { document, window } = parseHTML("<html><body><div id=app></div></body></html>");
     const nested = snapshot([

--- a/editors/vscode/test/webviewSecurity.test.ts
+++ b/editors/vscode/test/webviewSecurity.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it } from "node:test";
+
+describe("webview security contract", () => {
+  const provider = readFileSync(
+    resolve(process.cwd(), "src/concurrencyView.ts"),
+    "utf8",
+  );
+  const renderer = readFileSync(
+    resolve(process.cwd(), "src/webviewApp.ts"),
+    "utf8",
+  );
+
+  it("uses a nonce CSP and limits webview resources to dist", () => {
+    assert.match(provider, /default-src 'none'/);
+    assert.match(provider, /style-src 'nonce-\$\{nonce\}'/);
+    assert.match(provider, /script-src 'nonce-\$\{nonce\}'/);
+    assert.match(provider, /localResourceRoots: \[dist\]/);
+    assert.doesNotMatch(provider, /unsafe-inline|unsafe-eval|https?:\/\//);
+  });
+
+  it("renders tracee data through DOM APIs without HTML injection", () => {
+    assert.doesNotMatch(renderer, /\.innerHTML|insertAdjacentHTML|eval\s*\(/);
+    assert.match(renderer, /\.textContent =/);
+    assert.match(renderer, /createElementNS/);
+  });
+
+  it("keeps ready/rendered acknowledgements in the host protocol", () => {
+    assert.match(provider, /case "ready"/);
+    assert.match(provider, /case "rendered"/);
+    assert.match(provider, /#inFlightRevision/);
+  });
+});

--- a/editors/vscode/test/webviewSecurity.test.ts
+++ b/editors/vscode/test/webviewSecurity.test.ts
@@ -30,6 +30,7 @@ describe("webview security contract", () => {
   it("keeps ready/rendered acknowledgements in the host protocol", () => {
     assert.match(provider, /case "ready"/);
     assert.match(provider, /case "rendered"/);
-    assert.match(provider, /#inFlightRevision/);
+    assert.match(provider, /#delivery/);
+    assert.match(provider, /rejectDelivery/);
   });
 });

--- a/editors/vscode/test/workspace.test.ts
+++ b/editors/vscode/test/workspace.test.ts
@@ -165,6 +165,7 @@ describe("repository VS Code integration", () => {
     assert.doesNotMatch(platform, /win32|ia32|linux-arm64|darwin-x64/);
     assert.match(platform, /BINGO_VSCODE_TARGET/);
     assert.match(platform, /darwinCrossBuild/);
+    assert.match(platform, /linuxCrossBuild/);
     assert.match(packageScript, /"--target"/);
     assert.match(prepareScript, /"bingonative"/);
     assert.match(prepareScript, /"codesign"/);

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -4,7 +4,9 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": [
-      "ES2022"
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
     ],
     "types": [
       "node",

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,7 +27,9 @@ In VS Code, install the bingo extension, choose **bingo DAP: launch example
 (stop on entry)**, press F5, and select a level from the picker. The pre-launch
 task rebuilds all five binaries in `build/examples/` with
 `-gcflags="all=-N -l"`. The only other root debug configuration joins an
-existing bingo session.
+existing bingo session. **Bingo Concurrency** automatically joins the selected
+DAP session and makes the increasing hierarchy visible from level 1's single
+application goroutine through level 5's nested workflows and stages.
 
 For a terminal-only DAP session, start `just server`, run `just dapcli`, and
 launch a selected binary:
@@ -38,10 +40,10 @@ break examples/level3-worker-pool/main.go:20
 c
 ```
 
-Join the reported session with `go run ./cmd/wsmon -session <id>` to watch
-goroutine snapshots while DAP drives execution. Concurrent worker and workflow
-status lines can interleave differently between runs, but every level's final
-summary is sorted or otherwise deterministic.
+The graphical view requires no session-id copy. For a terminal-only observer,
+join the reported session with `go run ./cmd/wsmon -session <id>`. Concurrent
+worker and workflow status lines can interleave differently between runs, but
+every level's final summary is sorted or otherwise deterministic.
 
 [`spawntree`](spawntree/) remains the dedicated advanced hierarchy and lifecycle
 telemetry demo. Build it separately with `just build-spawntree` and follow

--- a/examples/level2-channel/main.go
+++ b/examples/level2-channel/main.go
@@ -18,8 +18,9 @@ func produce(values []int) <-chan int {
 }
 
 func main() {
+	output := produce([]int{2, 4, 6, 8})
 	values := make([]int, 0, 4)
-	for value := range produce([]int{2, 4, 6, 8}) {
+	for value := range output {
 		values = append(values, value)
 		fmt.Printf("received=%d square=%d\n", value, value*value)
 	}

--- a/internal/dap/handler.go
+++ b/internal/dap/handler.go
@@ -29,6 +29,18 @@ const cmdBufferSize = 64
 // genuinely wedged, so send() tears the connection down.
 const dapWriteTimeout = 10 * time.Second
 
+const sessionEventName = "bingo/session/v1"
+
+type sessionEvent struct {
+	godap.Event
+	Body sessionEventBody `json:"body"`
+}
+
+type sessionEventBody struct {
+	Version   int    `json:"version"`
+	SessionID string `json:"sessionId"`
+}
+
 // Handler bridges one DAP TCP client to a bingo hub session. It implements
 // hub.WSConn: the hub's write pump feeds it bingo events via WriteMessage
 // (translated to DAP), and the hub's read pump pulls bingo commands from it via
@@ -60,6 +72,9 @@ type Handler struct {
 
 	session Session
 	client  *hub.Client
+
+	sessionStarting  bool
+	sessionAnnounced bool
 
 	// Handshake / lifecycle flags.
 	launching   bool

--- a/internal/dap/handler.go
+++ b/internal/dap/handler.go
@@ -13,6 +13,7 @@ import (
 
 	godap "github.com/google/go-dap"
 
+	"github.com/bingosuite/bingo/internal/dapclient"
 	"github.com/bingosuite/bingo/internal/hub"
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
@@ -29,17 +30,10 @@ const cmdBufferSize = 64
 // genuinely wedged, so send() tears the connection down.
 const dapWriteTimeout = 10 * time.Second
 
-const sessionEventName = "bingo/session/v1"
+const sessionEventName = protocol.DAPSessionEventName
 
-type sessionEvent struct {
-	godap.Event
-	Body sessionEventBody `json:"body"`
-}
-
-type sessionEventBody struct {
-	Version   int    `json:"version"`
-	SessionID string `json:"sessionId"`
-}
+type sessionEvent = dapclient.SessionEvent
+type sessionEventBody = dapclient.SessionEventBody
 
 // Handler bridges one DAP TCP client to a bingo hub session. It implements
 // hub.WSConn: the hub's write pump feeds it bingo events via WriteMessage

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -67,6 +67,10 @@ type fakeSession struct {
 	cmds    *cmdRecorder
 	welcome protocol.SessionState
 	addErr  error
+
+	addStarted chan struct{}
+	allowAdd   <-chan struct{}
+	addOnce    sync.Once
 }
 
 func (s *fakeSession) SessionID() string { return s.id }
@@ -76,6 +80,12 @@ func (s *fakeSession) SessionID() string { return s.id }
 // handler's enqueued commands. The handler never calls methods on the
 // *hub.Client it stores.
 func (s *fakeSession) AddClient(conn hub.WSConn, _ *slog.Logger) (*hub.Client, error) {
+	if s.addStarted != nil {
+		s.addOnce.Do(func() { close(s.addStarted) })
+	}
+	if s.allowAdd != nil {
+		<-s.allowAdd
+	}
 	if s.addErr != nil {
 		_ = conn.Close()
 		return nil, s.addErr
@@ -99,16 +109,29 @@ func (s *fakeSession) AddClient(conn hub.WSConn, _ *slog.Logger) (*hub.Client, e
 			if err != nil {
 				return
 			}
-			s.cmds.add(data)
+			if s.cmds != nil {
+				s.cmds.add(data)
+			}
 		}
 	}()
 	return nil, nil
 }
 
-type fakeProvider struct{ sess *fakeSession }
+type fakeProvider struct {
+	sess      *fakeSession
+	createErr error
+}
 
-func (p *fakeProvider) CreateSession() (Session, error)   { return p.sess, nil }
-func (p *fakeProvider) GetSession(string) (Session, bool) { return p.sess, true }
+func (p *fakeProvider) CreateSession() (Session, error) {
+	if p.createErr != nil {
+		return nil, p.createErr
+	}
+	return p.sess, nil
+}
+
+func (p *fakeProvider) GetSession(string) (Session, bool) {
+	return p.sess, p.sess != nil
+}
 
 func TestStartSessionRejectsClosedHub(t *testing.T) {
 	serverConn, clientConn := net.Pipe()
@@ -128,7 +151,7 @@ func TestStartSessionRejectsClosedHub(t *testing.T) {
 	}
 	handler.mu.Lock()
 	defer handler.mu.Unlock()
-	if handler.session != nil || handler.client != nil {
+	if handler.session != nil || handler.client != nil || handler.sessionStarting || handler.sessionAnnounced {
 		t.Fatal("rejected session was retained by DAP handler")
 	}
 }
@@ -140,6 +163,7 @@ type harness struct {
 	handler *Handler
 	client  net.Conn
 	reader  *bufio.Reader
+	codec   *godap.Codec
 	cmds    *cmdRecorder
 	seq     int
 }
@@ -152,14 +176,18 @@ func newHarness(t *testing.T) *harness {
 // welcome state to a newly-added client (the empty string sends none).
 func newHarnessWelcome(t *testing.T, welcome protocol.SessionState) *harness {
 	t.Helper()
+	rec := &cmdRecorder{}
+	prov := &fakeProvider{sess: &fakeSession{id: "sess-test", cmds: rec, welcome: welcome}}
+	return newHarnessProvider(t, prov, rec)
+}
+
+func newHarnessProvider(t *testing.T, prov Provider, rec *cmdRecorder) *harness {
+	t.Helper()
 	ln, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = ln.Close() })
-
-	rec := &cmdRecorder{}
-	prov := &fakeProvider{sess: &fakeSession{id: "sess-test", cmds: rec, welcome: welcome}}
 
 	accepted := make(chan net.Conn, 1)
 	go func() {
@@ -179,12 +207,17 @@ func newHarnessWelcome(t *testing.T, welcome protocol.SessionState) *harness {
 	h := NewHandler(serverConn, prov, slog.New(slog.NewTextHandler(nopWriter{}, nil)))
 	go h.Serve()
 
+	codec := godap.NewCodec()
+	if err := codec.RegisterEvent(sessionEventName, func() godap.Message { return new(sessionEvent) }); err != nil {
+		t.Fatal(err)
+	}
+
 	t.Cleanup(func() {
 		_ = client.Close()
 		_ = h.Close()
 	})
 
-	return &harness{t: t, handler: h, client: client, reader: bufio.NewReader(client), cmds: rec}
+	return &harness{t: t, handler: h, client: client, reader: bufio.NewReader(client), codec: codec, cmds: rec}
 }
 
 type nopWriter struct{}
@@ -209,7 +242,11 @@ func (hh *harness) sendReq(command string, m godap.RequestMessage) int {
 func (hh *harness) recv() godap.Message {
 	hh.t.Helper()
 	_ = hh.client.SetReadDeadline(time.Now().Add(2 * time.Second))
-	m, err := godap.ReadProtocolMessage(hh.reader)
+	data, err := godap.ReadBaseMessage(hh.reader)
+	if err != nil {
+		hh.t.Fatalf("recv: %v", err)
+	}
+	m, err := hh.codec.DecodeMessage(data)
 	if err != nil {
 		hh.t.Fatalf("recv: %v", err)
 	}
@@ -270,6 +307,144 @@ func (hh *harness) doHandshake(t *testing.T) {
 	hh.cmds.waitForCommand(t, protocol.CmdContinue)
 	// Suppress our own continue.
 	hh.inject(protocol.EventContinued, protocol.ContinuedPayload{})
+}
+
+func TestLaunchAnnouncesManagedSessionAfterClientAttach(t *testing.T) {
+	rec := &cmdRecorder{}
+	addStarted := make(chan struct{})
+	allowAdd := make(chan struct{})
+	prov := &fakeProvider{sess: &fakeSession{
+		id:         "sess-launch",
+		cmds:       rec,
+		addStarted: addStarted,
+		allowAdd:   allowAdd,
+	}}
+	hh := newHarnessProvider(t, prov, rec)
+
+	hh.sendReq("initialize", initArgs())
+	_ = recvType[*godap.InitializeResponse](hh)
+	hh.sendReq("launch", &godap.LaunchRequest{Arguments: json.RawMessage(`{"program":"/bin/x"}`)})
+
+	select {
+	case <-addStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("AddClient was not called")
+	}
+	_ = hh.client.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	if _, err := hh.reader.Peek(1); err == nil {
+		t.Fatal("session event arrived before AddClient returned")
+	} else if nerr, ok := err.(net.Error); !ok || !nerr.Timeout() {
+		t.Fatalf("peek before AddClient returned: %v", err)
+	}
+	_ = hh.client.SetReadDeadline(time.Time{})
+
+	close(allowAdd)
+	event := recvType[*sessionEvent](hh)
+	if event.Body != (sessionEventBody{Version: 1, SessionID: "sess-launch"}) {
+		t.Fatalf("session event body = %+v", event.Body)
+	}
+	wire, err := json.Marshal(event)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = `{"seq":2,"type":"event","event":"bingo/session/v1","body":{"version":1,"sessionId":"sess-launch"}}`
+	if string(wire) != want {
+		t.Fatalf("session event JSON = %s, want %s", wire, want)
+	}
+
+	console := recvType[*godap.OutputEvent](hh)
+	if console.Body.Category != "console" ||
+		console.Body.Output != "bingo session sess-launch ready — observers can join with ?session=sess-launch\n" {
+		t.Fatalf("console announcement = %+v", console.Body)
+	}
+	hh.cmds.waitForCommand(t, protocol.CmdLaunch)
+}
+
+func TestJoinAnnouncesManagedSession(t *testing.T) {
+	hh := newHarness(t)
+	hh.sendReq("initialize", initArgs())
+	_ = recvType[*godap.InitializeResponse](hh)
+
+	hh.sendReq("attach", &godap.AttachRequest{Arguments: json.RawMessage(`{"session":"sess-test"}`)})
+	event := recvType[*sessionEvent](hh)
+	if event.Event.Event != sessionEventName {
+		t.Fatalf("event name = %q, want %q", event.Event.Event, sessionEventName)
+	}
+	if event.Body != (sessionEventBody{Version: 1, SessionID: "sess-test"}) {
+		t.Fatalf("session event body = %+v", event.Body)
+	}
+	_ = recvType[*godap.OutputEvent](hh)
+	_ = recvType[*godap.InitializedEvent](hh)
+}
+
+func TestSessionAnnouncementIsSingleWinnerUnderRace(t *testing.T) {
+	hh := newHarness(t)
+
+	const attempts = 32
+	start := make(chan struct{})
+	errs := make(chan error, attempts)
+	var starts sync.WaitGroup
+	for range attempts {
+		starts.Add(1)
+		go func() {
+			defer starts.Done()
+			<-start
+			errs <- hh.handler.startSession("")
+		}()
+	}
+	close(start)
+	starts.Wait()
+	close(errs)
+
+	successes := 0
+	for err := range errs {
+		if err == nil {
+			successes++
+		}
+	}
+	if successes != 1 {
+		t.Fatalf("successful concurrent starts = %d, want 1", successes)
+	}
+
+	var announcements sync.WaitGroup
+	for range attempts {
+		announcements.Add(1)
+		go func() {
+			defer announcements.Done()
+			hh.handler.announceSession()
+		}()
+	}
+	event := recvType[*sessionEvent](hh)
+	if event.Body.SessionID != "sess-test" {
+		t.Fatalf("session id = %q, want sess-test", event.Body.SessionID)
+	}
+	_ = recvType[*godap.OutputEvent](hh)
+	announcements.Wait()
+
+	_ = hh.client.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	if _, err := hh.reader.Peek(1); err == nil {
+		t.Fatal("duplicate session announcement received")
+	} else if nerr, ok := err.(net.Error); !ok || !nerr.Timeout() {
+		t.Fatalf("peek after announcements: %v", err)
+	}
+}
+
+func TestSessionEventNotEmittedWhenCreationFails(t *testing.T) {
+	hh := newHarnessProvider(t, &fakeProvider{createErr: errors.New("create failed")}, &cmdRecorder{})
+	hh.sendReq("initialize", initArgs())
+	_ = recvType[*godap.InitializeResponse](hh)
+
+	hh.sendReq("launch", &godap.LaunchRequest{Arguments: json.RawMessage(`{"program":"/bin/x"}`)})
+	resp := recvType[*godap.ErrorResponse](hh)
+	if resp.Success || resp.Command != "launch" {
+		t.Fatalf("launch response = %+v", resp.Response)
+	}
+	_ = hh.client.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	if _, err := hh.reader.Peek(1); err == nil {
+		t.Fatal("session event emitted after failed creation")
+	} else if nerr, ok := err.(net.Error); !ok || !nerr.Timeout() {
+		t.Fatalf("peek after failed creation: %v", err)
+	}
 }
 
 func TestLaunchIgnoresVSCodeEndpointFields(t *testing.T) {

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -447,6 +447,24 @@ func TestSessionEventNotEmittedWhenCreationFails(t *testing.T) {
 	}
 }
 
+func TestSessionEventNotEmittedWhenJoinFails(t *testing.T) {
+	hh := newHarnessProvider(t, &fakeProvider{}, &cmdRecorder{})
+	hh.sendReq("initialize", initArgs())
+	_ = recvType[*godap.InitializeResponse](hh)
+
+	hh.sendReq("attach", &godap.AttachRequest{Arguments: json.RawMessage(`{"session":"missing"}`)})
+	resp := recvType[*godap.ErrorResponse](hh)
+	if resp.Success || resp.Command != "attach" {
+		t.Fatalf("attach response = %+v", resp.Response)
+	}
+	_ = hh.client.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	if _, err := hh.reader.Peek(1); err == nil {
+		t.Fatal("session event emitted after failed join")
+	} else if nerr, ok := err.(net.Error); !ok || !nerr.Timeout() {
+		t.Fatalf("peek after failed join: %v", err)
+	}
+}
+
 func TestLaunchIgnoresVSCodeEndpointFields(t *testing.T) {
 	hh := newHarness(t)
 	hh.sendReq("initialize", initArgs())

--- a/internal/dap/requests.go
+++ b/internal/dap/requests.go
@@ -206,11 +206,22 @@ func (h *Handler) onJoin(req *godap.AttachRequest, cfg launchConfig) {
 // command is enqueued guarantees the entry-stop event is delivered to us.
 func (h *Handler) startSession(existingID string) error {
 	h.mu.Lock()
-	already := h.session != nil
-	h.mu.Unlock()
-	if already {
+	if h.session != nil || h.sessionStarting {
+		h.mu.Unlock()
 		return fmt.Errorf("session already started for this connection")
 	}
+	h.sessionStarting = true
+	h.mu.Unlock()
+
+	started := false
+	defer func() {
+		if started {
+			return
+		}
+		h.mu.Lock()
+		h.sessionStarting = false
+		h.mu.Unlock()
+	}()
 
 	var sess Session
 	if existingID != "" {
@@ -235,20 +246,30 @@ func (h *Handler) startSession(existingID string) error {
 	h.mu.Lock()
 	h.session = sess
 	h.client = client
+	h.sessionStarting = false
+	started = true
 	h.mu.Unlock()
 	return nil
 }
 
-// announceSession emits a console line naming the session id so WebSocket
-// observers know which session to join (also discoverable via /api/sessions).
+// announceSession publishes the managed-session identity once the handler is
+// attached. The state is claimed under mu, but DAP writes happen after unlock
+// because hub delivery and request handling can call this path concurrently.
 func (h *Handler) announceSession() {
 	h.mu.Lock()
 	sess := h.session
-	h.mu.Unlock()
-	if sess == nil {
+	if sess == nil || h.sessionAnnounced {
+		h.mu.Unlock()
 		return
 	}
 	id := sess.SessionID()
+	h.sessionAnnounced = true
+	h.mu.Unlock()
+
+	h.send(&sessionEvent{
+		Event: h.event(sessionEventName),
+		Body:  sessionEventBody{Version: 1, SessionID: id},
+	})
 	h.emitConsole(fmt.Sprintf("bingo session %s ready — observers can join with ?session=%s\n", id, id))
 }
 

--- a/internal/dap/requests.go
+++ b/internal/dap/requests.go
@@ -268,7 +268,10 @@ func (h *Handler) announceSession() {
 
 	h.send(&sessionEvent{
 		Event: h.event(sessionEventName),
-		Body:  sessionEventBody{Version: 1, SessionID: id},
+		Body: sessionEventBody{
+			Version:   protocol.DAPSessionEventVersion,
+			SessionID: id,
+		},
 	})
 	h.emitConsole(fmt.Sprintf("bingo session %s ready — observers can join with ?session=%s\n", id, id))
 }

--- a/internal/dapclient/codec.go
+++ b/internal/dapclient/codec.go
@@ -1,0 +1,50 @@
+// Package dapclient decodes the DAP stream extensions shared by bingo clients.
+package dapclient
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+
+	godap "github.com/google/go-dap"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+type SessionEvent struct {
+	godap.Event
+	Body SessionEventBody `json:"body"`
+}
+
+type SessionEventBody struct {
+	Version   int    `json:"version"`
+	SessionID string `json:"sessionId"`
+}
+
+// ReadProtocolMessage preserves go-dap's normal decoder while recognizing
+// bingo's versioned managed-session event.
+func ReadProtocolMessage(reader *bufio.Reader) (godap.Message, error) {
+	content, err := godap.ReadBaseMessage(reader)
+	if err != nil {
+		return nil, err
+	}
+	return DecodeProtocolMessage(content)
+}
+
+func DecodeProtocolMessage(content []byte) (godap.Message, error) {
+	var envelope struct {
+		Type  string `json:"type"`
+		Event string `json:"event"`
+	}
+	if err := json.Unmarshal(content, &envelope); err != nil {
+		return nil, fmt.Errorf("decode DAP envelope: %w", err)
+	}
+	if envelope.Type == "event" && envelope.Event == protocol.DAPSessionEventName {
+		var event SessionEvent
+		if err := json.Unmarshal(content, &event); err != nil {
+			return nil, fmt.Errorf("decode DAP session event: %w", err)
+		}
+		return &event, nil
+	}
+	return godap.DecodeProtocolMessage(content)
+}

--- a/internal/dapclient/codec_test.go
+++ b/internal/dapclient/codec_test.go
@@ -1,0 +1,59 @@
+package dapclient
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	godap "github.com/google/go-dap"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+func TestReadProtocolMessageAcceptsSessionEventAndNormalMessages(t *testing.T) {
+	var wire bytes.Buffer
+	session := &SessionEvent{
+		Event: godap.Event{
+			ProtocolMessage: godap.ProtocolMessage{Seq: 1, Type: "event"},
+			Event:           protocol.DAPSessionEventName,
+		},
+		Body: SessionEventBody{
+			Version:   protocol.DAPSessionEventVersion,
+			SessionID: "session-123",
+		},
+	}
+	if err := godap.WriteProtocolMessage(&wire, session); err != nil {
+		t.Fatal(err)
+	}
+	initialized := &godap.InitializedEvent{
+		Event: godap.Event{
+			ProtocolMessage: godap.ProtocolMessage{Seq: 2, Type: "event"},
+			Event:           "initialized",
+		},
+	}
+	if err := godap.WriteProtocolMessage(&wire, initialized); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := bufio.NewReader(&wire)
+	first, err := ReadProtocolMessage(reader)
+	if err != nil {
+		t.Fatalf("read session event: %v", err)
+	}
+	event, ok := first.(*SessionEvent)
+	if !ok {
+		t.Fatalf("session message type = %T", first)
+	}
+	if event.Body.Version != protocol.DAPSessionEventVersion ||
+		event.Body.SessionID != "session-123" {
+		t.Fatalf("session event body = %+v", event.Body)
+	}
+
+	second, err := ReadProtocolMessage(reader)
+	if err != nil {
+		t.Fatalf("read initialized event: %v", err)
+	}
+	if _, ok := second.(*godap.InitializedEvent); !ok {
+		t.Fatalf("normal message type = %T", second)
+	}
+}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -18,8 +18,9 @@ const (
 )
 
 type DAPHealth struct {
-	Enabled bool   `json:"enabled"`
-	Address string `json:"address"`
+	Enabled             bool   `json:"enabled"`
+	Address             string `json:"address"`
+	SessionEventVersion int    `json:"sessionEventVersion"`
 }
 
 type ManagedIdleShutdownHealth struct {
@@ -77,8 +78,9 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		WireProtocolVersion:  protocol.Version,
 		InstanceID:           instanceID,
 		DAP: DAPHealth{
-			Enabled: dapAddress != "",
-			Address: dapAddress,
+			Enabled:             dapAddress != "",
+			Address:             dapAddress,
+			SessionEventVersion: protocol.DAPSessionEventVersion,
 		},
 		ManagedIdleShutdown: ManagedIdleShutdownHealth{
 			Enabled:   idleTimeout > 0,

--- a/internal/server/lifecycle_test.go
+++ b/internal/server/lifecycle_test.go
@@ -99,7 +99,9 @@ func TestHealthDiscovery(t *testing.T) {
 	g.Expect(health.ManagementAPIVersion).To(Equal(ManagementAPIVersion))
 	g.Expect(health.WireProtocolVersion).To(Equal(protocol.Version))
 	g.Expect(uuid.Validate(health.InstanceID)).To(Succeed())
-	g.Expect(health.DAP).To(Equal(DAPHealth{}))
+	g.Expect(health.DAP).To(Equal(DAPHealth{
+		SessionEventVersion: protocol.DAPSessionEventVersion,
+	}))
 	g.Expect(health.ManagedIdleShutdown).To(Equal(ManagedIdleShutdownHealth{}))
 	g.Expect(health.SessionCount).To(Equal(0))
 

--- a/pkg/protocol/dap.go
+++ b/pkg/protocol/dap.go
@@ -1,0 +1,8 @@
+package protocol
+
+const (
+	// DAPSessionEventName identifies the adapter event that lets clients bind
+	// richer transports to the exact managed session created by DAP.
+	DAPSessionEventName    = "bingo/session/v1"
+	DAPSessionEventVersion = 1
+)

--- a/test/integration/debugger_e2e_dap_test.go
+++ b/test/integration/debugger_e2e_dap_test.go
@@ -34,6 +34,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/bingosuite/bingo/internal/dapclient"
 	"github.com/bingosuite/bingo/internal/server"
 	"github.com/bingosuite/bingo/pkg/client"
 	"github.com/bingosuite/bingo/pkg/protocol"
@@ -380,11 +381,6 @@ type dapClient struct {
 	events  chan godap.Message
 }
 
-type customEvent struct {
-	godap.Event
-	Body json.RawMessage `json:"body,omitempty"`
-}
-
 // dialDAP connects to the DAP server and starts the demux read loop. Cleanup
 // closes the connection.
 func dialDAP(addr string) *dapClient {
@@ -405,7 +401,7 @@ func dialDAP(addr string) *dapClient {
 
 func (c *dapClient) readLoop() {
 	for {
-		msg, err := readDAPMessage(c.reader)
+		msg, err := dapclient.ReadProtocolMessage(c.reader)
 		if err != nil {
 			return
 		}
@@ -429,28 +425,6 @@ func (c *dapClient) readLoop() {
 			}
 		}
 	}
-}
-
-func readDAPMessage(reader *bufio.Reader) (godap.Message, error) {
-	content, err := godap.ReadBaseMessage(reader)
-	if err != nil {
-		return nil, err
-	}
-	var envelope struct {
-		Type  string `json:"type"`
-		Event string `json:"event"`
-	}
-	if err := json.Unmarshal(content, &envelope); err != nil {
-		return nil, err
-	}
-	if envelope.Type == "event" && envelope.Event == "bingo/session/v1" {
-		var event customEvent
-		if err := json.Unmarshal(content, &event); err != nil {
-			return nil, err
-		}
-		return &event, nil
-	}
-	return godap.DecodeProtocolMessage(content)
 }
 
 // send writes a request with an auto-incrementing seq, registers a waiter for

--- a/test/integration/debugger_e2e_dap_test.go
+++ b/test/integration/debugger_e2e_dap_test.go
@@ -380,6 +380,11 @@ type dapClient struct {
 	events  chan godap.Message
 }
 
+type customEvent struct {
+	godap.Event
+	Body json.RawMessage `json:"body,omitempty"`
+}
+
 // dialDAP connects to the DAP server and starts the demux read loop. Cleanup
 // closes the connection.
 func dialDAP(addr string) *dapClient {
@@ -400,7 +405,7 @@ func dialDAP(addr string) *dapClient {
 
 func (c *dapClient) readLoop() {
 	for {
-		msg, err := godap.ReadProtocolMessage(c.reader)
+		msg, err := readDAPMessage(c.reader)
 		if err != nil {
 			return
 		}
@@ -424,6 +429,28 @@ func (c *dapClient) readLoop() {
 			}
 		}
 	}
+}
+
+func readDAPMessage(reader *bufio.Reader) (godap.Message, error) {
+	content, err := godap.ReadBaseMessage(reader)
+	if err != nil {
+		return nil, err
+	}
+	var envelope struct {
+		Type  string `json:"type"`
+		Event string `json:"event"`
+	}
+	if err := json.Unmarshal(content, &envelope); err != nil {
+		return nil, err
+	}
+	if envelope.Type == "event" && envelope.Event == "bingo/session/v1" {
+		var event customEvent
+		if err := json.Unmarshal(content, &event); err != nil {
+			return nil, err
+		}
+		return &event, nil
+	}
+	return godap.DecodeProtocolMessage(content)
 }
 
 // send writes a request with an auto-incrementing seq, registers a waiter for


### PR DESCRIPTION
## Final architecture

PR head: `43d03f844f524deafbf8f3cf7a61132b24ed2ab3`

- **DAP discovery and consumers:** the adapter emits one versioned `bingo/session/v1` event after successful managed create/join. Shared `internal/dapclient` recognizes it before delegating ordinary messages to go-dap; the real `cmd/dapcli` read loop and native DAP E2E client both use that path.
- **Capability-safe reuse:** `/api/health` advertises `dap.sessionEventVersion: 1`. Extension 0.3.1 requires it for reuse/readiness, so an older API-v1/wire-v1.2 process is safely reported as an occupied incompatible endpoint with no replacement spawn.
- **Generation-safe webview:** render deliveries and `rendered` acknowledgements carry document generation plus model revision. Late completions/acks from a destroyed document cannot mutate its replacement, even at the same revision.
- **Full-snapshot filtering:** search runs against the full validated snapshot (protocol bound: 5,000 goroutines), not the already capped tree. Matches retain at most four ancestors, then deterministically apply the 500-node render cap and receive a fresh compact layout/fit. Clearing search restores the original capped layout.
- **Safe empty graph:** graph transform/scene state is initialized before the empty-result return. Fit and both zoom controls remain callable without throwing when a filter matches nothing.
- **Accessible hierarchy:** SVG treeitems expose level, parent/root context, sibling position/size, selection, and synchronized arrow-key DOM focus. Filter-promoted roots describe their omitted reported parent.

The extension host remains the source of truth. Its strict v1.2 WebSocket observer sends only initial/explicit-refresh `GoroutineSnapshot` commands—never run control—and the nonce-CSP webview receives validated models. Root Run/Debug remains exactly **2 `type:bingo` configurations / 1 task** with no Go/Delve/extension-host additions.

## Focused regressions

- Real dapcli framed stream: custom session event followed by a normal response through the actual read loop; no disconnect and session ID captured.
- Health: exact marker accepted; missing/wrong marker rejected; compatible manager reuse and old-server occupied behavior both assert zero unsafe spawns.
- Webview: same-revision stale completion and acknowledgement tokens rejected after recreation.
- Tree: a 1,000-node chain with the only match at g1000 (outside the initial 500) renders g996–g1000, reports 995 omitted nodes, and compacts to `1142 × 496`.
- Empty result: real DOM clicks Fit, zoom-out, and zoom-in after a no-match filter with no exception or state corruption.
- Accessibility/interaction: root/child/omitted-parent labels, aria hierarchy/sibling/selection metadata, keyboard focus movement, filter clear, pan/zoom safety, and hostile tracee strings.

Three independent focused code-review passes were run. They found stale generation acknowledgements and keyboard-focus drift; both were fixed. The final filter/selection/focus/accessibility/pan/zoom review reported no significant issues. SonarCloud reports **0 open issues**.

## Validation

- `gofmt` + `go tool goimports`; clean diff checks
- `go test -tags bingonative -race ./...`
- `go vet -tags bingonative ./...`
- `go test -tags bingonative ./...`
- plain `go test -race ./cmd/dapcli ./internal/dapclient`
- E2E-tagged DAP client compile
- clean `npm ci --ignore-scripts`
- lint + strict typecheck
- TypeScript unit: **117/117**
- real DOM: **9/9**
- pinned VS Code 1.107.1 Electron activation/view/custom-event/generation-ack/refresh/terminate path
- final build, exact 10-entry VSIX allowlist, signed entitlements, health/idle smoke
- two-build reproducibility and package verification for Linux x64 and Darwin arm64

### Final native Darwin package proof

- Unique ports, no pre-existing server; production manager spawned the signed bundle.
- Compatible reuse retained instance `4b64548b-7d03-46d1-a7ac-94901f1ecf51` without competing spawn.
- Sessions: `fbac83be-8a42-42b3-bbf6-71abdae01c99`, `daae5758-99ab-475c-a4e1-fbe45ce973c6`, `76a50e88-f620-47c2-b540-8753964d7135`, `ce6c4066-ce64-4b72-81e7-d569a986a1d7`, `28551ca6-4e72-4a3c-8f79-e30ea9828e24`.
- Levels 1–5 reached application depths `0,1,1,1,2`; level 5 had 12 goroutines / 6 threads and seq 13.
- Serialized disconnect teardown reached zero sessions; server exited by idle policy with code 0/no signal and left no tracees.

## 0.3.1 artifacts and installation

| Target | VSIX bytes | Local VSIX SHA-256 | Local binary SHA-256 |
| --- | ---: | --- | --- |
| `darwin-arm64` | 6,005,289 | `a539b45842556a8ce65b8e02d28dfdd7e6751c7dd86cd44319d270d7f37eb720` | `de8b53c3b00427ae4809e136ba8db822d682496dbafcca4e51ed106697bce75b` |
| `linux-x64` | 6,316,071 | `5c776e44db54bb5b8fd1893970dac111d4fe4d1cf3c59543e202eb5e0e5efef3` | `4153165317c81b152a9f5140ce7a4651248b22722703ca50258324066b37654b` |

The final signed Darwin VSIX is force-installed and verified as `bingosuite.bingo@0.3.1` in:

- isolated: `dist/vscode-isolated-extensions/bingosuite.bingo-0.3.1`
- normal: `$HOME/.vscode/extensions/bingosuite.bingo-0.3.1`

## CI

All final-head checks are green: Go build/unit, CodeQL, SonarCloud, actions analysis, Darwin verification, native Linux/Darwin debugger suites, full-stack Linux/Darwin, and both Linux/macOS-15 arm64 extension package jobs. Linux also passed the real packaged DAP→WebSocket graphical path. The unrelated first Linux churn attempt reached its target watchdog; the unchanged-head rerun passed the complete 4m45s suite.

## Required local step

After installing/updating 0.3.1, run **Developer: Reload Window** once. Installation alone does not reload the active extension host.