### PR TITLE
test(vscode): clean up packaged process groups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -938,11 +938,14 @@ requires local/self-hosted Apple Silicon, where the same E2E covers all five
 examples. Both tests observe server-owned idle exit on success. On failure the
 test harness tracks the detached child's terminal outcome before signaling,
 requests graceful shutdown with SIGTERM to the exact captured server PID, and
-escalates to SIGKILL on only its captured process group when the tracked server
-remains live past a bounded grace. It then waits for the server outcome and
-confirms the owned group is absent before deleting scratch artifacts; incomplete
-cleanup is reported and preserves those artifacts. Cleanup is test-only and
-must never enter extension production code.
+escalates to SIGKILL on only its captured process group when that owned group
+remains nonempty past a bounded grace, even if the server leader exited first.
+The tracker permanently releases group ownership when an existence probe reports
+it absent, so cleanup never signals a later group that reused the numeric PGID.
+It then waits for the server outcome and confirms the owned group is absent
+before deleting scratch artifacts; incomplete cleanup is reported and preserves
+those artifacts. Cleanup is test-only and must never enter extension production
+code.
 Apple's external linker can vary `LC_UUID` even for identical cgo inputs, but
 current dyld rejects binaries with `-no_uuid`; `normalize-mach-o-uuid.mjs`
 therefore derives a stable UUID from the unsigned Mach-O with its UUID and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -936,9 +936,13 @@ activation/view/custom-event acknowledgement test; linux additionally runs the
 real packaged DAP→WebSocket graphical-model E2E. Darwin native-debug execution
 requires local/self-hosted Apple Silicon, where the same E2E covers all five
 examples. Both tests observe server-owned idle exit on success. On failure the
-smoke may SIGKILL only the detached process group it created; the packaged E2E
-may signal only its exact captured server PID. Cleanup is test-only and must
-never enter extension production code.
+test harness tracks the detached child's terminal outcome before signaling,
+requests graceful shutdown with SIGTERM to the exact captured server PID, and
+escalates to SIGKILL on only its captured process group when the tracked server
+remains live past a bounded grace. It then waits for the server outcome and
+confirms the owned group is absent before deleting scratch artifacts; incomplete
+cleanup is reported and preserves those artifacts. Cleanup is test-only and
+must never enter extension production code.
 Apple's external linker can vary `LC_UUID` even for identical cgo inputs, but
 current dyld rejects binaries with `-no_uuid`; `normalize-mach-o-uuid.mjs`
 therefore derives a stable UUID from the unsigned Mach-O with its UUID and

