### PR TITLE
fix(debugger): route emit logs through session logger

### DIFF
--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -1138,7 +1138,7 @@ func (e *engine) nextSeq() uint64 {
 func (e *engine) emit(kind protocol.EventKind, payload any) {
 	evt, err := protocol.NewEvent(kind, e.nextSeq(), payload)
 	if err != nil {
-		slog.Error("engine.emit: marshal event failed", "kind", kind, "err", err)
+		e.log.Error("engine.emit: marshal event failed", "kind", kind, "err", err)
 		return
 	}
 	// Non-blocking on purpose: this runs on the serialized loop, so blocking
@@ -1148,7 +1148,7 @@ func (e *engine) emit(kind protocol.EventKind, payload any) {
 	select {
 	case e.events <- evt:
 	default:
-		slog.Warn("engine.emit: events buffer full — dropping", "kind", kind)
+		e.log.Warn("engine.emit: events buffer full — dropping", "kind", kind)
 	}
 }
 

--- a/internal/debugger/engine_emit_test.go
+++ b/internal/debugger/engine_emit_test.go
@@ -1,0 +1,85 @@
+package debugger
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+type emitLogRecord struct {
+	level   slog.Level
+	message string
+}
+
+type emitLogCapture struct {
+	mu      sync.Mutex
+	records []emitLogRecord
+}
+
+func (h *emitLogCapture) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *emitLogCapture) Handle(_ context.Context, record slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, emitLogRecord{
+		level:   record.Level,
+		message: record.Message,
+	})
+	return nil
+}
+
+func (h *emitLogCapture) WithAttrs([]slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *emitLogCapture) WithGroup(string) slog.Handler {
+	return h
+}
+
+func (h *emitLogCapture) snapshot() []emitLogRecord {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]emitLogRecord(nil), h.records...)
+}
+
+func TestEngineEmitUsesInjectedLogger(t *testing.T) {
+	previousDefault := slog.Default()
+	globalCapture := &emitLogCapture{}
+	slog.SetDefault(slog.New(globalCapture))
+	t.Cleanup(func() {
+		slog.SetDefault(previousDefault)
+	})
+
+	injectedCapture := &emitLogCapture{}
+	e := &engine{
+		events: make(chan protocol.Event, 1),
+		log:    slog.New(injectedCapture),
+	}
+
+	e.emit(protocol.EventOutput, make(chan struct{}))
+	e.emit(protocol.EventOutput, protocol.OutputPayload{Content: "first"})
+	e.emit(protocol.EventOutput, protocol.OutputPayload{Content: "second"})
+
+	want := []emitLogRecord{
+		{level: slog.LevelError, message: "engine.emit: marshal event failed"},
+		{level: slog.LevelWarn, message: "engine.emit: events buffer full — dropping"},
+	}
+	got := injectedCapture.snapshot()
+	if len(got) != len(want) {
+		t.Fatalf("injected logger received %d records, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("injected record %d = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+
+	if got := globalCapture.snapshot(); len(got) != 0 {
+		t.Errorf("global logger received %d records, want none: %#v", len(got), got)
+	}
+}


### PR DESCRIPTION
## Summary
- route `engine.emit` marshal-failure and event-buffer-overflow diagnostics through the injected per-session logger
- add a deterministic same-package regression test covering both rare paths and guarding against global logger leakage

Fixes #131

## Testing
- `go test -tags bingonative ./internal/debugger -run '^TestEngineEmitUsesInjectedLogger$' -count=1`
- `go test -tags bingonative ./internal/debugger/... -count=1`
- `go vet -tags bingonative ./internal/debugger/...`
- `go test -tags bingonative -race ./internal/debugger/... -count=1`
