### PR TITLE
fix(client): fence correlatable replies after timeouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,13 +275,33 @@ created via `hub.New(dbg, log)` (tests / single-session) do not.
 In [pkg/client](pkg/client/), the `Client` interface splits methods by what
 they wait for:
 
-- **Synchronous** (`SetBreakpoint`, `ClearBreakpoint`, `Locals`, `StackFrames`,
-  `Goroutines`): block until the matching confirmation event (or `EventError`
-  for the same command kind) arrives. Implemented via `sendAndWait` in
-  [pkg/client/ws.go](pkg/client/ws.go).
-- **Fire-and-forget** (`Launch`, `Attach`, `Kill`, `Continue`, `Step*`):
+- **Synchronous** (`Restart`, `SetBreakpoint`, `ClearBreakpoint`, `Locals`,
+  `Evaluate`, `StackFrames`, `Goroutines`, `GoroutineSnapshot`): block until
+  the matching confirmation event (or `EventError` for the same command kind)
+  arrives. Implemented via `sendAndWait` in [pkg/client/ws.go](pkg/client/ws.go).
+- **Fire-and-forget** (`Launch`, `Attach`, `Kill`, `Continue`, `Step*`, `Pause`):
   return as soon as the command is on the wire. Results arrive asynchronously
   on the `Events()` channel.
+
+`syncMu` serializes synchronous commands, but a timeout does **not** cancel the
+command already sent to the server. The pending queue therefore retains a
+timed-out request as retired reply debt until its matching confirmation or
+matching `EventError` arrives. `routeToPending` always claims and removes the
+oldest matching entry under `pendingMu` before notifying a live waiter; retired
+matches are consumed without notification. This prevents a late response from
+one of this client's timed-out commands from satisfying a newer same-kind call,
+and prevents back-to-back matching frames from blocking the read pump on a
+waiter's one-element channel. If a debt never resolves, a newer same-kind call
+must time out rather than accept an ambiguous reply; subsequent same-kind calls
+continue timing out while that reply stream remains one response short. Keep the
+WebSocket open: disconnecting the last client tears down the hub/debuggee, while
+unrelated async events remain valid.
+
+This is deliberately bounded by the id-less broadcast protocol. The queue
+preserves this client's ordered command stream; it cannot distinguish an
+unsolicited same-kind event or confirmation caused by another driving client.
+The single-driver caveat still applies until the wire protocol gains correlation
+IDs.
 
 ## Engine concurrency model — non-obvious invariants
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,15 @@ continue timing out while that reply stream remains one response short. Keep the
 WebSocket open: disconnecting the last client tears down the hub/debuggee, while
 unrelated async events remain valid.
 
+`GoroutineSnapshot` is a temporary exception to timeout debt because
+`EventGoroutineSnapshot` is dual-purpose: it confirms `CmdGoroutineSnapshot`
+and is also pushed automatically after breakpoint, pause, and entry stops. A
+timed-out snapshot request is removed from the pending queue so it cannot consume
+the next unrelated telemetry snapshot. A genuinely late query reply therefore
+falls through to `Events()` too; the client cannot distinguish the two without
+wire correlation. The dependent snapshot/API cleanup removes this synchronous
+query surface rather than expanding the exception here.
+
 This is deliberately bounded by the id-less broadcast protocol. The queue
 preserves this client's ordered command stream; it cannot distinguish an
 unsolicited same-kind event or confirmation caused by another driving client.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,10 +301,12 @@ unrelated async events remain valid.
 `EventGoroutineSnapshot` is dual-purpose: it confirms `CmdGoroutineSnapshot`
 and is also pushed automatically after breakpoint, pause, and entry stops. A
 timed-out snapshot request is removed from the pending queue so it cannot consume
-the next unrelated telemetry snapshot. A genuinely late query reply therefore
-falls through to `Events()` too; the client cannot distinguish the two without
-wire correlation. The dependent snapshot/API cleanup removes this synchronous
-query surface rather than expanding the exception here.
+the next unrelated telemetry snapshot. This preserves the stream, not
+correlation: while the legacy synchronous API exists, a genuinely late query
+reply or an unrelated automatic push can still satisfy a later in-flight
+`GoroutineSnapshot` waiter; without a waiter, either falls through to `Events()`.
+Issue #187 and stacked PR #192 remove the synchronous query surface and that
+ambiguity rather than expanding the exception here.
 
 This is deliberately bounded by the id-less broadcast protocol. The queue
 preserves this client's ordered command stream; it cannot distinguish an

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -242,11 +242,12 @@ unrelated asynchronous events remain valid.
 `GoroutineSnapshot` is the temporary exception. Its confirmation event is also
 unsolicited telemetry emitted after breakpoint, pause, and entry stops, so a
 timed-out snapshot request is discarded instead of retired as debt. Otherwise
