### PR TITLE
fix(hub): serialize outbound event sequences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -695,11 +695,21 @@ of issue #32). Constructors accept a nil logger and fall back to
 
 ## Hub seq stream — why one counter
 
-The hub re-stamps every outbound event with its own atomic `seq` counter. The
-engine has its own seq, and the hub also synthesises events (errors,
-confirmations like `BreakpointSet`). If clients saw both streams interleaved,
-they'd see two overlapping monotonic sequences and couldn't detect drops.
-**Always go through `h.seq.Add(1)` before broadcasting.**
+The hub re-stamps every outbound event with its own `seq` counter. The engine
+has its own seq, and the hub also synthesises events (errors, confirmations like
+`BreakpointSet`). If clients saw both streams interleaved, they'd see two
+overlapping monotonic sequences and couldn't detect drops.
+
+**`broadcast` is the only sequence-allocation path.** Its `outboundMu` covers
+sequence assignment, marshal, and nonblocking `deliver` to the registry
+snapshot, so every connected client sees the same frames in the same order.
+Managed `AddClient` takes that same lock across registry admission and a
+**broadcast** `EventSessionState`; existing clients therefore learn the new
+client count without a phantom gap, and the join state is the new client's
+first frame. Do not unicast an allocated sequence, reuse `seq` without
+incrementing it, or route join state through `Run` (which may be blocked in the
+suspended wait). `shutdown` also takes `outboundMu` before registry teardown so
+admission plus its initial state enqueue cannot interleave with closure.
 
 ## Restart — hub-level, not engine-level
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1984,11 +1984,25 @@ of issue #32). Constructors accept a nil logger and fall back to
 
 ## Hub seq stream — why one counter
 