--- a/editors/vscode/scripts/owned-process.d.mts
+++ b/editors/vscode/scripts/owned-process.d.mts
@@ -16,8 +16,11 @@ export type OwnedProcessOutcome =
 export interface OwnedProcess {
   readonly pid: number | undefined;
   readonly outcome: Promise<OwnedProcessOutcome>;
+  hasProcessGroup(): boolean;
   isFinished(): boolean;
   ref(): void;
+  signalGroup(signal: NodeJS.Signals): boolean;
+  signalLeader(signal: NodeJS.Signals): boolean;
 }
 
 export interface OwnedProcessCleanupOptions {
@@ -25,10 +28,12 @@ export interface OwnedProcessCleanupOptions {
   readonly exitTimeoutMs?: number;
   readonly groupTimeoutMs?: number;
   readonly pollIntervalMs?: number;
-  readonly signalProcess?: ProcessSignal;
 }
 
-export function observeOwnedProcess(child: ChildProcess): OwnedProcess;
+export function observeOwnedProcess(
+  child: ChildProcess,
+  signalProcess?: ProcessSignal,
+): OwnedProcess;
 
 export function waitForOwnedProcessExit(
   ownedProcess: OwnedProcess,

--- a/editors/vscode/scripts/owned-process.d.mts
+++ b/editors/vscode/scripts/owned-process.d.mts
@@ -1,10 +1,42 @@
+import type { ChildProcess } from "node:child_process";
+
 export type ProcessSignal = (
   pid: number,
-  signal: NodeJS.Signals,
+  signal: NodeJS.Signals | number,
 ) => boolean;
 
+export type OwnedProcessOutcome =
+  | { readonly kind: "error"; readonly error: Error }
+  | {
+      readonly kind: "exit";
+      readonly code: number | null;
+      readonly signal: NodeJS.Signals | null;
+    };
+
+export interface OwnedProcess {
+  readonly pid: number | undefined;
+  readonly outcome: Promise<OwnedProcessOutcome>;
+  isFinished(): boolean;
+  ref(): void;
+}
+
+export interface OwnedProcessCleanupOptions {
+  readonly gracefulTimeoutMs?: number;
+  readonly exitTimeoutMs?: number;
+  readonly groupTimeoutMs?: number;
+  readonly pollIntervalMs?: number;
+  readonly signalProcess?: ProcessSignal;
+}
+
+export function observeOwnedProcess(child: ChildProcess): OwnedProcess;
+
+export function waitForOwnedProcessExit(
+  ownedProcess: OwnedProcess,
+  timeoutMs: number,
+  message: string,
+): Promise<OwnedProcessOutcome>;
+
 export function terminateOwnedProcessGroup(
-  pid: number,
-  exit: Promise<unknown>,
-  signalProcess?: ProcessSignal,
-): Promise<void>;
+  ownedProcess: OwnedProcess,
+  options?: OwnedProcessCleanupOptions,
+): Promise<OwnedProcessOutcome>;

--- a/editors/vscode/scripts/owned-process.mjs
+++ b/editors/vscode/scripts/owned-process.mjs
@@ -1,22 +1,180 @@
 import process from "node:process";
+import { clearTimeout, setTimeout } from "node:timers";
 
-import { withTimeout } from "./timing.mjs";
+const defaultGracefulTimeoutMs = 2000;
+const defaultExitTimeoutMs = 3000;
+const defaultGroupTimeoutMs = 2000;
+const defaultPollIntervalMs = 20;
+
+export function observeOwnedProcess(child) {
+  const pid = child.pid;
+  let finished = false;
+  let resolveOutcome;
+  const outcome = new Promise((resolve) => {
+    resolveOutcome = resolve;
+  });
+  const finish = (value) => {
+    if (finished) {
+      return;
+    }
+    finished = true;
+    resolveOutcome(value);
+  };
+
+  child.once("error", (error) => {
+    finish({ kind: "error", error });
+  });
+  child.once("exit", (code, signal) => {
+    finish({ kind: "exit", code, signal });
+  });
+
+  return {
+    pid,
+    outcome,
+    isFinished() {
+      return finished;
+    },
+    ref() {
+      child.ref();
+    },
+  };
+}
+
+export async function waitForOwnedProcessExit(
+  ownedProcess,
+  timeoutMs,
+  message,
+) {
+  ownedProcess.ref();
+  const outcome = await outcomeWithin(ownedProcess.outcome, timeoutMs);
+  if (outcome === undefined) {
+    throw new Error(message);
+  }
+  return outcome;
+}
 
 export async function terminateOwnedProcessGroup(
-  pid,
-  exit,
-  signalProcess = process.kill,
+  ownedProcess,
+  options = {},
 ) {
-  try {
-    signalProcess(-pid, "SIGKILL");
-  } catch (error) {
-    if (error?.code !== "ESRCH") {
-      throw error;
-    }
+  if (ownedProcess.isFinished()) {
+    throw new Error(
+      "test-owned server finished before cleanup; refusing to signal a potentially reused PID or process group",
+    );
   }
-  await withTimeout(
-    exit.catch(() => undefined),
-    2000,
-    "test-owned packaged server did not exit after emergency cleanup",
+  const pid = ownedProcess.pid;
+  if (pid === undefined) {
+    throw new Error("test-owned server has no process ID");
+  }
+
+  const signalProcess = options.signalProcess ?? process.kill;
+  const gracefulTimeoutMs =
+    options.gracefulTimeoutMs ?? defaultGracefulTimeoutMs;
+  const exitTimeoutMs = options.exitTimeoutMs ?? defaultExitTimeoutMs;
+  const groupTimeoutMs = options.groupTimeoutMs ?? defaultGroupTimeoutMs;
+  const pollIntervalMs =
+    options.pollIntervalMs ?? defaultPollIntervalMs;
+
+  ownedProcess.ref();
+  const gracefulSignalDelivered = sendSignal(
+    signalProcess,
+    pid,
+    "SIGTERM",
   );
+  const gracefulOutcome = await outcomeWithin(
+    ownedProcess.outcome,
+    gracefulTimeoutMs,
+  );
+  if (
+    gracefulOutcome === undefined &&
+    !ownedProcess.isFinished() &&
+    gracefulSignalDelivered &&
+    processExists(signalProcess, pid)
+  ) {
+    sendSignal(signalProcess, -pid, "SIGKILL");
+  }
+
+  const outcome =
+    gracefulOutcome ??
+    (await waitForOwnedProcessExit(
+      ownedProcess,
+      exitTimeoutMs,
+      "test-owned packaged server did not exit after cleanup",
+    ));
+  await waitForProcessGroupExit(
+    pid,
+    groupTimeoutMs,
+    pollIntervalMs,
+    signalProcess,
+  );
+  return outcome;
+}
+
+function sendSignal(signalProcess, pid, signal) {
+  try {
+    signalProcess(pid, signal);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function processExists(signalProcess, pid) {
+  try {
+    signalProcess(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") {
+      return false;
+    }
+    if (error?.code === "EPERM") {
+      return true;
+    }
+    throw error;
+  }
+}
+
+async function waitForProcessGroupExit(
+  pid,
+  timeoutMs,
+  pollIntervalMs,
+  signalProcess,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (processExists(signalProcess, -pid)) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new Error(
+        "test-owned packaged server process group remained alive after cleanup",
+      );
+    }
+    await delay(Math.min(pollIntervalMs, remaining));
+  }
+}
+
+function outcomeWithin(outcome, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      resolve(undefined);
+    }, timeoutMs);
+    outcome.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
 }

--- a/editors/vscode/scripts/owned-process.mjs
+++ b/editors/vscode/scripts/owned-process.mjs
@@ -6,9 +6,11 @@ const defaultExitTimeoutMs = 3000;
 const defaultGroupTimeoutMs = 2000;
 const defaultPollIntervalMs = 20;
 
-export function observeOwnedProcess(child) {
+export function observeOwnedProcess(child, signalProcess = process.kill) {
   const pid = child.pid;
   let finished = false;
+  let groupReleased = pid === undefined;
+  let groupProbeError;
   let resolveOutcome;
   const outcome = new Promise((resolve) => {
     resolveOutcome = resolve;
@@ -17,8 +19,50 @@ export function observeOwnedProcess(child) {
     if (finished) {
       return;
     }
+    try {
+      hasProcessGroup();
+    } catch {
+      // Cleanup reports the saved probe failure without throwing from an event callback.
+    }
     finished = true;
     resolveOutcome(value);
+  };
+  const hasProcessGroup = () => {
+    if (groupReleased) {
+      return false;
+    }
+    if (groupProbeError !== undefined) {
+      throw groupProbeError;
+    }
+    try {
+      signalProcess(-pid, 0);
+      return true;
+    } catch (error) {
+      if (error?.code === "ESRCH") {
+        groupReleased = true;
+        return false;
+      }
+      if (error?.code === "EPERM") {
+        return true;
+      }
+      groupProbeError = error;
+      throw error;
+    }
+  };
+  const signalGroup = (signal) => {
+    if (!hasProcessGroup()) {
+      return false;
+    }
+    try {
+      signalProcess(-pid, signal);
+      return true;
+    } catch (error) {
+      if (error?.code === "ESRCH") {
+        groupReleased = true;
+        return false;
+      }
+      throw error;
+    }
   };
 
   child.once("error", (error) => {
@@ -34,8 +78,16 @@ export function observeOwnedProcess(child) {
     isFinished() {
       return finished;
     },
+    hasProcessGroup,
     ref() {
       child.ref();
+    },
+    signalGroup,
+    signalLeader(signal) {
+      if (finished || pid === undefined) {
+        return false;
+      }
+      return sendSignal(signalProcess, pid, signal);
     },
   };
 }
@@ -57,17 +109,6 @@ export async function terminateOwnedProcessGroup(
   ownedProcess,
   options = {},
 ) {
-  if (ownedProcess.isFinished()) {
-    throw new Error(
-      "test-owned server finished before cleanup; refusing to signal a potentially reused PID or process group",
-    );
-  }
-  const pid = ownedProcess.pid;
-  if (pid === undefined) {
-    throw new Error("test-owned server has no process ID");
-  }
-
-  const signalProcess = options.signalProcess ?? process.kill;
   const gracefulTimeoutMs =
     options.gracefulTimeoutMs ?? defaultGracefulTimeoutMs;
   const exitTimeoutMs = options.exitTimeoutMs ?? defaultExitTimeoutMs;
@@ -76,37 +117,33 @@ export async function terminateOwnedProcessGroup(
     options.pollIntervalMs ?? defaultPollIntervalMs;
 
   ownedProcess.ref();
-  const gracefulSignalDelivered = sendSignal(
-    signalProcess,
-    pid,
-    "SIGTERM",
-  );
-  const gracefulOutcome = await outcomeWithin(
-    ownedProcess.outcome,
+  if (!ownedProcess.isFinished()) {
+    ownedProcess.signalLeader("SIGTERM");
+  }
+  const groupExited = await waitForProcessGroupExit(
+    ownedProcess,
     gracefulTimeoutMs,
+    pollIntervalMs,
   );
-  if (
-    gracefulOutcome === undefined &&
-    !ownedProcess.isFinished() &&
-    gracefulSignalDelivered &&
-    processExists(signalProcess, pid)
-  ) {
-    sendSignal(signalProcess, -pid, "SIGKILL");
+  if (!groupExited) {
+    ownedProcess.signalGroup("SIGKILL");
   }
 
-  const outcome =
-    gracefulOutcome ??
-    (await waitForOwnedProcessExit(
-      ownedProcess,
-      exitTimeoutMs,
-      "test-owned packaged server did not exit after cleanup",
-    ));
-  await waitForProcessGroupExit(
-    pid,
+  const outcome = await waitForOwnedProcessExit(
+    ownedProcess,
+    exitTimeoutMs,
+    "test-owned packaged server did not exit after cleanup",
+  );
+  const groupGone = await waitForProcessGroupExit(
+    ownedProcess,
     groupTimeoutMs,
     pollIntervalMs,
-    signalProcess,
   );
+  if (!groupGone) {
+    throw new Error(
+      "test-owned packaged server process group remained alive after cleanup",
+    );
+  }
   return outcome;
 }
 
@@ -122,37 +159,20 @@ function sendSignal(signalProcess, pid, signal) {
   }
 }
 
-function processExists(signalProcess, pid) {
-  try {
-    signalProcess(pid, 0);
-    return true;
-  } catch (error) {
-    if (error?.code === "ESRCH") {
-      return false;
-    }
-    if (error?.code === "EPERM") {
-      return true;
-    }
-    throw error;
-  }
-}
-
 async function waitForProcessGroupExit(
-  pid,
+  ownedProcess,
   timeoutMs,
   pollIntervalMs,
-  signalProcess,
 ) {
   const deadline = Date.now() + timeoutMs;
-  while (processExists(signalProcess, -pid)) {
+  while (ownedProcess.hasProcessGroup()) {
     const remaining = deadline - Date.now();
     if (remaining <= 0) {
-      throw new Error(
-        "test-owned packaged server process group remained alive after cleanup",
-      );
+      return false;
     }
     await delay(Math.min(pollIntervalMs, remaining));
   }
+  return true;
 }
 
 function outcomeWithin(outcome, timeoutMs) {

--- a/editors/vscode/scripts/smoke-server.mjs
+++ b/editors/vscode/scripts/smoke-server.mjs
@@ -15,8 +15,11 @@ import { fileURLToPath, URL } from "node:url";
 import { spawn, spawnSync } from "node:child_process";
 
 import { currentTarget } from "./platform.mjs";
-import { terminateOwnedProcessGroup } from "./owned-process.mjs";
-import { withTimeout } from "./timing.mjs";
+import {
+  observeOwnedProcess,
+  terminateOwnedProcessGroup,
+  waitForOwnedProcessExit,
+} from "./owned-process.mjs";
 
 const target = currentTarget();
 const vsix = fileURLToPath(
@@ -32,10 +35,9 @@ const extracted = join(
 rmSync(extracted, { force: true, recursive: true });
 mkdirSync(extracted, { recursive: true });
 const idleTimeoutMs = 2000;
-let child;
-let exit;
-let childExited = false;
+let ownedServer;
 let failure;
+let cleanupComplete = false;
 
 try {
   run("unzip", ["-q", vsix, "-d", extracted]);
@@ -43,7 +45,7 @@ try {
   const binary = join(extracted, "extension", "bin", "bingo");
   const logPath = join(extracted, "server.log");
   const logFD = openSync(logPath, "a", 0o600);
-  child = spawn(
+  const child = spawn(
     binary,
     [
       "-addr",
@@ -59,22 +61,16 @@ try {
       stdio: ["ignore", logFD, logFD],
     },
   );
-  exit = new Promise((resolve, reject) => {
-    child.once("error", (error) => {
-      childExited = true;
-      reject(error);
-    });
-    child.once("exit", (code, signal) => {
-      childExited = true;
-      resolve({ code, signal });
-    });
-  });
+  ownedServer = observeOwnedProcess(child);
   closeSync(logFD);
   child.unref();
-  // The harness must stay alive to observe server-owned exit without relying on a leaked timeout.
-  child.ref();
+  ownedServer.ref();
 
-  const health = await pollHealth(managementPort, dapPort, exit);
+  const health = await pollHealth(
+    managementPort,
+    dapPort,
+    ownedServer.outcome,
+  );
   if (
     health.service !== "bingo" ||
     health.managementApiVersion !== 1 ||
@@ -88,11 +84,14 @@ try {
     throw new Error(`unexpected packaged server health: ${JSON.stringify(health)}`);
   }
 
-  const outcome = await withTimeout(
-    exit,
+  const outcome = await waitForOwnedProcessExit(
+    ownedServer,
     idleTimeoutMs + 8000,
     "packaged server did not self-exit after its idle grace",
   );
+  if (outcome.kind === "error") {
+    throw outcome.error;
+  }
   if (outcome.code !== 0 || outcome.signal !== null) {
     throw new Error(
       `packaged server exited with code ${String(outcome.code)} signal ${String(outcome.signal)}`,
@@ -104,13 +103,10 @@ try {
 } catch (error) {
   failure = error;
 } finally {
-  if (failure !== undefined && child !== undefined && !childExited) {
+  if (failure !== undefined && ownedServer !== undefined) {
     try {
-      if (child.pid !== undefined && exit !== undefined) {
-        child.ref();
-        await terminateOwnedProcessGroup(child.pid, exit);
-        childExited = true;
-      }
+      await terminateOwnedProcessGroup(ownedServer);
+      cleanupComplete = true;
     } catch (cleanupError) {
       failure = new AggregateError(
         [failure, cleanupError],
@@ -118,7 +114,7 @@ try {
       );
     }
   }
-  if (child === undefined || childExited) {
+  if (failure === undefined || ownedServer === undefined || cleanupComplete) {
     try {
       rmSync(extracted, { force: true, recursive: true });
     } catch (cleanupError) {
@@ -131,7 +127,7 @@ try {
             );
     }
   } else {
-    log(`Preserved ${extracted}: test-owned server exit was not confirmed`);
+    log(`Preserved ${extracted}: test-owned process-group cleanup was incomplete`);
   }
 }
 

--- a/editors/vscode/test/owned-process.test.ts
+++ b/editors/vscode/test/owned-process.test.ts
@@ -1,52 +1,193 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import process from "node:process";
 import { describe, it } from "node:test";
 
 import {
+  observeOwnedProcess,
   terminateOwnedProcessGroup,
+  type OwnedProcess,
+  type OwnedProcessOutcome,
   type ProcessSignal,
 } from "../scripts/owned-process.mjs";
 
 describe("test-owned process cleanup", () => {
-  it("signals only the detached process group and waits for exit", async () => {
-    const calls: Array<{ readonly pid: number; readonly signal: NodeJS.Signals }> = [];
-    let finishExit: (() => void) | undefined;
-    const exit = new Promise<void>((resolve) => {
-      finishExit = resolve;
-    });
+  it(
+    "removes a detached parent and its inherited child",
+    { timeout: 5000 },
+    async (context) => {
+      const parent = spawn(
+        process.execPath,
+        [
+          "-e",
+          [
+            'const { spawn } = require("node:child_process");',
+            'process.on("SIGTERM", () => {});',
+            'const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });',
+            'process.stdout.write(`${String(child.pid)}\\n`);',
+            "setInterval(() => {}, 1000);",
+          ].join("\n"),
+        ],
+        {
+          detached: true,
+          stdio: ["ignore", "pipe", "ignore"],
+        },
+      );
+      const ownedProcess = observeOwnedProcess(parent);
+      context.after(async () => {
+        const pid = ownedProcess.pid;
+        if (pid === undefined || ownedProcess.isFinished()) {
+          return;
+        }
+        try {
+          process.kill(-pid, "SIGKILL");
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+            throw error;
+          }
+        }
+        await ownedProcess.outcome;
+      });
+
+      const stdout = parent.stdout;
+      if (stdout === null) {
+        throw new Error("detached test parent has no stdout");
+      }
+      const chunk = await new Promise<Buffer>((resolve, reject) => {
+        stdout.once("data", (data: Buffer) => {
+          resolve(data);
+        });
+        stdout.once("error", reject);
+      });
+      const childPid = Number(String(chunk).trim());
+      assert.ok(Number.isSafeInteger(childPid) && childPid > 0);
+
+      const outcome = await terminateOwnedProcessGroup(ownedProcess, {
+        gracefulTimeoutMs: 25,
+        exitTimeoutMs: 2000,
+        groupTimeoutMs: 2000,
+        pollIntervalMs: 5,
+      });
+
+      assert.deepEqual(outcome, {
+        kind: "exit",
+        code: null,
+        signal: "SIGKILL",
+      });
+      assert.equal(processExists(childPid), false);
+    },
+  );
+
+  it("escalates only after the graceful timeout", async () => {
+    const controlled = controlledOwnedProcess(4321);
+    const calls: Array<{
+      readonly pid: number;
+      readonly signal: NodeJS.Signals | number;
+    }> = [];
     const signalProcess: ProcessSignal = (pid, signal) => {
       calls.push({ pid, signal });
-      finishExit?.();
+      if (pid === -4321 && signal === "SIGKILL") {
+        controlled.finish({
+          kind: "exit",
+          code: null,
+          signal: "SIGKILL",
+        });
+      }
+      if (pid === -4321 && signal === 0) {
+        throw errno("ESRCH");
+      }
       return true;
     };
 
-    await terminateOwnedProcessGroup(4321, exit, signalProcess);
-    assert.deepEqual(calls, [{ pid: -4321, signal: "SIGKILL" }]);
+    await terminateOwnedProcessGroup(controlled.ownedProcess, {
+      gracefulTimeoutMs: 1,
+      exitTimeoutMs: 100,
+      groupTimeoutMs: 100,
+      pollIntervalMs: 1,
+      signalProcess,
+    });
+
+    assert.deepEqual(calls, [
+      { pid: 4321, signal: "SIGTERM" },
+      { pid: 4321, signal: 0 },
+      { pid: -4321, signal: "SIGKILL" },
+      { pid: -4321, signal: 0 },
+    ]);
   });
 
-  it("tolerates an already-exited owned process group", async () => {
-    const signalProcess: ProcessSignal = () => {
-      const error = new Error("gone") as NodeJS.ErrnoException;
-      error.code = "ESRCH";
-      throw error;
-    };
+  it("does not signal after the explicit outcome latch has settled", async () => {
+    const controlled = controlledOwnedProcess(4321);
+    controlled.finish({ kind: "exit", code: null, signal: "SIGKILL" });
+    const calls: Array<{
+      readonly pid: number;
+      readonly signal: NodeJS.Signals | number;
+    }> = [];
 
-    await terminateOwnedProcessGroup(
-      4321,
-      Promise.resolve(),
-      signalProcess,
+    await assert.rejects(
+      terminateOwnedProcessGroup(controlled.ownedProcess, {
+        signalProcess(pid, signal) {
+          calls.push({ pid, signal });
+          return true;
+        },
+      }),
+      /finished before cleanup/,
     );
+    assert.deepEqual(calls, []);
   });
 
   it("surfaces unexpected cleanup signal failures", async () => {
+    const controlled = controlledOwnedProcess(4321);
     const signalProcess: ProcessSignal = () => {
-      const error = new Error("permission denied") as NodeJS.ErrnoException;
-      error.code = "EPERM";
-      throw error;
+      throw errno("EPERM", "permission denied");
     };
 
     await assert.rejects(
-      terminateOwnedProcessGroup(4321, Promise.resolve(), signalProcess),
+      terminateOwnedProcessGroup(controlled.ownedProcess, { signalProcess }),
       /permission denied/,
     );
   });
 });
+
+function controlledOwnedProcess(pid: number): {
+  readonly ownedProcess: OwnedProcess;
+  finish(outcome: OwnedProcessOutcome): void;
+} {
+  let finished = false;
+  let resolveOutcome: ((outcome: OwnedProcessOutcome) => void) | undefined;
+  const outcome = new Promise<OwnedProcessOutcome>((resolve) => {
+    resolveOutcome = resolve;
+  });
+  return {
+    ownedProcess: {
+      pid,
+      outcome,
+      isFinished: () => finished,
+      ref() {},
+    },
+    finish(value) {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      resolveOutcome?.(value);
+    },
+  };
+}
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function errno(code: string, message = code): NodeJS.ErrnoException {
+  const error = new Error(message) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}

--- a/editors/vscode/test/owned-process.test.ts
+++ b/editors/vscode/test/owned-process.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import process from "node:process";
-import { describe, it } from "node:test";
+import { describe, it, type TestContext } from "node:test";
 
 import {
   observeOwnedProcess,
@@ -13,56 +13,15 @@ import {
 
 describe("test-owned process cleanup", () => {
   it(
-    "removes a detached parent and its inherited child",
+    "removes an uncooperative detached parent and its inherited child",
     { timeout: 5000 },
     async (context) => {
-      const parent = spawn(
-        process.execPath,
-        [
-          "-e",
-          [
-            'const { spawn } = require("node:child_process");',
-            'process.on("SIGTERM", () => {});',
-            'const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });',
-            'process.stdout.write(`${String(child.pid)}\\n`);',
-            "setInterval(() => {}, 1000);",
-          ].join("\n"),
-        ],
-        {
-          detached: true,
-          stdio: ["ignore", "pipe", "ignore"],
-        },
-      );
-      const ownedProcess = observeOwnedProcess(parent);
-      context.after(async () => {
-        const pid = ownedProcess.pid;
-        if (pid === undefined || ownedProcess.isFinished()) {
-          return;
-        }
-        try {
-          process.kill(-pid, "SIGKILL");
-        } catch (error) {
-          if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
-            throw error;
-          }
-        }
-        await ownedProcess.outcome;
-      });
+      const fixture = await spawnParentWithChild(context, [
+        'process.on("SIGTERM", () => {});',
+        "setInterval(() => {}, 1000);",
+      ]);
 
-      const stdout = parent.stdout;
-      if (stdout === null) {
-        throw new Error("detached test parent has no stdout");
-      }
-      const chunk = await new Promise<Buffer>((resolve, reject) => {
-        stdout.once("data", (data: Buffer) => {
-          resolve(data);
-        });
-        stdout.once("error", reject);
-      });
-      const childPid = Number(String(chunk).trim());
-      assert.ok(Number.isSafeInteger(childPid) && childPid > 0);
-
-      const outcome = await terminateOwnedProcessGroup(ownedProcess, {
+      const outcome = await terminateOwnedProcessGroup(fixture.ownedProcess, {
         gracefulTimeoutMs: 25,
         exitTimeoutMs: 2000,
         groupTimeoutMs: 2000,
@@ -74,104 +33,223 @@ describe("test-owned process cleanup", () => {
         code: null,
         signal: "SIGKILL",
       });
-      assert.equal(processExists(childPid), false);
+      assert.equal(processExists(fixture.childPid), false);
+    },
+  );
+
+  it(
+    "removes an inherited child after the detached parent exits first",
+    { timeout: 5000 },
+    async (context) => {
+      const fixture = await spawnParentWithChild(context, ["process.exit(23);"]);
+      const parentOutcome = await fixture.ownedProcess.outcome;
+      assert.deepEqual(parentOutcome, {
+        kind: "exit",
+        code: 23,
+        signal: null,
+      });
+      assert.equal(processExists(fixture.childPid), true);
+
+      const cleanupOutcome = await terminateOwnedProcessGroup(
+        fixture.ownedProcess,
+        {
+          gracefulTimeoutMs: 10,
+          exitTimeoutMs: 2000,
+          groupTimeoutMs: 2000,
+          pollIntervalMs: 5,
+        },
+      );
+
+      assert.deepEqual(cleanupOutcome, parentOutcome);
+      assert.equal(processExists(fixture.childPid), false);
+    },
+  );
+
+  it(
+    "does not signal after a detached process exits without descendants",
+    { timeout: 5000 },
+    async () => {
+      const calls: Array<{
+        readonly pid: number;
+        readonly signal: NodeJS.Signals | number;
+      }> = [];
+      const signalProcess: ProcessSignal = (pid, signal) => {
+        calls.push({ pid, signal });
+        return process.kill(pid, signal);
+      };
+      const child = spawn(process.execPath, ["-e", "process.exit(19)"], {
+        detached: true,
+        stdio: "ignore",
+      });
+      const ownedProcess = observeOwnedProcess(child, signalProcess);
+      const outcome = await ownedProcess.outcome;
+      assert.deepEqual(outcome, {
+        kind: "exit",
+        code: 19,
+        signal: null,
+      });
+      calls.length = 0;
+
+      const cleanupOutcome = await terminateOwnedProcessGroup(ownedProcess, {
+        gracefulTimeoutMs: 1,
+        exitTimeoutMs: 100,
+        groupTimeoutMs: 100,
+        pollIntervalMs: 1,
+      });
+
+      assert.deepEqual(cleanupOutcome, outcome);
+      assert.deepEqual(calls, []);
     },
   );
 
   it("escalates only after the graceful timeout", async () => {
     const controlled = controlledOwnedProcess(4321);
-    const calls: Array<{
-      readonly pid: number;
-      readonly signal: NodeJS.Signals | number;
-    }> = [];
-    const signalProcess: ProcessSignal = (pid, signal) => {
-      calls.push({ pid, signal });
-      if (pid === -4321 && signal === "SIGKILL") {
-        controlled.finish({
-          kind: "exit",
-          code: null,
-          signal: "SIGKILL",
-        });
-      }
-      if (pid === -4321 && signal === 0) {
-        throw errno("ESRCH");
-      }
-      return true;
-    };
 
     await terminateOwnedProcessGroup(controlled.ownedProcess, {
       gracefulTimeoutMs: 1,
       exitTimeoutMs: 100,
       groupTimeoutMs: 100,
       pollIntervalMs: 1,
-      signalProcess,
     });
 
-    assert.deepEqual(calls, [
+    assert.deepEqual(controlled.signals, [
       { pid: 4321, signal: "SIGTERM" },
-      { pid: 4321, signal: 0 },
       { pid: -4321, signal: "SIGKILL" },
-      { pid: -4321, signal: 0 },
     ]);
   });
 
-  it("does not signal after the explicit outcome latch has settled", async () => {
-    const controlled = controlledOwnedProcess(4321);
-    controlled.finish({ kind: "exit", code: null, signal: "SIGKILL" });
-    const calls: Array<{
-      readonly pid: number;
-      readonly signal: NodeJS.Signals | number;
-    }> = [];
-
-    await assert.rejects(
-      terminateOwnedProcessGroup(controlled.ownedProcess, {
-        signalProcess(pid, signal) {
-          calls.push({ pid, signal });
-          return true;
-        },
-      }),
-      /finished before cleanup/,
-    );
-    assert.deepEqual(calls, []);
-  });
-
   it("surfaces unexpected cleanup signal failures", async () => {
-    const controlled = controlledOwnedProcess(4321);
-    const signalProcess: ProcessSignal = () => {
-      throw errno("EPERM", "permission denied");
-    };
+    const controlled = controlledOwnedProcess(
+      4321,
+      new Error("permission denied"),
+    );
 
     await assert.rejects(
-      terminateOwnedProcessGroup(controlled.ownedProcess, { signalProcess }),
+      terminateOwnedProcessGroup(controlled.ownedProcess),
       /permission denied/,
     );
   });
 });
 
-function controlledOwnedProcess(pid: number): {
+async function spawnParentWithChild(
+  context: TestContext,
+  afterSpawn: readonly string[],
+): Promise<{
+  readonly childPid: number;
   readonly ownedProcess: OwnedProcess;
-  finish(outcome: OwnedProcessOutcome): void;
+}> {
+  const parent = spawn(
+    process.execPath,
+    [
+      "-e",
+      [
+        'const { spawn } = require("node:child_process");',
+        'const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });',
+        'process.stdout.write(`${String(child.pid)}\\n`);',
+        ...afterSpawn,
+      ].join("\n"),
+    ],
+    {
+      detached: true,
+      stdio: ["ignore", "pipe", "ignore"],
+    },
+  );
+  const ownedProcess = observeOwnedProcess(parent);
+  const stdout = parent.stdout;
+  if (stdout === null) {
+    throw new Error("detached test parent has no stdout");
+  }
+  const chunk = await new Promise<Buffer>((resolve, reject) => {
+    stdout.once("data", (data: Buffer) => {
+      resolve(data);
+    });
+    stdout.once("error", reject);
+  });
+  const childPid = Number(String(chunk).trim());
+  assert.ok(Number.isSafeInteger(childPid) && childPid > 0);
+  context.after(async () => {
+    await stopFixture(parent, ownedProcess, childPid);
+  });
+  return { childPid, ownedProcess };
+}
+
+async function stopFixture(
+  parent: ChildProcess,
+  ownedProcess: OwnedProcess,
+  childPid: number,
+): Promise<void> {
+  if (!ownedProcess.isFinished() && parent.pid !== undefined) {
+    sendIfPresent(parent.pid, "SIGKILL");
+  }
+  sendIfPresent(childPid, "SIGKILL");
+  if (!ownedProcess.isFinished()) {
+    await Promise.race([
+      ownedProcess.outcome,
+      new Promise((resolve) => {
+        setTimeout(resolve, 1000);
+      }),
+    ]);
+  }
+}
+
+function controlledOwnedProcess(
+  pid: number,
+  leaderSignalError?: Error,
+): {
+  readonly ownedProcess: OwnedProcess;
+  readonly signals: Array<{
+    readonly pid: number;
+    readonly signal: NodeJS.Signals;
+  }>;
 } {
   let finished = false;
+  let groupAlive = true;
   let resolveOutcome: ((outcome: OwnedProcessOutcome) => void) | undefined;
   const outcome = new Promise<OwnedProcessOutcome>((resolve) => {
     resolveOutcome = resolve;
   });
+  const signals: Array<{
+    readonly pid: number;
+    readonly signal: NodeJS.Signals;
+  }> = [];
   return {
     ownedProcess: {
       pid,
       outcome,
+      hasProcessGroup: () => groupAlive,
       isFinished: () => finished,
       ref() {},
+      signalGroup(signal) {
+        signals.push({ pid: -pid, signal });
+        groupAlive = false;
+        finished = true;
+        resolveOutcome?.({
+          kind: "exit",
+          code: null,
+          signal: "SIGKILL",
+        });
+        return true;
+      },
+      signalLeader(signal) {
+        if (leaderSignalError !== undefined) {
+          throw leaderSignalError;
+        }
+        signals.push({ pid, signal });
+        return true;
+      },
     },
-    finish(value) {
-      if (finished) {
-        return;
-      }
-      finished = true;
-      resolveOutcome?.(value);
-    },
+    signals,
   };
+}
+
+function sendIfPresent(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(pid, signal);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+      throw error;
+    }
+  }
 }
 
 function processExists(pid: number): boolean {
@@ -184,10 +262,4 @@ function processExists(pid: number): boolean {
     }
     throw error;
   }
-}
-
-function errno(code: string, message = code): NodeJS.ErrnoException {
-  const error = new Error(message) as NodeJS.ErrnoException;
-  error.code = code;
-  return error;
 }

--- a/editors/vscode/test/packagedE2E.ts
+++ b/editors/vscode/test/packagedE2E.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { EventEmitter, once } from "node:events";
 import {
   existsSync,
@@ -17,6 +17,12 @@ import { filterTree } from "../src/tree.js";
 import { SessionRegistry } from "../src/registry.js";
 import { defaultDelay, ServerManager } from "../src/serverManager.js";
 import { spawnDetachedServer } from "../src/serverProcess.js";
+import {
+  observeOwnedProcess,
+  terminateOwnedProcessGroup,
+  waitForOwnedProcessExit,
+  type OwnedProcess,
+} from "../scripts/owned-process.mjs";
 import {
   decodeSessionAnnouncement,
   sessionDAPEventName,
@@ -63,9 +69,10 @@ async function main(): Promise<void> {
   );
   rmSync(scratch, { force: true, recursive: true });
   mkdirSync(scratch, { recursive: true });
-  let child: ChildProcess | undefined;
+  let ownedServer: OwnedProcess | undefined;
   let manager: ServerManager | undefined;
-  let succeeded = false;
+  let failure: Error | undefined;
+  let cleanupComplete = false;
   try {
     const vsix = resolve(repositoryRoot, "dist", `bingo-${target}.vsix`);
     const extracted = join(scratch, "vsix");
@@ -92,7 +99,8 @@ async function main(): Promise<void> {
       spawnServer(request, onOutcome) {
         spawns += 1;
         return spawnDetachedServer(request, onOutcome, (command, args, options) => {
-          child = spawn(command, args, options);
+          const child = spawn(command, args, options);
+          ownedServer = observeOwnedProcess(child);
           return child;
         });
       },
@@ -145,36 +153,71 @@ async function main(): Promise<void> {
     assert.ok(firstDepth <= lastDepth);
 
     manager.dispose();
-    if (child === undefined) {
+    if (ownedServer === undefined) {
       throw new Error("managed server was not spawned");
     }
-    await waitForExit(child, config.idleTimeoutMs + 10_000);
+    const outcome = await waitForOwnedProcessExit(
+      ownedServer,
+      config.idleTimeoutMs + 10_000,
+      "managed server did not self-exit",
+    );
+    if (outcome.kind === "error") {
+      throw outcome.error;
+    }
     assert.equal(
-      child.exitCode,
+      outcome.code,
       0,
       "managed server must self-exit cleanly after idle",
     );
+    assert.equal(outcome.signal, null);
     process.stdout.write(
       `[idle] instance=${firstHealth.instanceId} self-exited after all sessions closed\n`,
     );
-    succeeded = true;
+  } catch (error) {
+    failure = asError(error);
   } finally {
-    if (!succeeded) {
+    if (failure !== undefined) {
       manager?.dispose();
     }
+    if (failure !== undefined && ownedServer !== undefined) {
+      try {
+        await terminateOwnedProcessGroup(ownedServer, {
+          gracefulTimeoutMs: 5000,
+          exitTimeoutMs: 5000,
+          groupTimeoutMs: 3000,
+        });
+        cleanupComplete = true;
+      } catch (cleanupError) {
+        failure = new AggregateError(
+          [failure, asError(cleanupError)],
+          "packaged concurrency E2E failed and test-owned process cleanup also failed",
+        );
+      }
+    }
     const serverLog = join(scratch, "server.log");
-    if (!succeeded && existsSync(serverLog)) {
+    if (failure !== undefined && existsSync(serverLog)) {
       process.stderr.write(`[server log]\n${readFileSync(serverLog, "utf8")}\n`);
     }
-    if (!succeeded && child?.pid !== undefined && child.exitCode === null) {
+    if (failure === undefined || ownedServer === undefined || cleanupComplete) {
       try {
-        process.kill(child.pid, "SIGKILL");
-      } catch {
-        // The exact test-owned server may already have exited.
+        rmSync(scratch, { force: true, recursive: true });
+      } catch (cleanupError) {
+        failure =
+          failure === undefined
+            ? asError(cleanupError)
+            : new AggregateError(
+                [failure, asError(cleanupError)],
+                "packaged concurrency E2E failed and scratch cleanup also failed",
+              );
       }
-      await Promise.race([once(child, "exit"), delay(3000)]);
+    } else {
+      process.stderr.write(
+        `Preserved ${scratch}: test-owned process-group cleanup was incomplete\n`,
+      );
     }
-    rmSync(scratch, { force: true, recursive: true });
+  }
+  if (failure !== undefined) {
+    throw failure;
   }
 }
 
@@ -551,22 +594,14 @@ async function freePort(): Promise<number> {
   return port;
 }
 
-async function waitForExit(process: ChildProcess, timeoutMs: number): Promise<void> {
-  if (process.exitCode !== null) {
-    return;
-  }
-  await Promise.race([
-    once(process, "exit").then(() => undefined),
-    delay(timeoutMs).then(() => {
-      throw new Error("managed server did not self-exit");
-    }),
-  ]);
-}
-
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolveDelay) => {
     setTimeout(resolveDelay, milliseconds);
   });
+}
+
+function asError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
 }
 
 function run(command: string, args: readonly string[]): void {

--- a/editors/vscode/test/workspace.test.ts
+++ b/editors/vscode/test/workspace.test.ts
@@ -47,15 +47,21 @@ describe("repository VS Code integration", () => {
     assert.doesNotMatch(productionProcessSources, /SIGKILL|process\.kill/);
     assert.match(
       readText("editors/vscode/scripts/owned-process.mjs"),
-      /signalProcess\(-pid, "SIGKILL"\)/,
+      /sendSignal\(signalProcess, -pid, "SIGKILL"\)/,
     );
     const smoke = readText("editors/vscode/scripts/smoke-server.mjs");
-    assert.match(
-      smoke,
-      /failure !== undefined && child !== undefined && !childExited/,
-    );
+    assert.match(smoke, /ownedServer = observeOwnedProcess\(child\)/);
     assert.match(smoke, /terminateOwnedProcessGroup/);
-    assert.match(smoke, /if \(child === undefined \|\| childExited\)/);
+    assert.match(smoke, /cleanupComplete/);
+    assert.match(smoke, /process-group cleanup was incomplete/);
+
+    const packagedE2E = readText("editors/vscode/test/packagedE2E.ts");
+    assert.match(packagedE2E, /ownedServer = observeOwnedProcess\(child\)/);
+    assert.match(packagedE2E, /terminateOwnedProcessGroup/);
+    assert.doesNotMatch(
+      packagedE2E,
+      /process\.kill\s*\(\s*child\.pid\s*,\s*["']SIGKILL["']/,
+    );
   });
 
   it("exposes exactly the two normal bingo debug choices", () => {

--- a/editors/vscode/test/workspace.test.ts
+++ b/editors/vscode/test/workspace.test.ts
@@ -47,7 +47,7 @@ describe("repository VS Code integration", () => {
     assert.doesNotMatch(productionProcessSources, /SIGKILL|process\.kill/);
     assert.match(
       readText("editors/vscode/scripts/owned-process.mjs"),
-      /sendSignal\(signalProcess, -pid, "SIGKILL"\)/,
+      /ownedProcess\.signalGroup\("SIGKILL"\)/,
     );
     const smoke = readText("editors/vscode/scripts/smoke-server.mjs");
     assert.match(smoke, /ownedServer = observeOwnedProcess\(child\)/);


### PR DESCRIPTION
## Summary

- track detached packaged servers with an explicit exit/error latch and one-way owned-group state before cleanup signaling
- request graceful exact-PID shutdown, then bound and verify owned process-group escalation even when the server leader exits before descendants
- aggregate cleanup failures, preserve scratch evidence, and align the documented test-only ownership invariant

## Testing

- `npm --prefix editors/vscode run check` (119/119 tests)
- cleanup process tests repeated 25/25 runs
- `go vet -tags bingonative ./...`
- `just vscode-package`
- `npm --prefix editors/vscode run smoke:server`
- `just build-examples && npm --prefix editors/vscode run e2e:packaged`

Fixes #153