-the next auto-pushed snapshot would disappear into the retired query. A
-genuinely late query reply consequently reaches `Events()`; the id-less protocol
-cannot distinguish it from an automatic snapshot. The dependent snapshot/API
-cleanup removes this synchronous query rather than redesigning its semantics
-here.
+the next auto-pushed snapshot would disappear into the retired query. This
+preserves telemetry but cannot create correlation: while the legacy synchronous
+API exists, either a genuinely late query reply or an automatic push can satisfy
+a later in-flight snapshot waiter; with no waiter, either reaches `Events()`.
+Issue #187 and stacked PR #192 remove the synchronous query and that ambiguity
+rather than redesigning its semantics here.
 
 This fence covers only the serialized command stream sent by that client.
 Confirmation events carry no request ID and are broadcast to every client, so

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -239,6 +239,15 @@ events. The client must not close the whole connection as timeout recovery
 because a last-client disconnect tears down the session and debuggee, while
 unrelated asynchronous events remain valid.
 
+`GoroutineSnapshot` is the temporary exception. Its confirmation event is also
+unsolicited telemetry emitted after breakpoint, pause, and entry stops, so a
+timed-out snapshot request is discarded instead of retired as debt. Otherwise
+the next auto-pushed snapshot would disappear into the retired query. A
+genuinely late query reply consequently reaches `Events()`; the id-less protocol
+cannot distinguish it from an automatic snapshot. The dependent snapshot/API
+cleanup removes this synchronous query rather than redesigning its semantics
+here.
+
 This fence covers only the serialized command stream sent by that client.
 Confirmation events carry no request ID and are broadcast to every client, so
 an unsolicited same-kind event or another driver's confirmation remains
@@ -312,4 +321,4 @@ server-side `slog` output and map to short client-facing messages there. The
 | Methods not on the `Debugger` interface          | Keep unexported on `engine`; return errors up the synchronous chain to the loop               |
 | Server → WebSocket client error                  | Broadcast a typed `EventError`; message text is intentionally surfaced (local tool)           |
 | Incompatible WebSocket envelope                  | Close only that peer with code 1002; never broadcast or allocate a hub sequence                |
-| Timed-out synchronous client command             | Retain ordered reply debt; consume its late reply/error before notifying a newer waiter       |
+| Timed-out synchronous client command             | Retain ordered reply debt, except discard the dual-purpose snapshot query to preserve telemetry |

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -213,11 +213,11 @@ dropped.
 ### Synchronous vs. fire-and-forget at the client boundary
 
 `pkg/client` splits methods by what they wait for. Synchronous methods
-(`SetBreakpoint`, `Locals`, `StackFrames`, `Goroutines`, `ClearBreakpoint`)
-block on their confirmation event **or** an `EventError` for the same command
-kind — see [`sendAndWait` / `routeToPending`](../pkg/client/ws.go). An
-`EventError` whose `Command` matches is turned back into a Go `error` for the
-caller:
+(`Restart`, `SetBreakpoint`, `ClearBreakpoint`, `Locals`, `Evaluate`,
+`StackFrames`, `Goroutines`, `GoroutineSnapshot`) block on their confirmation
+event **or** an `EventError` for the same command kind — see
+[`sendAndWait` / `routeToPending`](../pkg/client/ws.go). An `EventError` whose
+`Command` matches is turned back into a Go `error` for the caller:
 
 ```go
 case evt := <-ch:
@@ -228,10 +228,27 @@ case evt := <-ch:
     }
 ```
 
