### PR TITLE
test(integration): scale churn watchdog with iterations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -459,10 +459,12 @@ are detected by a `mach_msg` receive loop.
   tracer-thread handoff entirely (mirrors Delve). This is load-bearing for the
   goroutine snapshot: it issues dozens of small reads per stop across every live
   goroutine, and the old word-at-a-time-PEEKDATA-through-execPtrace path made a
-  snapshot-on-every-breakpoint so slow it pushed the `churn` e2e past its
-  target's 180s watchdog. The fallback keeps the original error semantics for
-  genuinely-unmapped addresses. (Darwin was never affected — it already
-  bulk-reads via `mach_vm_read`.)
+  snapshot-on-every-breakpoint so slow it pushed the `churn` e2e into its
+  then-fixed 180s target watchdog. The harness now derives that watchdog from
+  `BINGO_E2E_CHURN_ITERS` (2s per iteration plus 60s) before compiling the
+  target, so the tuning knob scales both test work and target lifetime. The
+  fallback keeps the original error semantics for genuinely-unmapped addresses.
+  (Darwin was never affected — it already bulk-reads via `mach_vm_read`.)
 - Single-step vs breakpoint disambiguation uses **both** `stepping` and
   `stepTID` (the exact TID `SingleStep` was issued against). Only a `cause==0`
   SIGTRAP on `stepTID` is the step's completion; the same stop on any other

--- a/test/integration/churn_watchdog_test.go
+++ b/test/integration/churn_watchdog_test.go
@@ -1,0 +1,120 @@
+package integration
+
+import (
+	"go/parser"
+	"go/token"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	churnWatchdogPlaceholder  = "__BINGO_CHURN_WATCHDOG_SECONDS__"
+	churnWatchdogPerIteration = 2 * time.Second
+	churnWatchdogMargin       = 60 * time.Second
+)
+
+// churnTargetSrcTemplate forces continuous OS-thread creation/teardown
+// (LockOSThread + short sleeps across GOMAXPROCS worker goroutines) so that
+// breakpoint stops and single-steps happen in a genuinely multi-threaded
+// context. This reproduces the darwin single-step race and stresses linux
+// clone/thread-exit handling.
+const churnTargetSrcTemplate = `package main
+
+import (
+	"os"
+	"runtime"
+	"sync/atomic"
+	"time"
+)
+
+var sink int64
+
+func churn() {
+	for {
+		runtime.LockOSThread()
+		var x int64
+		for i := 0; i < 2000; i++ {
+			x += int64(i)
+		}
+		atomic.AddInt64(&sink, x)
+		runtime.UnlockOSThread()
+		time.Sleep(50 * time.Microsecond)
+	}
+}
+
+func work(n int) int64 {
+	var s int64
+	for i := 0; i < n; i++ {
+		s += int64(i)
+	}
+	return s
+}
+
+func main() {
+	go func() { time.Sleep(__BINGO_CHURN_WATCHDOG_SECONDS__ * time.Second); os.Exit(0) }()
+	runtime.GOMAXPROCS(4)
+	for i := 0; i < 8; i++ {
+		go churn()
+	}
+	x := int64(0)
+	for i := 0; i < 1000000; i++ {
+		x += work(i % 50) // BP
+		x++
+		time.Sleep(time.Millisecond)
+		_ = x
+	}
+}
+`
+
+func churnWatchdogBudget(iterations int) time.Duration {
+	if iterations < 0 {
+		iterations = 0
+	}
+	return time.Duration(iterations)*churnWatchdogPerIteration + churnWatchdogMargin
+}
+
+func churnTargetSource(iterations int) (string, time.Duration) {
+	budget := churnWatchdogBudget(iterations)
+	seconds := strconv.FormatInt(int64(budget/time.Second), 10)
+	return strings.Replace(churnTargetSrcTemplate, churnWatchdogPlaceholder, seconds, 1), budget
+}
+
+func TestChurnTargetSource(t *testing.T) {
+	if count := strings.Count(churnTargetSrcTemplate, churnWatchdogPlaceholder); count != 1 {
+		t.Fatalf("watchdog placeholder count = %d, want 1", count)
+	}
+
+	tests := []struct {
+		name        string
+		iterations  int
+		wantBudget  time.Duration
+		wantSeconds string
+	}{
+		{name: "default", iterations: 200, wantBudget: 460 * time.Second, wantSeconds: "460"},
+		{name: "scaled", iterations: 400, wantBudget: 860 * time.Second, wantSeconds: "860"},
+		{name: "negative", iterations: -1, wantBudget: 60 * time.Second, wantSeconds: "60"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source, budget := churnTargetSource(tt.iterations)
+			if budget != tt.wantBudget {
+				t.Fatalf("watchdog budget = %s, want %s", budget, tt.wantBudget)
+			}
+			if strings.Contains(source, churnWatchdogPlaceholder) {
+				t.Fatal("rendered source still contains watchdog placeholder")
+			}
+			if !strings.Contains(source, "time.Sleep("+tt.wantSeconds+" * time.Second)") {
+				t.Fatalf("rendered source does not contain %s-second watchdog", tt.wantSeconds)
+			}
+			if !strings.Contains(source, "i % 50") {
+				t.Fatal("rendering changed the target's modulo expression")
+			}
+			if _, err := parser.ParseFile(token.NewFileSet(), "churn_target.go", source, 0); err != nil {
+				t.Fatalf("rendered source is invalid Go: %v", err)
+			}
+		})
+	}
+}

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -19,7 +19,7 @@
 // Tuning env vars:
 //
 //	BINGO_E2E_ITERS        (default 25)   basic continue+stepover iterations
