### PR TITLE
fix(dapcli): reject non-positive breakpoint IDs

### DIFF
--- a/cmd/dapcli/main.go
+++ b/cmd/dapcli/main.go
@@ -610,6 +610,11 @@ func (h *dapCLI) addBreakpoint(file string, line int) {
 }
 
 func (h *dapCLI) clearBreakpoint(id int) {
+	if id <= 0 {
+		fmt.Printf("  no breakpoint with id %d\n", id)
+		return
+	}
+
 	h.stateMu.Lock()
 	var file string
 	found := false

--- a/cmd/dapcli/main_test.go
+++ b/cmd/dapcli/main_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"runtime"
 	"strings"
 	"sync/atomic"
@@ -356,6 +357,115 @@ func TestDispatchRejectsInvalidFramesBeforeRequest(t *testing.T) {
 	}
 }
 
+func TestClearBreakpointRejectsNonPositiveIDs(t *testing.T) {
+	for _, id := range []int{0, -1} {
+		t.Run(fmt.Sprintf("id=%d", id), func(t *testing.T) {
+			h := &dapCLI{
+				configured: true,
+				bpsByFile: map[string][]breakpoint{
+					"main.go": {{line: 10, id: id}, {line: 20, id: 2, verified: true}},
+				},
+			}
+
+			output := captureStdout(t, func() {
+				h.clearBreakpoint(id)
+			})
+
+			if got := h.bpsByFile["main.go"]; len(got) != 2 || got[0].id != id || got[1].id != 2 {
+				t.Fatalf("breakpoints = %#v, want unchanged", got)
+			}
+			h.mu.Lock()
+			seq := h.seq
+			pending := len(h.pending)
+			h.mu.Unlock()
+			if seq != 0 || pending != 0 {
+				t.Fatalf("request state = (seq %d, pending %d), want no DAP request", seq, pending)
+			}
+			want := fmt.Sprintf("  no breakpoint with id %d\n", id)
+			if output != want {
+				t.Fatalf("output = %q, want %q", output, want)
+			}
+		})
+	}
+}
+
+func TestClearBreakpointPreservesPositiveID(t *testing.T) {
+	server, client := net.Pipe()
+	t.Cleanup(func() {
+		_ = server.Close()
+		_ = client.Close()
+	})
+
+	h := newTestDAPCLI(client, io.Discard, func() {})
+	h.configured = true
+	h.bpsByFile = map[string][]breakpoint{
+		"main.go":  {{line: 10, id: 1, verified: true}, {line: 20, id: 2, verified: true}},
+		"other.go": {{line: 30, id: 3, verified: true}},
+	}
+	requests := make(chan *godap.SetBreakpointsRequest, 1)
+	readErr := make(chan error, 1)
+	go func() {
+		message, err := readDAPMessage(bufio.NewReader(server))
+		if err != nil {
+			readErr <- err
+			return
+		}
+		request, ok := message.(*godap.SetBreakpointsRequest)
+		if !ok {
+			readErr <- fmt.Errorf("unexpected DAP message %T", message)
+			return
+		}
+		requests <- request
+		response := &godap.SetBreakpointsResponse{
+			Response: godap.Response{
+				ProtocolMessage: godap.ProtocolMessage{Seq: 1, Type: "response"},
+				RequestSeq:      request.Seq,
+				Success:         true,
+				Command:         "setBreakpoints",
+			},
+			Body: godap.SetBreakpointsResponseBody{
+				Breakpoints: []godap.Breakpoint{{Id: 2, Verified: true, Line: 20}},
+			},
+		}
+		h.onResponse(response, response)
+		readErr <- nil
+	}()
+
+	output := captureStdout(t, func() {
+		h.clearBreakpoint(1)
+	})
+
+	select {
+	case err := <-readErr:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("positive breakpoint clear did not send a DAP request")
+	}
+	var request *godap.SetBreakpointsRequest
+	select {
+	case request = <-requests:
+	case <-time.After(time.Second):
+		t.Fatal("positive breakpoint clear request was not recorded")
+	}
+	if request.Arguments.Source.Path != "main.go" {
+		t.Fatalf("source path = %q, want main.go", request.Arguments.Source.Path)
+	}
+	if got := request.Arguments.Breakpoints; len(got) != 1 || got[0].Line != 20 {
+		t.Fatalf("breakpoints request = %#v, want only line 20", got)
+	}
+	if got := h.bpsByFile["main.go"]; len(got) != 1 || got[0].id != 2 || got[0].line != 20 {
+		t.Fatalf("main.go breakpoints = %#v, want retained breakpoint 2", got)
+	}
+	if got := h.bpsByFile["other.go"]; len(got) != 1 || got[0].id != 3 {
+		t.Fatalf("other.go breakpoints = %#v, want unchanged", got)
+	}
+	if output != "  breakpoint 1 cleared\n" {
+		t.Fatalf("output = %q, want positive clear confirmation", output)
+	}
+}
+
 func newTestDAPCLI(conn net.Conn, out io.Writer, closeEditor func()) *dapCLI {
 	return &dapCLI{
 		conn:         conn,
@@ -367,6 +477,32 @@ func newTestDAPCLI(conn net.Conn, out io.Writer, closeEditor func()) *dapCLI {
 		disconnected: make(chan struct{}),
 		readDone:     make(chan struct{}),
 	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := os.Stdout
+	os.Stdout = writer
+	defer func() {
+		os.Stdout = original
+		_ = reader.Close()
+		_ = writer.Close()
+	}()
+
+	fn()
+	os.Stdout = original
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(output)
 }
 
 func writeDAPFrame(buffer *bytes.Buffer, content string) {


### PR DESCRIPTION
## Summary
- port the still-missing non-positive breakpoint ID guard onto current `main` after the merged #226 lifecycle changes
- reject `id <= 0` before scanning pending breakpoint state, preserving the existing `no breakpoint with id N` UX
- prove zero and negative IDs cannot mutate local breakpoint state or emit a replace-all DAP `setBreakpoints` request
- preserve positive-ID clearing behavior on the current `pendingResult` and shared REPL harness
- drop the historical read-loop changes, which current lifecycle handling supersedes

## Historical port mapping
- previous PR head: `011e3da097c3cd63c15699159445c68553f4fa92`
- current base (`main`): `6e5a0236282188a7a178018540ba0b0a1e99c9fe`
- replacement PR head: `5eeb03df14eb49fae464f9297fec8894b06f7341`

## Failure fixed
An unresolved breakpoint retains the default ID `0`. Without an early guard, `clear 0` could match that unresolved entry, remove it from local state, and send a replace-all DAP breakpoint request. Negative IDs were also invalid input and now follow the same no-breakpoint path before any state scan or transport activity.

## Validation
- `go test -tags bingonative -race -count=100 ./cmd/dapcli ./cmd/internal/repl`
- `go test -tags bingonative ./cmd/...`
- `go vet -tags bingonative ./cmd/dapcli ./cmd/internal/repl`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build ./cmd/dapcli`
- `go tool goimports -w cmd/dapcli/main.go cmd/dapcli/main_test.go`
- `git diff --check`

The parent audit and an independent code review are clean. The reviewer identified one possible test-only indefinite wait; bounded failure handling was added, and the final independent re-review found no significant issues.

Fixes #128