-Fire-and-forget methods (`Launch`, `Attach`, `Kill`, `Continue`, `Step*`) return
-once the command is on the wire; their results — including asynchronous
-`EventError`s with `Command == CmdNone` — arrive on `Events()` and are printed
-by the CLI's event loop.
+A synchronous timeout does not cancel the command on the server. Its pending
+entry becomes retired reply debt and stays ordered ahead of newer same-kind
+requests until a matching confirmation or matching `EventError` consumes it.
+The read pump claims and removes a match under `pendingMu` before sending to a
+live waiter's one-element channel; a retired match is consumed without a send.
+If the old reply never arrives, the same-kind reply stream stays one response
+behind and subsequent calls time out safely instead of accepting ambiguous
+events. The client must not close the whole connection as timeout recovery
+because a last-client disconnect tears down the session and debuggee, while
+unrelated asynchronous events remain valid.
+
+This fence covers only the serialized command stream sent by that client.
+Confirmation events carry no request ID and are broadcast to every client, so
+an unsolicited same-kind event or another driver's confirmation remains
+indistinguishable. That multi-driver limitation requires wire-level correlation
+IDs rather than more client-side guessing.
+
+Fire-and-forget methods (`Launch`, `Attach`, `Kill`, `Continue`, `Step*`,
+`Pause`) return once the command is on the wire; their results — including
+asynchronous `EventError`s with `Command == CmdNone` — arrive on `Events()` and
+are printed by the CLI's event loop.
 
 ## 8. Propagating errors to clients: typed `EventError`
 
@@ -295,3 +312,4 @@ server-side `slog` output and map to short client-facing messages there. The
 | Methods not on the `Debugger` interface          | Keep unexported on `engine`; return errors up the synchronous chain to the loop               |
 | Server → WebSocket client error                  | Broadcast a typed `EventError`; message text is intentionally surfaced (local tool)           |
 | Incompatible WebSocket envelope                  | Close only that peer with code 1002; never broadcast or allocate a hub sequence                |
+| Timed-out synchronous client command             | Retain ordered reply debt; consume its late reply/error before notifying a newer waiter       |

--- a/pkg/client/ws.go
+++ b/pkg/client/ws.go
@@ -252,7 +252,13 @@ func (c *wsClient) sendAndWait(cmd protocol.Command, wantKind protocol.EventKind
 		}
 		return evt, nil
 	case <-time.After(syncTimeout):
-		c.retirePending(req)
+		if cmd.Kind == protocol.CmdGoroutineSnapshot && wantKind == protocol.EventGoroutineSnapshot {
+			// Snapshot events are also unsolicited telemetry; debt would consume
+			// the next auto-pushed snapshot instead of delivering it to Events.
+			c.discardPending(req)
+		} else {
+			c.retirePending(req)
+		}
 		return protocol.Event{}, fmt.Errorf("timeout waiting for %s response", wantKind)
 	case <-c.done:
 		c.discardPending(req)