-//	BINGO_E2E_CHURN_ITERS  (default 200)  iterations under thread churn
+//	BINGO_E2E_CHURN_ITERS  (default 200)  churn iterations and target watchdog budget
 //	BINGO_E2E_DEBUG        (unset)        route engine debug logs + every event to stderr
 
 package integration
@@ -79,59 +79,6 @@ func main() {
 	x := 0
 	for i := 0; i < 1000000; i++ {
 		x += compute(i % 10) // BP
-		x++
-		time.Sleep(time.Millisecond)
-		_ = x
-	}
-}
-`
-
-// churnTargetSrc forces continuous OS-thread creation/teardown (LockOSThread +
-// short sleeps across GOMAXPROCS worker goroutines) so that breakpoint stops
-// and single-steps happen in a genuinely multi-threaded context. This is the
-// scenario that reproduces the darwin single-step race and stresses linux
-// clone/thread-exit handling.
-const churnTargetSrc = `package main
-
-import (
-	"os"
-	"runtime"
-	"sync/atomic"
-	"time"
-)
-
-var sink int64
-
-func churn() {
-	for {
-		runtime.LockOSThread()
-		var x int64
-		for i := 0; i < 2000; i++ {
-			x += int64(i)
-		}
-		atomic.AddInt64(&sink, x)
-		runtime.UnlockOSThread()
-		time.Sleep(50 * time.Microsecond)
-	}
-}
-
-func work(n int) int64 {
-	var s int64
-	for i := 0; i < n; i++ {
-		s += int64(i)
-	}
-	return s
-}
-
-func main() {
-	go func() { time.Sleep(180 * time.Second); os.Exit(0) }()
-	runtime.GOMAXPROCS(4)
-	for i := 0; i < 8; i++ {
-		go churn()
-	}
-	x := int64(0)
-	for i := 0; i < 1000000; i++ {
-		x += work(i % 50) // BP
 		x++
 		time.Sleep(time.Millisecond)
 		_ = x
@@ -409,16 +356,23 @@ func declareBasicStepOverSpec() {
 // note above).
 func declareChurnSpec() {
 	It("survives continue+step-over under continuous thread churn", Label("churn"), func() {
-		line := markerLine(churnTargetSrc, "// BP")
-		bin := buildTarget("churn_target", churnTargetSrc)
+		iters := envInt("BINGO_E2E_CHURN_ITERS", 200)
+		targetSource, watchdogBudget := churnTargetSource(iters)
+		AddReportEntry("churn-watchdog-budget", watchdogBudget.String())
 
+		line := markerLine(targetSource, "// BP")
+		bin := buildTarget("churn_target", targetSource)
+
+		started := time.Now()
+		defer func() {
+			AddReportEntry("churn-elapsed", time.Since(started).Round(time.Millisecond).String())
+		}()
 		h := newE2EHarness(bin)
 		h.waitFor(20*time.Second, protocol.EventStepped)
 
 		_, err := h.d.SetBreakpoint("churn_target.go", line)
 		Expect(err).NotTo(HaveOccurred(), "SetBreakpoint")
 
-		iters := envInt("BINGO_E2E_CHURN_ITERS", 200)
 		for i := 0; i < iters; i++ {
 			Expect(h.d.Continue()).To(Succeed(), "Continue #%d", i)
 			evt := h.waitFor(20*time.Second,


### PR DESCRIPTION
## Summary

- derive the churn target watchdog from `BINGO_E2E_CHURN_ITERS` as `2s * iterations + 60s`
- render the budget into the target source before compilation while preserving the default 200 iterations and every `Continue`/`StepOver` assertion
- add deterministic budget/source coverage, report watchdog budget and elapsed time, and document the harness invariant

## Root cause

The race-enabled 200-iteration Linux churn spec now takes roughly 177–181 seconds, but its target always called `os.Exit(0)` after 180 seconds. That safety watchdog raced the last assertions and made unrelated changes fail with `ProcessExited` despite correct debugger behavior. This change is test-harness-only and has no product-runtime impact.

## Validation

- `go test -tags bingonative -count=1 ./test/integration -run '^TestChurnTargetSource$'`
- `go test -tags 'e2e bingonative' -count=1 ./test/integration -run '^TestChurnTargetSource$'`
- `go test -tags bingonative ./...`
- `go vet -tags bingonative ./...`

Darwin cannot execute the Linux ptrace path locally. The PR's Linux `churn` CI job is the runtime acceptance gate. A Linux stress verifier can run:

```sh
BINGO_E2E_CHURN_ITERS=400 go test -tags e2e -race -count=1 -v -timeout 1200s ./test/integration -ginkgo.label-filter=churn
```

Fixes #146