-The hub re-stamps every outbound event with its own atomic `seq` counter. The
-engine has its own seq, and the hub also synthesises events (errors,
-confirmations like `BreakpointSet`). If clients saw both streams interleaved,
-they'd see two overlapping monotonic sequences and couldn't detect drops.
-**Always go through `h.seq.Add(1)` before broadcasting.**
+The hub re-stamps every outbound event with its own `seq` counter. The engine
+has its own seq, and the hub also synthesises events (errors, confirmations like
+`BreakpointSet`). If clients saw both streams interleaved, they'd see two
+overlapping monotonic sequences and couldn't detect drops.
+
+**`broadcast` is the only sequence-allocation path.** Its `outboundMu` covers
+sequence assignment, marshal, and nonblocking `deliver` to the registry
+snapshot, so every connected client sees the same frames in the same order.
+Managed `AddClient` takes that same lock across registry admission and a
+**broadcast** `EventSessionState`; existing clients therefore learn the new
+client count without a phantom gap, and the join state is the new client's
+first frame. Do not unicast an allocated sequence, reuse `seq` without
+incrementing it, or route join state through `Run` (which may be blocked in the
+suspended wait). `shutdown` also takes `outboundMu` before registry teardown so
+admission plus its initial state enqueue cannot interleave with closure.
+Suspending and process-exit events hold the same lock through their state
+transition and managed state broadcast. A join therefore lands wholly before
+the event (and observes it) or wholly after its new state; it cannot miss the
+cause event and receive a stale welcome that DAP would treat as authoritative.
 
 ## Hub debugger ownership — shutdown is a linearization point
 

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -249,12 +249,12 @@ type ErrorPayload struct {
 
 // internal/hub/hub.go
 func (h *Hub) broadcastError(kind protocol.CommandKind, err error) {
-    evt, e := protocol.NewEvent(protocol.EventError, h.seq.Add(1), protocol.ErrorPayload{
+    evt, e := protocol.NewEvent(protocol.EventError, 0, protocol.ErrorPayload{
         Command: kind,
         Message: err.Error(),
     })
     if e != nil {
-        h.log.Error("failed to marshal error event", "err", e)
+        h.log.Error("failed to marshal error event", "err", e, "cause", err)
         return
     }
     h.broadcast(evt)
@@ -267,6 +267,10 @@ version before hub injection, send that connection a close-1002 frame naming
 the expected and received versions, and disconnect it. Broadcasting an
 `EventError` would expose one client's malformed input to innocent clients and
 consume a shared hub sequence number for a connection-local failure.
+
+`broadcast` assigns the hub sequence while holding the outbound lock, then
+marshals and delivers the frame in that same order. Event constructors must not
+allocate or reuse hub sequence numbers themselves.
 
 ### On error message content
 

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -281,12 +281,12 @@ type ErrorPayload struct {
 
 // internal/hub/hub.go
 func (h *Hub) broadcastError(kind protocol.CommandKind, err error) {
-    evt, e := protocol.NewEvent(protocol.EventError, h.seq.Add(1), protocol.ErrorPayload{
+    evt, e := protocol.NewEvent(protocol.EventError, 0, protocol.ErrorPayload{
         Command: kind,
         Message: err.Error(),
     })
     if e != nil {
-        h.log.Error("failed to marshal error event", "err", e)
+        h.log.Error("failed to marshal error event", "err", e, "cause", err)
         return
     }
     h.broadcast(evt)
@@ -299,6 +299,10 @@ version before hub injection, send that connection a close-1002 frame naming
 the expected and received versions, and disconnect it. Broadcasting an
 `EventError` would expose one client's malformed input to innocent clients and
 consume a shared hub sequence number for a connection-local failure.
+
+`broadcast` assigns the hub sequence while holding the outbound lock, then
+marshals and delivers the frame in that same order. Event constructors must not
+allocate or reuse hub sequence numbers themselves.
 
 ### On error message content
 

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"sort"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/bingosuite/bingo/internal/debugger"
@@ -80,10 +79,11 @@ type Hub struct {
 	// resumeCh: capacity 1, first-write-wins. Extras dropped in injectCommand.
 	resumeCh chan protocol.Command
 
-	// seq is the single counter for ALL outbound events. The hub re-stamps
-	// debugger events with this counter, so clients see one monotonic stream
-	// and can detect gaps. The engine has its own seq.
-	seq atomic.Uint64
+	// outboundMu keeps admission, sequence allocation, marshal, and delivery in
+	// one order. deliver is nonblocking, so the lock is never held across socket
+	// I/O. The engine has its own seq; broadcastLocked re-stamps every event.
+	outboundMu sync.Mutex
+	seq        uint64
 
 	// shutdownOnce: Kill and registry teardown must happen exactly once,
 	// even when ctx.Done() and last-client-disconnect race.
@@ -215,17 +215,21 @@ func (h *Hub) setDbg(d debugger.Debugger) {
 // hub after its one-shot shutdown has completed.
 func (h *Hub) AddClient(conn WSConn, log *slog.Logger) (*Client, error) {
 	c := newClient(conn, h, log)
+
+	h.outboundMu.Lock()
 	if !h.registry.add(c) {
+		h.outboundMu.Unlock()
 		_ = conn.Close()
 		return nil, ErrHubClosed
 	}
+	if h.sessionID != "" {
+		h.broadcastSessionStateLocked()
+	}
+	h.outboundMu.Unlock()
+
 	go c.writePump()
 	go c.readPump()
 	h.log.Info("client connected", "total", h.registry.count())
-
-	if h.sessionID != "" {
-		h.sendStateTo(c)
-	}
 
 	return c, nil
 }
@@ -267,7 +271,6 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 		h.drainResumeCh()
 	}
 
-	evt.Seq = h.seq.Add(1)
 	h.broadcast(evt)
 
 	switch evt.Kind {
@@ -306,7 +309,6 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 				}
 				return
 			}
-			nextEvt.Seq = h.seq.Add(1)
 			h.broadcast(nextEvt)
 			if nextEvt.Kind == protocol.EventProcessExited {
 				h.transitionState(protocol.StateExited)
@@ -429,7 +431,6 @@ func (h *Hub) executeCommand(cmd protocol.Command) {
 	}
 
 	if result.event != nil {
-		result.event.Seq = h.seq.Add(1)
 		h.broadcast(*result.event)
 	}
 }
@@ -568,7 +569,7 @@ func (h *Hub) handleRestart(cmd protocol.Command) {
 	}
 	h.restartBreakpoints = newBreakpoints
 
-	evt, err := protocol.NewEvent(protocol.EventRestarted, h.seq.Add(1), protocol.RestartedPayload{
+	evt, err := protocol.NewEvent(protocol.EventRestarted, 0, protocol.RestartedPayload{
 		Program:     program,
 		Breakpoints: installed,
 		Discarded:   discarded,
@@ -628,11 +629,17 @@ func (h *Hub) transitionState(newState protocol.SessionState) {
 }
 
 func (h *Hub) broadcastSessionState() {
+	h.outboundMu.Lock()
+	defer h.outboundMu.Unlock()
+	h.broadcastSessionStateLocked()
+}
+
+func (h *Hub) broadcastSessionStateLocked() {
 	h.stateMu.RLock()
 	state := h.state
 	h.stateMu.RUnlock()
 
-	evt, err := protocol.NewEvent(protocol.EventSessionState, h.seq.Add(1), protocol.SessionStatePayload{
+	evt, err := protocol.NewEvent(protocol.EventSessionState, 0, protocol.SessionStatePayload{
 		SessionID: h.sessionID,
 		State:     state,
 		Clients:   h.registry.count(),
@@ -641,40 +648,24 @@ func (h *Hub) broadcastSessionState() {
 		h.log.Error("failed to create session state event", "err", err)
 		return
 	}
-	h.broadcast(evt)
-}
-
-// sendStateTo delivers the current state to a single client (welcome message).
-func (h *Hub) sendStateTo(c *Client) {
-	h.stateMu.RLock()
-	state := h.state
-	h.stateMu.RUnlock()
-
-	evt, err := protocol.NewEvent(protocol.EventSessionState, h.seq.Add(1), protocol.SessionStatePayload{
-		SessionID: h.sessionID,
-		State:     state,
-		Clients:   h.registry.count(),
-	})
-	if err != nil {
-		h.log.Error("failed to create welcome state event", "err", err)
-		return
-	}
-	wire, err := protocol.MarshalEvent(evt)
-	if err != nil {
-		h.log.Error("failed to marshal welcome state event", "err", err)
-		return
-	}
-	if !c.deliver(wire) {
-		h.removeClient(c)
-	}
+	h.broadcastLocked(evt)
 }
 
 func (h *Hub) broadcast(evt protocol.Event) {
+	h.outboundMu.Lock()
+	defer h.outboundMu.Unlock()
+	h.broadcastLocked(evt)
+}
+
+func (h *Hub) broadcastLocked(evt protocol.Event) {
+	nextSeq := h.seq + 1
+	evt.Seq = nextSeq
 	wire, err := protocol.MarshalEvent(evt)
 	if err != nil {
 		h.log.Error("marshal event failed", "err", err)
 		return
 	}
+	h.seq = nextSeq
 	for _, c := range h.registry.snapshot() {
 		if !c.deliver(wire) {
 			h.removeClient(c)
@@ -683,7 +674,7 @@ func (h *Hub) broadcast(evt protocol.Event) {
 }
 
 func (h *Hub) broadcastError(kind protocol.CommandKind, err error) {
-	evt, e := protocol.NewEvent(protocol.EventError, h.seq.Add(1), protocol.ErrorPayload{
+	evt, e := protocol.NewEvent(protocol.EventError, 0, protocol.ErrorPayload{
 		Command: kind,
 		Message: err.Error(),
 	})
@@ -700,7 +691,9 @@ func (h *Hub) shutdown() {
 	h.shutdownOnce.Do(func() {
 		h.log.Info("hub shutting down")
 		close(h.shutdownCh)
+		h.outboundMu.Lock()
 		h.registry.closeAll()
+		h.outboundMu.Unlock()
 		// shutdown may run on a non-Run goroutine (go h.shutdown() from
 		// removeClient), so snapshot dbg under dbgMu to avoid racing a
 		// mid-flight Launch/Restart on the Run goroutine.

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/bingosuite/bingo/internal/debugger"
@@ -87,10 +86,11 @@ type Hub struct {
 	// safety-resume path without a mutable process-wide setting.
 	suspendTimeout time.Duration
 
-	// seq is the single counter for ALL outbound events. The hub re-stamps
-	// debugger events with this counter, so clients see one monotonic stream
-	// and can detect gaps. The engine has its own seq.
-	seq atomic.Uint64
+	// outboundMu keeps admission, sequence allocation, marshal, and delivery in
+	// one order. deliver is nonblocking, so the lock is never held across socket
+	// I/O. The engine has its own seq; broadcastLocked re-stamps every event.
+	outboundMu sync.Mutex
+	seq        uint64
 
 	// shutdownOnce: Kill and registry teardown must happen exactly once,
 	// even when ctx.Done() and last-client-disconnect race.
@@ -274,17 +274,21 @@ func (h *Hub) discardDebugger(dbg debugger.Debugger, reason string) {
 // hub after its one-shot shutdown has completed.
 func (h *Hub) AddClient(conn WSConn, log *slog.Logger) (*Client, error) {
 	c := newClient(conn, h, log)
+
+	h.outboundMu.Lock()
 	if !h.registry.add(c) {
+		h.outboundMu.Unlock()
 		_ = conn.Close()
 		return nil, ErrHubClosed
 	}
+	if h.sessionID != "" {
+		h.broadcastSessionStateLocked()
+	}
+	h.outboundMu.Unlock()
+
 	go c.writePump()
 	go c.readPump()
 	h.log.Info("client connected", "total", h.registry.count())
-
-	if h.sessionID != "" {
-		h.sendStateTo(c)
-	}
 
 	return c, nil
 }
@@ -327,14 +331,13 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 		h.drainResumeCh()
 	}
 
-	evt.Seq = h.seq.Add(1)
-	h.broadcast(evt)
-
 	switch evt.Kind {
 	case protocol.EventBreakpointHit, protocol.EventPanic, protocol.EventStepped, protocol.EventPaused:
-		h.transitionState(protocol.StateSuspended)
+		h.broadcastAndTransition(evt, protocol.StateSuspended)
 	case protocol.EventProcessExited:
-		h.transitionState(protocol.StateExited)
+		h.broadcastAndTransition(evt, protocol.StateExited)
+	default:
+		h.broadcast(evt)
 	}
 
 	if !suspending {
@@ -367,12 +370,11 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 				return
 			}
 			nextEvt = h.localizeBreakpointIDs(nextEvt)
-			nextEvt.Seq = h.seq.Add(1)
-			h.broadcast(nextEvt)
 			if nextEvt.Kind == protocol.EventProcessExited {
-				h.transitionState(protocol.StateExited)
+				h.broadcastAndTransition(nextEvt, protocol.StateExited)
 				return
 			}
+			h.broadcast(nextEvt)
 
 		case cmd := <-h.resumeCh:
 			h.log.Info("resuming", "command", cmd.Kind)
@@ -558,7 +560,6 @@ func (h *Hub) executeCommand(cmd protocol.Command) {
 	}
 
 	if result.event != nil {
-		result.event.Seq = h.seq.Add(1)
 		h.broadcast(*result.event)
 	}
 }
@@ -720,7 +721,7 @@ func (h *Hub) handleRestart(cmd protocol.Command) {
 		installed = append(installed, bp)
 	}
 
-	evt, err := protocol.NewEvent(protocol.EventRestarted, h.seq.Add(1), protocol.RestartedPayload{
+	evt, err := protocol.NewEvent(protocol.EventRestarted, 0, protocol.RestartedPayload{
 		Program:     program,
 		Breakpoints: installed,
 		Discarded:   discarded,
@@ -792,6 +793,12 @@ func (h *Hub) drainResumeCh() {
 // transitionState updates state and, for managed sessions, broadcasts. State
 // changes linearize before shutdown so a closed hub cannot be resurrected.
 func (h *Hub) transitionState(newState protocol.SessionState) bool {
+	h.outboundMu.Lock()
+	defer h.outboundMu.Unlock()
+	return h.transitionStateLocked(newState)
+}
+
+func (h *Hub) transitionStateLocked(newState protocol.SessionState) bool {
 	h.dbgMu.Lock()
 	if h.closing {
 		h.dbgMu.Unlock()
@@ -811,17 +818,24 @@ func (h *Hub) transitionState(newState protocol.SessionState) bool {
 	h.log.Info("state transition", "from", old, "to", newState)
 
 	if h.sessionID != "" {
-		h.broadcastSessionState()
+		h.broadcastSessionStateLocked()
 	}
 	return true
 }
 
-func (h *Hub) broadcastSessionState() {
+func (h *Hub) broadcastAndTransition(evt protocol.Event, state protocol.SessionState) {
+	h.outboundMu.Lock()
+	defer h.outboundMu.Unlock()
+	h.broadcastLocked(evt)
+	h.transitionStateLocked(state)
+}
+
+func (h *Hub) broadcastSessionStateLocked() {
 	h.stateMu.RLock()
 	state := h.state
 	h.stateMu.RUnlock()
 
-	evt, err := protocol.NewEvent(protocol.EventSessionState, h.seq.Add(1), protocol.SessionStatePayload{
+	evt, err := protocol.NewEvent(protocol.EventSessionState, 0, protocol.SessionStatePayload{
 		SessionID: h.sessionID,
 		State:     state,
 		Clients:   h.registry.count(),
@@ -830,40 +844,24 @@ func (h *Hub) broadcastSessionState() {
 		h.log.Error("failed to create session state event", "err", err)
 		return
 	}
-	h.broadcast(evt)
-}
-
-// sendStateTo delivers the current state to a single client (welcome message).
-func (h *Hub) sendStateTo(c *Client) {
-	h.stateMu.RLock()
-	state := h.state
-	h.stateMu.RUnlock()
-
-	evt, err := protocol.NewEvent(protocol.EventSessionState, h.seq.Add(1), protocol.SessionStatePayload{
-		SessionID: h.sessionID,
-		State:     state,
-		Clients:   h.registry.count(),
-	})
-	if err != nil {
-		h.log.Error("failed to create welcome state event", "err", err)
-		return
-	}
-	wire, err := protocol.MarshalEvent(evt)
-	if err != nil {
-		h.log.Error("failed to marshal welcome state event", "err", err)
-		return
-	}
-	if !c.deliver(wire) {
-		h.removeClient(c)
-	}
+	h.broadcastLocked(evt)
 }
 
 func (h *Hub) broadcast(evt protocol.Event) {
+	h.outboundMu.Lock()
+	defer h.outboundMu.Unlock()
+	h.broadcastLocked(evt)
+}
+
+func (h *Hub) broadcastLocked(evt protocol.Event) {
+	nextSeq := h.seq + 1
+	evt.Seq = nextSeq
 	wire, err := protocol.MarshalEvent(evt)
 	if err != nil {
 		h.log.Error("marshal event failed", "err", err)
 		return
 	}
+	h.seq = nextSeq
 	for _, c := range h.registry.snapshot() {
 		if !c.deliver(wire) {
 			h.removeClient(c)
@@ -872,7 +870,7 @@ func (h *Hub) broadcast(evt protocol.Event) {
 }
 
 func (h *Hub) broadcastError(kind protocol.CommandKind, err error) {
-	evt, e := protocol.NewEvent(protocol.EventError, h.seq.Add(1), protocol.ErrorPayload{
+	evt, e := protocol.NewEvent(protocol.EventError, 0, protocol.ErrorPayload{
 		Command: kind,
 		Message: err.Error(),
 	})
@@ -890,7 +888,9 @@ func (h *Hub) shutdown() {
 		h.log.Info("hub shutting down")
 		dbg := h.beginShutdown()
 		close(h.shutdownCh)
+		h.outboundMu.Lock()
 		h.registry.closeAll()
+		h.outboundMu.Unlock()
 		h.discardDebugger(dbg, "hub shutdown")
 	})
 }

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -500,6 +500,161 @@ var _ = Describe("Hub", func() {
 	})
 
 	Describe("event sequence numbers", func() {
+		It("keeps existing clients on the managed-session sequence stream when another client joins", func() {
+			managedFD := newFakeDebugger()
+			managed := hub.NewSession("session", func() debugger.Debugger { return managedFD }, nil)
+			cancelManaged := runHub(managed)
+			defer cancelManaged()
+
+			conn1 := newFakeWSConn()
+			mustAddClient(managed, conn1)
+			first, ok := recvEvent(conn1)
+			Expect(ok).To(BeTrue())
+			Expect(first.Kind).To(Equal(protocol.EventSessionState))
+			Expect(first.Seq).To(Equal(uint64(1)))
+
+			conn2 := newFakeWSConn()
+			mustAddClient(managed, conn2)
+
+			existingState, ok := recvEvent(conn1)
+			Expect(ok).To(BeTrue())
+			joiningState, ok := recvEvent(conn2)
+			Expect(ok).To(BeTrue())
+			Expect(existingState.Kind).To(Equal(protocol.EventSessionState))
+			Expect(joiningState.Kind).To(Equal(protocol.EventSessionState))
+			Expect(existingState.Seq).To(Equal(first.Seq + 1))
+			Expect(joiningState.Seq).To(Equal(existingState.Seq))
+		})
+
+		It("serializes concurrent joins and broadcasts into contiguous client streams", func() {
+			managedFD := newFakeDebugger()
+			managed := hub.NewSession("session", func() debugger.Debugger { return managedFD }, nil)
+			cancelManaged := runHub(managed)
+			defer cancelManaged()
+
+			const (
+				joiners = 24
+				outputs = 64
+			)
+
+			conns := make([]*fakeWSConn, joiners+1)
+			conns[0] = newFakeWSConn()
+			mustAddClient(managed, conns[0])
+			welcome, ok := recvEvent(conns[0])
+			Expect(ok).To(BeTrue())
+			Expect(welcome.Seq).To(Equal(uint64(1)))
+
+			conns[0].inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "stress"}))
+			running, ok := recvEvent(conns[0])
+			Expect(ok).To(BeTrue())
+			Expect(running.Kind).To(Equal(protocol.EventSessionState))
+			Expect(running.Seq).To(Equal(welcome.Seq + 1))
+
+			start := make(chan struct{})
+			addErrs := make(chan error, joiners)
+			var joins sync.WaitGroup
+			joins.Add(joiners)
+			for i := 1; i <= joiners; i++ {
+				conns[i] = newFakeWSConn()
+				go func(conn *fakeWSConn) {
+					defer joins.Done()
+					<-start
+					_, err := managed.AddClient(conn, nil)
+					addErrs <- err
+				}(conns[i])
+			}
+
+			emitted := make(chan struct{})
+			go func() {
+				<-start
+				for i := 0; i < outputs; i++ {
+					managedFD.push(protocol.MustEvent(protocol.EventOutput, uint64(i+1),
+						protocol.OutputPayload{Content: fmt.Sprintf("output-%d", i)}))
+				}
+				close(emitted)
+			}()
+
+			close(start)
+			joins.Wait()
+			for i := 0; i < joiners; i++ {
+				Expect(<-addErrs).NotTo(HaveOccurred())
+			}
+			Eventually(emitted, "2s").Should(BeClosed())
+
+			managedFD.push(protocol.MustEvent(protocol.EventOutput, 1,
+				protocol.OutputPayload{Content: "sentinel"}))
+
+			for i, conn := range conns {
+				previous := uint64(0)
+				if i == 0 {
+					previous = running.Seq
+				} else {
+					first, ok := recvEvent(conn)
+					Expect(ok).To(BeTrue(), "client %d did not receive its join state", i)
+					Expect(first.Kind).To(Equal(protocol.EventSessionState))
+					Expect(first.Seq).To(BeNumerically(">=", uint64(1)))
+					previous = first.Seq
+				}
+
+				for {
+					evt, ok := recvEvent(conn)
+					Expect(ok).To(BeTrue(), "client %d stream ended before sentinel", i)
+					Expect(evt.Seq).To(Equal(previous+1),
+						"client %d received a non-contiguous stream", i)
+					previous = evt.Seq
+
+					if evt.Kind != protocol.EventOutput {
+						continue
+					}
+					var payload protocol.OutputPayload
+					Expect(protocol.DecodeEventPayload(evt, &payload)).To(Succeed())
+					if payload.Content == "sentinel" {
+						break
+					}
+				}
+			}
+		})
+
+		It("admits a client while Run is waiting for a suspended-session resume", func() {
+			managedFD := newFakeDebugger()
+			managed := hub.NewSession("session", func() debugger.Debugger { return managedFD }, nil)
+			cancelManaged := runHub(managed)
+			defer cancelManaged()
+
+			conn1 := newFakeWSConn()
+			mustAddClient(managed, conn1)
+			_, _ = recvEvent(conn1)
+			conn1.inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "paused"}))
+			_, _ = recvEvent(conn1)
+
+			managedFD.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+			waitForEventKind(conn1, protocol.EventBreakpointHit, nil)
+			suspended, ok := recvEvent(conn1)
+			Expect(ok).To(BeTrue())
+			Expect(suspended.Kind).To(Equal(protocol.EventSessionState))
+
+			conn2 := newFakeWSConn()
+			addResult := make(chan error, 1)
+			go func() {
+				_, err := managed.AddClient(conn2, nil)
+				addResult <- err
+			}()
+			Eventually(addResult, "500ms").Should(Receive(BeNil()))
+
+			existingState, ok := recvEvent(conn1)
+			Expect(ok).To(BeTrue())
+			joiningState, ok := recvEvent(conn2)
+			Expect(ok).To(BeTrue())
+			Expect(existingState.Seq).To(Equal(suspended.Seq + 1))
+			Expect(joiningState.Seq).To(Equal(existingState.Seq))
+
+			var payload protocol.SessionStatePayload
+			Expect(protocol.DecodeEventPayload(joiningState, &payload)).To(Succeed())
+			Expect(payload.State).To(Equal(protocol.StateSuspended))
+			Expect(payload.Clients).To(Equal(2))
+		})
+
 		It("assigns strictly increasing hub-managed seq to all outbound events", func() {
 			conn := newFakeWSConn()
 			_, err := h.AddClient(conn, nil)

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -424,6 +424,161 @@ var _ = Describe("Hub", func() {
 	})
 
 	Describe("event sequence numbers", func() {
+		It("keeps existing clients on the managed-session sequence stream when another client joins", func() {
+			managedFD := newFakeDebugger()
+			managed := hub.NewSession("session", func() debugger.Debugger { return managedFD }, nil)
+			cancelManaged := runHub(managed)
+			defer cancelManaged()
+
+			conn1 := newFakeWSConn()
+			mustAddClient(managed, conn1)
+			first, ok := recvEvent(conn1)
+			Expect(ok).To(BeTrue())
+			Expect(first.Kind).To(Equal(protocol.EventSessionState))
+			Expect(first.Seq).To(Equal(uint64(1)))
+
+			conn2 := newFakeWSConn()
+			mustAddClient(managed, conn2)
+
+			existingState, ok := recvEvent(conn1)
+			Expect(ok).To(BeTrue())
+			joiningState, ok := recvEvent(conn2)
+			Expect(ok).To(BeTrue())
+			Expect(existingState.Kind).To(Equal(protocol.EventSessionState))
+			Expect(joiningState.Kind).To(Equal(protocol.EventSessionState))
+			Expect(existingState.Seq).To(Equal(first.Seq + 1))
+			Expect(joiningState.Seq).To(Equal(existingState.Seq))
+		})
+
+		It("serializes concurrent joins and broadcasts into contiguous client streams", func() {
+			managedFD := newFakeDebugger()
+			managed := hub.NewSession("session", func() debugger.Debugger { return managedFD }, nil)
+			cancelManaged := runHub(managed)
+			defer cancelManaged()
+
+			const (
+				joiners = 24
+				outputs = 64
+			)
+
+			conns := make([]*fakeWSConn, joiners+1)
+			conns[0] = newFakeWSConn()
+			mustAddClient(managed, conns[0])
+			welcome, ok := recvEvent(conns[0])
+			Expect(ok).To(BeTrue())
+			Expect(welcome.Seq).To(Equal(uint64(1)))
+
+			conns[0].inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "stress"}))
+			running, ok := recvEvent(conns[0])
+			Expect(ok).To(BeTrue())
+			Expect(running.Kind).To(Equal(protocol.EventSessionState))
+			Expect(running.Seq).To(Equal(welcome.Seq + 1))
+
+			start := make(chan struct{})
+			addErrs := make(chan error, joiners)
+			var joins sync.WaitGroup
+			joins.Add(joiners)
+			for i := 1; i <= joiners; i++ {
+				conns[i] = newFakeWSConn()
+				go func(conn *fakeWSConn) {
+					defer joins.Done()
+					<-start
+					_, err := managed.AddClient(conn, nil)
+					addErrs <- err
+				}(conns[i])
+			}
+
+			emitted := make(chan struct{})
+			go func() {
+				<-start
+				for i := 0; i < outputs; i++ {
+					managedFD.push(protocol.MustEvent(protocol.EventOutput, uint64(i+1),
+						protocol.OutputPayload{Content: fmt.Sprintf("output-%d", i)}))
+				}
+				close(emitted)
+			}()
+
+			close(start)
+			joins.Wait()
+			for i := 0; i < joiners; i++ {
+				Expect(<-addErrs).NotTo(HaveOccurred())
+			}
+			Eventually(emitted, "2s").Should(BeClosed())
+
+			managedFD.push(protocol.MustEvent(protocol.EventOutput, 1,
+				protocol.OutputPayload{Content: "sentinel"}))
+
+			for i, conn := range conns {
+				previous := uint64(0)
+				if i == 0 {
+					previous = running.Seq
+				} else {
+					first, ok := recvEvent(conn)
+					Expect(ok).To(BeTrue(), "client %d did not receive its join state", i)
+					Expect(first.Kind).To(Equal(protocol.EventSessionState))
+					Expect(first.Seq).To(BeNumerically(">=", uint64(1)))
+					previous = first.Seq
+				}
+
+				for {
+					evt, ok := recvEvent(conn)
+					Expect(ok).To(BeTrue(), "client %d stream ended before sentinel", i)
+					Expect(evt.Seq).To(Equal(previous+1),
+						"client %d received a non-contiguous stream", i)
+					previous = evt.Seq
+
+					if evt.Kind != protocol.EventOutput {
+						continue
+					}
+					var payload protocol.OutputPayload
+					Expect(protocol.DecodeEventPayload(evt, &payload)).To(Succeed())
+					if payload.Content == "sentinel" {
+						break
+					}
+				}
+			}
+		})
+
+		It("admits a client while Run is waiting for a suspended-session resume", func() {
+			managedFD := newFakeDebugger()
+			managed := hub.NewSession("session", func() debugger.Debugger { return managedFD }, nil)
+			cancelManaged := runHub(managed)
+			defer cancelManaged()
+
+			conn1 := newFakeWSConn()
+			mustAddClient(managed, conn1)
+			_, _ = recvEvent(conn1)
+			conn1.inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "paused"}))
+			_, _ = recvEvent(conn1)
+
+			managedFD.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+			waitForEventKind(conn1, protocol.EventBreakpointHit, nil)
+			suspended, ok := recvEvent(conn1)
+			Expect(ok).To(BeTrue())
+			Expect(suspended.Kind).To(Equal(protocol.EventSessionState))
+
+			conn2 := newFakeWSConn()
+			addResult := make(chan error, 1)
+			go func() {
+				_, err := managed.AddClient(conn2, nil)
+				addResult <- err
+			}()
+			Eventually(addResult, "500ms").Should(Receive(BeNil()))
+
+			existingState, ok := recvEvent(conn1)
+			Expect(ok).To(BeTrue())
+			joiningState, ok := recvEvent(conn2)
+			Expect(ok).To(BeTrue())
+			Expect(existingState.Seq).To(Equal(suspended.Seq + 1))
+			Expect(joiningState.Seq).To(Equal(existingState.Seq))
+
+			var payload protocol.SessionStatePayload
+			Expect(protocol.DecodeEventPayload(joiningState, &payload)).To(Succeed())
+			Expect(payload.State).To(Equal(protocol.StateSuspended))
+			Expect(payload.Clients).To(Equal(2))
+		})
+
 		It("assigns strictly increasing hub-managed seq to all outbound events", func() {
 			conn := newFakeWSConn()
 			_, err := h.AddClient(conn, nil)

--- a/internal/hub/outbound_test.go
+++ b/internal/hub/outbound_test.go
@@ -1,0 +1,127 @@
+package hub
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+type outboundConn struct {
+	writes    chan []byte
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func newOutboundConn() *outboundConn {
+	return &outboundConn{
+		writes: make(chan []byte, 4),
+		closed: make(chan struct{}),
+	}
+}
+
+func (c *outboundConn) ReadMessage() (int, []byte, error) {
+	<-c.closed
+	return 0, nil, io.EOF
+}
+
+func (c *outboundConn) WriteMessage(messageType int, data []byte) error {
+	if messageType == TextMessage {
+		c.writes <- append([]byte(nil), data...)
+	}
+	return nil
+}
+
+func (*outboundConn) SetReadLimit(int64)                {}
+func (*outboundConn) SetReadDeadline(time.Time) error   { return nil }
+func (*outboundConn) SetWriteDeadline(time.Time) error  { return nil }
+func (*outboundConn) SetPongHandler(func(string) error) {}
+
+func (c *outboundConn) Close() error {
+	c.closeOnce.Do(func() { close(c.closed) })
+	return nil
+}
+
+func TestJoinCannotSplitSuspendingEventFromStateTransition(t *testing.T) {
+	h := newHub(nil)
+	h.sessionID = "session"
+	h.state = protocol.StateRunning
+
+	existing := newClient(newOutboundConn(), h, nil)
+	if !h.registry.add(existing) {
+		t.Fatal("existing client was not admitted")
+	}
+	existing.sendMu.Lock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	handled := make(chan struct{})
+	go func() {
+		h.handleEvent(ctx, protocol.MustEvent(protocol.EventBreakpointHit, 1,
+			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+		close(handled)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	for h.outboundMu.TryLock() {
+		h.outboundMu.Unlock()
+		if time.Now().After(deadline) {
+			t.Fatal("suspending event did not enter outbound delivery")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	joiningConn := newOutboundConn()
+	added := make(chan error, 1)
+	go func() {
+		_, err := h.AddClient(joiningConn, nil)
+		added <- err
+	}()
+
+	select {
+	case err := <-added:
+		t.Fatalf("join completed inside the stop/state transaction: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	existing.sendMu.Unlock()
+
+	select {
+	case <-handled:
+	case <-time.After(time.Second):
+		t.Fatal("suspending event did not complete")
+	}
+	select {
+	case err := <-added:
+		if err != nil {
+			t.Fatalf("join failed: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("join remained blocked after the stop/state transaction")
+	}
+
+	select {
+	case wire := <-joiningConn.writes:
+		evt, err := protocol.UnmarshalEvent(wire)
+		if err != nil {
+			t.Fatalf("decode join state: %v", err)
+		}
+		if evt.Kind != protocol.EventSessionState {
+			t.Fatalf("first join event = %s, want %s", evt.Kind, protocol.EventSessionState)
+		}
+		var state protocol.SessionStatePayload
+		if err := protocol.DecodeEventPayload(evt, &state); err != nil {
+			t.Fatalf("decode join state payload: %v", err)
+		}
+		if state.State != protocol.StateSuspended {
+			t.Fatalf("join state = %s, want %s", state.State, protocol.StateSuspended)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("join state was not delivered")
+	}
+
+	h.shutdown()
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -33,17 +33,22 @@ func serverOrigin(ts *httptest.Server) string {
 }
 
 func recvState(conn *websocket.Conn) (protocol.SessionStatePayload, error) {
+	_, payload, err := recvStateEvent(conn)
+	return payload, err
+}
+
+func recvStateEvent(conn *websocket.Conn) (protocol.Event, protocol.SessionStatePayload, error) {
 	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
 	_, msg, err := conn.ReadMessage()
 	if err != nil {
-		return protocol.SessionStatePayload{}, err
+		return protocol.Event{}, protocol.SessionStatePayload{}, err
 	}
-	var evt protocol.Event
-	if err := json.Unmarshal(msg, &evt); err != nil {
-		return protocol.SessionStatePayload{}, err
+	evt, err := protocol.UnmarshalEvent(msg)
+	if err != nil {
+		return protocol.Event{}, protocol.SessionStatePayload{}, err
 	}
 	var p protocol.SessionStatePayload
-	return p, protocol.DecodeEventPayload(evt, &p)
+	return evt, p, protocol.DecodeEventPayload(evt, &p)
 }
 
 func closeWS(conn *websocket.Conn) {
@@ -190,6 +195,11 @@ var _ = Describe("Server", func() {
 				_, err = recvState(good)
 				Expect(err).NotTo(HaveOccurred())
 
+				// A join broadcasts session state to every client, so the
+				// existing connection has that frame queued ahead of the close.
+				_, err = recvState(bad)
+				Expect(err).NotTo(HaveOccurred())
+
 				cmd := protocol.Command{
 					Version: "999.0",
 					Kind:    protocol.CmdSetBreakpoint,
@@ -232,17 +242,24 @@ var _ = Describe("Server", func() {
 				conn1, _, err := websocket.DefaultDialer.Dial(toWS(ts, "/ws?create"), nil)
 				Expect(err).NotTo(HaveOccurred())
 				defer closeWS(conn1)
-				p1, _ := recvState(conn1)
+				first, p1, err := recvStateEvent(conn1)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(first.Seq).To(BeNumerically(">=", uint64(1)))
 
 				conn2, _, err := websocket.DefaultDialer.Dial(
 					toWS(ts, "/ws?session="+p1.SessionID), nil)
 				Expect(err).NotTo(HaveOccurred())
 				defer closeWS(conn2)
 
-				p2, err := recvState(conn2)
+				existing, pExisting, err := recvStateEvent(conn1)
 				Expect(err).NotTo(HaveOccurred())
+				joining, p2, err := recvStateEvent(conn2)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pExisting).To(Equal(p2))
 				Expect(p2.SessionID).To(Equal(p1.SessionID))
 				Expect(p2.Clients).To(Equal(2))
+				Expect(existing.Seq).To(Equal(first.Seq + 1))
+				Expect(joining.Seq).To(Equal(existing.Seq))
 			})
 
 			It("closes the connection when the session does not exist", func() {


### PR DESCRIPTION
## Disposition

The original two accepted commits were audited against main and were not superseded: the managed-join sequence gap and concurrent outbound reordering still existed. The prior validated one-commit restack `7f70727a43cb25cae4f4aec2a20273b2737c6f63` has now been final-restacked, without semantic change, onto exact `origin/main` `baffc82c8bc5308ae9719144d0bf20c2560b0a33` after Linux wait repair #245 merged.

Mapping: `7f70727a43cb25cae4f4aec2a20273b2737c6f63` -> `5feef28ae0a635f0bd88563720b93f306c3dfc24`. Stable patch-id remains `c59a29727bae85aa7e7d1a2873f3062b25fe57a0`.

The change:
- serializes managed admission, sequence assignment, marshaling, and nonblocking delivery under one outbound lock
- broadcasts managed join state so existing clients retain a contiguous stream and the join state is the new client's first frame
- keeps suspending/process-exit delivery atomic with its state transition, preventing a joiner from missing the stop and receiving stale `running` state
- preserves registry admission closure, suspended joins, and DAP/WebSocket coexistence

No debugger, protocol, or DAP implementation changes are required.

## Validation on `baffc82c`

- `go tool goimports -w` on all changed Go files (clean)
- targeted `-race` hub/server/DAP suites
- deterministic stop/state join-race regression repeated 20 times
- hub concurrent join/broadcast stress repeated 20 suite runs
- real WebSocket join ordering repeated 20 suite runs
- DAP join/suspended-welcome tests repeated 20 times
- `go vet -tags bingonative ./...`
- `go test -tags bingonative ./...`
- `go test -tags bingonative -race ./...`
- fresh independent review against post-#245 main: no findings

Fixes #132