--- a/pkg/client/ws.go
+++ b/pkg/client/ws.go
@@ -15,13 +15,14 @@ import (
 var _ Client = (*wsClient)(nil)
 
 const (
-	syncTimeout     = 10 * time.Second
 	dialTimeout     = 5 * time.Second
 	eventBufferSize = 64
 )
 
-// pendingReq is a synchronous method blocked on its confirmation event (or an
-// EventError for the same command kind).
+var syncTimeout = 10 * time.Second
+
+// pendingReq keeps its place after a timeout because the server command is not
+// cancelled. A nil ch marks reply debt whose eventual response must be consumed.
 type pendingReq struct {
 	wantKind protocol.EventKind
 	cmdKind  protocol.CommandKind
@@ -41,10 +42,10 @@ type wsClient struct {
 	// syncMu serialises sendAndWait so one in-flight pending request at a time.
 	syncMu sync.Mutex
 
-	// pending: read-pump checks this on every event and routes matching
-	// confirmations / errors to pending.ch instead of the public events chan.
+	// pending preserves request order across timeouts so a late reply cannot be
+	// mistaken for a newer same-kind request.
 	pendingMu sync.Mutex
-	pending   *pendingReq
+	pending   []*pendingReq
 
 	// writeMu: gorilla allows one concurrent reader and one concurrent writer.
 	writeMu sync.Mutex
@@ -144,28 +145,67 @@ func (c *wsClient) readPump() {
 }
 
 func (c *wsClient) routeToPending(evt protocol.Event) bool {
-	c.pendingMu.Lock()
-	p := c.pending
-	c.pendingMu.Unlock()
-
-	if p == nil {
-		return false
-	}
-
-	if evt.Kind == p.wantKind {
-		p.ch <- evt
-		return true
-	}
-
+	var errorCommand protocol.CommandKind
 	if evt.Kind == protocol.EventError {
 		var ep protocol.ErrorPayload
-		if protocol.DecodeEventPayload(evt, &ep) == nil && ep.Command == p.cmdKind {
-			p.ch <- evt
-			return true
+		if protocol.DecodeEventPayload(evt, &ep) != nil {
+			return false
 		}
+		errorCommand = ep.Command
 	}
 
+	c.pendingMu.Lock()
+	for i, p := range c.pending {
+		matches := evt.Kind == p.wantKind
+		if evt.Kind == protocol.EventError {
+			matches = errorCommand == p.cmdKind
+		}
+		if !matches {
+			continue
+		}
+
+		ch := p.ch
+		c.removePendingAt(i)
+		c.pendingMu.Unlock()
+
+		if ch != nil {
+			ch <- evt
+		}
+		return true
+	}
+	c.pendingMu.Unlock()
+
 	return false
+}
+
+func (c *wsClient) removePendingAt(i int) {
+	copy(c.pending[i:], c.pending[i+1:])
+	c.pending[len(c.pending)-1] = nil
+	c.pending = c.pending[:len(c.pending)-1]
+}
+
+func (c *wsClient) discardPending(req *pendingReq) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+
+	for i, p := range c.pending {
+		if p == req {
+			c.removePendingAt(i)
+			return
+		}
+	}
+}
+
+func (c *wsClient) retirePending(req *pendingReq) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+
+	for _, p := range c.pending {
+		if p == req {
+			p.ch = nil
+			return
+		}
+	}
 }
 
 func (c *wsClient) send(cmd protocol.Command) error {
@@ -195,16 +235,11 @@ func (c *wsClient) sendAndWait(cmd protocol.Command, wantKind protocol.EventKind
 	req := &pendingReq{wantKind: wantKind, cmdKind: cmd.Kind, ch: ch}
 
 	c.pendingMu.Lock()
-	c.pending = req
+	c.pending = append(c.pending, req)
 	c.pendingMu.Unlock()
 
-	defer func() {
-		c.pendingMu.Lock()
-		c.pending = nil
-		c.pendingMu.Unlock()
-	}()
-
 	if err := c.send(cmd); err != nil {
+		c.discardPending(req)
 		return protocol.Event{}, err
 	}
 
@@ -217,8 +252,10 @@ func (c *wsClient) sendAndWait(cmd protocol.Command, wantKind protocol.EventKind
 		}
 		return evt, nil
 	case <-time.After(syncTimeout):
+		c.retirePending(req)
 		return protocol.Event{}, fmt.Errorf("timeout waiting for %s response", wantKind)
 	case <-c.done:
+		c.discardPending(req)
 		if err := c.terminalReadError(); err != nil {
 			return protocol.Event{}, err
 		}

--- a/pkg/client/ws_pending_test.go
+++ b/pkg/client/ws_pending_test.go
@@ -1,0 +1,425 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+
+	"github.com/gorilla/websocket"
+)
+
+type acceptedWebSocket struct {
+	conn *websocket.Conn
+	err  error
+}
+
+type loopbackClient struct {
+	client    *wsClient
+	conn      *websocket.Conn
+	server    *httptest.Server
+	release   chan struct{}
+	closeOnce sync.Once
+}
+
+func newLoopbackClient(t *testing.T) *loopbackClient {
+	t.Helper()
+
+	accepted := make(chan acceptedWebSocket, 1)
+	release := make(chan struct{})
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			accepted <- acceptedWebSocket{err: err}
+			return
+		}
+
+		welcome, err := protocol.MarshalEvent(protocol.MustEvent(
+			protocol.EventSessionState,
+			1,
+			protocol.SessionStatePayload{
+				SessionID: "test-session",
+				State:     protocol.StateIdle,
+				Clients:   1,
+			},
+		))
+		if err != nil {
+			accepted <- acceptedWebSocket{err: err}
+			_ = conn.Close()
+			return
+		}
+		if err := conn.WriteMessage(websocket.TextMessage, welcome); err != nil {
+			accepted <- acceptedWebSocket{err: err}
+			_ = conn.Close()
+			return
+		}
+
+		accepted <- acceptedWebSocket{conn: conn}
+		<-release
+		_ = conn.Close()
+	}))
+
+	rawClient, err := Create(strings.TrimPrefix(server.URL, "http://"))
+	if err != nil {
+		close(release)
+		server.Close()
+		t.Fatalf("Create: %v", err)
+	}
+
+	result := <-accepted
+	if result.err != nil {
+		_ = rawClient.Close()
+		close(release)
+		server.Close()
+		t.Fatalf("accept WebSocket: %v", result.err)
+	}
+
+	client, ok := rawClient.(*wsClient)
+	if !ok {
+		_ = rawClient.Close()
+		close(release)
+		server.Close()
+		t.Fatalf("client type = %T, want *wsClient", rawClient)
+	}
+
+	h := &loopbackClient{
+		client:  client,
+		conn:    result.conn,
+		server:  server,
+		release: release,
+	}
+	t.Cleanup(h.close)
+	return h
+}
+
+func (h *loopbackClient) close() {
+	h.closeOnce.Do(func() {
+		_ = h.client.Close()
+		close(h.release)
+		h.server.Close()
+	})
+}
+
+func (h *loopbackClient) readCommand(t *testing.T) protocol.Command {
+	t.Helper()
+
+	if err := h.conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set command read deadline: %v", err)
+	}
+	_, data, err := h.conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read command: %v", err)
+	}
+	if err := h.conn.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatalf("clear command read deadline: %v", err)
+	}
+
+	cmd, err := protocol.UnmarshalCommand(data)
+	if err != nil {
+		t.Fatalf("unmarshal command: %v", err)
+	}
+	return cmd
+}
+
+func (h *loopbackClient) writeEvent(t *testing.T, evt protocol.Event) {
+	t.Helper()
+
+	data, err := protocol.MarshalEvent(evt)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	if err := h.conn.SetWriteDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set event write deadline: %v", err)
+	}
+	if err := h.conn.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+	if err := h.conn.SetWriteDeadline(time.Time{}); err != nil {
+		t.Fatalf("clear event write deadline: %v", err)
+	}
+}
+
+func useSyncTimeout(t *testing.T, timeout time.Duration) {
+	t.Helper()
+
+	previous := syncTimeout
+	syncTimeout = timeout
+	t.Cleanup(func() {
+		syncTimeout = previous
+	})
+}
+
+type breakpointResult struct {
+	breakpoint protocol.Breakpoint
+	err        error
+}
+
+func callSetBreakpoint(c *wsClient, file string, line int) <-chan breakpointResult {
+	result := make(chan breakpointResult, 1)
+	go func() {
+		breakpoint, err := c.SetBreakpoint(file, line)
+		result <- breakpointResult{breakpoint: breakpoint, err: err}
+	}()
+	return result
+}
+
+func awaitBreakpoint(t *testing.T, result <-chan breakpointResult) breakpointResult {
+	t.Helper()
+
+	select {
+	case got := <-result:
+		return got
+	case <-time.After(2 * time.Second):
+		t.Fatal("SetBreakpoint did not return")
+		return breakpointResult{}
+	}
+}
+
+func awaitEvent(t *testing.T, events <-chan protocol.Event) protocol.Event {
+	t.Helper()
+
+	select {
+	case evt, ok := <-events:
+		if !ok {
+			t.Fatal("events channel closed")
+		}
+		return evt
+	case <-time.After(2 * time.Second):
+		t.Fatal("event did not arrive")
+		return protocol.Event{}
+	}
+}
+
+func assertCommandKind(t *testing.T, cmd protocol.Command, want protocol.CommandKind) {
+	t.Helper()
+
+	if cmd.Kind != want {
+		t.Fatalf("command kind = %s, want %s", cmd.Kind, want)
+	}
+}
+
+func TestTimedOutReplyDebtDoesNotSatisfyLaterRequest(t *testing.T) {
+	useSyncTimeout(t, 100*time.Millisecond)
+	h := newLoopbackClient(t)
+
+	first := callSetBreakpoint(h.client, "first.go", 10)
+	assertCommandKind(t, h.readCommand(t), protocol.CmdSetBreakpoint)
+	if result := awaitBreakpoint(t, first); result.err == nil || !strings.Contains(result.err.Error(), "timeout") {
+		t.Fatalf("first SetBreakpoint error = %v, want timeout", result.err)
+	}
+
+	localsResult := make(chan struct {
+		variables []protocol.Variable
+		err       error
+	}, 1)
+	go func() {
+		variables, err := h.client.Locals(0)
+		localsResult <- struct {
+			variables []protocol.Variable
+			err       error
+		}{variables: variables, err: err}
+	}()
+	assertCommandKind(t, h.readCommand(t), protocol.CmdLocals)
+	h.writeEvent(t, protocol.MustEvent(protocol.EventOutput, 2, protocol.OutputPayload{
+		Stream:  "stdout",
+		Content: "other-kind event",
+	}))
+	h.writeEvent(t, protocol.MustEvent(protocol.EventLocals, 3, protocol.LocalsPayload{
+		FrameIndex: 0,
+		Variables:  []protocol.Variable{{Name: "answer", Value: "42", Type: "int"}},
+	}))
+
+	select {
+	case result := <-localsResult:
+		if result.err != nil {
+			t.Fatalf("Locals: %v", result.err)
+		}
+		if len(result.variables) != 1 || result.variables[0].Value != "42" {
+			t.Fatalf("Locals variables = %+v", result.variables)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Locals did not return")
+	}
+	if evt := awaitEvent(t, h.client.Events()); evt.Kind != protocol.EventOutput {
+		t.Fatalf("async event kind = %s, want %s", evt.Kind, protocol.EventOutput)
+	}
+
+	second := callSetBreakpoint(h.client, "second.go", 20)
+	assertCommandKind(t, h.readCommand(t), protocol.CmdSetBreakpoint)
+	h.writeEvent(t, protocol.MustEvent(protocol.EventBreakpointSet, 4, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{
+			ID:       1,
+			Location: protocol.Location{File: "first.go", Line: 10},
+		},
+	}))
+	h.writeEvent(t, protocol.MustEvent(protocol.EventBreakpointSet, 5, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{
+			ID:       2,
+			Location: protocol.Location{File: "second.go", Line: 20},
+		},
+	}))
+	h.writeEvent(t, protocol.MustEvent(protocol.EventOutput, 6, protocol.OutputPayload{
+		Stream:  "stdout",
+		Content: "read pump active",
+	}))
+
+	result := awaitBreakpoint(t, second)
+	if result.err != nil {
+		t.Fatalf("second SetBreakpoint: %v", result.err)
+	}
+	if result.breakpoint.ID != 2 || result.breakpoint.Location.File != "second.go" {
+		t.Fatalf("second SetBreakpoint = %+v, want its own confirmation", result.breakpoint)
+	}
+	if evt := awaitEvent(t, h.client.Events()); evt.Kind != protocol.EventOutput {
+		t.Fatalf("post-reply event kind = %s, want %s", evt.Kind, protocol.EventOutput)
+	}
+
+	goroutinesResult := make(chan struct {
+		goroutines []protocol.Goroutine
+		err        error
+	}, 1)
+	go func() {
+		goroutines, err := h.client.Goroutines()
+		goroutinesResult <- struct {
+			goroutines []protocol.Goroutine
+			err        error
+		}{goroutines: goroutines, err: err}
+	}()
+	assertCommandKind(t, h.readCommand(t), protocol.CmdGoroutines)
+	h.writeEvent(t, protocol.MustEvent(protocol.EventGoroutines, 7, protocol.GoroutinesPayload{
+		Goroutines: []protocol.Goroutine{{ID: 9, Status: "waiting"}},
+	}))
+
+	select {
+	case result := <-goroutinesResult:
+		if result.err != nil {
+			t.Fatalf("Goroutines: %v", result.err)
+		}
+		if len(result.goroutines) != 1 || result.goroutines[0].ID != 9 {
+			t.Fatalf("Goroutines = %+v", result.goroutines)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Goroutines did not return")
+	}
+}
+
+func TestMatchingErrorConsumesReplyDebt(t *testing.T) {
+	useSyncTimeout(t, 100*time.Millisecond)
+	h := newLoopbackClient(t)
+
+	first := callSetBreakpoint(h.client, "first.go", 10)
+	assertCommandKind(t, h.readCommand(t), protocol.CmdSetBreakpoint)
+	if result := awaitBreakpoint(t, first); result.err == nil || !strings.Contains(result.err.Error(), "timeout") {
+		t.Fatalf("first SetBreakpoint error = %v, want timeout", result.err)
+	}
+
+	second := callSetBreakpoint(h.client, "second.go", 20)
+	assertCommandKind(t, h.readCommand(t), protocol.CmdSetBreakpoint)
+	h.writeEvent(t, protocol.MustEvent(protocol.EventError, 2, protocol.ErrorPayload{
+		Command: protocol.CmdSetBreakpoint,
+		Message: "first request failed late",
+	}))
+	h.writeEvent(t, protocol.MustEvent(protocol.EventBreakpointSet, 3, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{
+			ID:       2,
+			Location: protocol.Location{File: "second.go", Line: 20},
+		},
+	}))
+
+	result := awaitBreakpoint(t, second)
+	if result.err != nil {
+		t.Fatalf("second SetBreakpoint: %v", result.err)
+	}
+	if result.breakpoint.ID != 2 {
+		t.Fatalf("second SetBreakpoint = %+v, want ID 2", result.breakpoint)
+	}
+}
+
+func TestUnresolvedReplyDebtMakesLaterRequestTimeout(t *testing.T) {
+	useSyncTimeout(t, 100*time.Millisecond)
+	h := newLoopbackClient(t)
+
+	first := callSetBreakpoint(h.client, "first.go", 10)
+	assertCommandKind(t, h.readCommand(t), protocol.CmdSetBreakpoint)
+	if result := awaitBreakpoint(t, first); result.err == nil || !strings.Contains(result.err.Error(), "timeout") {
+		t.Fatalf("first SetBreakpoint error = %v, want timeout", result.err)
+	}
+
+	second := callSetBreakpoint(h.client, "second.go", 20)
+	assertCommandKind(t, h.readCommand(t), protocol.CmdSetBreakpoint)
+	h.writeEvent(t, protocol.MustEvent(protocol.EventBreakpointSet, 2, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{
+			ID:       2,
+			Location: protocol.Location{File: "second.go", Line: 20},
+		},
+	}))
+
+	result := awaitBreakpoint(t, second)
+	if result.err == nil || !strings.Contains(result.err.Error(), "timeout") {
+		t.Fatalf("second SetBreakpoint error = %v, want safe timeout", result.err)
+	}
+
+	localsResult := make(chan error, 1)
+	go func() {
+		_, err := h.client.Locals(0)
+		localsResult <- err
+	}()
+	assertCommandKind(t, h.readCommand(t), protocol.CmdLocals)
+	h.writeEvent(t, protocol.MustEvent(protocol.EventLocals, 3, protocol.LocalsPayload{FrameIndex: 0}))
+	select {
+	case err := <-localsResult:
+		if err != nil {
+			t.Fatalf("Locals after unresolved debt: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Locals after unresolved debt did not return")
+	}
+}
+
+func TestRouteToPendingClaimsBeforeDelivery(t *testing.T) {
+	ch := make(chan protocol.Event, 1)
+	client := &wsClient{
+		pending: []*pendingReq{{
+			wantKind: protocol.EventBreakpointSet,
+			cmdKind:  protocol.CmdSetBreakpoint,
+			ch:       ch,
+		}},
+	}
+	first := protocol.MustEvent(protocol.EventBreakpointSet, 1, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{ID: 1},
+	})
+	second := protocol.MustEvent(protocol.EventBreakpointSet, 2, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{ID: 2},
+	})
+
+	result := make(chan [2]bool, 1)
+	go func() {
+		result <- [2]bool{
+			client.routeToPending(first),
+			client.routeToPending(second),
+		}
+	}()
+
+	select {
+	case routed := <-result:
+		if !routed[0] || routed[1] {
+			t.Fatalf("route results = %v, want [true false]", routed)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("back-to-back matching events blocked pending delivery")
+	}
+
+	select {
+	case evt := <-ch:
+		if evt.Seq != first.Seq {
+			t.Fatalf("delivered seq = %d, want %d", evt.Seq, first.Seq)
+		}
+	default:
+		t.Fatal("first matching event was not delivered")
+	}
+}

