### PR TITLE
fix(vscode): reject endpoint collisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2555,7 +2555,9 @@ wire protocol or `launchConfig`.
 
 **VS Code connect-or-start invariants.** Default `serverMode:"auto"` is local
 only: management `127.0.0.1:6060`, DAP `127.0.0.1:4711`, readiness 5s, managed
-idle grace 30s. It health-checks before spawning and requires
+idle grace 30s. Its management and DAP endpoints must be distinct; an identical
+pair is rejected synchronously before probes or spawn, while `connectOnly`
+remains permissive. It health-checks before spawning and requires
 `service:"bingo"`, management API 1, the exact wire version, enabled DAP,
 `dap.sessionEventVersion:1`, and
 the expected DAP port/host (wildcard advertised hosts retain the configured
@@ -2593,7 +2595,7 @@ target metadata, architecture, mode, and entitlements.
 The extension package version is the installed-runtime upgrade boundary:
 material shipped behavior changes must bump both `package.json` and the lockfile
 or VS Code can retain an older bundle under the same identity. The manifest test
-and package verifier pin the current version (**0.4.1**) in source and VSIX
+and package verifier pin the current version (**0.4.2**) in source and VSIX
 metadata.
 The root Run and Debug dropdown exposes exactly two `"type":"bingo"` choices:
 launch one of five progressive examples through a `pickString`, and join a

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Lifecycle configuration is explicit per launch: `serverMode`,
 `auto`; remote, forwarded, and custom endpoints must use
 `"serverMode": "connectOnly"`, which neither probes nor spawns. Startup failures
 name the endpoint and persistent log path in the **bingo Server** output channel.
+Auto mode rejects identical management and DAP endpoints before either operation.
 
 Install the platform VSIX once (and update it when a newer version ships), then
 select **bingo DAP: launch example (stop on entry)** from the repository's Run

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -25,7 +25,8 @@ reuse, and 0.3.2 added wire 1.3's honest unknown stopped-goroutine rendering;
 **0.4.0** adds wire 1.4's bounded goroutine event contract, which is what keeps
 the concurrency view alive on highly concurrent targets. **0.4.1** adds
 bounded-family error classification, truthful omission states, and manual
-recovery after reconnect exhaustion. 0.4.0 is the minimum supported version.
+recovery after reconnect exhaustion. **0.4.2** rejects colliding management and
+DAP listeners before managed startup. 0.4.0 is the minimum supported version.
 Rerun the command to update, then run
 **Developer: Reload Window** once so the active extension host loads the new
 bundle. Package without installing with `just vscode-package`. Uninstall with:
@@ -62,6 +63,10 @@ Concurrent VS Code extension hosts may both try to start. Listener binding
 chooses the winner; a child that loses the race is harmless because both hosts
 reuse the compatible winner. Requests in one extension host for the same
 endpoint share one readiness operation.
+
+Auto mode requires distinct management and DAP endpoints and rejects an
+identical host/port pair before probing or spawning. `connectOnly` remains
+permissive for custom endpoint arrangements.
 
 The child is detached and logs to persistent extension storage. Open the
 **bingo Server** output channel to see the absolute server log path. The

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bingo",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bingo",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "ws": "8.18.3"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "bingo",
   "displayName": "bingo Debugger",
   "description": "Debug Go concurrency with bingo's DAP adapter and live goroutine visualization.",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "publisher": "bingosuite",
   "license": "MIT",
   "private": true,

--- a/editors/vscode/scripts/verify-package.mjs
+++ b/editors/vscode/scripts/verify-package.mjs
@@ -13,7 +13,7 @@ import { spawnSync } from "node:child_process";
 import { currentTarget } from "./platform.mjs";
 
 const target = currentTarget();
-const expectedExtensionVersion = "0.4.1";
+const expectedExtensionVersion = "0.4.2";
 const vsix = fileURLToPath(
   new URL(`../../../dist/bingo-${target}.vsix`, import.meta.url),
 );

--- a/editors/vscode/src/serverManager.ts
+++ b/editors/vscode/src/serverManager.ts
@@ -302,6 +302,15 @@ export class ServerManager {
         'bingo serverMode "auto" requires managementHost and dapHost to be 127.0.0.1; use "connectOnly" for remote or custom endpoints',
       );
     }
