### PR TITLE
perf(vscode): remove dead keyboard DOM scans

### DIFF
--- a/editors/vscode/src/webviewApp.ts
+++ b/editors/vscode/src/webviewApp.ts
@@ -353,12 +353,7 @@ function renderGraph(
       return;
     }
     event.preventDefault();
-    const visible = session.tree.nodes.filter((node) => {
-      const element = activeScene.querySelector<SVGGElement>(
-        `[data-goid="${String(node.goroutine.id)}"]`,
-      );
-      return element?.classList.contains("filtered") !== true;
-    });
+    const visible = session.tree.nodes;
     const current = visible.findIndex(
       (node) => node.goroutine.id === session.selectedGoroutine,
     );

--- a/editors/vscode/test/webviewDom.test.ts
+++ b/editors/vscode/test/webviewDom.test.ts
@@ -98,6 +98,15 @@ describe("concurrency webview DOM", () => {
     })(model());
     const first = document.querySelector<SVGGElement>('[data-goid="1"]')!;
     const second = document.querySelector<SVGGElement>('[data-goid="2"]')!;
+    const scene = document.querySelector<SVGGElement>("svg > g")!;
+    const querySelector = scene.querySelector.bind(scene);
+    let selectorCalls = 0;
+    Object.defineProperty(scene, "querySelector", {
+      value: (selector: string): Element | null => {
+        selectorCalls += 1;
+        return querySelector(selector);
+      },
+    });
     let focused = "";
     Object.defineProperty(first, "focus", {
       value: () => {
@@ -118,6 +127,7 @@ describe("concurrency webview DOM", () => {
     first.dispatchEvent(event);
 
     assert.equal(focused, "2");
+    assert.equal(selectorCalls, 1);
     assert.deepEqual(messages.at(-1), {
       type: "selectGoroutine",
       id: 2,


### PR DESCRIPTION
## Summary

- use the already-filtered `session.tree.nodes` directly during arrow-key navigation
- remove up to 500 dead per-node selector calls for a CSS class that is never assigned
- guard the interaction with a deterministic DOM test that permits only the final focus lookup

This does not bump the VS Code extension version: rendered behavior, protocols, and packaging are unchanged, so this is not a material shipped behavior change under the `AGENTS.md` versioning invariant.

## Tests

- `npm --prefix editors/vscode run lint`
- `npm --prefix editors/vscode run typecheck`
- `npm --prefix editors/vscode run test:unit`
- `npm --prefix editors/vscode run test:dom`
- `npm --prefix editors/vscode run build`
- `npm --prefix editors/vscode run package:list`

Fixes #129