--- a/pkg/client/ws_pending_test.go
+++ b/pkg/client/ws_pending_test.go
@@ -381,6 +381,53 @@ func TestUnresolvedReplyDebtMakesLaterRequestTimeout(t *testing.T) {
 	}
 }
 
+func TestTimedOutGoroutineSnapshotDoesNotConsumeAutoSnapshot(t *testing.T) {
+	useSyncTimeout(t, 100*time.Millisecond)
+	h := newLoopbackClient(t)
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := h.client.GoroutineSnapshot()
+		result <- err
+	}()
+	assertCommandKind(t, h.readCommand(t), protocol.CmdGoroutineSnapshot)
+
+	select {
+	case err := <-result:
+		if err == nil || !strings.Contains(err.Error(), "timeout") {
+			t.Fatalf("GoroutineSnapshot error = %v, want timeout", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("GoroutineSnapshot did not return")
+	}
+
+	h.writeEvent(t, protocol.MustEvent(
+		protocol.EventBreakpointHit,
+		2,
+		protocol.BreakpointHitPayload{},
+	))
+	h.writeEvent(t, protocol.MustEvent(
+		protocol.EventGoroutineSnapshot,
+		3,
+		protocol.GoroutineSnapshotPayload{Current: 42},
+	))
+
+	if evt := awaitEvent(t, h.client.Events()); evt.Kind != protocol.EventBreakpointHit {
+		t.Fatalf("first async event kind = %s, want %s", evt.Kind, protocol.EventBreakpointHit)
+	}
+	evt := awaitEvent(t, h.client.Events())
+	if evt.Kind != protocol.EventGoroutineSnapshot {
+		t.Fatalf("second async event kind = %s, want %s", evt.Kind, protocol.EventGoroutineSnapshot)
+	}
+	var snapshot protocol.GoroutineSnapshotPayload
+	if err := protocol.DecodeEventPayload(evt, &snapshot); err != nil {
+		t.Fatalf("decode auto snapshot: %v", err)
+	}
+	if snapshot.Current != 42 {
+		t.Fatalf("auto snapshot current = %d, want 42", snapshot.Current)
+	}
+}
+
 func TestRouteToPendingClaimsBeforeDelivery(t *testing.T) {
 	ch := make(chan protocol.Event, 1)
 	client := &wsClient{


### PR DESCRIPTION
## Summary
- retain timed-out requests for correlatable synchronous confirmations as ordered reply debt until their matching confirmation or `EventError` arrives
- atomically claim the oldest matching entry before notifying a live waiter, preserving unrelated asynchronous delivery and keeping the WebSocket usable
- apply the fence to `Restart`, `SetBreakpoint`, `ClearBreakpoint`, `Locals`, `Evaluate`, `StackFrames`, and `Goroutines`
- deliberately exempt dual-purpose `EventGoroutineSnapshot`: discard a timed-out snapshot query so debt cannot swallow the next auto-pushed snapshot, while preserving the documented late-reply/auto-push ambiguity
- preserve the id-less multi-driver caveat: another client's same-kind confirmation remains indistinguishable without wire-level correlation IDs
- add deterministic loopback WebSocket coverage for stale confirmations, matching error debt, unresolved debt, unrelated traffic, connection reuse, back-to-back matching frames, and snapshot telemetry after timeout

## Restack
Restacked directly onto exact current `origin/main` `1b2fadd574afe8cdf295b98f4fbb4134fb213d4b`.

The old stack's exact wire-version prerequisite (`2a26c6b`) was intentionally omitted because that contract is already on current main. Only the accepted #148-specific commits were replayed:

- `ad5d494` → `aec718b`
- `a4e6a78` → `4e20ef5`
- `8dd7593` → `29b487f`

`git range-diff` reports all three commits as exact matches. Stable patch IDs are unchanged:

- `3bceeff7287998e4775acfaf3165b4f718f96df6`
- `31f325b7cda42777c1718b2cd5b4e0bd507872a7`
- `fd5a3e2332b8a8d709917f905b910e1a9a2d698a`

## Validation
Exact local head: `29b487f3bb1336888a01f818b7f709749d29d58d`.

- `gofmt` and `go tool goimports` on changed Go files
- `go test -tags bingonative -race -count=1 ./pkg/client/... ./pkg/protocol/... ./internal/hub/... ./internal/server/...`
- `go test -tags bingonative -count=1 ./...`
- `go vet -tags bingonative ./...`
- Linux-context `golangci-lint run` — 0 issues
- Linux/amd64 cross-build of all packages plus test binaries for client, protocol, hub, server, debugger E2E, and integration E2E
- independent code review — no high-confidence findings
- `just e2e-darwin` — 22/22 passed on the exact head

Fixes #144