+    if (
+      formatEndpoint(config.managementEndpoint) ===
+      formatEndpoint(config.dapEndpoint)
+    ) {
+      throw new ServerManagerError(
+        "invalidConfiguration",
+        'bingo serverMode "auto" requires distinct management and DAP endpoints; choose different managementPort and dapPort values',
+      );
+    }
     const target = supportedTargetFor(this.#dependencies.runtime);
     if (target === undefined) {
       throw unsupportedTargetError(this.#dependencies.runtime);

--- a/editors/vscode/test/manifest.test.ts
+++ b/editors/vscode/test/manifest.test.ts
@@ -12,7 +12,7 @@ const manifest = requireRecord(
 const contributes = requireRecord(manifest.contributes);
 const debuggers = requireArray(contributes.debuggers);
 const debuggerContribution = requireRecord(debuggers[0]);
-const expectedExtensionVersion = "0.4.1";
+const expectedExtensionVersion = "0.4.2";
 
 describe("extension manifest", () => {
   it("versions the managed-server runtime as an installable upgrade", () => {

--- a/editors/vscode/test/serverManager.test.ts
+++ b/editors/vscode/test/serverManager.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import type { BingoServerConfiguration } from "../src/configuration.js";
+import {
+  resolveServerConfiguration,
+  type BingoServerConfiguration,
+} from "../src/configuration.js";
 import type {
   HealthProbe,
   HealthProbeResult,
@@ -201,7 +204,30 @@ describe("server manager", () => {
     await test.manager.ensureServer(configuration());
   });
 
-  it("rejects remote auto mode without probing or spawning", () => {
+  it("rejects normalized identical auto endpoints without probing or spawning", () => {
+    let probes = 0;
+    const test = harness(() => {
+      probes += 1;
+      return Promise.resolve(compatible);
+    });
+    const config = resolveServerConfiguration({
+      managementHost: " 127.0.0.1 ",
+      managementPort: 6060,
+      dapHost: "127.0.0.1",
+      dapPort: 6060,
+    });
+    assert.throws(
+      () => test.manager.ensureServer(config),
+      (error: unknown) =>
+        error instanceof ServerManagerError &&
+        error.code === "invalidConfiguration" &&
+        /requires distinct management and DAP endpoints/.test(error.message),
+    );
+    assert.equal(probes, 0);
+    assert.equal(test.requests.length, 0);
+  });
+
+  it("keeps literal auto-host validation ahead of endpoint equality", () => {
     let probes = 0;
     const test = harness(() => {
       probes += 1;
@@ -210,23 +236,29 @@ describe("server manager", () => {
     assert.throws(
       () => test.manager.ensureServer(
         configuration({
-          managementEndpoint: { host: "remote.example", port: 6060 },
+          managementEndpoint: { host: "localhost", port: 6060 },
+          dapEndpoint: { host: "localhost", port: 6060 },
         }),
       ),
-      hasCode("invalidConfiguration"),
+      (error: unknown) =>
+        error instanceof ServerManagerError &&
+        error.code === "invalidConfiguration" &&
+        /requires managementHost and dapHost to be 127\.0\.0\.1/.test(
+          error.message,
+        ),
     );
     assert.equal(probes, 0);
     assert.equal(test.requests.length, 0);
   });
 
-  it("connect-only bypasses platform, probing, binary checks, and spawning", async () => {
+  it("connect-only accepts identical custom endpoints without managed work", async () => {
     const test = harness(() =>
       Promise.reject(new Error("probe must not run")),
     );
     const config = configuration({
       mode: "connectOnly",
       managementEndpoint: { host: "remote.example", port: 16060 },
-      dapEndpoint: { host: "remote.example", port: 14711 },
+      dapEndpoint: { host: "remote.example", port: 16060 },
     });
 
     assert.deepEqual(await test.manager.ensureServer(config), config.dapEndpoint);

--- a/editors/vscode/test/telemetryBudget.test.ts
+++ b/editors/vscode/test/telemetryBudget.test.ts
@@ -178,7 +178,7 @@ describe("telemetry budget contract", () => {
     const manifest = JSON.parse(
       readFileSync(resolve(process.cwd(), "package.json"), "utf8"),
     ) as { readonly version: string };
-    assert.equal(manifest.version, "0.4.1");
+    assert.equal(manifest.version, "0.4.2");
   });
 });
 


### PR DESCRIPTION
## Summary

- restack the still-valid endpoint-collision fix from historical head `605541f876c9757d1d5483a87f48addc344d07b1`, through interim reviewed head `6cbb510b0a2da406fe48dbb65d0e2888f8a98304`, onto exact current `main` base `cce8d1357f0f502ad0939121818f2b25e1980fdd`
- publish the focused one-commit replacement as head `ea9b52ec3cb51e7807faa8cc876e9696d92ad364`, without replaying stale unrelated code
- reject identical management and DAP endpoints synchronously in VS Code `serverMode: "auto"` before health probes, binary/log resolution, or spawn
- preserve literal `127.0.0.1` auto-host validation precedence and permissive `connectOnly` behavior for custom endpoint arrangements
- cover whitespace-normalized user hosts, the `localhost` alias precedence case, zero probe/spawn work on rejection, and identical connect-only endpoints

## Restack proof

The accepted patch is unchanged across the new-base rebuild:

- old stable patch ID: `08b2f7438b6bf5c4a4e338b6da125ad2e83ea9a6`
- new stable patch ID: `08b2f7438b6bf5c4a4e338b6da125ad2e83ea9a6`
- `git range-diff 6e5a023..6cbb510 cce8d135..ea9b52e` reports `6cbb510 = ea9b52e`
- `origin/main..HEAD` contains exactly one commit

## Extension version

Bump the shipped extension runtime from `0.4.1` to `0.4.2` across every authoritative pin:

- `editors/vscode/package.json`
- root and package entries in `editors/vscode/package-lock.json`
- `editors/vscode/scripts/verify-package.mjs`
- `editors/vscode/test/manifest.test.ts`
- `editors/vscode/test/telemetryBudget.test.ts`
- `AGENTS.md` and the extension/root README documentation

## Local validation

Re-run on exact head `ea9b52ec3cb51e7807faa8cc876e9696d92ad364`:

- targeted TypeScript typecheck and unit/package-contract tests
- `just vscode-package` (lint, typecheck, full unit suite, bundles, package-list contract, reproducible VSIX build, exact archive verifier)
- `go vet -tags bingonative ./...`
- `git diff --check`

Independent exact-diff review on the new base found no issues. The parent production/version audit also confirmed the `0.4.2` pin set and packaging contract are complete.

Fixes #136