### PR TITLE
fix(dap): reconcile breakpoints after restart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1141,6 +1141,13 @@ breakpoint the process is currently parked on re-arms it through the engine's
 step-off path (see the clearbp spec), so the e2e continue-to-exit uses a
 no-breakpoint target, not a clear-then-continue.
 
+`bpByFile` keeps the stable DAP id separate from the debugger's internal id.
+After `EventRestarted`, reconcile its exact source-path/line keys from
+`RestartedPayload` before replying: retained entries adopt the fresh debugger
+id, while discarded entries are removed and emit a `breakpoint` changed event
+with their prior DAP id and `verified:false`. Do not reset `setQ`/`clearQ`;
+those FIFOs still own any in-flight confirmations.
+
 ### Server wiring + multi-client discovery
 
 `internal/server` implements `dap.Provider` (`dapProvider`): `CreateSession` →

--- a/internal/dap/breakpoints.go
+++ b/internal/dap/breakpoints.go
@@ -35,21 +35,21 @@ func (h *Handler) onSetBreakpoints(req *godap.SetBreakpointsRequest) {
 	h.mu.Lock()
 	current := h.bpByFile[file]
 	if current == nil {
-		current = make(map[int]int)
+		current = make(map[int]breakpointState)
 		h.bpByFile[file] = current
 	}
 
 	// Clear breakpoints no longer requested.
-	for line, id := range current {
+	for line, state := range current {
 		if desired[line] {
 			continue
 		}
 		delete(current, line)
-		if id == 0 {
+		if state.debuggerID == 0 {
 			continue // never confirmed; nothing to clear on the debugger
 		}
-		h.clearQ = append(h.clearQ, id)
-		if cmd, err := marshalCommand(protocol.CmdClearBreakpoint, protocol.ClearBreakpointPayload{ID: id}); err == nil {
+		h.clearQ = append(h.clearQ, state.debuggerID)
+		if cmd, err := marshalCommand(protocol.CmdClearBreakpoint, protocol.ClearBreakpointPayload{ID: state.debuggerID}); err == nil {
 			clears = append(clears, cmd)
 		}
 	}
@@ -59,13 +59,13 @@ func (h *Handler) onSetBreakpoints(req *godap.SetBreakpointsRequest) {
 		slot := &bpSlot{req: reqObj, file: file, line: b.Line}
 		reqObj.slots = append(reqObj.slots, slot)
 
-		if id, ok := current[b.Line]; ok && id != 0 {
+		if state, ok := current[b.Line]; ok && state.debuggerID != 0 {
 			slot.resolved = true
-			slot.bp = godap.Breakpoint{Id: id, Verified: true, Line: b.Line, Source: &src}
+			slot.bp = godap.Breakpoint{Id: state.dapID, Verified: true, Line: b.Line, Source: &src}
 			continue
 		}
 
-		current[b.Line] = 0 // pending sentinel, replaced on confirmation
+		current[b.Line] = breakpointState{} // pending sentinel, replaced on confirmation
 		h.setQ = append(h.setQ, slot)
 		if cmd, err := marshalCommand(protocol.CmdSetBreakpoint, protocol.SetBreakpointPayload{File: file, Line: b.Line}); err == nil {
 			sets = append(sets, cmd)

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -38,7 +38,7 @@ func (h *Handler) translateEvent(evt protocol.Event) {
 		// want goroutine data use the threads request; the rich snapshot is a
 		// WebSocket-only concurrency-visualization stream.
 	case protocol.EventRestarted:
-		h.onRestarted()
+		h.onRestarted(evt)
 	case protocol.EventError:
 		h.onError(evt)
 	case protocol.EventSessionState:
@@ -215,7 +215,10 @@ func (h *Handler) onBreakpointSet(evt protocol.Event) {
 		slot := h.setQ[0]
 		h.setQ = h.setQ[1:]
 		if lines := h.bpByFile[slot.file]; lines != nil {
-			lines[slot.line] = p.Breakpoint.ID
+			lines[slot.line] = breakpointState{
+				dapID:      p.Breakpoint.ID,
+				debuggerID: p.Breakpoint.ID,
+			}
 		}
 		slot.resolved = true
 		slot.bp = godap.Breakpoint{
@@ -346,15 +349,61 @@ func (h *Handler) onEvaluated(evt protocol.Event) {
 	})
 }
 
-func (h *Handler) onRestarted() {
+func (h *Handler) onRestarted(evt protocol.Event) {
+	var p protocol.RestartedPayload
+	decoded := protocol.DecodeEventPayload(evt, &p) == nil
+
 	h.mu.Lock()
 	seq := h.restartReqSeq
 	h.restartReqSeq = 0
+	var discarded []godap.Breakpoint
+	if decoded {
+		discarded = h.reconcileRestartBreakpointsLocked(p)
+	}
 	h.mu.Unlock()
 
+	for _, bp := range discarded {
+		h.send(&godap.BreakpointEvent{
+			Event: h.event("breakpoint"),
+			Body: godap.BreakpointEventBody{
+				Reason:     "changed",
+				Breakpoint: bp,
+			},
+		})
+	}
 	if seq != 0 {
 		h.send(&godap.RestartResponse{Response: h.response(seq, "restart")})
 	}
+}
+
+func (h *Handler) reconcileRestartBreakpointsLocked(p protocol.RestartedPayload) []godap.Breakpoint {
+	for _, bp := range p.Breakpoints {
+		lines := h.bpByFile[bp.Location.File]
+		state, ok := lines[bp.Location.Line]
+		if !ok || state.debuggerID == 0 {
+			continue
+		}
+		state.debuggerID = bp.ID
+		lines[bp.Location.Line] = state
+	}
+
+	discarded := make([]godap.Breakpoint, 0, len(p.Discarded))
+	for _, dropped := range p.Discarded {
+		lines := h.bpByFile[dropped.Location.File]
+		state, ok := lines[dropped.Location.Line]
+		if !ok || state.debuggerID == 0 {
+			continue
+		}
+		delete(lines, dropped.Location.Line)
+		discarded = append(discarded, godap.Breakpoint{
+			Id:       state.dapID,
+			Verified: false,
+			Message:  dropped.Reason,
+			Source:   dapSource(dropped.Location),
+			Line:     dropped.Location.Line,
+		})
+	}
+	return discarded
 }
 
 // onError routes a bingo EventError to the DAP request it corresponds to,

--- a/internal/dap/handler.go
+++ b/internal/dap/handler.go
@@ -99,11 +99,13 @@ type Handler struct {
 	// Suspend/resume (EventContinued).
 	pendingContinues int
 
-	// Breakpoint bookkeeping. bpByFile maps file -> requested line -> bingo
-	// breakpoint id (0 = set enqueued, awaiting confirmation). setQ/clearQ are
-	// FIFOs of in-flight confirmations, correlated to the hub's ordered
-	// event stream (valid while the DAP client is the sole breakpoint driver).
-	bpByFile map[string]map[int]int
+	// Breakpoint bookkeeping. bpByFile maps file -> requested line -> DAP and
+	// debugger identities. The two diverge after Restart: DAP identity remains
+	// stable while the fresh debugger assigns a new internal id.
+	// setQ/clearQ are FIFOs of in-flight confirmations, correlated to the hub's
+	// ordered event stream (valid while the DAP client is the sole breakpoint
+	// driver).
+	bpByFile map[string]map[int]breakpointState
 	setQ     []*bpSlot
 	clearQ   []int
 
@@ -139,6 +141,11 @@ type bpSlot struct {
 	line     int
 	resolved bool
 	bp       godap.Breakpoint
+}
+
+type breakpointState struct {
+	dapID      int
+	debuggerID int
 }
 
 // bpRequest collects the slots of a single setBreakpoints request; its response
@@ -194,7 +201,7 @@ func NewHandler(conn net.Conn, provider Provider, log *slog.Logger) *Handler {
 		log:      log,
 		cmdOut:   make(chan []byte, cmdBufferSize),
 		done:     make(chan struct{}),
-		bpByFile: make(map[string]map[int]int),
+		bpByFile: make(map[string]map[int]breakpointState),
 		varCache: make(map[int][]godap.Variable),
 	}
 }

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -613,13 +613,8 @@ func TestSetBreakpointsDiffAndFIFO(t *testing.T) {
 	hh.cmds.waitForCommand(t, protocol.CmdClearBreakpoint)
 }
 
-func TestRestartReconcilesBreakpointCache(t *testing.T) {
-	hh := newHarness(t)
-	hh.doHandshake(t)
-	hh.inject(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{Goroutine: protocol.Goroutine{ID: 1}})
-	_ = recvType[*godap.StoppedEvent](hh)
-
-	source := godap.Source{Path: "/x/main.go", Name: "main.go"}
+func seedRestartBreakpointCache(t *testing.T, hh *harness, source godap.Source) {
+	t.Helper()
 	hh.sendReq("setBreakpoints", &godap.SetBreakpointsRequest{Arguments: godap.SetBreakpointsArguments{
 		Source:      source,
 		Breakpoints: []godap.SourceBreakpoint{{Line: 10}, {Line: 20}},
@@ -632,21 +627,23 @@ func TestRestartReconcilesBreakpointCache(t *testing.T) {
 		Breakpoint: protocol.Breakpoint{ID: 42, Location: protocol.Location{File: source.Path, Line: 20}},
 	})
 	initial := recvType[*godap.SetBreakpointsResponse](hh)
-	if got := []int{initial.Body.Breakpoints[0].Id, initial.Body.Breakpoints[1].Id}; got[0] != 41 || got[1] != 42 {
-		t.Fatalf("initial breakpoint ids = %v, want [41 42]", got)
+	requireBreakpointIDs(t, initial, 41, 42)
+}
+
+func requireBreakpointIDs(t *testing.T, response *godap.SetBreakpointsResponse, want ...int) {
+	t.Helper()
+	if len(response.Body.Breakpoints) != len(want) {
+		t.Fatalf("breakpoint count = %d, want %d", len(response.Body.Breakpoints), len(want))
 	}
+	for i, id := range want {
+		if response.Body.Breakpoints[i].Id != id {
+			t.Fatalf("breakpoint ids = %+v, want %v", response.Body.Breakpoints, want)
+		}
+	}
+}
 
-	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
-	hh.cmds.waitForCommand(t, protocol.CmdRestart)
-	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{
-		Breakpoints: []protocol.Breakpoint{
-			{ID: 101, Location: protocol.Location{File: source.Path, Line: 10}},
-		},
-		Discarded: []protocol.DiscardedBreakpoint{
-			{Location: protocol.Location{File: source.Path, Line: 20}, Reason: "no such line"},
-		},
-	})
-
+func receiveRestartResult(t *testing.T, hh *harness, restartSeq int) *godap.BreakpointEvent {
+	t.Helper()
 	var changed *godap.BreakpointEvent
 	var restarted *godap.RestartResponse
 	for range 2 {
@@ -663,6 +660,11 @@ func TestRestartReconcilesBreakpointCache(t *testing.T) {
 	if changed == nil {
 		t.Fatal("discarded breakpoint did not emit a breakpoint event")
 	}
+	return changed
+}
+
+func requireDiscardedBreakpointEvent(t *testing.T, changed *godap.BreakpointEvent) {
+	t.Helper()
 	if changed.Body.Reason != "changed" ||
 		changed.Body.Breakpoint.Id != 42 ||
 		changed.Body.Breakpoint.Verified ||
@@ -670,7 +672,10 @@ func TestRestartReconcilesBreakpointCache(t *testing.T) {
 		changed.Body.Breakpoint.Message != "no such line" {
 		t.Fatalf("discarded breakpoint event = %+v", changed.Body)
 	}
+}
 
+func requireRestartBreakpointCache(t *testing.T, hh *harness, source godap.Source) {
+	t.Helper()
 	hh.handler.mu.Lock()
 	retained := hh.handler.bpByFile[source.Path][10]
 	_, droppedStillCached := hh.handler.bpByFile[source.Path][20]
@@ -681,7 +686,10 @@ func TestRestartReconcilesBreakpointCache(t *testing.T) {
 	if droppedStillCached {
 		t.Fatal("discarded breakpoint remained in cache")
 	}
+}
 
+func retryDiscardedBreakpoint(t *testing.T, hh *harness, source godap.Source) {
+	t.Helper()
 	hh.sendReq("setBreakpoints", &godap.SetBreakpointsRequest{Arguments: godap.SetBreakpointsArguments{
 		Source:      source,
 		Breakpoints: []godap.SourceBreakpoint{{Line: 10}, {Line: 20}},
@@ -698,10 +706,11 @@ func TestRestartReconcilesBreakpointCache(t *testing.T) {
 		Breakpoint: protocol.Breakpoint{ID: 202, Location: protocol.Location{File: source.Path, Line: 20}},
 	})
 	retried := recvType[*godap.SetBreakpointsResponse](hh)
-	if got := []int{retried.Body.Breakpoints[0].Id, retried.Body.Breakpoints[1].Id}; got[0] != 41 || got[1] != 202 {
-		t.Fatalf("post-restart breakpoint ids = %v, want stable retained id 41 and retried id 202", got)
-	}
+	requireBreakpointIDs(t, retried, 41, 202)
+}
 
+func clearReidentifiedBreakpoint(t *testing.T, hh *harness, source godap.Source) {
+	t.Helper()
 	hh.sendReq("setBreakpoints", &godap.SetBreakpointsRequest{Arguments: godap.SetBreakpointsArguments{
 		Source:      source,
 		Breakpoints: []godap.SourceBreakpoint{{Line: 20}},
@@ -715,6 +724,33 @@ func TestRestartReconcilesBreakpointCache(t *testing.T) {
 		t.Fatalf("clear breakpoint id = %d, want fresh debugger id 101", clear.ID)
 	}
 	_ = recvType[*godap.SetBreakpointsResponse](hh)
+}
+
+func TestRestartReconcilesBreakpointCache(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	hh.inject(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{Goroutine: protocol.Goroutine{ID: 1}})
+	_ = recvType[*godap.StoppedEvent](hh)
+
+	source := godap.Source{Path: "/x/main.go", Name: "main.go"}
+	seedRestartBreakpointCache(t, hh, source)
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{
+		Breakpoints: []protocol.Breakpoint{
+			{ID: 101, Location: protocol.Location{File: source.Path, Line: 10}},
+		},
+		Discarded: []protocol.DiscardedBreakpoint{
+			{Location: protocol.Location{File: source.Path, Line: 20}, Reason: "no such line"},
+		},
+	})
+
+	changed := receiveRestartResult(t, hh, restartSeq)
+	requireDiscardedBreakpointEvent(t, changed)
+	requireRestartBreakpointCache(t, hh, source)
+	retryDiscardedBreakpoint(t, hh, source)
+	clearReidentifiedBreakpoint(t, hh, source)
 }
 
 func TestRestartedPayloadDecodeFailureStillResponds(t *testing.T) {

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -62,6 +62,27 @@ func (r *cmdRecorder) waitForCommand(t *testing.T, kind protocol.CommandKind) pr
 	return protocol.Command{}
 }
 
+func (r *cmdRecorder) waitForCommands(t *testing.T, kind protocol.CommandKind, count int) []protocol.Command {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		r.mu.Lock()
+		var matches []protocol.Command
+		for _, cmd := range r.cmds {
+			if cmd.Kind == kind {
+				matches = append(matches, cmd)
+			}
+		}
+		r.mu.Unlock()
+		if len(matches) >= count {
+			return matches
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d commands of kind %s; saw %v", count, kind, r.kinds())
+	return nil
+}
+
 type fakeSession struct {
 	id      string
 	cmds    *cmdRecorder
@@ -590,6 +611,140 @@ func TestSetBreakpointsDiffAndFIFO(t *testing.T) {
 	}
 	// A ClearBreakpoint for the removed line 10 must have been enqueued.
 	hh.cmds.waitForCommand(t, protocol.CmdClearBreakpoint)
+}
+
+func TestRestartReconcilesBreakpointCache(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	hh.inject(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{Goroutine: protocol.Goroutine{ID: 1}})
+	_ = recvType[*godap.StoppedEvent](hh)
+
+	source := godap.Source{Path: "/x/main.go", Name: "main.go"}
+	hh.sendReq("setBreakpoints", &godap.SetBreakpointsRequest{Arguments: godap.SetBreakpointsArguments{
+		Source:      source,
+		Breakpoints: []godap.SourceBreakpoint{{Line: 10}, {Line: 20}},
+	}})
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 2)
+	hh.inject(protocol.EventBreakpointSet, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{ID: 41, Location: protocol.Location{File: source.Path, Line: 10}},
+	})
+	hh.inject(protocol.EventBreakpointSet, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{ID: 42, Location: protocol.Location{File: source.Path, Line: 20}},
+	})
+	initial := recvType[*godap.SetBreakpointsResponse](hh)
+	if got := []int{initial.Body.Breakpoints[0].Id, initial.Body.Breakpoints[1].Id}; got[0] != 41 || got[1] != 42 {
+		t.Fatalf("initial breakpoint ids = %v, want [41 42]", got)
+	}
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{
+		Breakpoints: []protocol.Breakpoint{
+			{ID: 101, Location: protocol.Location{File: source.Path, Line: 10}},
+		},
+		Discarded: []protocol.DiscardedBreakpoint{
+			{Location: protocol.Location{File: source.Path, Line: 20}, Reason: "no such line"},
+		},
+	})
+
+	var changed *godap.BreakpointEvent
+	var restarted *godap.RestartResponse
+	for range 2 {
+		switch msg := hh.recv().(type) {
+		case *godap.BreakpointEvent:
+			changed = msg
+		case *godap.RestartResponse:
+			restarted = msg
+		}
+	}
+	if restarted == nil || restarted.RequestSeq != restartSeq || !restarted.Success {
+		t.Fatalf("restart response = %+v, want success for request %d", restarted, restartSeq)
+	}
+	if changed == nil {
+		t.Fatal("discarded breakpoint did not emit a breakpoint event")
+	}
+	if changed.Body.Reason != "changed" ||
+		changed.Body.Breakpoint.Id != 42 ||
+		changed.Body.Breakpoint.Verified ||
+		changed.Body.Breakpoint.Line != 20 ||
+		changed.Body.Breakpoint.Message != "no such line" {
+		t.Fatalf("discarded breakpoint event = %+v", changed.Body)
+	}
+
+	hh.handler.mu.Lock()
+	retained := hh.handler.bpByFile[source.Path][10]
+	_, droppedStillCached := hh.handler.bpByFile[source.Path][20]
+	hh.handler.mu.Unlock()
+	if retained.debuggerID != 101 || retained.dapID != 41 {
+		t.Fatalf("retained breakpoint state = %+v, want debuggerID=101 dapID=41", retained)
+	}
+	if droppedStillCached {
+		t.Fatal("discarded breakpoint remained in cache")
+	}
+
+	hh.sendReq("setBreakpoints", &godap.SetBreakpointsRequest{Arguments: godap.SetBreakpointsArguments{
+		Source:      source,
+		Breakpoints: []godap.SourceBreakpoint{{Line: 10}, {Line: 20}},
+	}})
+	setCommands := hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 3)
+	var retry protocol.SetBreakpointPayload
+	if err := protocol.DecodeCommandPayload(setCommands[2], &retry); err != nil {
+		t.Fatal(err)
+	}
+	if retry.File != source.Path || retry.Line != 20 {
+		t.Fatalf("discarded breakpoint retry = %+v, want %s:20", retry, source.Path)
+	}
+	hh.inject(protocol.EventBreakpointSet, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{ID: 202, Location: protocol.Location{File: source.Path, Line: 20}},
+	})
+	retried := recvType[*godap.SetBreakpointsResponse](hh)
+	if got := []int{retried.Body.Breakpoints[0].Id, retried.Body.Breakpoints[1].Id}; got[0] != 41 || got[1] != 202 {
+		t.Fatalf("post-restart breakpoint ids = %v, want stable retained id 41 and retried id 202", got)
+	}
+
+	hh.sendReq("setBreakpoints", &godap.SetBreakpointsRequest{Arguments: godap.SetBreakpointsArguments{
+		Source:      source,
+		Breakpoints: []godap.SourceBreakpoint{{Line: 20}},
+	}})
+	clearCommands := hh.cmds.waitForCommands(t, protocol.CmdClearBreakpoint, 1)
+	var clear protocol.ClearBreakpointPayload
+	if err := protocol.DecodeCommandPayload(clearCommands[0], &clear); err != nil {
+		t.Fatal(err)
+	}
+	if clear.ID != 101 {
+		t.Fatalf("clear breakpoint id = %d, want fresh debugger id 101", clear.ID)
+	}
+	_ = recvType[*godap.SetBreakpointsResponse](hh)
+}
+
+func TestRestartedPayloadDecodeFailureStillResponds(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, map[string]any{"breakpoints": "invalid"})
+
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != restartSeq || !restarted.Success {
+		t.Fatalf("restart response = %+v, want success for request %d", restarted.Response, restartSeq)
+	}
+}
+
+func TestRestartPreservesBreakpointCorrelationQueues(t *testing.T) {
+	h := NewHandler(nil, nil, nil)
+	setSlot := &bpSlot{}
+	h.setQ = []*bpSlot{setSlot}
+	h.clearQ = []int{73}
+
+	h.onRestarted(protocol.MustEvent(protocol.EventRestarted, 1, protocol.RestartedPayload{}))
+
+	if len(h.setQ) != 1 || h.setQ[0] != setSlot {
+		t.Fatalf("setQ changed across restart: %+v", h.setQ)
+	}
+	if len(h.clearQ) != 1 || h.clearQ[0] != 73 {
+		t.Fatalf("clearQ changed across restart: %v", h.clearQ)
+	}
 }
 
 func TestStackTraceAndVariablesCorrelation(t *testing.T) {


### PR DESCRIPTION
## Summary
- reconcile DAP breakpoint state from the authoritative `RestartedPayload` before completing restart
- preserve stable client-facing breakpoint IDs while using fresh debugger IDs for later clears
- remove discarded breakpoints, emit changed/unverified DAP events, and preserve pending set/clear FIFOs
- keep restart acknowledgements resilient to malformed payloads

## Tests
- `go test -tags bingonative -race ./internal/dap/... ./internal/hub/... ./pkg/protocol/...`
- `go vet -tags bingonative ./...`

Fixes #127
