### PR TITLE
fix(protocol): enforce exact WebSocket wire versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,18 @@ Two envelope types: `Event` (server → client) and `Command` (client → server
 Both versioned; both carry `Kind` + raw-JSON `Payload`. Decode with
 `DecodeEventPayload` / `DecodeCommandPayload` after switching on `Kind`.
 
+**Exact-version ingress is mandatory.** Every Go WebSocket peer validates each
+inbound envelope with `protocol.ValidateVersion`, including the client's initial
+welcome event and every later event. The hub validates commands in the client
+read pump **before** `injectCommand`, so an incompatible `Continue` / `Step*`
+cannot enter `resumeCh`. A missing/empty version is incompatible. On mismatch,
+terminate only that connection with WebSocket close code 1002 and a reason that
+names the expected and received versions; do not broadcast `EventError` or
+increment the shared hub sequence for a peer-local compatibility failure.
+`/api/health` remains a discovery preflight, not a substitute for per-envelope
+validation. Exact enforcement of the existing contract does not itself require
+a `Version` bump.
+
 ### Suspend/resume protocol
 
 The hub blocks after broadcasting any of these "suspending" events until a

--- a/README.md
+++ b/README.md
@@ -78,12 +78,14 @@ Frontends can identify and reuse a compatible bingo process through
 
 The response is non-cacheable. `managementApiVersion` versions this HTTP
 contract independently of `wireProtocolVersion`; integrations should require
-management API v1 and separately check that they support the advertised bingo
-wire version. Graphical clients also require `dap.sessionEventVersion: 1`,
-which guarantees the server emits `bingo/session/v1` after managed session
-discovery. `instanceId` changes on every process start. The DAP address is the
-actual bound listener address, including the selected port when bingo was
-started with `-dap-addr ...:0`.
+management API v1 and exact equality with the advertised bingo wire version.
+Native WebSocket peers also enforce that equality on every command and event
+envelope, including the initial welcome; a missing or mismatched `v` closes only
+the incompatible connection. Graphical clients also require
+`dap.sessionEventVersion: 1`, which guarantees the server emits
+`bingo/session/v1` after managed session discovery. `instanceId` changes on
+every process start. The DAP address is the actual bound listener address,
+including the selected port when bingo was started with `-dap-addr ...:0`.
 
 The intended process-owner flow is **connect or start**: health-check the known
 management address, reuse a compatible bingo if present, otherwise start one

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -261,6 +261,13 @@ func (h *Hub) broadcastError(kind protocol.CommandKind, err error) {
 }
 ```
 
+An incompatible WebSocket envelope is not a command/debugger failure and must
+not use this broadcast path. It is local to the offending peer: validate the
+version before hub injection, send that connection a close-1002 frame naming
+the expected and received versions, and disconnect it. Broadcasting an
+`EventError` would expose one client's malformed input to innocent clients and
+consume a shared hub sequence number for a connection-local failure.
+
 ### On error message content
 
 Bingo is a **local developer tool**: the client is the operator debugging their
@@ -287,3 +294,4 @@ server-side `slog` output and map to short client-facing messages there. The
 | Goroutine → owner error propagation              | Emit a typed `protocol.Event` (`EventError` / `EventProcessExited`) on `Debugger.Events()`    |
 | Methods not on the `Debugger` interface          | Keep unexported on `engine`; return errors up the synchronous chain to the loop               |
 | Server → WebSocket client error                  | Broadcast a typed `EventError`; message text is intentionally surfaced (local tool)           |
+| Incompatible WebSocket envelope                  | Close only that peer with code 1002; never broadcast or allocate a hub sequence                |

--- a/internal/hub/client.go
+++ b/internal/hub/client.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
@@ -13,6 +14,9 @@ const (
 	pongTimeout    = 60 * time.Second
 	pingInterval   = 54 * time.Second
 	maxMessageSize = 64 * 1024
+
+	closeProtocolError = 1002
+	maxCloseReasonSize = 123
 )
 
 // WSConn is the subset of a WebSocket connection the Client needs. Abstracted
@@ -46,6 +50,10 @@ type Client struct {
 	send   chan []byte
 	sendMu sync.Mutex
 	closed bool
+
+	// writeMu serialises the normal write pump with a protocol close emitted by
+	// the read pump when an incompatible peer must be rejected immediately.
+	writeMu sync.Mutex
 }
 
 func newClient(conn WSConn, h *Hub, log *slog.Logger) *Client {
@@ -82,23 +90,52 @@ func (c *Client) writePump() {
 	for {
 		select {
 		case msg, ok := <-c.send:
-			_ = c.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
 			if !ok {
-				_ = c.conn.WriteMessage(CloseMessage, []byte{})
+				_ = c.writeMessage(CloseMessage, nil)
 				return
 			}
-			if err := c.conn.WriteMessage(TextMessage, msg); err != nil {
+			if err := c.writeMessage(TextMessage, msg); err != nil {
 				c.log.Warn("write error", "err", err)
 				return
 			}
 
 		case <-ticker.C:
-			_ = c.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
-			if err := c.conn.WriteMessage(PingMessage, []byte{}); err != nil {
+			if err := c.writeMessage(PingMessage, nil); err != nil {
 				return
 			}
 		}
 	}
+}
+
+func (c *Client) writeMessage(messageType int, data []byte) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	_ = c.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
+	return c.conn.WriteMessage(messageType, data)
+}
+
+func (c *Client) closeWithProtocolError(err error) {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
+	c.closeSend()
+	_ = c.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
+	_ = c.conn.WriteMessage(CloseMessage, formatCloseMessage(closeProtocolError, err.Error()))
+	_ = c.conn.Close()
+}
+
+func formatCloseMessage(code int, reason string) []byte {
+	if len(reason) > maxCloseReasonSize {
+		reason = reason[:maxCloseReasonSize]
+		for !utf8.ValidString(reason) {
+			reason = reason[:len(reason)-1]
+		}
+	}
+	msg := make([]byte, 2+len(reason))
+	msg[0] = byte(code >> 8)
+	msg[1] = byte(code)
+	copy(msg[2:], reason)
+	return msg
 }
 
 // readPump reads inbound messages and routes them to the hub. One goroutine
@@ -127,6 +164,11 @@ func (c *Client) readPump() {
 		if err != nil {
 			c.log.Warn("invalid command", "err", err, "raw", string(data))
 			continue
+		}
+		if err := protocol.ValidateVersion(cmd.Version); err != nil {
+			c.log.Warn("incompatible command", "err", err)
+			c.closeWithProtocolError(err)
+			return
 		}
 
 		c.hub.injectCommand(c, cmd)

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -114,7 +114,13 @@ type fakeWSConn struct {
 	mu       sync.Mutex
 	incoming chan []byte // messages written by the server (server → client)
 	outgoing chan []byte // messages injected by the test  (client → server)
+	writes   []fakeWSWrite
 	closed   bool
+}
+
+type fakeWSWrite struct {
+	messageType int
+	data        []byte
 }
 
 func newFakeWSConn() *fakeWSConn {
@@ -158,7 +164,7 @@ func (f *fakeWSConn) ReadMessage() (int, []byte, error) {
 	return hub.TextMessage, data, nil
 }
 
-func (f *fakeWSConn) WriteMessage(_ int, data []byte) error {
+func (f *fakeWSConn) WriteMessage(messageType int, data []byte) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.closed {
@@ -166,7 +172,10 @@ func (f *fakeWSConn) WriteMessage(_ int, data []byte) error {
 	}
 	cp := make([]byte, len(data))
 	copy(cp, data)
-	f.incoming <- cp
+	f.writes = append(f.writes, fakeWSWrite{messageType: messageType, data: cp})
+	if messageType == hub.TextMessage {
+		f.incoming <- cp
+	}
 	return nil
 }
 
@@ -183,6 +192,20 @@ func (f *fakeWSConn) Close() error {
 		close(f.outgoing)
 	}
 	return nil
+}
+
+func (f *fakeWSConn) closeFrame() (int, string, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i := len(f.writes) - 1; i >= 0; i-- {
+		write := f.writes[i]
+		if write.messageType != hub.CloseMessage || len(write.data) < 2 {
+			continue
+		}
+		code := int(write.data[0])<<8 | int(write.data[1])
+		return code, string(write.data[2:]), true
+	}
+	return 0, "", false
 }
 
 type connClosedErr struct{}
@@ -324,6 +347,79 @@ var _ = Describe("Hub", func() {
 				}
 				return count
 			}, "500ms", "10ms").Should(Equal(2))
+		})
+	})
+
+	Describe("wire protocol version enforcement", func() {
+		It("rejects an incompatible command before execution without affecting another client", func() {
+			bad := newFakeWSConn()
+			good := newFakeWSConn()
+			mustAddClient(h, bad)
+			mustAddClient(h, good)
+			fd.setBPResult = protocol.Breakpoint{ID: 1}
+
+			cmd := mustCommand(protocol.CmdSetBreakpoint,
+				protocol.SetBreakpointPayload{File: "main.go", Line: 42})
+			cmd.Version = "999.0"
+			bad.inject(cmd)
+
+			Eventually(h.ClientCount, "500ms", "10ms").Should(Equal(1))
+			Eventually(func() bool {
+				_, _, ok := bad.closeFrame()
+				return ok
+			}, "500ms", "10ms").Should(BeTrue())
+			code, reason, _ := bad.closeFrame()
+			Expect(code).To(Equal(1002))
+			Expect(reason).To(Equal(protocol.ValidateVersion("999.0").Error()))
+			Consistently(fd.recordedCalls, "100ms", "10ms").
+				ShouldNot(ContainElement("SetBreakpoint"))
+			Expect(len(good.incoming)).To(Equal(0),
+				"an incompatible peer must not broadcast an error to other clients")
+
+			good.inject(mustCommand(protocol.CmdSetBreakpoint,
+				protocol.SetBreakpointPayload{File: "main.go", Line: 42}))
+			Eventually(fd.recordedCalls, "500ms", "10ms").
+				Should(ContainElement("SetBreakpoint"))
+			evt, ok := recvEvent(good)
+			Expect(ok).To(BeTrue())
+			Expect(evt.Kind).To(Equal(protocol.EventBreakpointSet))
+			Expect(evt.Seq).To(Equal(uint64(1)),
+				"rejecting one peer must not consume a shared hub sequence")
+		})
+
+		It("cannot resume a suspended session with an incompatible command", func() {
+			bad := newFakeWSConn()
+			good := newFakeWSConn()
+			mustAddClient(h, bad)
+			mustAddClient(h, good)
+
+			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+			_, ok := recvEvent(bad)
+			Expect(ok).To(BeTrue())
+			stop, ok := recvEvent(good)
+			Expect(ok).To(BeTrue())
+
+			cmd := mustCommand(protocol.CmdContinue, struct{}{})
+			cmd.Version = "999.0"
+			bad.inject(cmd)
+
+			Eventually(h.ClientCount, "500ms", "10ms").Should(Equal(1))
+			Consistently(fd.recordedCalls, "100ms", "10ms").
+				ShouldNot(ContainElement("Continue"))
+			Expect(h.State()).To(Equal(protocol.StateSuspended))
+
+			good.inject(mustCommand(protocol.CmdContinue, struct{}{}))
+			Eventually(fd.recordedCalls, "500ms", "10ms").
+				Should(ContainElement("Continue"))
+
+			fd.push(protocol.MustEvent(protocol.EventOutput, 2,
+				protocol.OutputPayload{Content: "still connected"}))
+			next, ok := recvEvent(good)
+			Expect(ok).To(BeTrue())
+			Expect(next.Kind).To(Equal(protocol.EventOutput))
+			Expect(next.Seq).To(Equal(stop.Seq+1),
+				"rejecting a resume must not create a private event or sequence gap")
 		})
 	})
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -173,6 +174,56 @@ var _ = Describe("Server", func() {
 
 				Expect(p1.SessionID).NotTo(Equal(p2.SessionID))
 				Expect(srv.sessions.count()).To(Equal(2))
+			})
+
+			It("closes only a client that sends an incompatible command version", func() {
+				bad, _, err := websocket.DefaultDialer.Dial(toWS(ts, "/ws?create"), nil)
+				Expect(err).NotTo(HaveOccurred())
+				defer closeWS(bad)
+				welcome, err := recvState(bad)
+				Expect(err).NotTo(HaveOccurred())
+
+				good, _, err := websocket.DefaultDialer.Dial(
+					toWS(ts, "/ws?session="+welcome.SessionID), nil)
+				Expect(err).NotTo(HaveOccurred())
+				defer closeWS(good)
+				_, err = recvState(good)
+				Expect(err).NotTo(HaveOccurred())
+
+				cmd := protocol.Command{
+					Version: "999.0",
+					Kind:    protocol.CmdSetBreakpoint,
+					Payload: json.RawMessage(`{"file":"main.go","line":1}`),
+				}
+				data, err := json.Marshal(cmd)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(bad.WriteMessage(websocket.TextMessage, data)).To(Succeed())
+
+				_ = bad.SetReadDeadline(time.Now().Add(time.Second))
+				_, _, err = bad.ReadMessage()
+				var closeErr *websocket.CloseError
+				Expect(errors.As(err, &closeErr)).To(BeTrue())
+				Expect(closeErr.Code).To(Equal(websocket.CloseProtocolError))
+				Expect(closeErr.Text).To(Equal(protocol.ValidateVersion("999.0").Error()))
+
+				session := srv.sessions.get(welcome.SessionID)
+				Expect(session).NotTo(BeNil())
+				Eventually(session.hub.ClientCount, "2s", "10ms").Should(Equal(1))
+
+				cmd.Version = protocol.Version
+				data, err = json.Marshal(cmd)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(good.WriteMessage(websocket.TextMessage, data)).To(Succeed())
+
+				_ = good.SetReadDeadline(time.Now().Add(time.Second))
+				_, response, err := good.ReadMessage()
+				Expect(err).NotTo(HaveOccurred())
+				event, err := protocol.UnmarshalEvent(response)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(event.Kind).To(Equal(protocol.EventError))
+				var payload protocol.ErrorPayload
+				Expect(protocol.DecodeEventPayload(event, &payload)).To(Succeed())
+				Expect(payload.Command).To(Equal(protocol.CmdSetBreakpoint))
 			})
 		})
 

--- a/pkg/client/ws.go
+++ b/pkg/client/ws.go
@@ -49,6 +49,9 @@ type wsClient struct {
 	// writeMu: gorilla allows one concurrent reader and one concurrent writer.
 	writeMu sync.Mutex
 
+	readErrMu sync.RWMutex
+	readErr   error
+
 	done      chan struct{}
 	closeOnce sync.Once
 }
@@ -80,6 +83,9 @@ func dial(addr, query string) (Client, error) {
 	select {
 	case evt, ok := <-c.events:
 		if !ok {
+			if err := c.terminalReadError(); err != nil {
+				return nil, err
+			}
 			return nil, fmt.Errorf("connection closed before receiving session state")
 		}
 		if evt.Kind != protocol.EventSessionState {
@@ -109,6 +115,10 @@ func (c *wsClient) readPump() {
 		if err != nil {
 			c.log.Warn("invalid event from server", "err", err)
 			continue
+		}
+		if err := protocol.ValidateVersion(evt.Version); err != nil {
+			c.terminateRead(fmt.Errorf("server event: %w", err))
+			return
 		}
 
 		if evt.Kind == protocol.EventSessionState {
@@ -159,13 +169,20 @@ func (c *wsClient) routeToPending(evt protocol.Event) bool {
 }
 
 func (c *wsClient) send(cmd protocol.Command) error {
+	if err := c.terminalReadError(); err != nil {
+		return err
+	}
 	data, err := json.Marshal(cmd)
 	if err != nil {
 		return fmt.Errorf("marshal command: %w", err)
 	}
 	c.writeMu.Lock()
-	defer c.writeMu.Unlock()
-	return c.conn.WriteMessage(websocket.TextMessage, data)
+	writeErr := c.conn.WriteMessage(websocket.TextMessage, data)
+	c.writeMu.Unlock()
+	if err := c.terminalReadError(); err != nil {
+		return err
+	}
+	return writeErr
 }
 
 // sendAndWait sends cmd and blocks for the matching confirmation event or an
@@ -202,8 +219,26 @@ func (c *wsClient) sendAndWait(cmd protocol.Command, wantKind protocol.EventKind
 	case <-time.After(syncTimeout):
 		return protocol.Event{}, fmt.Errorf("timeout waiting for %s response", wantKind)
 	case <-c.done:
+		if err := c.terminalReadError(); err != nil {
+			return protocol.Event{}, err
+		}
 		return protocol.Event{}, fmt.Errorf("client closed")
 	}
+}
+
+func (c *wsClient) terminateRead(err error) {
+	c.readErrMu.Lock()
+	if c.readErr == nil {
+		c.readErr = err
+	}
+	c.readErrMu.Unlock()
+	_ = c.conn.Close()
+}
+
+func (c *wsClient) terminalReadError() error {
+	c.readErrMu.RLock()
+	defer c.readErrMu.RUnlock()
+	return c.readErr
 }
 
 func newCommand(kind protocol.CommandKind, payload any) (protocol.Command, error) {

--- a/pkg/client/ws_test.go
+++ b/pkg/client/ws_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/bingosuite/bingo/pkg/client"
 	"github.com/bingosuite/bingo/pkg/protocol"
@@ -82,6 +83,36 @@ func (fs *fakeServer) lastCommand() (protocol.Command, bool) {
 	return fs.commands[len(fs.commands)-1], true
 }
 
+func newScriptedServer(t *testing.T, script func(*websocket.Conn)) (*httptest.Server, <-chan struct{}) {
+	t.Helper()
+	done := make(chan struct{})
+	up := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade WebSocket: %v", err)
+			close(done)
+			return
+		}
+		defer close(done)
+		defer func() { _ = conn.Close() }()
+		script(conn)
+	}))
+	return ts, done
+}
+
+func writeServerEvent(t *testing.T, conn *websocket.Conn, event protocol.Event) {
+	t.Helper()
+	data, err := protocol.MarshalEvent(event)
+	if err != nil {
+		t.Errorf("marshal event: %v", err)
+		return
+	}
+	if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Errorf("write event: %v", err)
+	}
+}
+
 func replyEvent(kind protocol.EventKind, payload any) protocol.Event {
 	return protocol.MustEvent(kind, 2, payload)
 }
@@ -93,6 +124,125 @@ func dialTestClient(t *testing.T, fs *fakeServer) client.Client {
 		t.Fatalf("Create: %v", err)
 	}
 	return c
+}
+
+func TestCreateRejectsIncompatibleWelcomeVersion(t *testing.T) {
+	ts, handlerDone := newScriptedServer(t, func(conn *websocket.Conn) {
+		welcome := protocol.MustEvent(protocol.EventSessionState, 1, protocol.SessionStatePayload{
+			SessionID: "test-session",
+			State:     protocol.StateIdle,
+			Clients:   1,
+		})
+		welcome.Version = "999.0"
+		writeServerEvent(t, conn, welcome)
+		_, _, _ = conn.ReadMessage()
+	})
+	defer ts.Close()
+
+	c, err := client.Create(strings.TrimPrefix(ts.URL, "http://"))
+	if c != nil {
+		_ = c.Close()
+		t.Fatal("Create returned a client for an incompatible welcome")
+	}
+	if err == nil ||
+		!strings.Contains(err.Error(), `expected "`+protocol.Version+`"`) ||
+		!strings.Contains(err.Error(), `received "999.0"`) {
+		t.Fatalf("Create error does not identify both versions: %v", err)
+	}
+
+	select {
+	case <-handlerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("client did not close the incompatible welcome connection")
+	}
+}
+
+func TestMidstreamVersionMismatchFailsPendingRequest(t *testing.T) {
+	ts, handlerDone := newScriptedServer(t, func(conn *websocket.Conn) {
+		writeServerEvent(t, conn, protocol.MustEvent(
+			protocol.EventSessionState,
+			1,
+			protocol.SessionStatePayload{
+				SessionID: "test-session",
+				State:     protocol.StateIdle,
+				Clients:   1,
+			},
+		))
+
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			t.Errorf("read SetBreakpoint: %v", err)
+			return
+		}
+		cmd, err := protocol.UnmarshalCommand(data)
+		if err != nil {
+			t.Errorf("unmarshal SetBreakpoint: %v", err)
+			return
+		}
+		if cmd.Kind != protocol.CmdSetBreakpoint {
+			t.Errorf("command kind = %s, want %s", cmd.Kind, protocol.CmdSetBreakpoint)
+			return
+		}
+
+		reply := protocol.MustEvent(
+			protocol.EventBreakpointSet,
+			2,
+			protocol.BreakpointSetPayload{Breakpoint: protocol.Breakpoint{ID: 1}},
+		)
+		reply.Version = "999.0"
+		writeServerEvent(t, conn, reply)
+		_, _, _ = conn.ReadMessage()
+	})
+	defer ts.Close()
+
+	c, err := client.Create(strings.TrimPrefix(ts.URL, "http://"))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := c.SetBreakpoint("main.go", 42)
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil ||
+			!strings.Contains(err.Error(), `expected "`+protocol.Version+`"`) ||
+			!strings.Contains(err.Error(), `received "999.0"`) {
+			t.Fatalf("SetBreakpoint error does not preserve the terminal version error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("SetBreakpoint waited instead of failing on the terminal version error")
+	}
+
+	select {
+	case _, ok := <-c.Events():
+		if ok {
+			t.Fatal("Events remained open after a terminal version mismatch")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("client read pump did not terminate after a version mismatch")
+	}
+
+	start := time.Now()
+	_, err = c.SetBreakpoint("main.go", 43)
+	if err == nil ||
+		!strings.Contains(err.Error(), `expected "`+protocol.Version+`"`) ||
+		!strings.Contains(err.Error(), `received "999.0"`) {
+		t.Fatalf("later request did not preserve the terminal version error: %v", err)
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("later request waited instead of reusing the terminal version error")
+	}
+
+	select {
+	case <-handlerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("client did not close the mid-stream incompatible connection")
+	}
 }
 
 // TestRestartEmptyArgsOverrideReachesWire is the client-side regression for

--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -2,9 +2,30 @@
 // between the bingo server and its clients over WebSocket.
 package protocol
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 const Version = "1.2"
+
+// VersionError reports that a peer used a wire version other than Version.
+type VersionError struct {
+	Expected string
+	Received string
+}
+
+func (e *VersionError) Error() string {
+	return fmt.Sprintf("protocol version mismatch: expected %q, received %q", e.Expected, e.Received)
+}
+
+// ValidateVersion requires exact wire-version equality.
+func ValidateVersion(received string) error {
+	if received != Version {
+		return &VersionError{Expected: Version, Received: received}
+	}
+	return nil
+}
 
 // Event is the envelope for all server-to-client messages.
 type Event struct {

--- a/pkg/protocol/protocol_test.go
+++ b/pkg/protocol/protocol_test.go
@@ -2,6 +2,7 @@ package protocol_test
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -752,6 +753,25 @@ var _ = Describe("Version", func() {
 	It("is non-empty", func() {
 		Expect(protocol.Version).NotTo(BeEmpty())
 	})
+	It("accepts the exact current version", func() {
+		Expect(protocol.ValidateVersion(protocol.Version)).To(Succeed())
+	})
+	DescribeTable("rejects every other version",
+		func(received string) {
+			err := protocol.ValidateVersion(received)
+			Expect(err).To(HaveOccurred())
+
+			var versionErr *protocol.VersionError
+			Expect(errors.As(err, &versionErr)).To(BeTrue())
+			Expect(versionErr.Expected).To(Equal(protocol.Version))
+			Expect(versionErr.Received).To(Equal(received))
+			Expect(err.Error()).To(ContainSubstring(`expected "` + protocol.Version + `"`))
+			Expect(err.Error()).To(ContainSubstring(`received "` + received + `"`))
+		},
+		Entry("newer", "999.0"),
+		Entry("older", "1.1"),
+		Entry("omitted", ""),
+	)
 	It("is stamped on every event", func() {
 		e, err := protocol.NewEvent(protocol.EventOutput, 1, protocol.OutputPayload{Content: "x"})
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary
- require exact `pkg/protocol.Version` equality for every inbound Go WebSocket envelope
- reject incompatible welcome and mid-stream events while preserving the terminal version error for pending and later client requests
- reject incompatible commands before hub injection, including resumes, with a connection-local close-1002 reason and no `EventError` or hub sequence allocation
- document the exact-version invariant and cover peer isolation, close reasons, empty versions, pending requests, and suspend/resume safety

## Testing
- `go vet -tags bingonative ./...`
- `golangci-lint run --build-tags bingonative ./...`
- `go test -tags bingonative -race -count=1 ./...`
- targeted protocol/client/hub/server wire-version regressions repeated 20 times with the existing Go/Ginkgo runners
- `just e2e-darwin` (22/22 specs; 200 churn iterations completed in 2m49s under the scaled 7m40s watchdog)

Fixes #145