### PR TITLE
fix(dap): reject overlapping restart requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1034,6 +1034,15 @@ context; arrow navigation moves DOM focus with selection.
    (`pendingContinues++`). Restart reuses a `restarting` flag so the post-restart
    entry `EventStepped` is treated as a fresh entry.
 
+`restartReqSeq` separately gates only an unanswered DAP restart. A second
+request before `EventRestarted`/`EventError` is rejected without enqueueing
+another destructive `CmdRestart`; once the response is sent, a new restart is
+allowed even if the prior process's entry stop has not arrived yet. In that
+race, `onStop` suppresses the superseded entry while a newer `restartReqSeq` is
+pending and preserves `restarting` for the replacement process. This relies on
+the hub/client FIFO ordering each restart's `EventRestarted` before its own
+entry `EventStepped`.
+
 ### Joining an existing session (no relaunch)
 
 A DAP `attach` carrying a `session` argument and **no** `pid` means "join an

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -138,6 +138,13 @@ func (h *Handler) onStop(evt protocol.Event) {
 
 	// The first Stepped after a Restart is the new process's entry stop.
 	if restarting && evt.Kind == protocol.EventStepped {
+		if h.restartReqSeq != 0 {
+			// EventRestarted precedes its process's entry in the hub/client FIFO.
+			// A pending newer response makes this the superseded process's entry;
+			// preserve the latch for the replacement process.
+			h.mu.Unlock()
+			return
+		}
 		h.restarting = false
 		if stopOnEntry {
 			h.suspended = true

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -83,6 +83,32 @@ func (r *cmdRecorder) waitForCommands(t *testing.T, kind protocol.CommandKind, c
 	return nil
 }
 
+func (r *cmdRecorder) count(kind protocol.CommandKind) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := 0
+	for _, cmd := range r.cmds {
+		if cmd.Kind == kind {
+			count++
+		}
+	}
+	return count
+}
+
+func (r *cmdRecorder) requireNoAdditionalCommands(t *testing.T, kind protocol.CommandKind, expected int) {
+	t.Helper()
+	deadline := time.Now().Add(50 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if got := r.count(kind); got != expected {
+			t.Fatalf("%s command count = %d, want %d throughout quiet period; saw %v", kind, got, expected, r.kinds())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if got := r.count(kind); got != expected {
+		t.Fatalf("%s command count = %d, want %d after quiet period; saw %v", kind, got, expected, r.kinds())
+	}
+}
+
 type fakeSession struct {
 	id      string
 	cmds    *cmdRecorder
@@ -777,15 +803,43 @@ func TestRestartRejectsOverlappingRequest(t *testing.T) {
 	if rejected.RequestSeq != secondSeq || rejected.Success || rejected.Message != "restart already in progress" {
 		t.Fatalf("overlapping restart response = %+v, want immediate error for request %d", rejected.Response, secondSeq)
 	}
-	if commands := hh.cmds.waitForCommands(t, protocol.CmdRestart, 1); len(commands) != 1 {
-		t.Fatalf("restart commands = %d, want exactly 1", len(commands))
-	}
+	hh.cmds.waitForCommands(t, protocol.CmdRestart, 1)
+	hh.cmds.requireNoAdditionalCommands(t, protocol.CmdRestart, 1)
 
 	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
 	restarted := recvType[*godap.RestartResponse](hh)
 	if restarted.RequestSeq != firstSeq || !restarted.Success {
 		t.Fatalf("restart response = %+v, want success for original request %d", restarted.Response, firstSeq)
 	}
+}
+
+func TestRestartAfterSuccessSupersedesPendingEntry(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+
+	firstSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	first := recvType[*godap.RestartResponse](hh)
+	if first.RequestSeq != firstSeq || !first.Success {
+		t.Fatalf("first restart response = %+v, want success for request %d", first.Response, firstSeq)
+	}
+
+	secondSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommands(t, protocol.CmdRestart, 2)
+
+	continues := hh.cmds.count(protocol.CmdContinue)
+	hh.inject(protocol.EventStepped, protocol.SteppedPayload{Goroutine: protocol.Goroutine{ID: 1}})
+	hh.cmds.requireNoAdditionalCommands(t, protocol.CmdContinue, continues)
+
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	second := recvType[*godap.RestartResponse](hh)
+	if second.RequestSeq != secondSeq || !second.Success {
+		t.Fatalf("second restart response = %+v, want success for request %d", second.Response, secondSeq)
+	}
+	hh.inject(protocol.EventStepped, protocol.SteppedPayload{Goroutine: protocol.Goroutine{ID: 2}})
+	hh.cmds.waitForCommands(t, protocol.CmdContinue, continues+1)
+	hh.inject(protocol.EventContinued, protocol.ContinuedPayload{})
 }
 
 func TestRestartErrorAllowsRetry(t *testing.T) {

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -767,6 +767,50 @@ func TestRestartedPayloadDecodeFailureStillResponds(t *testing.T) {
 	}
 }
 
+func TestRestartRejectsOverlappingRequest(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+
+	firstSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	secondSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	rejected := recvType[*godap.ErrorResponse](hh)
+	if rejected.RequestSeq != secondSeq || rejected.Success || rejected.Message != "restart already in progress" {
+		t.Fatalf("overlapping restart response = %+v, want immediate error for request %d", rejected.Response, secondSeq)
+	}
+	if commands := hh.cmds.waitForCommands(t, protocol.CmdRestart, 1); len(commands) != 1 {
+		t.Fatalf("restart commands = %d, want exactly 1", len(commands))
+	}
+
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != firstSeq || !restarted.Success {
+		t.Fatalf("restart response = %+v, want success for original request %d", restarted.Response, firstSeq)
+	}
+}
+
+func TestRestartErrorAllowsRetry(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+
+	firstSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: protocol.CmdRestart, Message: "relaunch failed"})
+	failed := recvType[*godap.ErrorResponse](hh)
+	if failed.RequestSeq != firstSeq || failed.Success {
+		t.Fatalf("failed restart response = %+v, want error for request %d", failed.Response, firstSeq)
+	}
+
+	secondSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	if commands := hh.cmds.waitForCommands(t, protocol.CmdRestart, 2); len(commands) != 2 {
+		t.Fatalf("restart commands after retry = %d, want 2", len(commands))
+	}
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != secondSeq || !restarted.Success {
+		t.Fatalf("retried restart response = %+v, want success for request %d", restarted.Response, secondSeq)
+	}
+}
+
 func TestRestartPreservesBreakpointCorrelationQueues(t *testing.T) {
 	h := NewHandler(nil, nil, nil)
 	setSlot := &bpSlot{}

--- a/internal/dap/requests.go
+++ b/internal/dap/requests.go
@@ -507,17 +507,20 @@ func (h *Handler) onTerminate(req *godap.TerminateRequest) {
 
 func (h *Handler) onRestart(req *godap.RestartRequest) {
 	h.mu.Lock()
+	if h.restarting {
+		h.mu.Unlock()
+		h.send(h.errorResponse(req.Seq, "restart", "restart already in progress"))
+		return
+	}
 	hasSession := h.session != nil
-	h.restarting = true
-	h.restartReqSeq = req.Seq
-	h.suspended = false
+	if hasSession {
+		h.restarting = true
+		h.restartReqSeq = req.Seq
+		h.suspended = false
+	}
 	h.mu.Unlock()
 
 	if !hasSession {
-		h.mu.Lock()
-		h.restarting = false
-		h.restartReqSeq = 0
-		h.mu.Unlock()
 		h.send(h.errorResponse(req.Seq, "restart", "no session to restart"))
 		return
 	}

--- a/internal/dap/requests.go
+++ b/internal/dap/requests.go
@@ -507,7 +507,9 @@ func (h *Handler) onTerminate(req *godap.TerminateRequest) {
 
 func (h *Handler) onRestart(req *godap.RestartRequest) {
 	h.mu.Lock()
-	if h.restarting {
+	// restartReqSeq gates only the unanswered DAP request. restarting stays set
+	// longer so the subsequent entry EventStepped is still recognized.
+	if h.restartReqSeq != 0 {
 		h.mu.Unlock()
 		h.send(h.errorResponse(req.Seq, "restart", "restart already in progress"))
 		return


### PR DESCRIPTION
## Summary
- synchronously reject a DAP restart only while another restart request is awaiting its `EventRestarted`/`EventError` response
- preserve the original request sequence and enqueue only one destructive `CmdRestart` for genuinely overlapping requests
- keep response admission separate from the `restarting` entry latch, allowing a new restart after success while suppressing a superseded process's pending entry stop
- cover the immediate overlap error, bounded no-extra-command interval, original request success, failure-then-retry cleanup, and accepted restart after prior success
- document the response/entry state split and the hub/client FIFO ordering it relies on

## Stack
This is stack layer 2 atop draft PR #138. Its base must remain `xsachax-fix-dap-restart-breakpoints`; layer 1 owns breakpoint reconciliation and is unchanged here.

## Tests
- `go test -tags bingonative -race ./internal/dap/... ./internal/hub/... ./pkg/protocol/...`
- `go test -tags bingonative -race ./internal/dap -run '^(TestRestartRejectsOverlappingRequest|TestRestartAfterSuccessSupersedesPendingEntry|TestRestartErrorAllowsRetry)$' -count=50`
- `go vet -tags bingonative ./...`
- `go tool goimports -d internal/dap/requests.go internal/dap/events.go internal/dap/handler_test.go`
- lefthook pre-commit goimports and commit-message checks

Fixes #142