### PR TITLE
fix(ci): fail Darwin verification closed for fork updates

### DIFF
--- a/.github/scripts/darwin-verification-gate.sh
+++ b/.github/scripts/darwin-verification-gate.sh
@@ -19,18 +19,33 @@ declared_changed_files=$(jq -er \
   "$GITHUB_EVENT_PATH")
 run_url="${GITHUB_SERVER_URL:-https://github.com}/$GITHUB_REPOSITORY/actions/runs/${GITHUB_RUN_ID:-0}"
 final_status_posted=false
+decision_file=${DARWIN_GATE_DECISION_FILE:-}
+
+# The workflow treats an absent decision as "interrupted after posting pending"
+# and fails the head closed, so only terminal outcomes may be recorded here.
+record_decision() {
+  [ -n "$decision_file" ] || return 0
+  printf '%s\n' "$1" > "$decision_file"
+}
 
 post_status() {
   local state=$1
   local description=$2
 
-  gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$head_sha" \
+  # A decision is only real once GitHub accepted it, and `fail_closed` runs with
+  # `set +e`, so the POST result must be checked explicitly rather than relying
+  # on `set -e` to abort here.
+  if ! gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$head_sha" \
     -f state="$state" \
     -f context="$status_context" \
     -f description="$description" \
-    -f target_url="$run_url" >/dev/null
+    -f target_url="$run_url" >/dev/null; then
+    return 1
+  fi
+
   if [ "$state" != "pending" ]; then
     final_status_posted=true
+    record_decision "$state"
   fi
 }
 
@@ -57,6 +72,7 @@ esac
 if { [ "$event_action" = "labeled" ] || [ "$event_action" = "unlabeled" ]; } &&
   [ "$event_label" != "$verified_label" ]; then
   echo "Ignoring unrelated '$event_label' label event; the existing head-SHA status remains authoritative."
+  record_decision ignored
   exit 0
 fi
 

--- a/.github/scripts/darwin-verification-gate.sh
+++ b/.github/scripts/darwin-verification-gate.sh
@@ -1,29 +1,70 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -Eeuo pipefail
 
 : "${GITHUB_EVENT_PATH:?GITHUB_EVENT_PATH is required}"
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 
 readonly verified_label='darwin-e2e-verified'
+readonly status_context='Darwin E2E verified'
 readonly darwin_native_regex='^(internal/debugger/.*_darwin_.*|internal/debugger/trap_arm64\.go|test/integration/.*_darwin_.*_test\.go|entitlements\.plist)$'
 
 event_action=$(jq -er '.action' "$GITHUB_EVENT_PATH")
 pr_number=$(jq -er '.pull_request.number' "$GITHUB_EVENT_PATH")
+head_sha=$(jq -er '.pull_request.head.sha | select(test("^[0-9a-fA-F]{40,64}$"))' "$GITHUB_EVENT_PATH")
 head_repository=$(jq -er '.pull_request.head.repo.full_name // ""' "$GITHUB_EVENT_PATH")
 event_label=$(jq -er '.label.name // ""' "$GITHUB_EVENT_PATH")
+declared_changed_files=$(jq -er \
+  '.pull_request.changed_files | numbers | select(. >= 0 and floor == .)' \
+  "$GITHUB_EVENT_PATH")
+run_url="${GITHUB_SERVER_URL:-https://github.com}/$GITHUB_REPOSITORY/actions/runs/${GITHUB_RUN_ID:-0}"
+final_status_posted=false
+
+post_status() {
+  local state=$1
+  local description=$2
+
+  gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$head_sha" \
+    -f state="$state" \
+    -f context="$status_context" \
+    -f description="$description" \
+    -f target_url="$run_url" >/dev/null
+  if [ "$state" != "pending" ]; then
+    final_status_posted=true
+  fi
+}
+
+fail_closed() {
+  local exit_code=$?
+
+  trap - ERR
+  if [ "$final_status_posted" != "true" ]; then
+    set +e
+    post_status failure 'Darwin verification gate could not evaluate this head.'
+  fi
+  exit "$exit_code"
+}
+trap fail_closed ERR
 
 case "$event_action" in
   opened | synchronize | reopened | labeled | unlabeled) ;;
   *)
-    echo "Unsupported pull_request action: $event_action" >&2
+    echo "Unsupported pull_request_target action: $event_action" >&2
     exit 2
     ;;
 esac
 
+if { [ "$event_action" = "labeled" ] || [ "$event_action" = "unlabeled" ]; } &&
+  [ "$event_label" != "$verified_label" ]; then
+  echo "Ignoring unrelated '$event_label' label event; the existing head-SHA status remains authoritative."
+  exit 0
+fi
+
+post_status pending 'Evaluating Darwin verification policy.'
+
 label_cleanup=not-run
 if [ "$event_action" = "synchronize" ] || [ "$event_action" = "reopened" ]; then
-  if output=$(gh pr edit "$pr_number" --repo "$GITHUB_REPOSITORY" \
+  if output=$(trap - ERR; gh pr edit "$pr_number" --repo "$GITHUB_REPOSITORY" \
     --remove-label "$verified_label" 2>&1); then
     label_cleanup=cleared
     echo "Cleared '$verified_label' if present; this head requires re-verification."
@@ -31,59 +72,79 @@ if [ "$event_action" = "synchronize" ] || [ "$event_action" = "reopened" ]; then
     exit_code=$?
     label_cleanup=failed
     if [ "$head_repository" != "$GITHUB_REPOSITORY" ]; then
-      echo "::warning title=Stale Darwin verification label not removed::The public-fork GITHUB_TOKEN is read-only, so '$verified_label' could not be removed (exit $exit_code). The gate will fail closed; remove or toggle the stale label, then re-add it to verify this head."
+      echo "::warning title=Stale Darwin verification label not removed::The public-fork GITHUB_TOKEN could not remove '$verified_label' (exit $exit_code). The head status will fail closed; remove or toggle the stale label, then re-add it after local verification."
     else
-      echo "::warning title=Stale Darwin verification label not removed::The API failed to remove '$verified_label' (exit $exit_code). The gate will fail closed; remove or toggle the stale label, then re-add it to verify this head."
+      echo "::warning title=Stale Darwin verification label not removed::The API could not remove '$verified_label' (exit $exit_code). The head status will fail closed; remove or toggle the stale label, then re-add it after local verification."
     fi
     printf '%s\n' "$output" >&2
   fi
 fi
 
-changed_files=$(mktemp)
-trap 'rm -f "$changed_files"' EXIT
-gh pr diff "$pr_number" --repo "$GITHUB_REPOSITORY" --name-only > "$changed_files"
+files_json=$(mktemp)
+trap 'rm -f "$files_json"' EXIT
+gh api --paginate --slurp \
+  "repos/$GITHUB_REPOSITORY/pulls/$pr_number/files?per_page=100" > "$files_json"
+listed_changed_files=$(jq -er '[.[][]] | length' "$files_json")
+
+if [ "$listed_changed_files" -ne "$declared_changed_files" ]; then
+  echo "PR files API returned $listed_changed_files of $declared_changed_files changed files; refusing an incomplete gate decision." >&2
+  false
+fi
 
 echo "Changed files in this PR:"
-sed 's/^/  /' "$changed_files"
+jq -r '.[][] | .filename | @json' "$files_json" | sed 's/^/  /'
 echo
 
-if ! grep -Eq "$darwin_native_regex" "$changed_files"; then
+darwin_changed=$(jq -r --arg regex "$darwin_native_regex" \
+  'any(.[][]; .filename | test($regex))' "$files_json")
+
+if [ "$darwin_changed" = "false" ]; then
+  post_status success 'No Darwin-native files changed.'
   echo "No darwin-native code changed; gate not required."
   exit 0
 fi
 
+if [ "$darwin_changed" != "true" ]; then
+  echo "Unexpected Darwin path decision: $darwin_changed" >&2
+  false
+fi
+
 echo "Darwin-native (CI-unexecutable) files changed:"
-grep -E "$darwin_native_regex" "$changed_files" | sed 's/^/  /'
+jq -r --arg regex "$darwin_native_regex" \
+  '.[][] | .filename | select(test($regex)) | @json' \
+  "$files_json" | sed 's/^/  /'
 echo
 
-if [ "$event_action" = "synchronize" ] || [ "$event_action" = "reopened" ]; then
-  if [ "$label_cleanup" = "failed" ]; then
-    echo "::error title=Darwin E2E re-verification required::New commits and reopened pull requests invalidate prior Darwin verification. The stale '$verified_label' label could not be removed. Run 'just e2e-darwin' locally on Apple Silicon, remove or toggle the stale label, then re-add it to re-run verification for this head."
-  else
-    echo "::error title=Darwin E2E re-verification required::New commits and reopened pull requests invalidate prior Darwin verification. Run 'just e2e-darwin' locally on Apple Silicon, confirm it passes, then add the '$verified_label' label to re-run verification for this head."
-  fi
-  exit 1
-fi
-
-has_label=$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json labels \
-  -q "[.labels[].name] | any(. == \"$verified_label\")")
-
-if { [ "$event_action" = "labeled" ] || [ "$event_action" = "unlabeled" ]; } &&
-  [ "$event_label" != "$verified_label" ]; then
-  echo "::error title=Darwin E2E verification unchanged::The '$event_label' label event cannot verify this head. Remove or toggle '$verified_label', then re-add it after local verification."
-  exit 1
-fi
-
-case "$has_label" in
-  true)
-    echo "'$verified_label' label present; darwin backend verified locally."
-    ;;
-  false)
-    echo "::error title=Darwin E2E verification required::This PR changes darwin-native debugger code that cannot be executed on GitHub-hosted runners. Run 'just e2e-darwin' locally on Apple Silicon, confirm it passes, then add the '$verified_label' label to this PR."
+case "$event_action" in
+  synchronize | reopened)
+    if [ "$label_cleanup" = "failed" ]; then
+      echo "::error title=Darwin E2E re-verification required::The stale '$verified_label' label could not be removed. Run 'just e2e-darwin' locally on Apple Silicon, remove or toggle the stale label, then re-add it to verify this head."
+    else
+      echo "::error title=Darwin E2E re-verification required::Run 'just e2e-darwin' locally on Apple Silicon, confirm it passes, then add the '$verified_label' label to verify this head."
+    fi
+    post_status failure 'New commits or reopening require Darwin re-verification.'
+    trap - ERR
     exit 1
     ;;
-  *)
-    echo "Unexpected label query result: $has_label" >&2
-    exit 2
+  opened)
+    post_status failure 'Darwin E2E verification is required for this head.'
+    echo "::error title=Darwin E2E verification required::Run 'just e2e-darwin' locally on Apple Silicon, confirm it passes, then add the '$verified_label' label to this PR."
+    trap - ERR
+    exit 1
+    ;;
+  labeled | unlabeled)
+    live_labels=$(gh api --paginate \
+      "repos/$GITHUB_REPOSITORY/issues/$pr_number/labels?per_page=100" \
+      --jq '.[].name')
+    if grep -Fxq "$verified_label" <<< "$live_labels"; then
+      post_status success 'Darwin E2E verified for this head SHA.'
+      echo "'$verified_label' label present; darwin backend verified locally for $head_sha."
+      exit 0
+    fi
+
+    post_status failure 'Darwin verification label is not currently present.'
+    echo "::error title=Darwin E2E verification required::The '$verified_label' label is not currently present on this PR."
+    trap - ERR
+    exit 1
     ;;
 esac

--- a/.github/scripts/darwin-verification-gate.sh
+++ b/.github/scripts/darwin-verification-gate.sh
@@ -59,6 +59,10 @@ fail_closed() {
   fi
   exit "$exit_code"
 }
+# `set -E` propagates this trap into command-substitution subshells, where a
+# failure would post a status the parent then posts again (and where
+# `final_status_posted` cannot propagate back out). Every `$(...)` below the
+# trap therefore disarms it so the parent shell stays the only decision point.
 trap fail_closed ERR
 
 case "$event_action" in
@@ -96,11 +100,11 @@ if [ "$event_action" = "synchronize" ] || [ "$event_action" = "reopened" ]; then
   fi
 fi
 
-files_json=$(mktemp)
+files_json=$(trap - ERR; mktemp)
 trap 'rm -f "$files_json"' EXIT
 gh api --paginate --slurp \
   "repos/$GITHUB_REPOSITORY/pulls/$pr_number/files?per_page=100" > "$files_json"
-listed_changed_files=$(jq -er '[.[][]] | length' "$files_json")
+listed_changed_files=$(trap - ERR; jq -er '[.[][]] | length' "$files_json")
 
 if [ "$listed_changed_files" -ne "$declared_changed_files" ]; then
   echo "PR files API returned $listed_changed_files of $declared_changed_files changed files; refusing an incomplete gate decision." >&2
@@ -111,7 +115,7 @@ echo "Changed files in this PR:"
 jq -r '.[][] | .filename | @json' "$files_json" | sed 's/^/  /'
 echo
 
-darwin_changed=$(jq -r --arg regex "$darwin_native_regex" \
+darwin_changed=$(trap - ERR; jq -r --arg regex "$darwin_native_regex" \
   'any(.[][]; .filename | test($regex))' "$files_json")
 
 if [ "$darwin_changed" = "false" ]; then
@@ -149,7 +153,7 @@ case "$event_action" in
     exit 1
     ;;
   labeled | unlabeled)
-    live_labels=$(gh api --paginate \
+    live_labels=$(trap - ERR; gh api --paginate \
       "repos/$GITHUB_REPOSITORY/issues/$pr_number/labels?per_page=100" \
       --jq '.[].name')
     if grep -Fxq "$verified_label" <<< "$live_labels"; then

--- a/.github/scripts/darwin-verification-gate.sh
+++ b/.github/scripts/darwin-verification-gate.sh
@@ -7,19 +7,19 @@ set -Eeuo pipefail
 
 readonly verified_label='darwin-e2e-verified'
 readonly status_context='Darwin E2E verified'
-readonly darwin_native_regex='^(internal/debugger/.*_darwin_.*|internal/debugger/trap_arm64\.go|test/integration/.*_darwin_.*_test\.go|entitlements\.plist)$'
+readonly darwin_native_regex='^(internal/debugger/.*|test/integration/.*|justfile|entitlements\.plist|go\.(mod|sum)|(.*/)?[^/]*_(darwin|arm64)(_[^/.]+)*\.(go|s|S|c|cc|cpp|cxx|h|hh|hpp|hxx|m|mm|syso)|(.*/)?[^/]*\.(c|cc|cpp|cxx|h|hh|hpp|hxx|m|mm|s|S|syso))$'
 
 event_action=$(jq -er '.action' "$GITHUB_EVENT_PATH")
 pr_number=$(jq -er '.pull_request.number' "$GITHUB_EVENT_PATH")
 head_sha=$(jq -er '.pull_request.head.sha | select(test("^[0-9a-fA-F]{40,64}$"))' "$GITHUB_EVENT_PATH")
+base_sha=$(jq -er '.pull_request.base.sha | select(test("^[0-9a-fA-F]{40,64}$"))' "$GITHUB_EVENT_PATH")
 head_repository=$(jq -er '.pull_request.head.repo.full_name // ""' "$GITHUB_EVENT_PATH")
 event_label=$(jq -er '.label.name // ""' "$GITHUB_EVENT_PATH")
-declared_changed_files=$(jq -er \
-  '.pull_request.changed_files | numbers | select(. >= 0 and floor == .)' \
-  "$GITHUB_EVENT_PATH")
+base_changed=$(jq -r '(.changes.base // null) != null' "$GITHUB_EVENT_PATH")
 run_url="${GITHUB_SERVER_URL:-https://github.com}/$GITHUB_REPOSITORY/actions/runs/${GITHUB_RUN_ID:-0}"
 final_status_posted=false
 decision_file=${DARWIN_GATE_DECISION_FILE:-}
+approval_ready=false
 
 # The workflow treats an absent decision as "interrupted after posting pending"
 # and fails the head closed, so only terminal outcomes may be recorded here.
@@ -66,7 +66,7 @@ fail_closed() {
 trap fail_closed ERR
 
 case "$event_action" in
-  opened | synchronize | reopened | labeled | unlabeled) ;;
+  opened | synchronize | reopened | edited | labeled | unlabeled) ;;
   *)
     echo "Unsupported pull_request_target action: $event_action" >&2
     exit 2
@@ -80,10 +80,40 @@ if { [ "$event_action" = "labeled" ] || [ "$event_action" = "unlabeled" ]; } &&
   exit 0
 fi
 
+if [ "$event_action" = "edited" ] && [ "$base_changed" != "true" ]; then
+  echo "Ignoring pull request edit that did not change the base; the existing head-SHA status remains authoritative."
+  record_decision ignored
+  exit 0
+fi
+
+if [ "$event_action" = "labeled" ] && [ "$event_label" = "$verified_label" ]; then
+  prior_statuses_json=$(trap - ERR; mktemp)
+  trap 'rm -f "$prior_statuses_json"' EXIT
+  gh api --paginate --slurp \
+    "repos/$GITHUB_REPOSITORY/commits/$head_sha/statuses?per_page=100" \
+    > "$prior_statuses_json"
+  approval_ready=$(trap - ERR; jq -r \
+    --arg context "$status_context" \
+    --arg run_prefix "${GITHUB_SERVER_URL:-https://github.com}/$GITHUB_REPOSITORY/actions/runs/" '
+      [
+        .[][]
+        | select(.context == $context)
+      ][0] as $latest
+      | (
+          $latest.state == "failure"
+          and $latest.creator.login == "github-actions[bot]"
+          and (($latest.target_url // "") | startswith($run_prefix))
+        )
+    ' "$prior_statuses_json")
+  rm -f "$prior_statuses_json"
+fi
+
 post_status pending 'Evaluating Darwin verification policy.'
 
 label_cleanup=not-run
-if [ "$event_action" = "synchronize" ] || [ "$event_action" = "reopened" ]; then
+if [ "$event_action" = "synchronize" ] ||
+  [ "$event_action" = "reopened" ] ||
+  [ "$event_action" = "edited" ]; then
   if output=$(trap - ERR; gh pr edit "$pr_number" --repo "$GITHUB_REPOSITORY" \
     --remove-label "$verified_label" 2>&1); then
     label_cleanup=cleared
@@ -100,23 +130,95 @@ if [ "$event_action" = "synchronize" ] || [ "$event_action" = "reopened" ]; then
   fi
 fi
 
-files_json=$(trap - ERR; mktemp)
-trap 'rm -f "$files_json"' EXIT
-gh api --paginate --slurp \
-  "repos/$GITHUB_REPOSITORY/pulls/$pr_number/files?per_page=100" > "$files_json"
-listed_changed_files=$(trap - ERR; jq -er '[.[][]] | length' "$files_json")
+base_tree_json=$(trap - ERR; mktemp)
+head_tree_json=$(trap - ERR; mktemp)
+changed_paths_json=$(trap - ERR; mktemp)
+trap 'rm -f "$base_tree_json" "$head_tree_json" "$changed_paths_json"' EXIT
 
-if [ "$listed_changed_files" -ne "$declared_changed_files" ]; then
-  echo "PR files API returned $listed_changed_files of $declared_changed_files changed files; refusing an incomplete gate decision." >&2
+merge_base_sha=$(trap - ERR; gh api \
+  "repos/$GITHUB_REPOSITORY/compare/$base_sha...$head_sha" \
+  --jq '.merge_base_commit.sha')
+case "$merge_base_sha" in
+  '' | *[!0-9a-fA-F]*)
+    echo "Compare API returned an invalid merge-base SHA." >&2
+    false
+    ;;
+esac
+
+merge_base_tree_sha=$(trap - ERR; gh api \
+  "repos/$GITHUB_REPOSITORY/git/commits/$merge_base_sha" --jq '.tree.sha')
+head_tree_sha=$(trap - ERR; gh api \
+  "repos/$GITHUB_REPOSITORY/git/commits/$head_sha" --jq '.tree.sha')
+
+gh api "repos/$GITHUB_REPOSITORY/git/trees/$merge_base_tree_sha?recursive=1" \
+  > "$base_tree_json"
+gh api "repos/$GITHUB_REPOSITORY/git/trees/$head_tree_sha?recursive=1" \
+  > "$head_tree_json"
+
+if ! jq -e '.truncated == false and (.tree | type == "array")' \
+  "$base_tree_json" >/dev/null ||
+  ! jq -e '.truncated == false and (.tree | type == "array")' \
+    "$head_tree_json" >/dev/null; then
+  echo "Git tree API returned a truncated or malformed tree; refusing an incomplete gate decision." >&2
+  false
+fi
+
+jq -n \
+  --slurpfile base "$base_tree_json" \
+  --slurpfile head "$head_tree_json" '
+    def entries($doc):
+      reduce ($doc[0].tree[] | select(.type != "tree")) as $entry
+        ({};
+          .[$entry.path] = {
+            mode: $entry.mode,
+            sha: $entry.sha,
+            type: $entry.type
+          });
+    entries($base) as $before
+    | entries($head) as $after
+    | (($before | keys_unsorted) + ($after | keys_unsorted) | unique)
+    | map(select($before[.] != $after[.]) | {
+        path: .,
+        before: $before[.],
+        after: $after[.]
+      })
+  ' > "$changed_paths_json"
+
+listed_changed_files=$(trap - ERR; jq -er 'length' "$changed_paths_json")
+if [ "$listed_changed_files" -eq 0 ]; then
+  echo "Immutable base/head comparison returned no changed files; refusing an empty gate decision." >&2
   false
 fi
 
 echo "Changed files in this PR:"
-jq -r '.[][] | .filename | @json' "$files_json" | sed 's/^/  /'
+jq -r '.[].path | @json' "$changed_paths_json" | sed 's/^/  /'
 echo
 
 darwin_changed=$(trap - ERR; jq -r --arg regex "$darwin_native_regex" \
-  'any(.[][]; .filename | test($regex))' "$files_json")
+  'any(.[].path; test($regex) or test("[[:cntrl:]]"))' \
+  "$changed_paths_json")
+
+if [ "$darwin_changed" = "false" ]; then
+  blob_shas=$(trap - ERR; jq -r '
+    .[]
+    | select(.path | endswith(".go"))
+    | .before.sha, .after.sha
+    | select(type == "string")
+  ' "$changed_paths_json" | sort -u)
+  while IFS= read -r blob_sha; do
+    [ -n "$blob_sha" ] || continue
+    blob_file=$(trap - ERR; mktemp)
+    gh api "repos/$GITHUB_REPOSITORY/git/blobs/$blob_sha" \
+      --jq '.content' | base64 -d > "$blob_file"
+    if grep -Eq '^[[:space:]]*//[[:space:]]*(go:build|\+build)[[:space:]]' \
+      "$blob_file"; then
+      darwin_changed=true
+      rm -f "$blob_file"
+      break
+    fi
+    rm -f "$blob_file"
+  done <<< "$blob_shas"
+fi
 
 if [ "$darwin_changed" = "false" ]; then
   post_status success 'No Darwin-native files changed.'
@@ -131,16 +233,16 @@ fi
 
 echo "Darwin-native (CI-unexecutable) files changed:"
 jq -r --arg regex "$darwin_native_regex" \
-  '.[][] | .filename | select(test($regex)) | @json' \
-  "$files_json" | sed 's/^/  /'
+  '.[].path | select(test($regex) or test("[[:cntrl:]]")) | @json' \
+  "$changed_paths_json" | sed 's/^/  /'
 echo
 
 case "$event_action" in
-  synchronize | reopened)
+  synchronize | reopened | edited)
     if [ "$label_cleanup" = "failed" ]; then
-      echo "::error title=Darwin E2E re-verification required::The stale '$verified_label' label could not be removed. Run 'just e2e-darwin' locally on Apple Silicon, remove or toggle the stale label, then re-add it to verify this head."
+      echo "::error title=Darwin E2E re-verification required::The stale '$verified_label' label could not be removed. Using the trusted base branch's justfile, run the e2e-darwin recipe against this head on Apple Silicon; then remove or toggle the stale label and re-add it."
     else
-      echo "::error title=Darwin E2E re-verification required::Run 'just e2e-darwin' locally on Apple Silicon, confirm it passes, then add the '$verified_label' label to verify this head."
+      echo "::error title=Darwin E2E re-verification required::Using the trusted base branch's justfile, run the e2e-darwin recipe against this head on Apple Silicon, review any PR changes to the recipe, confirm it passes, then add the '$verified_label' label."
     fi
     post_status failure 'New commits or reopening require Darwin re-verification.'
     trap - ERR
@@ -148,7 +250,7 @@ case "$event_action" in
     ;;
   opened)
     post_status failure 'Darwin E2E verification is required for this head.'
-    echo "::error title=Darwin E2E verification required::Run 'just e2e-darwin' locally on Apple Silicon, confirm it passes, then add the '$verified_label' label to this PR."
+    echo "::error title=Darwin E2E verification required::Using the trusted base branch's justfile, run the e2e-darwin recipe against this head on Apple Silicon, review any PR changes to the recipe, confirm it passes, then add the '$verified_label' label."
     trap - ERR
     exit 1
     ;;
@@ -157,6 +259,12 @@ case "$event_action" in
       "repos/$GITHUB_REPOSITORY/issues/$pr_number/labels?per_page=100" \
       --jq '.[].name')
     if grep -Fxq "$verified_label" <<< "$live_labels"; then
+      if [ "$event_action" = "labeled" ] && [ "$approval_ready" != "true" ]; then
+        post_status failure 'Darwin verification must follow a head evaluation.'
+        echo "::error title=Darwin E2E verification not ready::This head has not completed a trusted failing gate run yet. Wait for that run, then toggle '$verified_label' again."
+        trap - ERR
+        exit 1
+      fi
       post_status success 'Darwin E2E verified for this head SHA.'
       echo "'$verified_label' label present; darwin backend verified locally for $head_sha."
       exit 0

--- a/.github/scripts/darwin-verification-gate.sh
+++ b/.github/scripts/darwin-verification-gate.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${EVENT_ACTION:?EVENT_ACTION is required}"
+: "${CHANGED_FILES:?CHANGED_FILES is required}"
+
+VERIFIED_LABEL="${VERIFIED_LABEL:-darwin-e2e-verified}"
+HAS_VERIFIED_LABEL="${HAS_VERIFIED_LABEL:-}"
+LABEL_CLEANUP="${LABEL_CLEANUP:-not-run}"
+
+# These paths require runtime verification on real darwin/arm64 hardware.
+readonly DARWIN_NATIVE_REGEX="${DARWIN_NATIVE_REGEX:-^(internal/debugger/.*_darwin_.*|internal/debugger/trap_arm64\.go|test/integration/.*_darwin_.*_test\.go|entitlements\.plist)$}"
+
+if [ ! -r "$CHANGED_FILES" ]; then
+  echo "Changed-files list is not readable: $CHANGED_FILES" >&2
+  exit 2
+fi
+
+echo "Changed files in this PR:"
+sed 's/^/  /' "$CHANGED_FILES"
+echo
+
+if ! grep -Eq "$DARWIN_NATIVE_REGEX" "$CHANGED_FILES"; then
+  echo "No darwin-native code changed; gate not required."
+  exit 0
+fi
+
+echo "Darwin-native (CI-unexecutable) files changed:"
+grep -E "$DARWIN_NATIVE_REGEX" "$CHANGED_FILES" | sed 's/^/  /'
+echo
+
+if [ "$EVENT_ACTION" = "synchronize" ]; then
+  if [ "$LABEL_CLEANUP" = "failed" ]; then
+    echo "::error title=Darwin E2E re-verification required::New commits always invalidate prior Darwin verification. The stale '$VERIFIED_LABEL' label could not be removed. Run 'just e2e-darwin' locally on Apple Silicon, remove or toggle the stale label, then re-add it to re-run verification for this head."
+  else
+    echo "::error title=Darwin E2E re-verification required::New commits always invalidate prior Darwin verification. Run 'just e2e-darwin' locally on Apple Silicon, confirm it passes, then add the '$VERIFIED_LABEL' label to re-run verification for this head."
+  fi
+  exit 1
+fi
+
+case "$HAS_VERIFIED_LABEL" in
+  true)
+    echo "'$VERIFIED_LABEL' label present; darwin backend verified locally."
+    ;;
+  false)
+    echo "::error title=Darwin E2E verification required::This PR changes darwin-native debugger code that cannot be executed on GitHub-hosted runners. Run 'just e2e-darwin' locally on Apple Silicon, confirm it passes, then add the '$VERIFIED_LABEL' label to this PR."
+    exit 1
+    ;;
+  *)
+    echo "HAS_VERIFIED_LABEL must be true or false for '$EVENT_ACTION' events" >&2
+    exit 2
+    ;;
+esac

--- a/.github/scripts/darwin-verification-gate.sh
+++ b/.github/scripts/darwin-verification-gate.sh
@@ -21,7 +21,7 @@ readonly darwin_native_exts='swigcxx|swig|f90|for|syso|cpp|cxx|hpp|hxx|cc|hh|sx|
 readonly darwin_native_regex="^(internal/debugger/.*|test/integration/.*|justfile|entitlements\\.plist|go\\.(mod|sum)|(.*/)?[^/]*_(darwin|arm64)(_[^/.]+)*\\.(go|$darwin_native_exts)|(.*/)?[^/]*\\.($darwin_native_exts))\$"
 
 event_action=$(jq -er '.action' "$GITHUB_EVENT_PATH")
-pr_number=$(jq -er '.pull_request.number' "$GITHUB_EVENT_PATH")
+pr_number=$(jq -er '.pull_request.number | select(type == "number" and . > 0 and . == floor) | tostring' "$GITHUB_EVENT_PATH")
 head_sha=$(jq -er '.pull_request.head.sha | select(test("^[0-9a-fA-F]{40,64}$"))' "$GITHUB_EVENT_PATH")
 base_sha=$(jq -er '.pull_request.base.sha | select(test("^[0-9a-fA-F]{40,64}$"))' "$GITHUB_EVENT_PATH")
 base_ref=$(jq -er '.pull_request.base.ref // ""' "$GITHUB_EVENT_PATH")
@@ -230,8 +230,21 @@ scan_blob_for_build_constraint() {
     target=$blob_scan
   fi
 
+  # `//go:build` / `// +build` are the explicit constraint forms, but a cgo file
+  # can be Darwin-specific with none of them: `#cgo darwin CFLAGS: …` inside the
+  # preamble makes the file's native behaviour platform-dependent, and
+  # `import "C"` alone pulls in a C toolchain whose flags may differ per OS.
+  # Both are cheap to detect and gating them only over-gates.
   if grep -Eq '^[[:space:]]*//[[:space:]]*(go:build|\+build)[[:space:]]' \
     "$target"; then
+    return 0
+  fi
+
+  # cgo preambles appear either as `// #cgo …` line comments or as bare `#cgo …`
+  # lines inside the `/* … */` block that precedes `import "C"`. A bare `#cgo`
+  # at the start of a line is not valid Go outside such a comment, so anchoring
+  # there cannot false-positive on real code.
+  if grep -Eq '^[[:space:]]*(//[[:space:]]*)?#cgo[[:space:]]' "$target"; then
     return 0
   fi
 
@@ -317,6 +330,18 @@ merge_base_tree_sha=$(trap - ERR; gh api \
   "repos/$GITHUB_REPOSITORY/git/commits/$merge_base_sha" --jq '.tree.sha')
 head_tree_sha=$(trap - ERR; gh api \
   "repos/$GITHUB_REPOSITORY/git/commits/$head_sha" --jq '.tree.sha')
+
+# These reach a URL path. They come from GitHub, not the PR, but an unexpected
+# shape must not be pasted into a request — reject it here rather than relying
+# on the resulting 404 to fail closed.
+for tree_sha in "$merge_base_tree_sha" "$head_tree_sha"; do
+  case "$tree_sha" in
+    '' | *[!0-9a-fA-F]*)
+      echo "Git commit API returned an invalid tree SHA." >&2
+      false
+      ;;
+  esac
+done
 
 gh api "repos/$GITHUB_REPOSITORY/git/trees/$merge_base_tree_sha?recursive=1" \
   > "$base_tree_json"

--- a/.github/scripts/darwin-verification-gate.sh
+++ b/.github/scripts/darwin-verification-gate.sh
@@ -7,19 +7,43 @@ set -Eeuo pipefail
 
 readonly verified_label='darwin-e2e-verified'
 readonly status_context='Darwin E2E verified'
-readonly darwin_native_regex='^(internal/debugger/.*|test/integration/.*|justfile|entitlements\.plist|go\.(mod|sum)|(.*/)?[^/]*_(darwin|arm64)(_[^/.]+)*\.(go|s|S|c|cc|cpp|cxx|h|hh|hpp|hxx|m|mm|syso)|(.*/)?[^/]*\.(c|cc|cpp|cxx|h|hh|hpp|hxx|m|mm|s|S|syso))$'
+readonly required_base_ref='main'
+
+# The extension set is the full list `go/build` compiles, not just the ones this
+# repository happens to use today: an untagged cgo wrapper plus a
+# `shim_darwin.sx` is enough to ship darwin-only machine code, and Go applies the
+# implicit `_darwin`/`_arm64` suffix constraint to every one of these. Only
+# `.go` blobs are content-scanned for explicit constraints, so any other native
+# extension must be caught by name or it is never inspected at all — which is
+# why plain `.go` is absent from `darwin_native_exts` but present in the
+# suffix-constrained alternation.
+readonly darwin_native_exts='swigcxx|swig|f90|for|syso|cpp|cxx|hpp|hxx|cc|hh|sx|s|S|c|h|m|mm|f|F'
+readonly darwin_native_regex="^(internal/debugger/.*|test/integration/.*|justfile|entitlements\\.plist|go\\.(mod|sum)|(.*/)?[^/]*_(darwin|arm64)(_[^/.]+)*\\.(go|$darwin_native_exts)|(.*/)?[^/]*\\.($darwin_native_exts))\$"
 
 event_action=$(jq -er '.action' "$GITHUB_EVENT_PATH")
 pr_number=$(jq -er '.pull_request.number' "$GITHUB_EVENT_PATH")
 head_sha=$(jq -er '.pull_request.head.sha | select(test("^[0-9a-fA-F]{40,64}$"))' "$GITHUB_EVENT_PATH")
 base_sha=$(jq -er '.pull_request.base.sha | select(test("^[0-9a-fA-F]{40,64}$"))' "$GITHUB_EVENT_PATH")
+base_ref=$(jq -er '.pull_request.base.ref // ""' "$GITHUB_EVENT_PATH")
 head_repository=$(jq -er '.pull_request.head.repo.full_name // ""' "$GITHUB_EVENT_PATH")
 event_label=$(jq -er '.label.name // ""' "$GITHUB_EVENT_PATH")
+actor_login=$(jq -er '.sender.login // ""' "$GITHUB_EVENT_PATH")
+actor_type=$(jq -er '.sender.type // ""' "$GITHUB_EVENT_PATH")
 base_changed=$(jq -r '(.changes.base // null) != null' "$GITHUB_EVENT_PATH")
 run_url="${GITHUB_SERVER_URL:-https://github.com}/$GITHUB_REPOSITORY/actions/runs/${GITHUB_RUN_ID:-0}"
 final_status_posted=false
 decision_file=${DARWIN_GATE_DECISION_FILE:-}
-approval_ready=false
+
+# --- ERR-trap guarded region -------------------------------------------------
+#
+# Everything below either defines or runs code that executes with the
+# `fail_closed` ERR trap installed. `set -E` propagates that trap into
+# command-substitution subshells, where a failure would publish a status the
+# parent then publishes again — and where `final_status_posted` cannot travel
+# back out. Every `$(...)` from this marker onwards therefore disarms the trap
+# so the top-level shell stays the only decision point. A contract test enforces
+# that statically, because the duplicate-publication symptom only reproduces on
+# bash >= 4.4 and not on the macOS system bash.
 
 # The workflow treats an absent decision as "interrupted after posting pending"
 # and fails the head closed, so only terminal outcomes may be recorded here.
@@ -59,10 +83,161 @@ fail_closed() {
   fi
   exit "$exit_code"
 }
-# `set -E` propagates this trap into command-substitution subshells, where a
-# failure would post a status the parent then posts again (and where
-# `final_status_posted` cannot propagate back out). Every `$(...)` below the
-# trap therefore disarms it so the parent shell stays the only decision point.
+
+# Commit statuses are SHA-global: the same head SHA can belong to several pull
+# requests, and a queued event can reach the runner long after the pull request
+# it described was force-pushed, retargeted or closed. Publishing success is the
+# only irreversible direction, so every success re-reads the live pull request
+# and refuses unless the event's generation is still the current one.
+require_current_generation() {
+  local live_ok live_summary
+
+  gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number" > "$live_pr_json"
+
+  live_summary=$(trap - ERR; jq -r '
+    "state=\(.state // "?")"
+    + " base=\(.base.ref // "?")@\(.base.sha // "?")"
+    + " head=\(.head.sha // "?")"
+    + " headRepo=\(.head.repo.full_name // "?")"
+  ' "$live_pr_json")
+
+  live_ok=$(trap - ERR; jq -r \
+    --arg base_ref "$required_base_ref" \
+    --arg base_sha "$base_sha" \
+    --arg head_sha "$head_sha" \
+    --arg head_repository "$head_repository" '
+      ((.state // "") == "open")
+      and ((.base.ref // "") == $base_ref)
+      and ((.base.sha // "") == $base_sha)
+      and ((.head.sha // "") == $head_sha)
+      and ((.head.repo.full_name // "") == $head_repository)
+    ' "$live_pr_json")
+
+  if [ "$live_ok" != "true" ]; then
+    post_status failure 'Pull request moved while the Darwin gate was evaluating.'
+    echo "::error title=Darwin E2E verification is stale::This run described base '$base_ref'@$base_sha with head $head_sha, but the live pull request is now $live_summary. Re-run the gate against the current head before asserting verification."
+    trap - ERR
+    exit 1
+  fi
+
+  echo "Live pull request generation confirmed: $live_summary"
+}
+
+deny_label() {
+  post_status failure 'Darwin verification requires an authorized maintainer.'
+  echo "::error title=Darwin E2E verification not authorized::$1. Only a repository collaborator with write, maintain or admin permission may assert Darwin verification by adding the '$verified_label' label."
+  trap - ERR
+  exit 1
+}
+
+# The "Darwin E2E verified" status is an Actions status and is therefore NOT
+# cryptographically attributable: any workflow in this repository runs as the
+# same `github-actions[bot]` identity and can write the same context. The gate
+# consequently derives its authorization from the human who performed the label
+# action — the trusted event actor, checked against the repository permission
+# API — and never from a previously published status.
+require_authorized_labeler() {
+  local permission role_name api_login
+
+  case "$actor_type" in
+    User) ;;
+    *)
+      deny_label "the '${actor_type:-unknown}' actor '$actor_login' is not a human collaborator"
+      ;;
+  esac
+
+  # Validated before interpolation into an API path, and restricted to the shape
+  # GitHub actually allows for user logins.
+  case "$actor_login" in
+    '' | *'[bot]' | -* | *- | *[!A-Za-z0-9-]*)
+      deny_label "the actor login '$actor_login' is not a plain GitHub user login"
+      ;;
+  esac
+
+  gh api "repos/$GITHUB_REPOSITORY/collaborators/$actor_login/permission" \
+    > "$permission_json"
+
+  api_login=$(trap - ERR; jq -r '.user.login // ""' "$permission_json")
+  permission=$(trap - ERR; jq -r '.permission // ""' "$permission_json")
+  role_name=$(trap - ERR; jq -r '.role_name // ""' "$permission_json")
+
+  if [ "$api_login" != "$actor_login" ]; then
+    deny_label "the permission API answered for '$api_login' rather than '$actor_login'"
+  fi
+
+  # The legacy `permission` field folds maintain into write and triage into
+  # read, so admin/write is exactly "write, maintain or admin".
+  case "$permission" in
+    admin | maintain | write) ;;
+    *)
+      deny_label "'$actor_login' holds '${permission:-unknown}' permission (role '${role_name:-unknown}'), which is below write"
+      ;;
+  esac
+
+  echo "Authorized labeler: $actor_login (permission '$permission', role '${role_name:-unknown}')."
+}
+
+# A tree response is only usable when it is complete AND every entry has the
+# shape the diff below assumes. Anything else is an ambiguous answer about what
+# changed, so it fails closed rather than producing a partial decision.
+validate_tree_document() {
+  jq -e '
+    (.truncated == false)
+    and ((.tree | type) == "array")
+    and (
+      .tree
+      | all(
+          ((.path | type) == "string")
+          and ((.path | length) > 0)
+          and ((.mode | type) == "string")
+          and (.mode | test("^[0-7]{6}$"))
+          and ((.type | type) == "string")
+          and ((.type == "blob") or (.type == "tree") or (.type == "commit"))
+          and (
+            (.type == "tree")
+            or (
+              ((.sha | type) == "string")
+              and (.sha | test("^[0-9a-fA-F]{40,64}$"))
+            )
+          )
+        )
+    )
+  ' "$1" >/dev/null
+}
+
+# Go honours a single leading UTF-8 byte-order mark, so an anchored build-tag
+# scan must look past it; a file that starts with any other BOM cannot be read
+# as Go source at all and its first line is hidden from this scan either way.
+#
+# Exit codes: 0 constraint found, 1 no constraint, 2 undecidable encoding,
+# 3 the blob could not be inspected.
+scan_blob_for_build_constraint() {
+  local raw=$1
+  local target=$raw
+  local b0='' b1='' b2='' rest=''
+
+  od -An -tx1 -N4 "$raw" > "$bom_probe" || return 3
+  read -r b0 b1 b2 rest < "$bom_probe" || true
+
+  case "$b0$b1" in
+    fffe | feff)
+      return 2
+      ;;
+  esac
+
+  if [ "$b0$b1$b2" = "efbbbf" ]; then
+    tail -c +4 "$raw" > "$blob_scan" || return 3
+    target=$blob_scan
+  fi
+
+  if grep -Eq '^[[:space:]]*//[[:space:]]*(go:build|\+build)[[:space:]]' \
+    "$target"; then
+    return 0
+  fi
+
+  return 1
+}
+
 trap fail_closed ERR
 
 case "$event_action" in
@@ -86,27 +261,25 @@ if [ "$event_action" = "edited" ] && [ "$base_changed" != "true" ]; then
   exit 0
 fi
 
-if [ "$event_action" = "labeled" ] && [ "$event_label" = "$verified_label" ]; then
-  prior_statuses_json=$(trap - ERR; mktemp)
-  trap 'rm -f "$prior_statuses_json"' EXIT
-  gh api --paginate --slurp \
-    "repos/$GITHUB_REPOSITORY/commits/$head_sha/statuses?per_page=100" \
-    > "$prior_statuses_json"
-  approval_ready=$(trap - ERR; jq -r \
-    --arg context "$status_context" \
-    --arg run_prefix "${GITHUB_SERVER_URL:-https://github.com}/$GITHUB_REPOSITORY/actions/runs/" '
-      [
-        .[][]
-        | select(.context == $context)
-      ][0] as $latest
-      | (
-          $latest.state == "failure"
-          and $latest.creator.login == "github-actions[bot]"
-          and (($latest.target_url // "") | startswith($run_prefix))
-        )
-    ' "$prior_statuses_json")
-  rm -f "$prior_statuses_json"
+# The workflow trigger is already restricted to `main`, but statuses are
+# SHA-global and this script is fetched by SHA, so it re-asserts the scope
+# itself rather than trusting the trigger it was invoked from.
+if [ "$base_ref" != "$required_base_ref" ]; then
+  echo "This gate only governs pull requests targeting '$required_base_ref'; refusing to decide for base '$base_ref'." >&2
+  false
 fi
+
+base_tree_json=$(trap - ERR; mktemp)
+head_tree_json=$(trap - ERR; mktemp)
+changed_paths_json=$(trap - ERR; mktemp)
+go_blobs_tsv=$(trap - ERR; mktemp)
+blob_json=$(trap - ERR; mktemp)
+blob_raw=$(trap - ERR; mktemp)
+blob_scan=$(trap - ERR; mktemp)
+bom_probe=$(trap - ERR; mktemp)
+live_pr_json=$(trap - ERR; mktemp)
+permission_json=$(trap - ERR; mktemp)
+trap 'rm -f "$base_tree_json" "$head_tree_json" "$changed_paths_json" "$go_blobs_tsv" "$blob_json" "$blob_raw" "$blob_scan" "$bom_probe" "$live_pr_json" "$permission_json"' EXIT
 
 post_status pending 'Evaluating Darwin verification policy.'
 
@@ -130,11 +303,6 @@ if [ "$event_action" = "synchronize" ] ||
   fi
 fi
 
-base_tree_json=$(trap - ERR; mktemp)
-head_tree_json=$(trap - ERR; mktemp)
-changed_paths_json=$(trap - ERR; mktemp)
-trap 'rm -f "$base_tree_json" "$head_tree_json" "$changed_paths_json"' EXIT
-
 merge_base_sha=$(trap - ERR; gh api \
   "repos/$GITHUB_REPOSITORY/compare/$base_sha...$head_sha" \
   --jq '.merge_base_commit.sha')
@@ -155,10 +323,8 @@ gh api "repos/$GITHUB_REPOSITORY/git/trees/$merge_base_tree_sha?recursive=1" \
 gh api "repos/$GITHUB_REPOSITORY/git/trees/$head_tree_sha?recursive=1" \
   > "$head_tree_json"
 
-if ! jq -e '.truncated == false and (.tree | type == "array")' \
-  "$base_tree_json" >/dev/null ||
-  ! jq -e '.truncated == false and (.tree | type == "array")' \
-    "$head_tree_json" >/dev/null; then
+if ! validate_tree_document "$base_tree_json" ||
+  ! validate_tree_document "$head_tree_json"; then
   echo "Git tree API returned a truncated or malformed tree; refusing an incomplete gate decision." >&2
   false
 fi
@@ -172,7 +338,11 @@ jq -n \
           .[$entry.path] = {
             mode: $entry.mode,
             sha: $entry.sha,
-            type: $entry.type
+            type: $entry.type,
+            regular: (
+              $entry.type == "blob"
+              and ($entry.mode == "100644" or $entry.mode == "100755")
+            )
           });
     entries($base) as $before
     | entries($head) as $after
@@ -194,33 +364,85 @@ echo "Changed files in this PR:"
 jq -r '.[].path | @json' "$changed_paths_json" | sed 's/^/  /'
 echo
 
+# A symlink, a submodule pointer or any other non-regular entry only exposes its
+# link text to the tree scan, so a `.go` symlink can name a Darwin-constrained
+# payload this gate would otherwise never read. Every such change is gated.
+irregular_changed=$(trap - ERR; jq -r '
+  any(.[];
+    ((.before != null) and (.before.regular != true))
+    or ((.after != null) and (.after.regular != true)))
+' "$changed_paths_json")
+
+if [ "$irregular_changed" = "true" ]; then
+  echo "Changed entries that are not regular files (symlink, submodule or unexpected mode):"
+  jq -r '
+    .[]
+    | select(
+        ((.before != null) and (.before.regular != true))
+        or ((.after != null) and (.after.regular != true))
+      )
+    | "\(.path | @json) before=\(.before.mode // "-")/\(.before.type // "-") after=\(.after.mode // "-")/\(.after.type // "-")"
+  ' "$changed_paths_json" | sed 's/^/  /'
+  echo
+fi
+
 darwin_changed=$(trap - ERR; jq -r --arg regex "$darwin_native_regex" \
   'any(.[].path; test($regex) or test("[[:cntrl:]]"))' \
   "$changed_paths_json")
 
+if [ "$darwin_changed" = "false" ] && [ "$irregular_changed" = "true" ]; then
+  darwin_changed=true
+fi
+
+constraint_path=
 if [ "$darwin_changed" = "false" ]; then
-  blob_shas=$(trap - ERR; jq -r '
+  jq -r '
     .[]
     | select(.path | endswith(".go"))
-    | .before.sha, .after.sha
-    | select(type == "string")
-  ' "$changed_paths_json" | sort -u)
-  while IFS= read -r blob_sha; do
+    | .path as $path
+    | (.before, .after)
+    | select(. != null and .regular == true)
+    | "\(.sha)\t\($path)"
+  ' "$changed_paths_json" | sort -u > "$go_blobs_tsv"
+
+  while IFS=$'\t' read -r blob_sha blob_path; do
     [ -n "$blob_sha" ] || continue
-    blob_file=$(trap - ERR; mktemp)
-    gh api "repos/$GITHUB_REPOSITORY/git/blobs/$blob_sha" \
-      --jq '.content' | base64 -d > "$blob_file"
-    if grep -Eq '^[[:space:]]*//[[:space:]]*(go:build|\+build)[[:space:]]' \
-      "$blob_file"; then
-      darwin_changed=true
-      rm -f "$blob_file"
-      break
+
+    gh api "repos/$GITHUB_REPOSITORY/git/blobs/$blob_sha" > "$blob_json"
+    blob_decodable=$(trap - ERR; jq -r '
+      ((.encoding // "") == "base64") and ((.content | type) == "string")
+    ' "$blob_json")
+    if [ "$blob_decodable" != "true" ]; then
+      echo "Blob $blob_sha ($blob_path) was not returned as decodable content; refusing an incomplete gate decision." >&2
+      false
     fi
-    rm -f "$blob_file"
-  done <<< "$blob_shas"
+    jq -r '.content' "$blob_json" | base64 -d > "$blob_raw"
+
+    scan_status=0
+    scan_blob_for_build_constraint "$blob_raw" || scan_status=$?
+    case "$scan_status" in
+      0)
+        darwin_changed=true
+        constraint_path=$blob_path
+        break
+        ;;
+      1) ;;
+      2)
+        darwin_changed=true
+        constraint_path=$blob_path
+        echo "::warning title=Undecidable Go source encoding::$blob_path starts with a non-UTF-8 byte-order mark, so its build constraints cannot be read; gating conservatively."
+        break
+        ;;
+      *)
+        echo "Blob $blob_sha ($blob_path) could not be inspected for build constraints; refusing an incomplete gate decision." >&2
+        false
+        ;;
+    esac
+  done < "$go_blobs_tsv"
 fi
 
 if [ "$darwin_changed" = "false" ]; then
+  require_current_generation
   post_status success 'No Darwin-native files changed.'
   echo "No darwin-native code changed; gate not required."
   exit 0
@@ -231,10 +453,16 @@ if [ "$darwin_changed" != "true" ]; then
   false
 fi
 
-echo "Darwin-native (CI-unexecutable) files changed:"
+echo "Darwin-native (CI-unexecutable) changes detected:"
 jq -r --arg regex "$darwin_native_regex" \
   '.[].path | select(test($regex) or test("[[:cntrl:]]")) | @json' \
   "$changed_paths_json" | sed 's/^/  /'
+if [ "$irregular_changed" = "true" ]; then
+  echo "  (plus non-regular tree entries listed above)"
+fi
+if [ -n "$constraint_path" ]; then
+  printf '  %s (explicit Go build constraint)\n' "$constraint_path"
+fi
 echo
 
 case "$event_action" in
@@ -255,24 +483,31 @@ case "$event_action" in
     exit 1
     ;;
   labeled | unlabeled)
+    # Only a real, authorized `labeled` action may assert verification. A label
+    # removal is never restorative even when the label is live again by the time
+    # this run reads it: the re-add produced its own `labeled` event, and that
+    # event is the only one allowed to publish success.
+    if [ "$event_action" = "unlabeled" ]; then
+      post_status failure 'Darwin verification was withdrawn for this head.'
+      echo "::error title=Darwin E2E verification withdrawn::Removing '$verified_label' invalidates verification for this head. Re-run the e2e-darwin recipe on Apple Silicon and add the label again; only a fresh, authorized label addition can restore this status."
+      trap - ERR
+      exit 1
+    fi
+
     live_labels=$(trap - ERR; gh api --paginate \
       "repos/$GITHUB_REPOSITORY/issues/$pr_number/labels?per_page=100" \
       --jq '.[].name')
-    if grep -Fxq "$verified_label" <<< "$live_labels"; then
-      if [ "$event_action" = "labeled" ] && [ "$approval_ready" != "true" ]; then
-        post_status failure 'Darwin verification must follow a head evaluation.'
-        echo "::error title=Darwin E2E verification not ready::This head has not completed a trusted failing gate run yet. Wait for that run, then toggle '$verified_label' again."
-        trap - ERR
-        exit 1
-      fi
-      post_status success 'Darwin E2E verified for this head SHA.'
-      echo "'$verified_label' label present; darwin backend verified locally for $head_sha."
-      exit 0
+    if ! grep -Fxq "$verified_label" <<< "$live_labels"; then
+      post_status failure 'Darwin verification label is not currently present.'
+      echo "::error title=Darwin E2E verification required::The '$verified_label' label is not currently present on this PR."
+      trap - ERR
+      exit 1
     fi
 
-    post_status failure 'Darwin verification label is not currently present.'
-    echo "::error title=Darwin E2E verification required::The '$verified_label' label is not currently present on this PR."
-    trap - ERR
-    exit 1
+    require_authorized_labeler
+    require_current_generation
+    post_status success 'Darwin E2E verified for this head SHA.'
+    echo "'$verified_label' label added by $actor_login; darwin backend verified locally for $head_sha."
+    exit 0
     ;;
 esac

--- a/.github/scripts/darwin-verification-gate.sh
+++ b/.github/scripts/darwin-verification-gate.sh
@@ -2,53 +2,88 @@
 
 set -euo pipefail
 
-: "${EVENT_ACTION:?EVENT_ACTION is required}"
-: "${CHANGED_FILES:?CHANGED_FILES is required}"
+: "${GITHUB_EVENT_PATH:?GITHUB_EVENT_PATH is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 
-VERIFIED_LABEL="${VERIFIED_LABEL:-darwin-e2e-verified}"
-HAS_VERIFIED_LABEL="${HAS_VERIFIED_LABEL:-}"
-LABEL_CLEANUP="${LABEL_CLEANUP:-not-run}"
+readonly verified_label='darwin-e2e-verified'
+readonly darwin_native_regex='^(internal/debugger/.*_darwin_.*|internal/debugger/trap_arm64\.go|test/integration/.*_darwin_.*_test\.go|entitlements\.plist)$'
 
-# These paths require runtime verification on real darwin/arm64 hardware.
-readonly DARWIN_NATIVE_REGEX="${DARWIN_NATIVE_REGEX:-^(internal/debugger/.*_darwin_.*|internal/debugger/trap_arm64\.go|test/integration/.*_darwin_.*_test\.go|entitlements\.plist)$}"
+event_action=$(jq -er '.action' "$GITHUB_EVENT_PATH")
+pr_number=$(jq -er '.pull_request.number' "$GITHUB_EVENT_PATH")
+head_repository=$(jq -er '.pull_request.head.repo.full_name // ""' "$GITHUB_EVENT_PATH")
+event_label=$(jq -er '.label.name // ""' "$GITHUB_EVENT_PATH")
 
-if [ ! -r "$CHANGED_FILES" ]; then
-  echo "Changed-files list is not readable: $CHANGED_FILES" >&2
-  exit 2
+case "$event_action" in
+  opened | synchronize | reopened | labeled | unlabeled) ;;
+  *)
+    echo "Unsupported pull_request action: $event_action" >&2
+    exit 2
+    ;;
+esac
+
+label_cleanup=not-run
+if [ "$event_action" = "synchronize" ] || [ "$event_action" = "reopened" ]; then
+  if output=$(gh pr edit "$pr_number" --repo "$GITHUB_REPOSITORY" \
+    --remove-label "$verified_label" 2>&1); then
+    label_cleanup=cleared
+    echo "Cleared '$verified_label' if present; this head requires re-verification."
+  else
+    exit_code=$?
+    label_cleanup=failed
+    if [ "$head_repository" != "$GITHUB_REPOSITORY" ]; then
+      echo "::warning title=Stale Darwin verification label not removed::The public-fork GITHUB_TOKEN is read-only, so '$verified_label' could not be removed (exit $exit_code). The gate will fail closed; remove or toggle the stale label, then re-add it to verify this head."
+    else
+      echo "::warning title=Stale Darwin verification label not removed::The API failed to remove '$verified_label' (exit $exit_code). The gate will fail closed; remove or toggle the stale label, then re-add it to verify this head."
+    fi
+    printf '%s\n' "$output" >&2
+  fi
 fi
 
+changed_files=$(mktemp)
+trap 'rm -f "$changed_files"' EXIT
+gh pr diff "$pr_number" --repo "$GITHUB_REPOSITORY" --name-only > "$changed_files"
+
 echo "Changed files in this PR:"
-sed 's/^/  /' "$CHANGED_FILES"
+sed 's/^/  /' "$changed_files"
 echo
 
-if ! grep -Eq "$DARWIN_NATIVE_REGEX" "$CHANGED_FILES"; then
+if ! grep -Eq "$darwin_native_regex" "$changed_files"; then
   echo "No darwin-native code changed; gate not required."
   exit 0
 fi
 
 echo "Darwin-native (CI-unexecutable) files changed:"
-grep -E "$DARWIN_NATIVE_REGEX" "$CHANGED_FILES" | sed 's/^/  /'
+grep -E "$darwin_native_regex" "$changed_files" | sed 's/^/  /'
 echo
 
-if [ "$EVENT_ACTION" = "synchronize" ]; then
-  if [ "$LABEL_CLEANUP" = "failed" ]; then
-    echo "::error title=Darwin E2E re-verification required::New commits always invalidate prior Darwin verification. The stale '$VERIFIED_LABEL' label could not be removed. Run 'just e2e-darwin' locally on Apple Silicon, remove or toggle the stale label, then re-add it to re-run verification for this head."
+if [ "$event_action" = "synchronize" ] || [ "$event_action" = "reopened" ]; then
+  if [ "$label_cleanup" = "failed" ]; then
+    echo "::error title=Darwin E2E re-verification required::New commits and reopened pull requests invalidate prior Darwin verification. The stale '$verified_label' label could not be removed. Run 'just e2e-darwin' locally on Apple Silicon, remove or toggle the stale label, then re-add it to re-run verification for this head."
   else
-    echo "::error title=Darwin E2E re-verification required::New commits always invalidate prior Darwin verification. Run 'just e2e-darwin' locally on Apple Silicon, confirm it passes, then add the '$VERIFIED_LABEL' label to re-run verification for this head."
+    echo "::error title=Darwin E2E re-verification required::New commits and reopened pull requests invalidate prior Darwin verification. Run 'just e2e-darwin' locally on Apple Silicon, confirm it passes, then add the '$verified_label' label to re-run verification for this head."
   fi
   exit 1
 fi
 
-case "$HAS_VERIFIED_LABEL" in
+has_label=$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json labels \
+  -q "[.labels[].name] | any(. == \"$verified_label\")")
+
+if { [ "$event_action" = "labeled" ] || [ "$event_action" = "unlabeled" ]; } &&
+  [ "$event_label" != "$verified_label" ]; then
+  echo "::error title=Darwin E2E verification unchanged::The '$event_label' label event cannot verify this head. Remove or toggle '$verified_label', then re-add it after local verification."
+  exit 1
+fi
+
+case "$has_label" in
   true)
-    echo "'$VERIFIED_LABEL' label present; darwin backend verified locally."
+    echo "'$verified_label' label present; darwin backend verified locally."
     ;;
   false)
-    echo "::error title=Darwin E2E verification required::This PR changes darwin-native debugger code that cannot be executed on GitHub-hosted runners. Run 'just e2e-darwin' locally on Apple Silicon, confirm it passes, then add the '$VERIFIED_LABEL' label to this PR."
+    echo "::error title=Darwin E2E verification required::This PR changes darwin-native debugger code that cannot be executed on GitHub-hosted runners. Run 'just e2e-darwin' locally on Apple Silicon, confirm it passes, then add the '$verified_label' label to this PR."
     exit 1
     ;;
   *)
-    echo "HAS_VERIFIED_LABEL must be true or false for '$EVENT_ACTION' events" >&2
+    echo "Unexpected label query result: $has_label" >&2
     exit 2
     ;;
 esac

--- a/.github/scripts/darwin-verification-gate_test.sh
+++ b/.github/scripts/darwin-verification-gate_test.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 gate="$script_dir/darwin-verification-gate.sh"
-workflow="$script_dir/../workflows/darwin-verification-gate.yml"
+trusted_workflow="$script_dir/../workflows/darwin-verification-gate.yml"
+head_test_workflow="$script_dir/../workflows/darwin-verification-policy-test.yml"
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
@@ -16,21 +17,51 @@ set -euo pipefail
 
 printf '%s\n' "$*" >> "$MOCK_GH_LOG"
 
-case "$1 $2" in
-  "pr edit")
-    if [ "$MOCK_EDIT_STATUS" -ne 0 ]; then
-      echo "HTTP 403: Resource not accessible by integration" >&2
-      exit "$MOCK_EDIT_STATUS"
+if [ "$1 $2" = "pr edit" ]; then
+  if [ "$MOCK_EDIT_STATUS" -ne 0 ]; then
+    echo "HTTP 403: Resource not accessible by integration" >&2
+    exit "$MOCK_EDIT_STATUS"
+  fi
+  exit 0
+fi
+
+if [ "$1" != "api" ]; then
+  echo "Unexpected gh command: $*" >&2
+  exit 2
+fi
+
+case "$*" in
+  *"/statuses/"*)
+    state=
+    context=
+    endpoint=
+    for arg in "$@"; do
+      case "$arg" in
+        repos/*/statuses/*) endpoint=$arg ;;
+        state=*) state=${arg#state=} ;;
+        context=*) context=${arg#context=} ;;
+      esac
+    done
+    printf '%s|%s|%s\n' "$endpoint" "$state" "$context" >> "$MOCK_STATUS_LOG"
+    ;;
+  *"/pulls/"*"/files?"*)
+    if [ "$MOCK_DIFF_STATUS" -ne 0 ]; then
+      echo "diff API failed" >&2
+      exit "$MOCK_DIFF_STATUS"
+    fi
+    jq -n --arg filename "$MOCK_CHANGED_PATH" '[[{filename: $filename}]]'
+    ;;
+  *"/issues/"*"/labels?"*)
+    if [ "$MOCK_LABEL_STATUS" -ne 0 ]; then
+      echo "label API failed" >&2
+      exit "$MOCK_LABEL_STATUS"
+    fi
+    if [ "$MOCK_HAS_LABEL" = "true" ]; then
+      printf '%s\n' darwin-e2e-verified
     fi
     ;;
-  "pr diff")
-    printf '%s\n' "$MOCK_CHANGED_PATH"
-    ;;
-  "pr view")
-    printf '%s\n' "$MOCK_HAS_LABEL"
-    ;;
   *)
-    echo "Unexpected gh command: $*" >&2
+    echo "Unexpected gh api call: $*" >&2
     exit 2
     ;;
 esac
@@ -39,26 +70,70 @@ chmod +x "$tmpdir/bin/gh"
 
 case_count=0
 
-while IFS='|' read -r name action event_label head_repository changed_path has_label edit_status expected_status expected_output expect_view; do
+run_case() {
+  local name=$1
+  local action=$2
+  local event_label=$3
+  local head_repository=$4
+  local changed_path=$5
+  local has_label=$6
+  local edit_status=$7
+  local expected_exit=$8
+  local expected_state=$9
+  local expected_output=${10}
+  local expected_label_query=${11}
+  local diff_status=${12:-0}
+  local label_status=${13:-0}
+  local declared_changed_files=${14:-}
+  local case_id
+  local event_path
+  local gh_log
+  local status_log
+  local head_sha
+  local output
+  local status=0
+
   case_count=$((case_count + 1))
-  event_path="$tmpdir/event-$case_count.json"
-  log_path="$tmpdir/gh-$case_count.log"
+  case_id=$case_count
+  event_path="$tmpdir/event-$case_id.json"
+  gh_log="$tmpdir/gh-$case_id.log"
+  status_log="$tmpdir/status-$case_id.log"
+  head_sha=$(printf '%040x' "$case_id")
+  if [ -z "$declared_changed_files" ]; then
+    declared_changed_files=$(printf '%s\n' "$changed_path" | wc -l | tr -d ' ')
+  fi
+  : > "$gh_log"
+  : > "$status_log"
+
   jq -n \
     --arg action "$action" \
     --arg event_label "$event_label" \
     --arg head_repository "$head_repository" \
-    '{action: $action, label: {name: $event_label}, pull_request: {number: 17, head: {repo: {full_name: $head_repository}}}}' \
-    > "$event_path"
+    --arg head_sha "$head_sha" \
+    --argjson changed_files "$declared_changed_files" \
+    '{
+      action: $action,
+      label: {name: $event_label},
+      pull_request: {
+        number: 17,
+        changed_files: $changed_files,
+        head: {sha: $head_sha, repo: {full_name: $head_repository}}
+      }
+    }' > "$event_path"
 
-  status=0
   output=$(
     PATH="$tmpdir/bin:$PATH" \
       GITHUB_EVENT_PATH="$event_path" \
       GITHUB_REPOSITORY=bingosuite/bingo \
-      MOCK_GH_LOG="$log_path" \
+      GITHUB_SERVER_URL=https://github.com \
+      GITHUB_RUN_ID=123 \
+      MOCK_GH_LOG="$gh_log" \
+      MOCK_STATUS_LOG="$status_log" \
       MOCK_CHANGED_PATH="$changed_path" \
       MOCK_HAS_LABEL="$has_label" \
       MOCK_EDIT_STATUS="$edit_status" \
+      MOCK_DIFF_STATUS="$diff_status" \
+      MOCK_LABEL_STATUS="$label_status" \
       DARWIN_NATIVE_REGEX='^never-match$' \
       VERIFIED_LABEL=attacker-controlled \
       EVENT_ACTION=opened \
@@ -68,12 +143,13 @@ while IFS='|' read -r name action event_label head_repository changed_path has_l
       IS_FORK=false \
       PR_NUMBER=999 \
       REPOSITORY=attacker/repository \
+      GITHUB_WORKSPACE="$tmpdir/hostile-head" \
       bash "$gate" 2>&1
   ) || status=$?
 
-  if [ "$status" -ne "$expected_status" ]; then
+  if [ "$status" -ne "$expected_exit" ]; then
     printf 'not ok - %s (status %s, expected %s)\n%s\n' \
-      "$name" "$status" "$expected_status" "$output" >&2
+      "$name" "$status" "$expected_exit" "$output" >&2
     exit 1
   fi
 
@@ -83,78 +159,245 @@ while IFS='|' read -r name action event_label head_repository changed_path has_l
     exit 1
   fi
 
-  if ! grep -Fq -- '--repo bingosuite/bingo' "$log_path"; then
-    printf 'not ok - %s (trusted repository was not used)\n' "$name" >&2
+  if grep -Eq 'attacker-controlled|attacker/repository| 999 ' "$gh_log"; then
+    printf 'not ok - %s (hostile environment reached gh)\n' "$name" >&2
     exit 1
   fi
 
-  if grep -Fq 'attacker-controlled' "$log_path"; then
-    printf 'not ok - %s (hostile label override reached gh)\n' "$name" >&2
-    exit 1
-  fi
-
-  if grep -Fq 'attacker/repository' "$log_path"; then
-    printf 'not ok - %s (hostile repository override reached gh)\n' "$name" >&2
-    exit 1
-  fi
-
-  if grep -Fq ' 999 ' "$log_path"; then
-    printf 'not ok - %s (hostile PR number override reached gh)\n' "$name" >&2
-    exit 1
-  fi
-
-  if [ "$action" = "synchronize" ] || [ "$action" = "reopened" ]; then
-    if ! grep -Fq 'pr edit 17 --repo bingosuite/bingo --remove-label darwin-e2e-verified' "$log_path"; then
-      printf 'not ok - %s (trusted cleanup inputs were not used)\n' "$name" >&2
-      exit 1
-    fi
-  elif grep -Fq 'pr edit' "$log_path"; then
-    printf 'not ok - %s (hostile action override triggered cleanup)\n' "$name" >&2
-    exit 1
-  fi
-
-  if [ "$expect_view" = "true" ] && ! grep -Fq 'pr view' "$log_path"; then
+  if [ "$expected_label_query" = "true" ] &&
+    ! grep -Fq "/issues/17/labels?" "$gh_log"; then
     printf 'not ok - %s (expected live label query)\n' "$name" >&2
     exit 1
   fi
 
-  if [ "$expect_view" = "false" ] && grep -Fq 'pr view' "$log_path"; then
+  if [ "$expected_label_query" = "false" ] &&
+    grep -Fq "/issues/17/labels?" "$gh_log"; then
     printf 'not ok - %s (unexpected live label query)\n' "$name" >&2
     exit 1
   fi
 
+  if [ "$expected_state" = "none" ]; then
+    if [ -s "$status_log" ]; then
+      printf 'not ok - %s (unexpected head status)\n' "$name" >&2
+      exit 1
+    fi
+  else
+    expected_status="repos/bingosuite/bingo/statuses/$head_sha|$expected_state|Darwin E2E verified"
+    if [ "$(tail -n 1 "$status_log")" != "$expected_status" ]; then
+      printf 'not ok - %s (missing head-SHA status: %s)\n' \
+        "$name" "$expected_status" >&2
+      cat "$status_log" >&2
+      exit 1
+    fi
+  fi
+
   printf 'ok - %s\n' "$name"
-done <<'CASES'
-hostile policy overrides cannot bypass fork synchronize|synchronize||contributor/fork|internal/debugger/backend_darwin_arm64.go|true|1|1|public-fork GITHUB_TOKEN is read-only|false
-same-repository synchronize invalidates prior verification|synchronize||bingosuite/bingo|entitlements.plist|false|0|1|New commits and reopened pull requests invalidate prior Darwin verification|false
-reopened fork fails closed with stale verification|reopened||contributor/fork|entitlements.plist|true|1|1|remove or toggle the stale label|false
-verified label addition passes with live label|labeled|darwin-e2e-verified|contributor/fork|test/integration/debugger_e2e_darwin_arm64_test.go|true|0|0|label present; darwin backend verified locally|true
-verified label removal fails without live label|unlabeled|darwin-e2e-verified|contributor/fork|internal/debugger/trap_arm64.go|false|0|1|Darwin E2E verification required|true
-unrelated label cannot revive stale verification|labeled|triage|contributor/fork|entitlements.plist|true|0|1|label event cannot verify this head|true
-unrelated unlabel cannot revive stale verification|unlabeled|triage|contributor/fork|entitlements.plist|true|0|1|label event cannot verify this head|true
-non-Darwin synchronize bypasses gate after cleanup attempt|synchronize||contributor/fork|internal/debugger/engine.go|true|1|0|No darwin-native code changed; gate not required|false
-near-match outside preserved regex bypasses gate|opened||contributor/fork|docs/backend_darwin_arm64.go|false|0|0|No darwin-native code changed; gate not required|false
-CASES
+}
+
+mkdir -p "$tmpdir/hostile-head/.github/workflows" "$tmpdir/hostile-head/.github/scripts"
+printf '%s\n' 'jobs: {gate: {steps: [{run: "exit 0"}]}}' \
+  > "$tmpdir/hostile-head/.github/workflows/darwin-verification-gate.yml"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' \
+  > "$tmpdir/hostile-head/.github/scripts/darwin-verification-gate.sh"
+
+run_case \
+  "fork workflow exit 0 cannot bypass trusted synchronize" \
+  synchronize "" contributor/fork internal/debugger/backend_darwin_arm64.go \
+  true 1 1 failure "public-fork GITHUB_TOKEN could not remove" false
+run_case \
+  "same-repository synchronize fails current head" \
+  synchronize "" bingosuite/bingo entitlements.plist \
+  false 0 1 failure "re-verification required" false
+run_case \
+  "reopened pull request fails current head" \
+  reopened "" contributor/fork entitlements.plist \
+  true 1 1 failure "re-verification required" false
+run_case \
+  "verified label publishes success to current head" \
+  labeled darwin-e2e-verified contributor/fork \
+  test/integration/debugger_e2e_darwin_arm64_test.go \
+  true 0 0 success "verified locally" true
+run_case \
+  "verified label removal publishes failure" \
+  unlabeled darwin-e2e-verified contributor/fork internal/debugger/trap_arm64.go \
+  false 0 1 failure "not currently present" true
+run_case \
+  "re-added verified label survives delayed unlabel event" \
+  unlabeled darwin-e2e-verified contributor/fork internal/debugger/trap_arm64.go \
+  true 0 0 success "verified locally" true
+run_case \
+  "unrelated label leaves prior status untouched" \
+  labeled triage contributor/fork entitlements.plist \
+  true 0 0 none "existing head-SHA status remains authoritative" false
+run_case \
+  "unrelated unlabel leaves prior status untouched" \
+  unlabeled triage contributor/fork entitlements.plist \
+  true 0 0 none "existing head-SHA status remains authoritative" false
+run_case \
+  "non-Darwin synchronize publishes success" \
+  synchronize "" contributor/fork internal/debugger/engine.go \
+  true 1 0 success "No darwin-native code changed" false
+run_case \
+  "opened Darwin change publishes failure" \
+  opened "" contributor/fork entitlements.plist \
+  false 0 1 failure "verification required" false
+run_case \
+  "near-match outside regex publishes success" \
+  opened "" contributor/fork docs/backend_darwin_arm64.go \
+  false 0 0 success "No darwin-native code changed" false
+run_case \
+  "diff API failure replaces pending with failure" \
+  opened "" contributor/fork entitlements.plist \
+  false 0 1 failure "diff API failed" false 1
+run_case \
+  "truncated PR files response fails closed" \
+  opened "" contributor/fork docs/readme.md \
+  false 0 1 failure "refusing an incomplete gate decision" false 0 0 3001
+run_case \
+  "newline filename cannot hide truncated response" \
+  opened "" contributor/fork $'000-padding\nextra-line' \
+  false 0 1 failure "returned 1 of 2 changed files" false 0 0 2
+
+run_status_persistence_sequence() {
+  local name=$1
+  local first_action=$2
+  local first_event_label=$3
+  local first_has_label=$4
+  local first_edit_status=$5
+  local expected_state=$6
+  local expected_first_exit=$7
+  local case_id
+  local head_sha
+  local gh_log
+  local status_log
+  local first_event
+  local unrelated_event
+  local first_status=0
+  local second_status=0
+
+  case_count=$((case_count + 1))
+  case_id=$case_count
+  head_sha=$(printf '%040x' "$case_id")
+  gh_log="$tmpdir/sequence-gh-$case_id.log"
+  status_log="$tmpdir/sequence-status-$case_id.log"
+  first_event="$tmpdir/sequence-first-$case_id.json"
+  unrelated_event="$tmpdir/sequence-unrelated-$case_id.json"
+  : > "$gh_log"
+  : > "$status_log"
+
+  jq -n \
+    --arg action "$first_action" \
+    --arg event_label "$first_event_label" \
+    --arg head_sha "$head_sha" \
+    '{
+      action: $action,
+      label: {name: $event_label},
+      pull_request: {
+        number: 17,
+        changed_files: 1,
+        head: {sha: $head_sha, repo: {full_name: "contributor/fork"}}
+      }
+    }' > "$first_event"
+  jq -n \
+    --arg head_sha "$head_sha" \
+    '{
+      action: "labeled",
+      label: {name: "triage"},
+      pull_request: {
+        number: 17,
+        changed_files: 1,
+        head: {sha: $head_sha, repo: {full_name: "contributor/fork"}}
+      }
+    }' > "$unrelated_event"
+
+  PATH="$tmpdir/bin:$PATH" \
+    GITHUB_EVENT_PATH="$first_event" \
+    GITHUB_REPOSITORY=bingosuite/bingo \
+    MOCK_GH_LOG="$gh_log" \
+    MOCK_STATUS_LOG="$status_log" \
+    MOCK_CHANGED_PATH=entitlements.plist \
+    MOCK_HAS_LABEL="$first_has_label" \
+    MOCK_EDIT_STATUS="$first_edit_status" \
+    MOCK_DIFF_STATUS=0 \
+    MOCK_LABEL_STATUS=0 \
+    bash "$gate" >/dev/null 2>&1 || first_status=$?
+
+  PATH="$tmpdir/bin:$PATH" \
+    GITHUB_EVENT_PATH="$unrelated_event" \
+    GITHUB_REPOSITORY=bingosuite/bingo \
+    MOCK_GH_LOG="$gh_log" \
+    MOCK_STATUS_LOG="$status_log" \
+    MOCK_CHANGED_PATH=entitlements.plist \
+    MOCK_HAS_LABEL=true \
+    MOCK_EDIT_STATUS=0 \
+    MOCK_DIFF_STATUS=0 \
+    MOCK_LABEL_STATUS=0 \
+    bash "$gate" >/dev/null 2>&1 || second_status=$?
+
+  if [ "$first_status" -ne "$expected_first_exit" ] ||
+    [ "$second_status" -ne 0 ]; then
+    printf 'not ok - %s (event statuses %s/%s)\n' \
+      "$name" "$first_status" "$second_status" >&2
+    exit 1
+  fi
+
+  expected_status="repos/bingosuite/bingo/statuses/$head_sha|$expected_state|Darwin E2E verified"
+  if [ "$(wc -l < "$status_log" | tr -d ' ')" -ne 2 ] ||
+    [ "$(tail -n 1 "$status_log")" != "$expected_status" ]; then
+    printf 'not ok - %s (unrelated label changed the SHA-bound status)\n' \
+      "$name" >&2
+    cat "$status_log" >&2
+    cat "$gh_log" >&2
+    exit 1
+  fi
+
+  printf 'ok - %s\n' "$name"
+}
+
+run_status_persistence_sequence \
+  "denied cleanup plus unrelated label preserves failure" \
+  synchronize "" true 1 failure 1
+run_status_persistence_sequence \
+  "verified head plus unrelated label preserves success" \
+  labeled darwin-e2e-verified true 0 success 0
 
 case_count=$((case_count + 1))
-if ! grep -Fq 'ref: ${{ github.event.pull_request.base.sha }}' "$workflow"; then
-  echo "not ok - workflow executes the gate from the trusted base SHA" >&2
+if ! grep -Eq '^[[:space:]]+pull_request_target:' "$trusted_workflow" ||
+  grep -Eq '^[[:space:]]+pull_request:' "$trusted_workflow"; then
+  echo "not ok - trusted workflow is base-controlled pull_request_target only" >&2
   exit 1
 fi
-echo "ok - workflow executes the gate from the trusted base SHA"
+echo "ok - trusted workflow is base-controlled pull_request_target only"
 
 case_count=$((case_count + 1))
-if grep -Eq '^[[:space:]]+(DARWIN_NATIVE_REGEX|VERIFIED_LABEL|EVENT_ACTION|HAS_VERIFIED_LABEL|LABEL_CLEANUP|PR_NUMBER|REPOSITORY):' "$workflow"; then
-  echo "not ok - workflow supplies policy or decision inputs to the trusted gate" >&2
+if ! grep -Fq 'ref: ${{ github.event.pull_request.base.sha }}' "$trusted_workflow" ||
+  grep -Fq 'github.event.pull_request.head.sha }}' "$trusted_workflow"; then
+  echo "not ok - trusted workflow checks out only the base policy" >&2
   exit 1
 fi
-echo "ok - workflow supplies no policy or decision inputs to the trusted gate"
+echo "ok - trusted workflow checks out only the base policy"
 
 case_count=$((case_count + 1))
-if ! grep -Fq 'verification policy unavailable' "$workflow"; then
-  echo "not ok - workflow fails closed when the trusted policy is unavailable" >&2
+if ! grep -Eq '^[[:space:]]+pull_request:' "$head_test_workflow" ||
+  ! grep -Fq 'bash .github/scripts/darwin-verification-gate_test.sh' "$head_test_workflow"; then
+  echo "not ok - unprivileged pull_request workflow tests proposed HEAD policy" >&2
   exit 1
 fi
-echo "ok - workflow fails closed when the trusted policy is unavailable"
+echo "ok - unprivileged pull_request workflow tests proposed HEAD policy"
+
+case_count=$((case_count + 1))
+if grep -Fq 'Darwin E2E verified' "$head_test_workflow"; then
+  echo "not ok - untrusted policy test can collide with required status context" >&2
+  exit 1
+fi
+echo "ok - untrusted policy test has a distinct check name"
+
+case_count=$((case_count + 1))
+if ! grep -Fq 'statuses: write' "$trusted_workflow" ||
+  grep -Eq 'statuses:[[:space:]]*write' "$head_test_workflow"; then
+  echo "not ok - only the trusted workflow may publish commit statuses" >&2
+  exit 1
+fi
+echo "ok - only the trusted workflow may publish commit statuses"
 
 printf '1..%s\n' "$case_count"

--- a/.github/scripts/darwin-verification-gate_test.sh
+++ b/.github/scripts/darwin-verification-gate_test.sh
@@ -648,6 +648,23 @@ head_tests_cannot_write_pull_requests() {
   ! grep -Eq 'pull-requests:[[:space:]]*write' "$head_test_workflow"
 }
 
+# Bash >= 4.4 propagates an ERR trap into command-substitution subshells, so an
+# unguarded $(...) publishes a duplicate status from the subshell before the
+# parent publishes its own. Every substitution below the trap must disarm it.
+# shellcheck disable=SC2016  # shell syntax is matched literally, not expanded.
+command_substitutions_disarm_the_err_trap() {
+  local body
+  body=$(awk '/^trap fail_closed ERR$/ {found = 1; next} found' "$gate")
+  [ -n "$body" ] || return 1
+
+  local offenders
+  offenders=$(printf '%s\n' "$body" | grep -F '$(' | grep -Fv '$(trap - ERR;' || true)
+  if [ -n "$offenders" ]; then
+    printf 'unguarded command substitution:\n%s\n' "$offenders" >&2
+    return 1
+  fi
+}
+
 gate_workflows_are_valid_yaml() {
   python3 -c 'import sys, yaml
 for path in sys.argv[1:]:
@@ -677,6 +694,8 @@ assert_workflow "only the trusted workflow may publish commit statuses" \
   only_trusted_publishes_statuses
 assert_workflow "untrusted policy test cannot write pull requests" \
   head_tests_cannot_write_pull_requests
+assert_workflow "command substitutions cannot double-publish a status" \
+  command_substitutions_disarm_the_err_trap
 
 if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' 2>/dev/null; then
   assert_workflow "gate workflows are valid YAML" gate_workflows_are_valid_yaml

--- a/.github/scripts/darwin-verification-gate_test.sh
+++ b/.github/scripts/darwin-verification-gate_test.sh
@@ -8,19 +8,66 @@ workflow="$script_dir/../workflows/darwin-verification-gate.yml"
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
+mkdir "$tmpdir/bin"
+cat > "$tmpdir/bin/gh" <<'MOCK'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$MOCK_GH_LOG"
+
+case "$1 $2" in
+  "pr edit")
+    if [ "$MOCK_EDIT_STATUS" -ne 0 ]; then
+      echo "HTTP 403: Resource not accessible by integration" >&2
+      exit "$MOCK_EDIT_STATUS"
+    fi
+    ;;
+  "pr diff")
+    printf '%s\n' "$MOCK_CHANGED_PATH"
+    ;;
+  "pr view")
+    printf '%s\n' "$MOCK_HAS_LABEL"
+    ;;
+  *)
+    echo "Unexpected gh command: $*" >&2
+    exit 2
+    ;;
+esac
+MOCK
+chmod +x "$tmpdir/bin/gh"
+
 case_count=0
 
-while IFS='|' read -r name action changed_path has_label cleanup expected_status expected_output; do
+while IFS='|' read -r name action event_label head_repository changed_path has_label edit_status expected_status expected_output expect_view; do
   case_count=$((case_count + 1))
-  changed_files="$tmpdir/changed-$case_count.txt"
-  printf '%s\n' "$changed_path" > "$changed_files"
+  event_path="$tmpdir/event-$case_count.json"
+  log_path="$tmpdir/gh-$case_count.log"
+  jq -n \
+    --arg action "$action" \
+    --arg event_label "$event_label" \
+    --arg head_repository "$head_repository" \
+    '{action: $action, label: {name: $event_label}, pull_request: {number: 17, head: {repo: {full_name: $head_repository}}}}' \
+    > "$event_path"
 
   status=0
   output=$(
-    EVENT_ACTION="$action" \
-      CHANGED_FILES="$changed_files" \
-      HAS_VERIFIED_LABEL="$has_label" \
-      LABEL_CLEANUP="$cleanup" \
+    PATH="$tmpdir/bin:$PATH" \
+      GITHUB_EVENT_PATH="$event_path" \
+      GITHUB_REPOSITORY=bingosuite/bingo \
+      MOCK_GH_LOG="$log_path" \
+      MOCK_CHANGED_PATH="$changed_path" \
+      MOCK_HAS_LABEL="$has_label" \
+      MOCK_EDIT_STATUS="$edit_status" \
+      DARWIN_NATIVE_REGEX='^never-match$' \
+      VERIFIED_LABEL=attacker-controlled \
+      EVENT_ACTION=opened \
+      HAS_VERIFIED_LABEL=true \
+      LABEL_CLEANUP=cleared \
+      CHANGED_FILES="$tmpdir/attacker-changed.txt" \
+      IS_FORK=false \
+      PR_NUMBER=999 \
+      REPOSITORY=attacker/repository \
       bash "$gate" 2>&1
   ) || status=$?
 
@@ -36,15 +83,57 @@ while IFS='|' read -r name action changed_path has_label cleanup expected_status
     exit 1
   fi
 
+  if ! grep -Fq -- '--repo bingosuite/bingo' "$log_path"; then
+    printf 'not ok - %s (trusted repository was not used)\n' "$name" >&2
+    exit 1
+  fi
+
+  if grep -Fq 'attacker-controlled' "$log_path"; then
+    printf 'not ok - %s (hostile label override reached gh)\n' "$name" >&2
+    exit 1
+  fi
+
+  if grep -Fq 'attacker/repository' "$log_path"; then
+    printf 'not ok - %s (hostile repository override reached gh)\n' "$name" >&2
+    exit 1
+  fi
+
+  if grep -Fq ' 999 ' "$log_path"; then
+    printf 'not ok - %s (hostile PR number override reached gh)\n' "$name" >&2
+    exit 1
+  fi
+
+  if [ "$action" = "synchronize" ] || [ "$action" = "reopened" ]; then
+    if ! grep -Fq 'pr edit 17 --repo bingosuite/bingo --remove-label darwin-e2e-verified' "$log_path"; then
+      printf 'not ok - %s (trusted cleanup inputs were not used)\n' "$name" >&2
+      exit 1
+    fi
+  elif grep -Fq 'pr edit' "$log_path"; then
+    printf 'not ok - %s (hostile action override triggered cleanup)\n' "$name" >&2
+    exit 1
+  fi
+
+  if [ "$expect_view" = "true" ] && ! grep -Fq 'pr view' "$log_path"; then
+    printf 'not ok - %s (expected live label query)\n' "$name" >&2
+    exit 1
+  fi
+
+  if [ "$expect_view" = "false" ] && grep -Fq 'pr view' "$log_path"; then
+    printf 'not ok - %s (unexpected live label query)\n' "$name" >&2
+    exit 1
+  fi
+
   printf 'ok - %s\n' "$name"
 done <<'CASES'
-fork removal denied ignores stale live label|synchronize|internal/debugger/backend_darwin_arm64.go|true|failed|1|remove or toggle the stale label
-same-repository synchronize invalidates prior verification|synchronize|entitlements.plist|false|cleared|1|New commits always invalidate prior Darwin verification
-same-repository relabel verifies the same head|labeled|entitlements.plist|true|not-run|0|label present; darwin backend verified locally
-labeled Darwin change passes with live label|labeled|test/integration/debugger_e2e_darwin_arm64_test.go|true|not-run|0|label present; darwin backend verified locally
-unlabeled Darwin change fails without live label|unlabeled|internal/debugger/trap_arm64.go|false|not-run|1|Darwin E2E verification required
-non-Darwin change bypasses gate|synchronize|internal/debugger/engine.go|true|failed|0|No darwin-native code changed; gate not required
-near-match outside preserved regex bypasses gate|opened|docs/backend_darwin_arm64.go|false|not-run|0|No darwin-native code changed; gate not required
+hostile policy overrides cannot bypass fork synchronize|synchronize||contributor/fork|internal/debugger/backend_darwin_arm64.go|true|1|1|public-fork GITHUB_TOKEN is read-only|false
+same-repository synchronize invalidates prior verification|synchronize||bingosuite/bingo|entitlements.plist|false|0|1|New commits and reopened pull requests invalidate prior Darwin verification|false
+reopened fork fails closed with stale verification|reopened||contributor/fork|entitlements.plist|true|1|1|remove or toggle the stale label|false
+verified label addition passes with live label|labeled|darwin-e2e-verified|contributor/fork|test/integration/debugger_e2e_darwin_arm64_test.go|true|0|0|label present; darwin backend verified locally|true
+verified label removal fails without live label|unlabeled|darwin-e2e-verified|contributor/fork|internal/debugger/trap_arm64.go|false|0|1|Darwin E2E verification required|true
+unrelated label cannot revive stale verification|labeled|triage|contributor/fork|entitlements.plist|true|0|1|label event cannot verify this head|true
+unrelated unlabel cannot revive stale verification|unlabeled|triage|contributor/fork|entitlements.plist|true|0|1|label event cannot verify this head|true
+non-Darwin synchronize bypasses gate after cleanup attempt|synchronize||contributor/fork|internal/debugger/engine.go|true|1|0|No darwin-native code changed; gate not required|false
+near-match outside preserved regex bypasses gate|opened||contributor/fork|docs/backend_darwin_arm64.go|false|0|0|No darwin-native code changed; gate not required|false
 CASES
 
 case_count=$((case_count + 1))
@@ -55,11 +144,17 @@ fi
 echo "ok - workflow executes the gate from the trusted base SHA"
 
 case_count=$((case_count + 1))
-expected_regex='^(internal/debugger/.*_darwin_.*|internal/debugger/trap_arm64\.go|test/integration/.*_darwin_.*_test\.go|entitlements\.plist)$'
-if ! grep -Fq "DARWIN_NATIVE_REGEX: '$expected_regex'" "$workflow"; then
-  echo "not ok - workflow bootstrap preserves the Darwin path regex" >&2
+if grep -Eq '^[[:space:]]+(DARWIN_NATIVE_REGEX|VERIFIED_LABEL|EVENT_ACTION|HAS_VERIFIED_LABEL|LABEL_CLEANUP|PR_NUMBER|REPOSITORY):' "$workflow"; then
+  echo "not ok - workflow supplies policy or decision inputs to the trusted gate" >&2
   exit 1
 fi
-echo "ok - workflow bootstrap preserves the Darwin path regex"
+echo "ok - workflow supplies no policy or decision inputs to the trusted gate"
+
+case_count=$((case_count + 1))
+if ! grep -Fq 'verification policy unavailable' "$workflow"; then
+  echo "not ok - workflow fails closed when the trusted policy is unavailable" >&2
+  exit 1
+fi
+echo "ok - workflow fails closed when the trusted policy is unavailable"
 
 printf '1..%s\n' "$case_count"

--- a/.github/scripts/darwin-verification-gate_test.sh
+++ b/.github/scripts/darwin-verification-gate_test.sh
@@ -592,11 +592,18 @@ trusted_is_base_controlled() {
     ! grep -Eq '^[[:space:]]+pull_request:' "$trusted_workflow"
 }
 
+# The privileged job must never materialise a working tree, and the only code it
+# runs must be read from the base SHA, which a pull request cannot influence.
 # GitHub Actions '${{ }}' expressions are matched literally, not expanded.
 # shellcheck disable=SC2016
-trusted_checks_out_base_only() {
-  grep -Fq 'ref: ${{ github.event.pull_request.base.sha }}' "$trusted_workflow" &&
-    ! grep -Fq 'github.event.pull_request.head.sha }}' "$trusted_workflow"
+trusted_runs_base_policy_only() {
+  ! grep -Eq 'uses:[[:space:]]*actions/checkout' "$trusted_workflow" &&
+    grep -Fq 'BASE_SHA: ${{ github.event.pull_request.base.sha }}' \
+      "$trusted_workflow" &&
+    grep -Fq 'contents/.github/scripts/darwin-verification-gate.sh?ref=$BASE_SHA' \
+      "$trusted_workflow" &&
+    ! grep -Fq 'github.event.pull_request.head.sha }}' "$trusted_workflow" &&
+    ! grep -Fq 'github.event.pull_request.head.ref' "$trusted_workflow"
 }
 
 trusted_subscribes_to_gated_actions() {
@@ -674,8 +681,8 @@ for path in sys.argv[1:]:
 
 assert_workflow "trusted workflow is base-controlled pull_request_target only" \
   trusted_is_base_controlled
-assert_workflow "trusted workflow checks out only the base policy" \
-  trusted_checks_out_base_only
+assert_workflow "trusted workflow runs only base-SHA policy and never checks out" \
+  trusted_runs_base_policy_only
 assert_workflow "trusted workflow subscribes to every gated action" \
   trusted_subscribes_to_gated_actions
 assert_workflow "trusted workflow never cancels a run in progress" \

--- a/.github/scripts/darwin-verification-gate_test.sh
+++ b/.github/scripts/darwin-verification-gate_test.sh
@@ -670,6 +670,15 @@ command_substitutions_disarm_the_err_trap() {
     printf 'unguarded command substitution:\n%s\n' "$offenders" >&2
     return 1
   fi
+
+  # Backticks, process substitution and explicit subshells inherit the ERR trap
+  # exactly like '$( )' does, but carry no '$(' for the scan above to catch.
+  # Ban them outright so the guarded form stays the only way to spawn a subshell.
+  offenders=$(printf '%s\n' "$body" | grep -E '`|<\(|>\(' || true)
+  if [ -n "$offenders" ]; then
+    printf 'subshell form that cannot be guarded:\n%s\n' "$offenders" >&2
+    return 1
+  fi
 }
 
 gate_workflows_are_valid_yaml() {

--- a/.github/scripts/darwin-verification-gate_test.sh
+++ b/.github/scripts/darwin-verification-gate_test.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+gate="$script_dir/darwin-verification-gate.sh"
+workflow="$script_dir/../workflows/darwin-verification-gate.yml"
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+case_count=0
+
+while IFS='|' read -r name action changed_path has_label cleanup expected_status expected_output; do
+  case_count=$((case_count + 1))
+  changed_files="$tmpdir/changed-$case_count.txt"
+  printf '%s\n' "$changed_path" > "$changed_files"
+
+  status=0
+  output=$(
+    EVENT_ACTION="$action" \
+      CHANGED_FILES="$changed_files" \
+      HAS_VERIFIED_LABEL="$has_label" \
+      LABEL_CLEANUP="$cleanup" \
+      bash "$gate" 2>&1
+  ) || status=$?
+
+  if [ "$status" -ne "$expected_status" ]; then
+    printf 'not ok - %s (status %s, expected %s)\n%s\n' \
+      "$name" "$status" "$expected_status" "$output" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq "$expected_output" <<< "$output"; then
+    printf 'not ok - %s (missing output: %s)\n%s\n' \
+      "$name" "$expected_output" "$output" >&2
+    exit 1
+  fi
+
+  printf 'ok - %s\n' "$name"
+done <<'CASES'
+fork removal denied ignores stale live label|synchronize|internal/debugger/backend_darwin_arm64.go|true|failed|1|remove or toggle the stale label
+same-repository synchronize invalidates prior verification|synchronize|entitlements.plist|false|cleared|1|New commits always invalidate prior Darwin verification
+same-repository relabel verifies the same head|labeled|entitlements.plist|true|not-run|0|label present; darwin backend verified locally
+labeled Darwin change passes with live label|labeled|test/integration/debugger_e2e_darwin_arm64_test.go|true|not-run|0|label present; darwin backend verified locally
+unlabeled Darwin change fails without live label|unlabeled|internal/debugger/trap_arm64.go|false|not-run|1|Darwin E2E verification required
+non-Darwin change bypasses gate|synchronize|internal/debugger/engine.go|true|failed|0|No darwin-native code changed; gate not required
+near-match outside preserved regex bypasses gate|opened|docs/backend_darwin_arm64.go|false|not-run|0|No darwin-native code changed; gate not required
+CASES
+
+case_count=$((case_count + 1))
+if ! grep -Fq 'ref: ${{ github.event.pull_request.base.sha }}' "$workflow"; then
+  echo "not ok - workflow executes the gate from the trusted base SHA" >&2
+  exit 1
+fi
+echo "ok - workflow executes the gate from the trusted base SHA"
+
+case_count=$((case_count + 1))
+expected_regex='^(internal/debugger/.*_darwin_.*|internal/debugger/trap_arm64\.go|test/integration/.*_darwin_.*_test\.go|entitlements\.plist)$'
+if ! grep -Fq "DARWIN_NATIVE_REGEX: '$expected_regex'" "$workflow"; then
+  echo "not ok - workflow bootstrap preserves the Darwin path regex" >&2
+  exit 1
+fi
+echo "ok - workflow bootstrap preserves the Darwin path regex"
+
+printf '1..%s\n' "$case_count"

--- a/.github/scripts/darwin-verification-gate_test.sh
+++ b/.github/scripts/darwin-verification-gate_test.sh
@@ -133,7 +133,7 @@ case "$*" in
     done
     sha=${path##*/}
     content=$(jq -r --arg sha "$sha" '.[$sha] // "package bingo\n"' \
-      <<< "$MOCK_BLOB_CONTENTS_JSON")
+      "$MOCK_BLOB_CONTENTS_FILE")
     printf '%s' "$content" | base64
     ;;
   *"/issues/"*"/labels?"*)
@@ -232,6 +232,7 @@ run_case() {
   local gh_log="$tmpdir/gh-$case_id.log"
   local status_log="$tmpdir/status-$case_id.log"
   local decision_file="$tmpdir/decision-$case_id.txt"
+  local blob_contents_file="$tmpdir/blobs-$case_id.json"
   local head_sha
   head_sha=$(printf '%040x' "$case_id")
   local base_sha
@@ -250,6 +251,7 @@ run_case() {
   fi
   : > "$gh_log"
   : > "$status_log"
+  printf '%s\n' "$blob_contents_json" > "$blob_contents_file"
   rm -f "$decision_file"
 
   jq -n \
@@ -294,7 +296,7 @@ run_case() {
       MOCK_BASE_TREE_SHA="$base_tree_sha" \
       MOCK_HEAD_TREE_SHA="$head_tree_sha" \
       MOCK_HEAD_SHA="$head_sha" \
-      MOCK_BLOB_CONTENTS_JSON="$blob_contents_json" \
+      MOCK_BLOB_CONTENTS_FILE="$blob_contents_file" \
       MOCK_PRIOR_STATUS_STATE="$prior_status" \
       MOCK_PRIOR_STATUS_CREATOR="$prior_creator" \
       MOCK_PRIOR_STATUS_TARGET="$prior_target" \
@@ -629,7 +631,10 @@ large_padding=$(awk 'BEGIN {
 }')
 large_header=$(printf '//go:build darwin && arm64\n%s\npackage debugger\n' \
   "$large_padding")
-large_constraint_blob=$(jq -n --arg content "$large_header" '{"0":$content}')
+large_header_file="$tmpdir/large-header.go"
+printf '%s' "$large_header" > "$large_header_file"
+large_constraint_blob=$(jq -n --rawfile content "$large_header_file" \
+  '{"0":$content}')
 run_case "large pre-package header cannot bypass build constraint detection" \
   action=opened head_repo=contributor/fork \
   path=internal/hub/largeheader.go \
@@ -797,6 +802,7 @@ run_status_persistence_sequence() {
   unrelated_event="$tmpdir/sequence-unrelated-$case_id.json"
   : > "$gh_log"
   : > "$status_log"
+  printf '%s\n' '{}' > "$tmpdir/blobs-sequence-$case_id.json"
 
   jq -n \
     --arg action "$first_action" \
@@ -840,7 +846,7 @@ run_status_persistence_sequence() {
     MOCK_BASE_TREE_SHA="$base_tree_sha" \
     MOCK_HEAD_TREE_SHA="$head_tree_sha" \
     MOCK_HEAD_SHA="$head_sha" \
-    MOCK_BLOB_CONTENTS_JSON='{}' \
+    MOCK_BLOB_CONTENTS_FILE="$tmpdir/blobs-sequence-$case_id.json" \
     MOCK_PRIOR_STATUS_STATE=failure \
     MOCK_PRIOR_STATUS_CREATOR='github-actions[bot]' \
     MOCK_PRIOR_STATUS_TARGET='https://github.com/bingosuite/bingo/actions/runs/122' \
@@ -863,7 +869,7 @@ run_status_persistence_sequence() {
     MOCK_BASE_TREE_SHA="$base_tree_sha" \
     MOCK_HEAD_TREE_SHA="$head_tree_sha" \
     MOCK_HEAD_SHA="$head_sha" \
-    MOCK_BLOB_CONTENTS_JSON='{}' \
+    MOCK_BLOB_CONTENTS_FILE="$tmpdir/blobs-sequence-$case_id.json" \
     MOCK_PRIOR_STATUS_STATE=failure \
     MOCK_PRIOR_STATUS_CREATOR='github-actions[bot]' \
     MOCK_PRIOR_STATUS_TARGET='https://github.com/bingosuite/bingo/actions/runs/122' \

--- a/.github/scripts/darwin-verification-gate_test.sh
+++ b/.github/scripts/darwin-verification-gate_test.sh
@@ -1,1058 +1,1643 @@
 #!/usr/bin/env bash
+# Adversarial tests for the trusted Darwin verification gate policy.
+#
+# Every case runs the real policy script against a mocked `gh` CLI and a
+# synthetic `pull_request_target` event, then asserts the exact statuses the
+# gate published, the decision marker it recorded, and which API calls it did
+# (and did not) make. The suite must pass under Bash 3.2 (macOS) and Bash 5.
 
-set -euo pipefail
+set -uo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$script_dir/../.." && pwd)
 gate="$script_dir/darwin-verification-gate.sh"
-trusted_workflow="$script_dir/../workflows/darwin-verification-gate.yml"
-head_test_workflow="$script_dir/../workflows/darwin-verification-policy-test.yml"
+workflow="$repo_root/.github/workflows/darwin-verification-gate.yml"
+policy_test_workflow="$repo_root/.github/workflows/darwin-verification-policy-test.yml"
+
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
-mkdir "$tmpdir/bin"
-cat > "$tmpdir/bin/gh" <<'MOCK'
-#!/usr/bin/env bash
+failures=0
+cases=0
 
-set -euo pipefail
+fail() {
+  failures=$((failures + 1))
+  printf 'FAIL: %s\n' "$1" >&2
+}
+
+pass() {
+  printf 'ok   %s\n' "$1"
+}
+
+# ---------------------------------------------------------------------------
+# Mock `gh`
+# ---------------------------------------------------------------------------
+# The mock answers every endpoint the gate uses. Anything else is a hard error,
+# so a policy change that reaches for a new API surface fails the suite instead
+# of silently succeeding. Reading previously published commit statuses is
+# explicitly poisoned: that data is forgeable by any same-repository workflow,
+# so the gate must never consult it.
+
+mock_bin="$tmpdir/bin"
+mkdir -p "$mock_bin"
+
+cat > "$mock_bin/gh" <<'MOCK'
+#!/usr/bin/env bash
+set -uo pipefail
 
 printf '%s\n' "$*" >> "$MOCK_GH_LOG"
 
-if [ "$1 $2" = "pr edit" ]; then
-  if [ "$MOCK_EDIT_STATUS" -ne 0 ]; then
-    echo "HTTP 403: Resource not accessible by integration" >&2
-    exit "$MOCK_EDIT_STATUS"
+# `gh api --jq <expr>` filters the response client-side; the gate relies on it,
+# so the mock has to honour it rather than returning raw JSON.
+mock_jq_filter=''
+mock_prev=''
+for mock_arg in "$@"; do
+  if [ "$mock_prev" = "--jq" ]; then
+    mock_jq_filter=$mock_arg
+  fi
+  mock_prev=$mock_arg
+done
+
+emit() {
+  if [ -n "$mock_jq_filter" ]; then
+    jq -r "$mock_jq_filter"
+  else
+    cat
+  fi
+}
+
+if [ "${1:-}" = "pr" ] && [ "${2:-}" = "edit" ]; then
+  if [ "${MOCK_LABEL_REMOVE_STATUS:-0}" != "0" ]; then
+    echo "mock: label removal denied" >&2
+    exit 1
   fi
   exit 0
 fi
 
-if [ "$1" != "api" ]; then
-  echo "Unexpected gh command: $*" >&2
-  exit 2
+if [ "${1:-}" != "api" ]; then
+  echo "mock: unsupported gh invocation: $*" >&2
+  exit 90
 fi
 
 case "$*" in
-  *"/commits/"*"/statuses?"*)
-    jq -n \
-      --arg state "$MOCK_PRIOR_STATUS_STATE" \
-      --arg creator "$MOCK_PRIOR_STATUS_CREATOR" \
-      --arg target "$MOCK_PRIOR_STATUS_TARGET" '
-        if $state == "" then
-          [[]]
-        else
-          [[{
-            context: "Darwin E2E verified",
-            state: $state,
-            creator: {login: $creator},
-            target_url: $target
-          }]]
-        end
-      '
-    ;;
-  *"/statuses/"*)
-    state=
-    context=
-    endpoint=
-    for arg in "$@"; do
-      case "$arg" in
-        repos/*/statuses/*) endpoint=$arg ;;
-        state=*) state=${arg#state=} ;;
-        context=*) context=${arg#context=} ;;
-      esac
-    done
-    # Only successfully published statuses are logged, so the log is an exact
-    # record of what GitHub would show on the head SHA.
-    for failing in ${MOCK_STATUS_FAIL_STATES:-}; do
-      if [ "$failing" = "$state" ]; then
-        echo "status API failed for state $state" >&2
-        exit 1
-      fi
-    done
-    printf '%s|%s|%s\n' "$endpoint" "$state" "$context" >> "$MOCK_STATUS_LOG"
-    ;;
-  *"/compare/"*)
-    if [ "$MOCK_DIFF_STATUS" -ne 0 ]; then
-      echo "diff API failed" >&2
-      exit "$MOCK_DIFF_STATUS"
-    fi
-    printf '%s\n' "$MOCK_MERGE_BASE_SHA"
-    ;;
-  *"/git/commits/"*)
-    case "$*" in
-      *"/git/commits/$MOCK_MERGE_BASE_SHA"*)
-        printf '%s\n' "$MOCK_BASE_TREE_SHA"
-        ;;
-      *"/git/commits/$MOCK_HEAD_SHA"*)
-        printf '%s\n' "$MOCK_HEAD_TREE_SHA"
-        ;;
-      *)
-        echo "Unexpected commit lookup: $*" >&2
-        exit 2
-        ;;
-    esac
-    ;;
-  *"/git/trees/"*)
-    paths='[]'
-    truncated=false
-    case "$*" in
-      *"/git/trees/$MOCK_BASE_TREE_SHA"*)
-        paths=$MOCK_BASE_PATHS_JSON
-        truncated=$MOCK_BASE_TREE_TRUNCATED
-        ;;
-      *"/git/trees/$MOCK_HEAD_TREE_SHA"*)
-        paths=$MOCK_CHANGED_PATHS_JSON
-        truncated=$MOCK_TREE_TRUNCATED
-        ;;
-      *)
-        echo "Unexpected tree lookup: $*" >&2
-        exit 2
-        ;;
-    esac
-    jq -n \
-      --argjson paths "$paths" \
-      --argjson truncated "$truncated" '
-        {
-          truncated: $truncated,
-          tree: [
-            range(0; $paths | length) as $index
-            | {
-                mode: "100644",
-                path: $paths[$index],
-                sha: ($index | tostring),
-                type: "blob"
-              }
-          ]
-        }
-      '
-    ;;
-  *"/git/blobs/"*)
-    path=
-    for arg in "$@"; do
-      case "$arg" in
-        repos/*/git/blobs/*) path=$arg ;;
-      esac
-    done
-    sha=${path##*/}
-    content=$(jq -r --arg sha "$sha" '.[$sha] // "package bingo\n"' \
-      "$MOCK_BLOB_CONTENTS_FILE")
-    printf '%s' "$content" | base64
-    ;;
-  *"/issues/"*"/labels?"*)
-    if [ "$MOCK_LABEL_STATUS" -ne 0 ]; then
-      echo "label API failed" >&2
-      exit "$MOCK_LABEL_STATUS"
-    fi
-    # Anything other than true/false is emitted verbatim as the live label set,
-    # so a case can pin that only an exact match counts as verification.
-    case "$MOCK_HAS_LABEL" in
-      true) printf '%s\n' darwin-e2e-verified ;;
-      false) ;;
-      *) printf '%s\n' "$MOCK_HAS_LABEL" ;;
-    esac
-    ;;
-  *)
-    echo "Unexpected gh api call: $*" >&2
-    exit 2
+  *"/commits/"*"/statuses"*)
+    echo "mock: the gate must never read previously published statuses" >&2
+    exit 91
     ;;
 esac
+
+case "$*" in
+  *--method\ POST*"/statuses/"*)
+    state=""
+    context=""
+    description=""
+    target=""
+    prev=""
+    for arg in "$@"; do
+      case "$prev" in
+        state=*) ;;
+      esac
+      case "$arg" in
+        state=*) state=${arg#state=} ;;
+        context=*) context=${arg#context=} ;;
+        description=*) description=${arg#description=} ;;
+        target_url=*) target=${arg#target_url=} ;;
+      esac
+      prev=$arg
+    done
+    if [ "${MOCK_STATUS_POST_STATUS:-0}" != "0" ]; then
+      echo "mock: status POST denied" >&2
+      exit 1
+    fi
+    printf '%s\n' "$state" >> "$MOCK_STATE_LOG"
+    printf '%s|%s|%s\n' "$context" "$state" "$description" >> "$MOCK_STATUS_LOG"
+    printf '%s\n' "$target" >> "$MOCK_TARGET_LOG"
+    exit 0
+    ;;
+  *"/collaborators/"*"/permission"*)
+    if [ "${MOCK_PERMISSION_STATUS:-0}" != "0" ]; then
+      echo "mock: permission lookup failed" >&2
+      exit 1
+    fi
+    printf '%s\n' "${MOCK_PERMISSION_JSON:-{\}}" | emit
+    exit 0
+    ;;
+  *"/pulls/"*/*)
+    echo "mock: mutable pull request sub-resource is banned: $path" >&2
+    exit 92
+    ;;
+  *"/pulls/"*)
+    if [ "${MOCK_LIVE_PR_STATUS:-0}" != "0" ]; then
+      echo "mock: live pull request lookup failed" >&2
+      exit 1
+    fi
+    printf '%s\n' "${MOCK_LIVE_PR_JSON:-{\}}" | emit
+    exit 0
+    ;;
+  *"/issues/"*"/labels"*)
+    if [ "${MOCK_LABEL_STATUS:-0}" != "0" ]; then
+      echo "mock: label lookup failed" >&2
+      exit 1
+    fi
+    printf '%s\n' "${MOCK_LABELS_JSON:-[]}" | emit
+    exit 0
+    ;;
+  *"/compare/"*)
+    if [ "${MOCK_COMPARE_STATUS:-0}" != "0" ]; then
+      echo "mock: compare failed" >&2
+      exit 1
+    fi
+    printf '%s\n' "${MOCK_COMPARE_JSON}" | emit
+    exit 0
+    ;;
+  *"/git/commits/"*)
+    all=$*
+    ref=${all##*/git/commits/}
+    ref=${ref%% *}
+    if [ "$ref" = "$MOCK_MERGE_BASE_SHA" ]; then
+      tree=$MOCK_BASE_TREE_SHA
+    elif [ "$ref" = "$MOCK_HEAD_SHA" ]; then
+      tree=$MOCK_HEAD_TREE_SHA
+    else
+      echo "mock: unexpected commit ref $ref" >&2
+      exit 92
+    fi
+    jq -n --arg tree "$tree" '{tree: {sha: $tree}}' | emit
+    exit 0
+    ;;
+  *"/git/trees/"*)
+    all=$*
+    ref=${all##*/git/trees/}
+    ref=${ref%%\?*}
+    ref=${ref%% *}
+    if [ "$ref" = "$MOCK_BASE_TREE_SHA" ]; then
+      entries=$MOCK_BASE_TREE_ENTRIES
+      truncated=$MOCK_BASE_TREE_TRUNCATED
+      status=${MOCK_BASE_TREE_STATUS:-0}
+    elif [ "$ref" = "$MOCK_HEAD_TREE_SHA" ]; then
+      entries=$MOCK_HEAD_TREE_ENTRIES
+      truncated=$MOCK_HEAD_TREE_TRUNCATED
+      status=${MOCK_HEAD_TREE_STATUS:-0}
+    else
+      echo "mock: unexpected tree ref $ref" >&2
+      exit 93
+    fi
+    if [ "$status" != "0" ]; then
+      echo "mock: tree read failed" >&2
+      exit 1
+    fi
+    # Entries are either bare path strings (regular blobs with a synthetic
+    # 40-hex SHA derived from their index) or objects that override any of
+    # path/mode/type/sha, plus `drop_sha` to omit the field entirely.
+    printf '%s' "$entries" | jq \
+      --argjson truncated "$truncated" \
+      '{
+         truncated: $truncated,
+         tree: (to_entries | map(
+           (.key | tostring) as $i
+           | (("0000000000000000000000000000000000000000" + $i) | .[-40:]) as $auto
+           | (if (.value | type) == "string" then {path: .value} else .value end) as $spec
+           | {
+               path: $spec.path,
+               mode: ($spec.mode // "100644"),
+               type: ($spec.type // "blob"),
+               sha: ($spec.sha // $auto)
+             }
+           | if ($spec.drop_sha // false) then del(.sha) else . end
+         ))
+       }' | emit
+    exit 0
+    ;;
+  *"/git/blobs/"*)
+    all=$*
+    sha=${all##*/git/blobs/}
+    sha=${sha%% *}
+    alt=$(printf '%s' "$sha" | sed 's/^0*//')
+    [ -n "$alt" ] || alt=0
+    if [ "${MOCK_BLOB_STATUS:-0}" != "0" ]; then
+      echo "mock: blob read failed" >&2
+      exit 1
+    fi
+    b64=$(jq -r --arg sha "$sha" --arg alt "$alt" \
+      '(.[$sha] // .[$alt] // "")' "$MOCK_BLOB_B64_FILE")
+    if [ -z "$b64" ]; then
+      content=$(jq -r --arg sha "$sha" --arg alt "$alt" \
+        '(.[$sha] // .[$alt] // "package bingo\n")' "$MOCK_BLOB_CONTENTS_FILE")
+      b64=$(printf '%s' "$content" | base64 | tr -d '\n')
+    fi
+    jq -n \
+      --arg encoding "${MOCK_BLOB_ENCODING:-base64}" \
+      --arg content "$b64" \
+      '{encoding: $encoding, content: $content}' | emit
+    exit 0
+    ;;
+esac
+
+echo "mock: unexpected gh api call: $*" >&2
+exit 94
 MOCK
-chmod +x "$tmpdir/bin/gh"
+chmod +x "$mock_bin/gh"
 
-case_count=0
+# ---------------------------------------------------------------------------
+# Case harness
+# ---------------------------------------------------------------------------
 
-fail_case() {
-  printf 'not ok - %s\n' "$1" >&2
-  shift
-  if [ "$#" -gt 0 ]; then
-    printf '%s\n' "$@" >&2
-  fi
-  exit 1
-}
+case_id=0
 
-# run_case NAME key=value...
-#
-# Keys: action, label, head_repo, path, paths_json, base_paths_json,
-# base_changed, tree_truncated, blob_contents_json, prior_status,
-# prior_creator, prior_target, has_label, edit_status, diff_status, label_status,
-# status_fail, exit, state, states, output, label_query, decision, gh_contains,
-# gh_missing.
+# run_case <name> [key=value ...]
 run_case() {
   local name=$1
   shift
+  cases=$((cases + 1))
+  case_id=$((case_id + 1))
 
-  local action=opened label='' head_repo=contributor/fork
-  local path=entitlements.plist paths_json='' base_paths_json='[]'
-  local base_changed=false base_tree_truncated=false tree_truncated=false
-  local blob_contents_json='{}'
-  local prior_status=failure prior_creator='github-actions[bot]'
-  local prior_target='https://github.com/bingosuite/bingo/actions/runs/122'
-  local has_label=false edit_status=0 diff_status=0 label_status=0
-  local status_fail='' expect_exit=0 expect_state=none
+  local action=synchronize
+  local label_name=darwin-e2e-verified
+  local has_label=false
+  local labels_json=""
+  local label_status=0
+  local label_remove_status=0
+  local status_post_status=0
+  local compare_status=0
+  local base_tree_status=0
+  local head_tree_status=0
+  local blob_status=0
+  local blob_encoding=base64
+  local base_tree_truncated=false
+  local head_tree_truncated=false
+  # Default fixture: one Darwin-sensitive addition, so a case only has to
+  # describe the behaviour it is actually probing.
+  local base_entries='[]'
+  local head_entries='["internal/debugger/engine.go"]'
+  local blob_contents='{}'
+  local blob_b64='{}'
+  local edited_changes='{}'
+  local base_ref=main
+  local actor=maintainer-jo
+  local actor_type=User
+  local perm_status=0
+  local perm_permission=admin
+  local perm_role=admin
+  local perm_login=''
+  local live_status=0
+  local live_state=open
+  local live_base_ref=main
+  local live_base_sha=same
+  local live_head_sha=same
+  local live_head_repo=same
+  local head_repo=contributor/fork
+
+  local expect_exit=0
   local expect_states=''
-  local expect_output='' expect_label_query=any expect_decision=''
-  local gh_contains='' gh_missing=''
-  local kv key value
+  local expect_decision=''
+  local expect_output=''
+  local expect_missing_output=''
+  local expect_description=''
+  local gh_expect=''
+  local gh_missing=''
+  local expect_label_query=''
 
+  local kv key value
   for kv in "$@"; do
     key=${kv%%=*}
     value=${kv#*=}
     case "$key" in
       action) action=$value ;;
-      label) label=$value ;;
-      head_repo) head_repo=$value ;;
-      path) path=$value ;;
-      paths_json) paths_json=$value ;;
-      base_paths_json) base_paths_json=$value ;;
-      base_changed) base_changed=$value ;;
-      base_tree_truncated) base_tree_truncated=$value ;;
-      tree_truncated) tree_truncated=$value ;;
-      blob_contents_json) blob_contents_json=$value ;;
-      prior_status) prior_status=$value ;;
-      prior_creator) prior_creator=$value ;;
-      prior_target) prior_target=$value ;;
+      label_name) label_name=$value ;;
       has_label) has_label=$value ;;
-      edit_status) edit_status=$value ;;
-      diff_status) diff_status=$value ;;
+      labels_json) labels_json=$value ;;
       label_status) label_status=$value ;;
-      status_fail) status_fail=$value ;;
-      exit) expect_exit=$value ;;
-      state) expect_state=$value ;;
-      states) expect_states=$value ;;
-      output) expect_output=$value ;;
-      label_query) expect_label_query=$value ;;
-      decision) expect_decision=$value ;;
-      gh_contains) gh_contains=$value ;;
+      label_remove_status) label_remove_status=$value ;;
+      status_post_status) status_post_status=$value ;;
+      compare_status) compare_status=$value ;;
+      base_tree_status) base_tree_status=$value ;;
+      head_tree_status) head_tree_status=$value ;;
+      blob_status) blob_status=$value ;;
+      blob_encoding) blob_encoding=$value ;;
+      base_tree_truncated) base_tree_truncated=$value ;;
+      head_tree_truncated) head_tree_truncated=$value ;;
+      base_entries) base_entries=$value ;;
+      head_entries) head_entries=$value ;;
+      blob_contents) blob_contents=$value ;;
+      blob_b64) blob_b64=$value ;;
+      edited_changes) edited_changes=$value ;;
+      base_ref) base_ref=$value ;;
+      actor) actor=$value ;;
+      actor_type) actor_type=$value ;;
+      perm_status) perm_status=$value ;;
+      perm_permission) perm_permission=$value ;;
+      perm_role) perm_role=$value ;;
+      perm_login) perm_login=$value ;;
+      live_status) live_status=$value ;;
+      live_state) live_state=$value ;;
+      live_base_ref) live_base_ref=$value ;;
+      live_base_sha) live_base_sha=$value ;;
+      live_head_sha) live_head_sha=$value ;;
+      live_head_repo) live_head_repo=$value ;;
+      head_repo) head_repo=$value ;;
+      expect_exit) expect_exit=$value ;;
+      expect_states) expect_states=$value ;;
+      expect_decision) expect_decision=$value ;;
+      expect_output) expect_output=$value ;;
+      expect_missing_output) expect_missing_output=$value ;;
+      expect_description) expect_description=$value ;;
+      gh_expect) gh_expect=$value ;;
       gh_missing) gh_missing=$value ;;
-      *) fail_case "$name" "unknown run_case key: $key" ;;
+      expect_label_query) expect_label_query=$value ;;
+      *)
+        fail "$name: unknown harness key '$key'"
+        return
+        ;;
     esac
   done
 
-  case_count=$((case_count + 1))
-  local case_id=$case_count
-  local event_path="$tmpdir/event-$case_id.json"
-  local gh_log="$tmpdir/gh-$case_id.log"
-  local status_log="$tmpdir/status-$case_id.log"
-  local decision_file="$tmpdir/decision-$case_id.txt"
-  local blob_contents_file="$tmpdir/blobs-$case_id.json"
-  local head_sha
-  head_sha=$(printf '%040x' "$case_id")
-  local base_sha
-  base_sha=$(printf 'f%039x' "$case_id")
-  local merge_base_sha
-  merge_base_sha=$(printf 'e%039x' "$case_id")
-  local base_tree_sha
-  base_tree_sha=$(printf 'c%039x' "$case_id")
-  local head_tree_sha
-  head_tree_sha=$(printf 'd%039x' "$case_id")
-  local output
-  local status=0
+  local work="$tmpdir/case-$case_id"
+  mkdir -p "$work"
+  printf '%s\n' "$name" > "$work/name"
 
-  if [ -z "$paths_json" ]; then
-    paths_json=$(jq -n --arg path "$path" '[$path]')
+  local head_sha base_sha merge_base_sha
+  head_sha=$(printf 'ad%038x' "$case_id")
+  base_sha=$(printf 'be%038x' "$case_id")
+  merge_base_sha=$(printf 'cc%038x' "$case_id")
+
+  local other_sha
+  other_sha=$(printf 'fe%038x' "$case_id")
+
+  local live_base_sha_value=$base_sha
+  [ "$live_base_sha" = "other" ] && live_base_sha_value=$other_sha
+  [ "$live_base_sha" != "same" ] && [ "$live_base_sha" != "other" ] && live_base_sha_value=$live_base_sha
+
+  local live_head_sha_value=$head_sha
+  [ "$live_head_sha" = "other" ] && live_head_sha_value=$other_sha
+  [ "$live_head_sha" != "same" ] && [ "$live_head_sha" != "other" ] && live_head_sha_value=$live_head_sha
+
+  local live_head_repo_value=$head_repo
+  [ "$live_head_repo" != "same" ] && live_head_repo_value=$live_head_repo
+
+  local perm_login_value=$actor
+  [ -n "$perm_login" ] && perm_login_value=$perm_login
+
+  if [ -z "$labels_json" ]; then
+    if [ "$has_label" = "true" ]; then
+      labels_json='[{"name":"darwin-e2e-verified"}]'
+    else
+      labels_json='[{"name":"needs-review"}]'
+    fi
   fi
-  : > "$gh_log"
-  : > "$status_log"
-  printf '%s\n' "$blob_contents_json" > "$blob_contents_file"
-  rm -f "$decision_file"
 
+  local event="$work/event.json"
   jq -n \
+    --arg head "$head_sha" \
+    --arg base "$base_sha" \
+    --arg base_ref "$base_ref" \
     --arg action "$action" \
-    --arg event_label "$label" \
-    --arg head_repository "$head_repo" \
-    --arg head_sha "$head_sha" \
-    --arg base_sha "$base_sha" \
-    --argjson base_changed "$base_changed" \
-    --argjson changed_files "$(jq -n --argjson paths "$paths_json" '$paths | length')" \
+    --arg label "$label_name" \
+    --arg head_repo "$head_repo" \
+    --arg actor "$actor" \
+    --arg actor_type "$actor_type" \
+    --argjson changes "$edited_changes" \
     '{
       action: $action,
-      label: {name: $event_label},
-      changes: (
-        if $base_changed
-        then {base: {ref: {from: "previous-base"}}}
-        else {}
-        end
-      ),
+      sender: {login: $actor, type: $actor_type},
+      label: {name: $label},
+      changes: $changes,
       pull_request: {
         number: 17,
-        changed_files: $changed_files,
-        base: {sha: $base_sha},
-        head: {sha: $head_sha, repo: {full_name: $head_repository}}
+        state: "open",
+        head: {sha: $head, repo: {full_name: $head_repo}},
+        base: {sha: $base, ref: $base_ref}
       }
-    }' > "$event_path"
+    }' > "$event"
 
-  output=$(
-    PATH="$tmpdir/bin:$PATH" \
-      GITHUB_EVENT_PATH="$event_path" \
-      GITHUB_REPOSITORY=bingosuite/bingo \
-      GITHUB_SERVER_URL=https://github.com \
-      GITHUB_RUN_ID=123 \
-      DARWIN_GATE_DECISION_FILE="$decision_file" \
-      MOCK_GH_LOG="$gh_log" \
-      MOCK_STATUS_LOG="$status_log" \
-      MOCK_CHANGED_PATHS_JSON="$paths_json" \
-      MOCK_BASE_PATHS_JSON="$base_paths_json" \
-      MOCK_BASE_TREE_TRUNCATED="$base_tree_truncated" \
-      MOCK_TREE_TRUNCATED="$tree_truncated" \
-      MOCK_MERGE_BASE_SHA="$merge_base_sha" \
-      MOCK_BASE_TREE_SHA="$base_tree_sha" \
-      MOCK_HEAD_TREE_SHA="$head_tree_sha" \
-      MOCK_HEAD_SHA="$head_sha" \
-      MOCK_BLOB_CONTENTS_FILE="$blob_contents_file" \
-      MOCK_PRIOR_STATUS_STATE="$prior_status" \
-      MOCK_PRIOR_STATUS_CREATOR="$prior_creator" \
-      MOCK_PRIOR_STATUS_TARGET="$prior_target" \
-      MOCK_HAS_LABEL="$has_label" \
-      MOCK_EDIT_STATUS="$edit_status" \
-      MOCK_DIFF_STATUS="$diff_status" \
-      MOCK_LABEL_STATUS="$label_status" \
-      MOCK_STATUS_FAIL_STATES="$status_fail" \
-      DARWIN_NATIVE_REGEX='^never-match$' \
-      VERIFIED_LABEL=attacker-controlled \
-      EVENT_ACTION=opened \
-      HAS_VERIFIED_LABEL=true \
-      LABEL_CLEANUP=cleared \
-      CHANGED_FILES="$tmpdir/attacker-changed.txt" \
-      IS_FORK=false \
-      PR_NUMBER=999 \
-      REPOSITORY=attacker/repository \
-      GITHUB_WORKSPACE="$tmpdir/hostile-head" \
-      bash "$gate" 2>&1
-  ) || status=$?
+  local compare_json
+  compare_json=$(jq -n --arg mb "$merge_base_sha" '{merge_base_commit: {sha: $mb}}')
 
-  if [ "$status" -ne "$expect_exit" ]; then
-    fail_case "$name" "status $status, expected $expect_exit" "$output"
+  local live_pr_json
+  live_pr_json=$(jq -n \
+    --arg state "$live_state" \
+    --arg base_ref "$live_base_ref" \
+    --arg base_sha "$live_base_sha_value" \
+    --arg head_sha "$live_head_sha_value" \
+    --arg head_repo "$live_head_repo_value" \
+    '{
+      state: $state,
+      base: {ref: $base_ref, sha: $base_sha},
+      head: {sha: $head_sha, repo: {full_name: $head_repo}}
+    }')
+
+  local permission_json
+  permission_json=$(jq -n \
+    --arg permission "$perm_permission" \
+    --arg role "$perm_role" \
+    --arg login "$perm_login_value" \
+    '{permission: $permission, role_name: $role, user: {login: $login}}')
+
+  printf '%s' "$blob_contents" > "$work/blobs.json"
+  printf '%s' "$blob_b64" > "$work/blobs-b64.json"
+
+  local out="$work/output.txt"
+  local decision="$work/decision"
+
+  (
+    PATH="$mock_bin:$PATH" \
+    GITHUB_EVENT_PATH="$event" \
+    GITHUB_REPOSITORY=bingosuite/bingo \
+    GITHUB_SERVER_URL=https://github.com \
+    GITHUB_RUN_ID=4242 \
+    DARWIN_GATE_DECISION_FILE="$decision" \
+    MOCK_GH_LOG="$work/gh.log" \
+    MOCK_STATE_LOG="$work/states.log" \
+    MOCK_STATUS_LOG="$work/statuses.log" \
+    MOCK_TARGET_LOG="$work/targets.log" \
+    MOCK_LABELS_JSON="$labels_json" \
+    MOCK_LABEL_STATUS="$label_status" \
+    MOCK_LABEL_REMOVE_STATUS="$label_remove_status" \
+    MOCK_STATUS_POST_STATUS="$status_post_status" \
+    MOCK_COMPARE_JSON="$compare_json" \
+    MOCK_COMPARE_STATUS="$compare_status" \
+    MOCK_MERGE_BASE_SHA="$merge_base_sha" \
+    MOCK_HEAD_SHA="$head_sha" \
+    MOCK_BASE_TREE_SHA=$(printf 'da%038x' $((case_id * 2))) \
+    MOCK_HEAD_TREE_SHA=$(printf 'da%038x' $((case_id * 2 + 1))) \
+    MOCK_BASE_TREE_ENTRIES="$base_entries" \
+    MOCK_HEAD_TREE_ENTRIES="$head_entries" \
+    MOCK_BASE_TREE_TRUNCATED="$base_tree_truncated" \
+    MOCK_HEAD_TREE_TRUNCATED="$head_tree_truncated" \
+    MOCK_BASE_TREE_STATUS="$base_tree_status" \
+    MOCK_HEAD_TREE_STATUS="$head_tree_status" \
+    MOCK_BLOB_CONTENTS_FILE="$work/blobs.json" \
+    MOCK_BLOB_B64_FILE="$work/blobs-b64.json" \
+    MOCK_BLOB_STATUS="$blob_status" \
+    MOCK_BLOB_ENCODING="$blob_encoding" \
+    MOCK_LIVE_PR_JSON="$live_pr_json" \
+    MOCK_LIVE_PR_STATUS="$live_status" \
+    MOCK_PERMISSION_JSON="$permission_json" \
+    MOCK_PERMISSION_STATUS="$perm_status" \
+    bash "$gate"
+  ) > "$out" 2>&1
+  local actual_exit=$?
+
+  local ok=1
+
+  if [ "$actual_exit" != "$expect_exit" ]; then
+    fail "$name: expected exit $expect_exit, got $actual_exit"
+    ok=0
   fi
 
-  if [ -n "$expect_output" ] && ! grep -Fq -- "$expect_output" <<< "$output"; then
-    fail_case "$name" "missing output: $expect_output" "$output"
+  local actual_states=''
+  if [ -f "$work/states.log" ]; then
+    actual_states=$(paste -sd, - < "$work/states.log")
+  fi
+  if [ "$actual_states" != "$expect_states" ]; then
+    fail "$name: expected states '$expect_states', got '$actual_states'"
+    ok=0
   fi
 
-  if grep -Eq 'attacker-controlled|attacker/repository| 999 ' "$gh_log"; then
-    fail_case "$name" "hostile environment reached gh" "$(cat "$gh_log")"
+  local actual_decision=''
+  [ -f "$decision" ] && actual_decision=$(cat "$decision")
+  if [ "$actual_decision" != "$expect_decision" ]; then
+    fail "$name: expected decision '$expect_decision', got '$actual_decision'"
+    ok=0
   fi
 
-  if grep -Fq "/pulls/17/files" "$gh_log"; then
-    fail_case "$name" "gate consulted the live pull request file list" \
-      "$(cat "$gh_log")"
+  if [ -n "$expect_output" ] && ! grep -Fq "$expect_output" "$out"; then
+    fail "$name: expected output to contain '$expect_output'"
+    ok=0
   fi
 
-  if grep -Fq '|pending|' "$status_log" &&
-    ! grep -Fq "/compare/$base_sha...$head_sha" "$gh_log"; then
-    fail_case "$name" "gate did not bind its diff to event base/head SHAs" \
-      "$(cat "$gh_log")"
+  if [ -n "$expect_missing_output" ] && grep -Fq "$expect_missing_output" "$out"; then
+    fail "$name: output unexpectedly contains '$expect_missing_output'"
+    ok=0
   fi
 
-  if [ "$expect_label_query" = "true" ] &&
-    ! grep -Fq "/issues/17/labels?" "$gh_log"; then
-    fail_case "$name" "expected live label query" "$(cat "$gh_log")"
+  touch "$work/statuses.log"
+  if [ -n "$expect_description" ] &&
+    ! grep -Fq "$expect_description" "$work/statuses.log"; then
+    fail "$name: expected a status description containing '$expect_description'"
+    ok=0
   fi
 
-  if [ "$expect_label_query" = "false" ] &&
-    grep -Fq "/issues/17/labels?" "$gh_log"; then
-    fail_case "$name" "unexpected live label query" "$(cat "$gh_log")"
+  touch "$work/gh.log"
+
+  if [ -n "$gh_expect" ] && ! grep -Fq "$gh_expect" "$work/gh.log"; then
+    fail "$name: expected gh call containing '$gh_expect'"
+    ok=0
   fi
 
-  if [ -n "$gh_contains" ] && ! grep -Fq -- "$gh_contains" "$gh_log"; then
-    fail_case "$name" "expected gh call: $gh_contains" "$(cat "$gh_log")"
+  if [ -n "$gh_missing" ] && grep -Fq "$gh_missing" "$work/gh.log"; then
+    fail "$name: gh log unexpectedly contains '$gh_missing'"
+    ok=0
   fi
 
-  if [ -n "$gh_missing" ] && grep -Fq -- "$gh_missing" "$gh_log"; then
-    fail_case "$name" "unexpected gh call: $gh_missing" "$(cat "$gh_log")"
-  fi
-
-  if [ "$expect_state" = "none" ]; then
-    if [ -s "$status_log" ]; then
-      fail_case "$name" "unexpected head status" "$(cat "$status_log")"
-    fi
-  else
-    local expected_status="repos/bingosuite/bingo/statuses/$head_sha|$expect_state|Darwin E2E verified"
-    if [ "$(tail -n 1 "$status_log")" != "$expected_status" ]; then
-      fail_case "$name" "missing head-SHA status: $expected_status" \
-        "$(cat "$status_log")"
-    fi
-  fi
-
-  # Assert the exact published sequence, not just the terminal status: the head
-  # must move `pending` -> decision, and nothing may follow a decision.
-  local want_states=$expect_states
-  if [ -z "$want_states" ]; then
-    if [ "$expect_state" = "none" ]; then
-      want_states=''
+  if [ -n "$expect_label_query" ]; then
+    if grep -Fq "/issues/17/labels" "$work/gh.log"; then
+      if [ "$expect_label_query" != "true" ]; then
+        fail "$name: gate queried live labels but should not have"
+        ok=0
+      fi
     else
-      want_states="pending,$expect_state"
-    fi
-  fi
-  [ "$want_states" = "none" ] && want_states=''
-  local actual_states
-  actual_states=$(cut -d'|' -f2 "$status_log" | paste -sd, -)
-  if [ "$actual_states" != "$want_states" ]; then
-    fail_case "$name" "status sequence '$actual_states', expected '$want_states'" \
-      "$(cat "$status_log")"
-  fi
-
-  local decision=''
-  if [ -f "$decision_file" ]; then
-    decision=$(tr -d '\n' < "$decision_file")
-  fi
-  if [ -n "$expect_decision" ]; then
-    local want=$expect_decision
-    [ "$want" = "none" ] && want=''
-    if [ "$decision" != "$want" ]; then
-      fail_case "$name" "decision '$decision', expected '$want'"
+      if [ "$expect_label_query" = "true" ]; then
+        fail "$name: gate did not query live labels"
+        ok=0
+      fi
     fi
   fi
 
-  printf 'ok - %s\n' "$name"
+  # Universal invariants, asserted for every single case.
+  if grep -Eq '/commits/[0-9a-fA-F]+/statuses' "$work/gh.log"; then
+    fail "$name: gate read forgeable prior commit statuses"
+    ok=0
+  fi
+
+  # No `gh` invocation may carry pull-request-authored text. Titles, branch
+  # names and bodies are attacker-controlled; only fixed paths, the numeric PR
+  # id and hex SHAs may ever reach the API surface.
+  if grep -Eq '(^| )(-f|-F|--jq|--field)?[^ ]*(<script|; *rm |\$\(|`)' "$work/gh.log"; then
+    fail "$name: gate passed shell metacharacters to gh"
+    ok=0
+  fi
+  if [ -n "${CASE_UNTRUSTED_TOKEN:-}" ] &&
+    grep -Fq "$CASE_UNTRUSTED_TOKEN" "$work/gh.log"; then
+    fail "$name: gate consumed untrusted pull request content"
+    ok=0
+  fi
+
+  if [ -f "$work/targets.log" ] && [ -s "$work/targets.log" ]; then
+    if grep -vq '^https://github.com/bingosuite/bingo/actions/runs/4242$' "$work/targets.log"; then
+      fail "$name: status target_url did not point at this run"
+      ok=0
+    fi
+  fi
+
+  if [ -f "$work/statuses.log" ] && [ -s "$work/statuses.log" ]; then
+    if grep -vq '^Darwin E2E verified|' "$work/statuses.log"; then
+      fail "$name: gate published an unexpected status context"
+      ok=0
+    fi
+  fi
+
+  [ "$ok" = "1" ] && pass "$name"
 }
 
-mkdir -p "$tmpdir/hostile-head/.github/workflows" "$tmpdir/hostile-head/.github/scripts"
-printf '%s\n' 'jobs: {gate: {steps: [{run: "exit 0"}]}}' \
-  > "$tmpdir/hostile-head/.github/workflows/darwin-verification-gate.yml"
-printf '%s\n' '#!/usr/bin/env bash' 'exit 0' \
-  > "$tmpdir/hostile-head/.github/scripts/darwin-verification-gate.sh"
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
-# --- synchronize / reopened: always unverify the new head --------------------
+darwin_source='//go:build darwin && arm64
 
-run_case "fork workflow exit 0 cannot bypass trusted synchronize" \
-  action=synchronize head_repo=contributor/fork \
-  path=internal/debugger/backend_darwin_arm64.go has_label=true edit_status=1 \
-  exit=1 state=failure label_query=false decision=failure \
-  output="public-fork GITHUB_TOKEN could not remove"
+package debugger
+'
+plain_source='package hub
 
-run_case "same-repository synchronize fails current head" \
-  action=synchronize head_repo=bingosuite/bingo path=entitlements.plist \
-  exit=1 state=failure label_query=false decision=failure \
-  gh_contains="pr edit 17" output="re-verification required"
+func Noop() {}
+'
+# Pre-1.17 syntax. `go build` still honors it, so the scanner must too.
+legacy_source='// +build darwin
 
-run_case "same-repository cleanup denial warns without fork wording" \
-  action=synchronize head_repo=bingosuite/bingo path=entitlements.plist \
-  has_label=true edit_status=1 \
-  exit=1 state=failure label_query=false decision=failure \
-  output="The API could not remove"
+package debugger
+'
 
-run_case "successful cleanup omits the stale-label recovery hint" \
-  action=synchronize head_repo=contributor/fork path=entitlements.plist \
-  has_label=true edit_status=0 \
-  exit=1 state=failure label_query=false decision=failure \
-  gh_contains="--remove-label darwin-e2e-verified" \
-  output="then add the 'darwin-e2e-verified' label"
+# A header long enough that a naive fixed-size prefix read would miss the
+# constraint that follows it.
+large_padding=''
+i=0
+while [ "$i" -lt 400 ]; do
+  large_padding="$large_padding// filler line to push the build constraint far down the file
+"
+  i=$((i + 1))
+done
 
-run_case "reopened pull request fails current head" \
-  action=reopened head_repo=contributor/fork path=entitlements.plist \
-  has_label=true edit_status=1 \
-  exit=1 state=failure label_query=false decision=failure \
-  output="re-verification required"
+bom=$(printf '\357\273\277')
+bom_constraint_b64=$(printf '%s%s' "$bom" "$darwin_source" | base64 | tr -d '\n')
+bom_plain_b64=$(printf '%s%s' "$bom" "$plain_source" | base64 | tr -d '\n')
+bom_large_b64=$(printf '%s%s%s%s' "$bom" "$large_padding" "$darwin_source" "$plain_source" | base64 | tr -d '\n')
+utf16_b64=$(printf '\377\376/\000/\000g\000o\000\072\000b\000u\000i\000l\000d\000 \000d\000a\000r\000w\000i\000n\000' | base64 | tr -d '\n')
 
-run_case "synchronize with a live verified label still fails closed" \
-  action=synchronize head_repo=contributor/fork \
-  path=internal/debugger/trap_arm64.go has_label=true edit_status=0 \
-  exit=1 state=failure label_query=false decision=failure \
-  output="re-verification required"
+# ---------------------------------------------------------------------------
+# Scope: what the gate ignores
+# ---------------------------------------------------------------------------
 
-# --- opened ------------------------------------------------------------------
+run_case "unrelated label events publish nothing" \
+  action=labeled label_name=needs-review \
+  expect_exit=0 expect_states='' expect_decision=ignored \
+  expect_output="Ignoring unrelated 'needs-review' label event" \
+  expect_label_query=false gh_missing='/statuses/'
 
-run_case "opened Darwin change publishes failure" \
-  action=opened head_repo=contributor/fork path=entitlements.plist \
-  exit=1 state=failure label_query=false decision=failure \
-  gh_missing="pr edit" output="verification required"
+run_case "unrelated unlabel events publish nothing" \
+  action=unlabeled label_name=needs-review \
+  expect_exit=0 expect_states='' expect_decision=ignored \
+  expect_label_query=false gh_missing='/statuses/'
 
-run_case "opened Darwin change ignores a pre-existing label" \
-  action=opened head_repo=contributor/fork path=entitlements.plist \
-  has_label=true \
-  exit=1 state=failure label_query=false decision=failure \
-  output="verification required"
+run_case "non-base pull request edits publish nothing" \
+  action=edited edited_changes='{"title":{"from":"old"}}' \
+  expect_exit=0 expect_states='' expect_decision=ignored \
+  expect_output='did not change the base' \
+  gh_missing='/statuses/'
 
-# --- verified label add / remove ---------------------------------------------
+run_case "unsupported event actions publish nothing" \
+  action=assigned \
+  expect_exit=2 expect_states='' expect_decision='' \
+  gh_missing='/statuses/'
 
-run_case "verified label publishes success to current head" \
-  action=labeled label=darwin-e2e-verified head_repo=contributor/fork \
-  path=test/integration/debugger_e2e_darwin_arm64_test.go has_label=true \
-  exit=0 state=success label_query=true decision=success \
-  gh_missing="pr edit" output="verified locally"
+# ---------------------------------------------------------------------------
+# Blocker 1 + 5: trigger scope, base binding, SHA-global statuses
+# ---------------------------------------------------------------------------
 
-run_case "verified label cannot supersede an unevaluated head" \
-  action=labeled label=darwin-e2e-verified head_repo=contributor/fork \
-  path=entitlements.plist has_label=true prior_status='' \
-  exit=1 state=failure label_query=true decision=failure \
-  output="has not completed a trusted failing gate run"
+run_case "a pull request targeting another base is refused outright" \
+  base_ref=release-1.x \
+  head_entries='["internal/hub/hub.go"]' \
+  expect_exit=1 expect_states='failure' expect_decision=failure \
+  expect_output='only governs pull requests targeting' \
+  gh_missing='/compare/'
 
-run_case "untrusted prior failure cannot authorize a verified label" \
-  action=labeled label=darwin-e2e-verified head_repo=contributor/fork \
-  path=entitlements.plist has_label=true prior_creator=octocat \
-  exit=1 state=failure label_query=true decision=failure \
-  output="has not completed a trusted failing gate run"
+run_case "a verified label on an alternate base cannot publish success" \
+  action=labeled has_label=true base_ref=attacker-base \
+  expect_exit=1 expect_states='failure' expect_decision=failure \
+  expect_output='only governs pull requests targeting' \
+  expect_label_query=false
 
-run_case "verified label removal publishes failure" \
-  action=unlabeled label=darwin-e2e-verified head_repo=contributor/fork \
-  path=internal/debugger/trap_arm64.go has_label=false \
-  exit=1 state=failure label_query=true decision=failure \
-  output="not currently present"
+run_case "retargeting the base during the run blocks success" \
+  head_entries='["internal/hub/hub.go"]' \
+  live_base_ref=release-1.x \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='moved while the Darwin gate was evaluating'
 
-run_case "re-added verified label survives delayed unlabel event" \
-  action=unlabeled label=darwin-e2e-verified head_repo=contributor/fork \
-  path=internal/debugger/trap_arm64.go has_label=true \
-  exit=0 state=success label_query=true decision=success \
-  output="verified locally"
+run_case "base branch movement during the run blocks success" \
+  head_entries='["internal/hub/hub.go"]' \
+  live_base_sha=other \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='moved while the Darwin gate was evaluating'
 
-run_case "removed verified label defeats a delayed label event" \
-  action=labeled label=darwin-e2e-verified head_repo=contributor/fork \
-  path=internal/debugger/trap_arm64.go has_label=false \
-  exit=1 state=failure label_query=true decision=failure \
-  output="not currently present"
+run_case "a force-pushed head blocks a stale success" \
+  head_entries='["internal/hub/hub.go"]' \
+  live_head_sha=other \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='moved while the Darwin gate was evaluating'
 
-run_case "live label API failure fails closed" \
-  action=labeled label=darwin-e2e-verified head_repo=contributor/fork \
-  path=entitlements.plist has_label=true label_status=1 \
-  exit=1 state=failure decision=failure output="label API failed"
+run_case "a closed pull request cannot receive a fresh success" \
+  head_entries='["internal/hub/hub.go"]' \
+  live_state=closed \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='moved while the Darwin gate was evaluating'
 
-# --- unrelated labels --------------------------------------------------------
+run_case "swapping the head repository blocks success" \
+  head_entries='["internal/hub/hub.go"]' \
+  live_head_repo=attacker/fork \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='moved while the Darwin gate was evaluating'
 
-run_case "unrelated label leaves prior status untouched" \
-  action=labeled label=triage head_repo=contributor/fork \
-  path=entitlements.plist has_label=true \
-  exit=0 state=none label_query=false decision=ignored \
-  gh_missing="statuses/" output="existing head-SHA status remains authoritative"
+run_case "an unreadable live pull request fails closed" \
+  head_entries='["internal/hub/hub.go"]' \
+  live_status=1 \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='could not evaluate this head'
 
-run_case "unrelated unlabel leaves prior status untouched" \
-  action=unlabeled label=triage head_repo=contributor/fork \
-  path=entitlements.plist has_label=true \
-  exit=0 state=none label_query=false decision=ignored \
-  output="existing head-SHA status remains authoritative"
+run_case "a delayed verified label cannot green a newer head" \
+  action=labeled has_label=true live_head_sha=other \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='moved while the Darwin gate was evaluating'
 
-run_case "verified-label prefix does not count as the verified label" \
-  action=labeled label=darwin-e2e-verified-2 head_repo=contributor/fork \
-  path=entitlements.plist has_label=true \
-  exit=0 state=none label_query=false decision=ignored \
-  output="existing head-SHA status remains authoritative"
+run_case "a delayed verified label cannot green a retargeted pull request" \
+  action=labeled has_label=true live_base_ref=release-1.x \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='moved while the Darwin gate was evaluating'
 
-# The live-label read is the only path that can publish a green status, so a
-# label that merely contains the verified name must not satisfy it.
-run_case "a live label that only contains the verified name is not a match" \
-  action=labeled label=darwin-e2e-verified head_repo=contributor/fork \
-  path=entitlements.plist has_label=darwin-e2e-verified-2 \
-  exit=1 state=failure label_query=true decision=failure \
-  output="not currently present"
+# ---------------------------------------------------------------------------
+# Darwin scope detection
+# ---------------------------------------------------------------------------
+
+run_case "pure documentation changes pass without verification" \
+  head_entries='["README.md","docs/ErrorHandling.md"]' \
+  expect_exit=0 expect_states='pending,success' expect_decision=success \
+  expect_output='No darwin-native code changed'
+
+run_case "debugger changes require verification" \
+  head_entries='["internal/debugger/engine.go"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='Darwin-native (CI-unexecutable) changes detected'
+
+run_case "the verified label publishes success to the current head" \
+  action=labeled has_label=true \
+  expect_exit=0 expect_states='pending,success' expect_decision=success \
+  expect_output='label added by maintainer-jo' \
+  expect_label_query=true
+
+run_case "integration test changes require verification" \
+  head_entries='["test/integration/debugger_e2e_common_test.go"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure
+
+run_case "justfile changes require verification" \
+  head_entries='["justfile"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure
+
+run_case "entitlements changes require verification" \
+  head_entries='["entitlements.plist"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure
+
+run_case "module graph changes require verification" \
+  head_entries='["go.mod"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure
+
+run_case "darwin file suffixes anywhere require verification" \
+  head_entries='["cmd/wsmon/render_darwin.go"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure
+
+run_case "arm64 file suffixes anywhere require verification" \
+  head_entries='["pkg/client/tuning_arm64.go"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure
+
+run_case "native sources require verification" \
+  head_entries='["internal/somewhere/shim.c"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure
+
+# `go/build` compiles far more than this repository currently checks in, and
+# only `.go` blobs are content-scanned. An extension Go accepts but the selector
+# misses would ship darwin-only machine code past the gate: `shim_darwin.sx`
+# carries an implicit darwin constraint and is never read by the blob scan.
+for ext in sx S s f F for f90 swig swigcxx syso cc cpp cxx hh hpp hxx h m mm; do
+  run_case "a .$ext native source requires verification" \
+    head_entries="[\"internal/somewhere/shim.$ext\"]" \
+    expect_exit=1 expect_states='pending,failure' expect_decision=failure
+
+  run_case "a darwin-suffixed .$ext source requires verification" \
+    head_entries="[\"cmd/wsmon/glue_darwin.$ext\"]" \
+    expect_exit=1 expect_states='pending,failure' expect_decision=failure
+
+  run_case "deleting a .$ext native source still requires verification" \
+    base_entries="[\"internal/somewhere/shim.$ext\"]" head_entries='[]' \
+    expect_exit=1 expect_states='pending,failure' expect_decision=failure
+done
+
+# The extension list must stay a suffix allow-list, not a substring match.
+run_case "an extension that merely starts like a native one does not gate" \
+  head_entries='["docs/notes.form"]' \
+  expect_exit=0 expect_states='pending,success' expect_decision=success
+
+run_case "a Go-adjacent extension does not gate" \
+  head_entries='["testdata/fixture.golden"]' \
+  expect_exit=0 expect_states='pending,success' expect_decision=success
+
+run_case "a build constraint gates a convention-free Go file" \
+  head_entries='["internal/hub/machfix.go"]' \
+  blob_contents="$(jq -n --arg src "$darwin_source" '{"0":$src}')" \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='internal/hub/machfix.go'
+
+run_case "deleting a constrained Go file still gates" \
+  base_entries='["internal/hub/machfix.go"]' head_entries='[]' \
+  blob_contents="$(jq -n --arg src "$darwin_source" '{"0":$src}')" \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure
+
+run_case "a legacy // +build constraint gates" \
+  head_entries='["internal/hub/legacy.go"]' \
+  blob_contents="$(jq -n --arg src "$legacy_source" '{"0":$src}')" \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='internal/hub/legacy.go'
+
+run_case "an unconstrained Go file does not gate" \
+  head_entries='["internal/hub/plain.go"]' \
+  blob_contents="$(jq -n --arg src "$plain_source" '{"0":$src}')" \
+  expect_exit=0 expect_states='pending,success' expect_decision=success
+
+run_case "control characters in a path gate conservatively" \
+  head_entries='["internal/hub/we\ni\rrd.go"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure
+
+# ---------------------------------------------------------------------------
+# Blocker 2: UTF-8 byte-order marks
+# ---------------------------------------------------------------------------
+
+run_case "a UTF-8 BOM cannot hide a Darwin build constraint" \
+  head_entries='["internal/hub/bomfix.go"]' \
+  blob_b64="$(jq -n --arg b64 "$bom_constraint_b64" '{"0":$b64}')" \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='internal/hub/bomfix.go'
+
+run_case "deleting a BOM-prefixed constrained file still gates" \
+  base_entries='["internal/hub/bomfix.go"]' head_entries='[]' \
+  blob_b64="$(jq -n --arg b64 "$bom_constraint_b64" '{"0":$b64}')" \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure
+
+run_case "a BOM behind a very large header still gates" \
+  head_entries='["internal/hub/bomlarge.go"]' \
+  blob_b64="$(jq -n --arg b64 "$bom_large_b64" '{"0":$b64}')" \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure
+
+run_case "a UTF-8 BOM without a constraint does not gate" \
+  head_entries='["internal/hub/bomplain.go"]' \
+  blob_b64="$(jq -n --arg b64 "$bom_plain_b64" '{"0":$b64}')" \
+  expect_exit=0 expect_states='pending,success' expect_decision=success
+
+run_case "a non-UTF-8 byte-order mark gates conservatively" \
+  head_entries='["internal/hub/utf16.go"]' \
+  blob_b64="$(jq -n --arg b64 "$utf16_b64" '{"0":$b64}')" \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='non-UTF-8 byte-order mark'
+
+run_case "an undecodable blob response fails closed" \
+  head_entries='["internal/hub/plain.go"]' \
+  blob_encoding=none \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='could not evaluate this head'
+
+run_case "an unreadable blob fails closed" \
+  head_entries='["internal/hub/plain.go"]' \
+  blob_status=1 \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='could not evaluate this head'
+
+# ---------------------------------------------------------------------------
+# Blocker 3: symlinks, gitlinks and other non-regular tree entries
+# ---------------------------------------------------------------------------
+
+run_case "a changed Go symlink is gated without trusting its link text" \
+  head_entries='[{"path":"internal/hub/link.go","mode":"120000","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='internal/hub/link.go' \
+  gh_missing='/git/blobs/'
+
+run_case "deleting a Go symlink is gated" \
+  base_entries='[{"path":"internal/hub/link.go","mode":"120000","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]' \
+  head_entries='[]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  gh_missing='/git/blobs/'
+
+run_case "a submodule pointer change is gated" \
+  head_entries='[{"path":"vendor/thirdparty","mode":"160000","type":"commit","sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='vendor/thirdparty'
+
+run_case "an unexpected file mode is gated" \
+  head_entries='[{"path":"internal/hub/odd.go","mode":"100664","sha":"cccccccccccccccccccccccccccccccccccccccc"}]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  gh_missing='/git/blobs/'
+
+run_case "an executable Go file is still scanned normally" \
+  head_entries='[{"path":"internal/hub/exec.go","mode":"100755","sha":"0000000000000000000000000000000000000000"}]' \
+  blob_contents="$(jq -n --arg src "$plain_source" '{"0":$src}')" \
+  expect_exit=0 expect_states='pending,success' expect_decision=success \
+  gh_expect='/git/blobs/'
+
+run_case "an unknown tree entry type fails closed" \
+  head_entries='[{"path":"internal/hub/weird.go","type":"symlink","sha":"dddddddddddddddddddddddddddddddddddddddd"}]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='truncated or malformed tree'
+
+run_case "a malformed tree entry mode fails closed" \
+  head_entries='[{"path":"internal/hub/weird.go","mode":"644"}]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='truncated or malformed tree'
+
+run_case "a tree entry without a SHA fails closed" \
+  head_entries='[{"path":"internal/hub/weird.go","drop_sha":true}]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='truncated or malformed tree'
+
+run_case "a tree entry with an empty path fails closed" \
+  head_entries='[{"path":""}]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='truncated or malformed tree'
+
+# ---------------------------------------------------------------------------
+# Immutable diff integrity
+# ---------------------------------------------------------------------------
+
+run_case "a truncated head tree fails closed" \
+  head_tree_truncated=true \
+  head_entries='["README.md"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='truncated or malformed tree'
+
+run_case "a truncated base tree cannot hide a Darwin deletion" \
+  base_tree_truncated=true \
+  base_entries='["internal/debugger/engine.go"]' head_entries='[]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='truncated or malformed tree'
+
+run_case "an empty diff fails closed" \
+  base_entries='["README.md"]' head_entries='["README.md"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='no changed files'
+
+run_case "a compare API failure fails closed" \
+  compare_status=1 \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='could not evaluate this head'
+
+run_case "a base tree read failure fails closed" \
+  base_tree_status=1 head_entries='["README.md"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='could not evaluate this head'
+
+run_case "a head tree read failure fails closed" \
+  head_tree_status=1 head_entries='["README.md"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='could not evaluate this head'
+
+run_case "identical content with a different mode is a change" \
+  base_entries='[{"path":"justfile","mode":"100644","sha":"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"}]' \
+  head_entries='[{"path":"justfile","mode":"100755","sha":"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"}]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure
+
+# ---------------------------------------------------------------------------
+# Blocker 4: authorization is bound to a human actor, never to a status
+# ---------------------------------------------------------------------------
+
+run_case "write permission authorizes the verified label" \
+  action=labeled has_label=true perm_permission=write perm_role=write \
+  expect_exit=0 expect_states='pending,success' expect_decision=success \
+  gh_expect='collaborators/maintainer-jo/permission'
+
+run_case "maintain permission authorizes the verified label" \
+  action=labeled has_label=true perm_permission=maintain perm_role=maintain \
+  expect_exit=0 expect_states='pending,success' expect_decision=success
+
+run_case "read permission cannot authorize the verified label" \
+  action=labeled has_label=true perm_permission=read perm_role=triage \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='requires an authorized maintainer'
+
+run_case "a non-collaborator cannot authorize the verified label" \
+  action=labeled has_label=true perm_permission=none perm_role=none \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='requires an authorized maintainer'
+
+run_case "bot actors cannot assert Darwin verification" \
+  action=labeled has_label=true actor='github-actions[bot]' actor_type=Bot \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='requires an authorized maintainer' \
+  gh_missing='collaborators/'
+
+run_case "a User-typed login shaped like a bot is refused" \
+  action=labeled has_label=true actor='sneaky[bot]' actor_type=User \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  gh_missing='collaborators/'
+
+run_case "organization actors cannot assert Darwin verification" \
+  action=labeled has_label=true actor=bingosuite actor_type=Organization \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  gh_missing='collaborators/'
+
+run_case "path-like actor logins never reach the permission API" \
+  action=labeled has_label=true actor='../../admin' actor_type=User \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  gh_missing='collaborators/'
+
+run_case "an empty actor login is refused" \
+  action=labeled has_label=true actor='' actor_type=User \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  gh_missing='collaborators/'
+
+run_case "a permission API failure fails the label closed" \
+  action=labeled has_label=true perm_status=1 \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='could not evaluate this head'
+
+run_case "a permission response for another login is refused" \
+  action=labeled has_label=true perm_login=someone-else \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='requires an authorized maintainer'
+
+run_case "a forged head status cannot influence the decision" \
+  action=labeled has_label=true \
+  expect_exit=0 expect_states='pending,success' expect_decision=success \
+  gh_missing='/statuses?per_page'
+
+# ---------------------------------------------------------------------------
+# Label lifecycle
+# ---------------------------------------------------------------------------
+
+run_case "an opened pull request is evaluated like any other head" \
+  action=opened head_entries='["internal/debugger/engine.go"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='Darwin-native (CI-unexecutable) changes detected'
+
+run_case "a reopened pull request is re-evaluated" \
+  action=reopened head_entries='["README.md"]' \
+  expect_exit=0 expect_states='pending,success' expect_decision=success \
+  expect_output='No darwin-native code changed'
+
+# Documented deliberately: with nothing Darwin-native in the head there is
+# nothing to withdraw, so the scope check short-circuits to success before any
+# label arm runs. Pinning it keeps AGENTS.md and the code from diverging.
+run_case "an unlabel on a head with no darwin change still passes" \
+  action=unlabeled has_label=false head_entries='["README.md"]' \
+  expect_exit=0 expect_states='pending,success' expect_decision=success \
+  expect_output='No darwin-native code changed'
+
+run_case "removing the verified label always withdraws verification" \
+  action=unlabeled has_label=false \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='withdrawn for this head' \
+  expect_label_query=false
+
+run_case "a re-added label cannot rescue a delayed unlabel event" \
+  action=unlabeled has_label=true \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='withdrawn for this head' \
+  expect_label_query=false
+
+run_case "a removed label defeats a delayed label event" \
+  action=labeled has_label=false \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='not currently present' \
+  expect_label_query=true
+
+run_case "a live label API failure fails closed" \
+  action=labeled has_label=true label_status=1 \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='could not evaluate this head'
+
+run_case "a label that merely contains the verified name is not a match" \
+  action=labeled has_label=true \
+  labels_json='[{"name":"darwin-e2e-verified-later"}]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_description='not currently present'
 
 run_case "the verified label counts among several live labels" \
-  action=labeled label=darwin-e2e-verified head_repo=contributor/fork \
-  path=entitlements.plist has_label='triage
-darwin-e2e-verified
-needs-review' \
-  exit=0 state=success label_query=true decision=success \
-  output="verified locally"
+  action=labeled has_label=true \
+  labels_json='[{"name":"needs-review"},{"name":"darwin-e2e-verified"},{"name":"area/debugger"}]' \
+  expect_exit=0 expect_states='pending,success' expect_decision=success
 
-# --- pull request edits ------------------------------------------------------
+run_case "synchronize clears a stale verified label" \
+  head_entries='["internal/debugger/engine.go"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  gh_expect='pr edit'
 
-run_case "non-base pull request edit preserves the current status" \
-  action=edited base_changed=false head_repo=contributor/fork \
-  path=entitlements.plist \
-  exit=0 state=none decision=ignored gh_missing="statuses/" \
-  output="did not change the base"
+run_case "a failed label cleanup still publishes failure" \
+  label_remove_status=1 \
+  head_entries='["internal/debugger/engine.go"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='could not remove'
 
-run_case "base retarget invalidates Darwin verification" \
-  action=edited base_changed=true head_repo=contributor/fork \
-  path=entitlements.plist has_label=true edit_status=1 \
-  exit=1 state=failure decision=failure label_query=false \
-  output="re-verification required"
+run_case "a base-changing edit invalidates verification" \
+  action=edited edited_changes='{"base":{"ref":{"from":"main"}}}' \
+  head_entries='["internal/debugger/engine.go"]' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure
 
-# --- path matching -----------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Status publication integrity
+# ---------------------------------------------------------------------------
 
-run_case "non-Darwin synchronize publishes success" \
-  action=synchronize head_repo=contributor/fork path=internal/hub/hub.go \
-  has_label=true edit_status=1 \
-  exit=0 state=success label_query=false decision=success \
-  output="No darwin-native code changed"
+run_case "a failed status POST records no decision" \
+  status_post_status=1 \
+  head_entries='["README.md"]' \
+  expect_exit=1 expect_states='' expect_decision=''
 
-run_case "near-match outside regex publishes success" \
-  action=opened head_repo=contributor/fork path=docs/backend-darwin-arm64.go \
-  exit=0 state=success label_query=false decision=success \
-  output="No darwin-native code changed"
-
-run_case "darwin GOOS suffix without arch still gates" \
-  action=opened head_repo=contributor/fork \
-  path=internal/debugger/backend_darwin.go \
-  exit=1 state=failure decision=failure output="verification required"
-
-run_case "darwin suffix in a new package still gates" \
-  action=opened head_repo=contributor/fork \
-  path=internal/hub/attach_darwin.go \
-  exit=1 state=failure decision=failure output="verification required"
-
-run_case "arm64 assembly in a new package still gates" \
-  action=opened head_repo=contributor/fork \
-  path=internal/hub/attach_arm64.s \
-  exit=1 state=failure decision=failure output="verification required"
-
-run_case "arm64 test suffix still gates" \
-  action=opened head_repo=contributor/fork \
-  path=internal/debugger/trap_arm64_test.go \
-  exit=1 state=failure decision=failure output="verification required"
-
-run_case "native source without platform suffix gates conservatively" \
-  action=opened head_repo=contributor/fork \
-  path=internal/debugger/machtrap.s \
-  exit=1 state=failure decision=failure output="verification required"
-
-darwin_constraint_blob=$(jq -n \
-  '{"0":"//go:build darwin && arm64 && bingonative\n\npackage debugger\n"}')
-run_case "darwin build constraint gates convention-free Go file" \
-  action=opened head_repo=contributor/fork \
-  path=internal/hub/machfix.go \
-  blob_contents_json="$darwin_constraint_blob" \
-  exit=1 state=failure decision=failure output="verification required"
-
-negated_constraint_blob=$(jq -n \
-  '{"0":"//go:build !linux && !windows\n\npackage debugger\n"}')
-run_case "negated platform constraint is evaluated as Darwin-only" \
-  action=opened head_repo=contributor/fork \
-  path=internal/hub/negated.go \
-  blob_contents_json="$negated_constraint_blob" \
-  exit=1 state=failure decision=failure output="verification required"
-
-legacy_constraint_blob=$(jq -n \
-  '{"0":"// +build darwin,arm64\n\npackage debugger\n"}')
-run_case "legacy Darwin build constraint still gates" \
-  action=opened head_repo=contributor/fork \
-  path=internal/hub/legacy.go \
-  blob_contents_json="$legacy_constraint_blob" \
-  exit=1 state=failure decision=failure output="verification required"
-
-cross_platform_constraint_blob=$(jq -n \
-  '{"0":"//go:build (linux && amd64) || (darwin && arm64)\n\npackage debugger\n"}')
-run_case "cross-platform build constraint gates conservatively" \
-  action=opened head_repo=contributor/fork \
-  path=internal/hub/crossplatform.go \
-  blob_contents_json="$cross_platform_constraint_blob" \
-  exit=1 state=failure decision=failure output="verification required"
-
-large_padding=$(awk 'BEGIN {
-  for (i = 0; i < 4000; i++) {
-    print "// padding padding padding padding padding"
-  }
-}')
-large_header=$(printf '//go:build darwin && arm64\n%s\npackage debugger\n' \
-  "$large_padding")
-large_header_file="$tmpdir/large-header.go"
-printf '%s' "$large_header" > "$large_header_file"
-large_constraint_blob=$(jq -n --rawfile content "$large_header_file" \
-  '{"0":$content}')
-run_case "large pre-package header cannot bypass build constraint detection" \
-  action=opened head_repo=contributor/fork \
-  path=internal/hub/largeheader.go \
-  blob_contents_json="$large_constraint_blob" \
-  exit=1 state=failure decision=failure output="verification required"
-
-decoy_constraint_blob=$(jq -n \
-  '{"0":"/*\n//go:build ignore\n*/\npackage debugger\n"}')
-run_case "constraint-like comment gates conservatively rather than false-green" \
-  action=opened head_repo=contributor/fork \
-  path=internal/hub/decoy.go \
-  blob_contents_json="$decoy_constraint_blob" \
-  exit=1 state=failure decision=failure output="verification required"
-
-run_case "existing Darwin probe constraint is gated" \
-  action=opened head_repo=contributor/fork \
-  path=internal/debugger/gcpreempt_probe_test.go \
-  blob_contents_json="$darwin_constraint_blob" \
-  exit=1 state=failure decision=failure output="verification required"
-
-run_case "ordinary Go change without Darwin constraint stays ungated" \
-  action=opened head_repo=contributor/fork \
-  path=internal/hub/hub.go \
-  exit=0 state=success decision=success output="No darwin-native code changed"
-
-run_case "runtime-dispatched debugger code always gates" \
-  action=opened head_repo=contributor/fork \
-  path=internal/debugger/dwarf.go \
-  exit=1 state=failure decision=failure output="verification required"
-
-run_case "integration suite entry point always gates" \
-  action=opened head_repo=contributor/fork \
-  path=test/integration/integration_suite_test.go \
-  exit=1 state=failure decision=failure output="verification required"
-
-run_case "Darwin verification recipe always gates" \
-  action=opened head_repo=contributor/fork path=justfile \
-  exit=1 state=failure decision=failure output="verification required"
-
-run_case "module graph changes always gate" \
-  action=opened head_repo=contributor/fork path=go.mod \
-  exit=1 state=failure decision=failure output="verification required"
-
-run_case "one Darwin file among many still gates" \
-  action=opened head_repo=contributor/fork \
-  paths_json='["README.md","internal/hub/hub.go","internal/debugger/backend_darwin_arm64.go","docs/x.md"]' \
-  exit=1 state=failure decision=failure output="verification required"
-
-# --- immutable tree diff integrity -------------------------------------------
-
-many_paths_json=$(jq -n \
-  '[range(0; 150) | "docs/generated-\(.).md"] + ["entitlements.plist"]')
-run_case "more than 100 changed files are evaluated immutably" \
-  action=opened head_repo=contributor/fork \
-  paths_json="$many_paths_json" \
-  exit=1 state=failure decision=failure output="verification required"
-
-run_case "multi-file non-Darwin tree diff publishes success" \
-  action=opened head_repo=contributor/fork \
-  paths_json='["a.md","b.md","c.md","d.md","e.md","f.md"]' \
-  exit=0 state=success decision=success output="No darwin-native code changed"
-
-run_case "truncated Git tree response fails closed" \
-  action=opened head_repo=contributor/fork path=docs/readme.md \
-  tree_truncated=true \
-  exit=1 state=failure decision=failure \
-  output="truncated or malformed tree"
-
-run_case "truncated base tree cannot hide a Darwin deletion" \
-  action=opened head_repo=contributor/fork \
-  base_paths_json='["entitlements.plist","README.md"]' \
-  paths_json='["README.md"]' base_tree_truncated=true \
-  exit=1 state=failure decision=failure \
-  output="truncated or malformed tree"
-
-run_case "control character filename fails closed" \
-  action=opened head_repo=contributor/fork \
-  path=$'000-padding\nentitlements.plist' \
-  exit=1 state=failure decision=failure output="verification required"
-
-run_case "empty immutable diff fails closed" \
-  action=opened head_repo=contributor/fork paths_json='[]' \
-  exit=1 state=failure decision=failure \
-  output="refusing an empty gate decision"
-
-run_case "deleting a Darwin file still requires verification" \
-  action=opened head_repo=contributor/fork \
-  base_paths_json='["entitlements.plist"]' paths_json='[]' \
-  exit=1 state=failure decision=failure output="verification required"
-
-run_case "deleting a convention-free Darwin constrained file is gated" \
-  action=opened head_repo=contributor/fork \
-  base_paths_json='["internal/hub/machfix.go"]' paths_json='[]' \
-  blob_contents_json="$darwin_constraint_blob" \
-  exit=1 state=failure decision=failure output="verification required"
-
-run_case "diff API failure replaces pending with failure" \
-  action=opened head_repo=contributor/fork path=entitlements.plist \
-  diff_status=1 \
-  exit=1 state=failure decision=failure output="diff API failed"
-
-# --- status API failures -----------------------------------------------------
-
-# A pending POST that fails aborts before any evaluation; the ERR trap still
-# publishes an explicit failure to the head.
-run_case "pending status failure still fails the head closed" \
-  action=opened head_repo=contributor/fork path=entitlements.plist \
-  status_fail=pending \
-  exit=1 state=failure states=failure decision=failure \
-  output="status API failed for state pending"
-
-# When even the fail-closed POST cannot be delivered, no decision is recorded and
-# the workflow guard step takes over.
-run_case "unpublishable failure records no decision" \
-  action=opened head_repo=contributor/fork path=entitlements.plist \
-  status_fail=failure \
-  exit=1 state=pending states=pending decision=none \
-  output="status API failed for state failure"
-
-# A success POST that fails must degrade to failure, never to silence.
-run_case "unpublishable success degrades to failure" \
-  action=synchronize head_repo=contributor/fork path=internal/hub/hub.go \
-  status_fail=success \
-  exit=1 state=failure states=pending,failure decision=failure \
-  output="status API failed for state success"
-
-# --- unsupported actions -----------------------------------------------------
-
-run_case "unsupported action refuses to decide" \
-  action=closed head_repo=contributor/fork path=entitlements.plist \
-  exit=2 state=none decision=none gh_missing="statuses/" \
-  output="Unsupported pull_request_target action: closed"
+# ---------------------------------------------------------------------------
+# Status persistence across a sequence of events on one head
+# ---------------------------------------------------------------------------
 
 run_status_persistence_sequence() {
-  local name=$1
-  local first_action=$2
-  local first_event_label=$3
-  local first_has_label=$4
-  local first_edit_status=$5
-  local expected_state=$6
-  local expected_first_exit=$7
-  local case_id
-  local head_sha
-  local gh_log
-  local status_log
-  local first_event
-  local unrelated_event
-  local first_status=0
-  local second_status=0
-  local base_sha
-  local merge_base_sha
-  local base_tree_sha
-  local head_tree_sha
+  local name="a verified head survives an unrelated label event"
+  cases=$((cases + 1))
 
-  case_count=$((case_count + 1))
-  case_id=$case_count
-  head_sha=$(printf '%040x' "$case_id")
-  base_sha=$(printf 'f%039x' "$case_id")
-  merge_base_sha=$(printf 'e%039x' "$case_id")
-  base_tree_sha=$(printf 'c%039x' "$case_id")
-  head_tree_sha=$(printf 'd%039x' "$case_id")
-  gh_log="$tmpdir/sequence-gh-$case_id.log"
-  status_log="$tmpdir/sequence-status-$case_id.log"
-  first_event="$tmpdir/sequence-first-$case_id.json"
-  unrelated_event="$tmpdir/sequence-unrelated-$case_id.json"
-  : > "$gh_log"
-  : > "$status_log"
-  printf '%s\n' '{}' > "$tmpdir/blobs-sequence-$case_id.json"
+  local work="$tmpdir/sequence"
+  mkdir -p "$work"
 
-  jq -n \
-    --arg action "$first_action" \
-    --arg event_label "$first_event_label" \
-    --arg head_sha "$head_sha" \
-    --arg base_sha "$base_sha" \
-    '{
-      action: $action,
-      label: {name: $event_label},
-      pull_request: {
-        number: 17,
-        changed_files: 1,
-        base: {sha: $base_sha},
-        head: {sha: $head_sha, repo: {full_name: "contributor/fork"}}
-      }
-    }' > "$first_event"
-  jq -n \
-    --arg head_sha "$head_sha" \
-    --arg base_sha "$base_sha" \
-    '{
-      action: "labeled",
-      label: {name: "triage"},
-      pull_request: {
-        number: 17,
-        changed_files: 1,
-        base: {sha: $base_sha},
-        head: {sha: $head_sha, repo: {full_name: "contributor/fork"}}
-      }
-    }' > "$unrelated_event"
+  local head_sha=deadbeef00000000000000000000000000000001
+  local base_sha=ba5eba1100000000000000000000000000000002
+  local merge_base=cafebabe00000000000000000000000000000003
+  local base_tree=feedface00000000000000000000000000000004
+  local head_tree=feedface00000000000000000000000000000005
 
-  PATH="$tmpdir/bin:$PATH" \
-    GITHUB_EVENT_PATH="$first_event" \
-    GITHUB_REPOSITORY=bingosuite/bingo \
-    MOCK_GH_LOG="$gh_log" \
-    MOCK_STATUS_LOG="$status_log" \
-    MOCK_CHANGED_PATHS_JSON='["entitlements.plist"]' \
-    MOCK_BASE_PATHS_JSON='[]' \
-    MOCK_BASE_TREE_TRUNCATED=false \
-    MOCK_TREE_TRUNCATED=false \
-    MOCK_MERGE_BASE_SHA="$merge_base_sha" \
-    MOCK_BASE_TREE_SHA="$base_tree_sha" \
-    MOCK_HEAD_TREE_SHA="$head_tree_sha" \
-    MOCK_HEAD_SHA="$head_sha" \
-    MOCK_BLOB_CONTENTS_FILE="$tmpdir/blobs-sequence-$case_id.json" \
-    MOCK_PRIOR_STATUS_STATE=failure \
-    MOCK_PRIOR_STATUS_CREATOR='github-actions[bot]' \
-    MOCK_PRIOR_STATUS_TARGET='https://github.com/bingosuite/bingo/actions/runs/122' \
-    MOCK_HAS_LABEL="$first_has_label" \
-    MOCK_EDIT_STATUS="$first_edit_status" \
-    MOCK_DIFF_STATUS=0 \
-    MOCK_LABEL_STATUS=0 \
-    bash "$gate" >/dev/null 2>&1 || first_status=$?
+  local compare_json
+  compare_json=$(jq -n --arg mb "$merge_base" '{merge_base_commit: {sha: $mb}}')
 
-  PATH="$tmpdir/bin:$PATH" \
-    GITHUB_EVENT_PATH="$unrelated_event" \
-    GITHUB_REPOSITORY=bingosuite/bingo \
-    MOCK_GH_LOG="$gh_log" \
-    MOCK_STATUS_LOG="$status_log" \
-    MOCK_CHANGED_PATHS_JSON='["entitlements.plist"]' \
-    MOCK_BASE_PATHS_JSON='[]' \
-    MOCK_BASE_TREE_TRUNCATED=false \
-    MOCK_TREE_TRUNCATED=false \
-    MOCK_MERGE_BASE_SHA="$merge_base_sha" \
-    MOCK_BASE_TREE_SHA="$base_tree_sha" \
-    MOCK_HEAD_TREE_SHA="$head_tree_sha" \
-    MOCK_HEAD_SHA="$head_sha" \
-    MOCK_BLOB_CONTENTS_FILE="$tmpdir/blobs-sequence-$case_id.json" \
-    MOCK_PRIOR_STATUS_STATE=failure \
-    MOCK_PRIOR_STATUS_CREATOR='github-actions[bot]' \
-    MOCK_PRIOR_STATUS_TARGET='https://github.com/bingosuite/bingo/actions/runs/122' \
-    MOCK_HAS_LABEL=true \
-    MOCK_EDIT_STATUS=0 \
-    MOCK_DIFF_STATUS=0 \
-    MOCK_LABEL_STATUS=0 \
-    bash "$gate" >/dev/null 2>&1 || second_status=$?
+  local live_pr_json
+  live_pr_json=$(jq -n \
+    --arg base_sha "$base_sha" --arg head_sha "$head_sha" \
+    '{state:"open", base:{ref:"main", sha:$base_sha},
+      head:{sha:$head_sha, repo:{full_name:"contributor/fork"}}}')
 
-  if [ "$first_status" -ne "$expected_first_exit" ] ||
-    [ "$second_status" -ne 0 ]; then
-    fail_case "$name" "event statuses $first_status/$second_status"
+  local permission_json
+  permission_json=$(jq -n '{permission:"admin", role_name:"admin", user:{login:"maintainer-jo"}}')
+
+  printf '{}' > "$work/blobs.json"
+  printf '{}' > "$work/blobs-b64.json"
+
+  run_step() {
+    local step=$1 action=$2 label=$3 has_label=$4
+    local event="$work/event-$step.json"
+    local labels='[{"name":"needs-review"}]'
+    [ "$has_label" = "true" ] && labels='[{"name":"darwin-e2e-verified"}]'
+
+    jq -n --arg head "$head_sha" --arg base "$base_sha" \
+      --arg action "$action" --arg label "$label" \
+      '{action: $action, sender: {login: "maintainer-jo", type: "User"},
+        label: {name: $label}, changes: {},
+        pull_request: {number: 17, state: "open",
+          head: {sha: $head, repo: {full_name: "contributor/fork"}},
+          base: {sha: $base, ref: "main"}}}' > "$event"
+
+    (
+      PATH="$mock_bin:$PATH" \
+      GITHUB_EVENT_PATH="$event" \
+      GITHUB_REPOSITORY=bingosuite/bingo \
+      GITHUB_SERVER_URL=https://github.com \
+      GITHUB_RUN_ID=4242 \
+      DARWIN_GATE_DECISION_FILE="$work/decision-$step" \
+      MOCK_GH_LOG="$work/gh.log" \
+      MOCK_STATE_LOG="$work/states.log" \
+      MOCK_STATUS_LOG="$work/statuses.log" \
+      MOCK_TARGET_LOG="$work/targets.log" \
+      MOCK_LABELS_JSON="$labels" \
+      MOCK_COMPARE_JSON="$compare_json" \
+      MOCK_MERGE_BASE_SHA="$merge_base" \
+      MOCK_HEAD_SHA="$head_sha" \
+      MOCK_BASE_TREE_SHA="$base_tree" \
+      MOCK_HEAD_TREE_SHA="$head_tree" \
+      MOCK_BASE_TREE_ENTRIES='[]' \
+      MOCK_HEAD_TREE_ENTRIES='["internal/debugger/engine.go"]' \
+      MOCK_BASE_TREE_TRUNCATED=false \
+      MOCK_HEAD_TREE_TRUNCATED=false \
+      MOCK_BLOB_CONTENTS_FILE="$work/blobs.json" \
+      MOCK_BLOB_B64_FILE="$work/blobs-b64.json" \
+      MOCK_LIVE_PR_JSON="$live_pr_json" \
+      MOCK_PERMISSION_JSON="$permission_json" \
+      bash "$gate"
+    ) > "$work/out-$step.txt" 2>&1
+    printf '%s' $?
+  }
+
+  local rc1 rc2 rc3
+  rc1=$(run_step 1 synchronize darwin-e2e-verified false)
+  rc2=$(run_step 2 labeled darwin-e2e-verified true)
+  rc3=$(run_step 3 labeled needs-review true)
+
+  local ok=1
+  [ "$rc1" = "1" ] || { fail "$name: synchronize should fail closed (got $rc1)"; ok=0; }
+  [ "$rc2" = "0" ] || { fail "$name: verified label should succeed (got $rc2)"; ok=0; }
+  [ "$rc3" = "0" ] || { fail "$name: unrelated label should be ignored (got $rc3)"; ok=0; }
+
+  local states
+  states=$(paste -sd, - < "$work/states.log")
+  if [ "$states" != "pending,failure,pending,success" ]; then
+    fail "$name: expected 'pending,failure,pending,success', got '$states'"
+    ok=0
   fi
 
-  expected_status="repos/bingosuite/bingo/statuses/$head_sha|$expected_state|Darwin E2E verified"
-  if [ "$(wc -l < "$status_log" | tr -d ' ')" -ne 2 ] ||
-    [ "$(tail -n 1 "$status_log")" != "$expected_status" ]; then
-    fail_case "$name" "unrelated label changed the SHA-bound status" \
-      "$(cat "$status_log")" "$(cat "$gh_log")"
-  fi
+  [ -f "$work/decision-3" ] && [ "$(cat "$work/decision-3")" = "ignored" ] || {
+    fail "$name: unrelated label should record an ignored decision"
+    ok=0
+  }
 
-  printf 'ok - %s\n' "$name"
+  [ "$ok" = "1" ] && pass "$name"
 }
 
-run_status_persistence_sequence \
-  "denied cleanup plus unrelated label preserves failure" \
-  synchronize "" true 1 failure 1
-run_status_persistence_sequence \
-  "verified head plus unrelated label preserves success" \
-  labeled darwin-e2e-verified true 0 success 0
+run_status_persistence_sequence
 
-# Workflow invariants are asserted through named predicates rather than an
-# `eval`'d string so the checks stay statically analysable.
-assert_workflow() {
+# Commit statuses are SHA-global, so two pull requests can point at the same head
+# commit. Only a generation that targets `main` may publish success for it.
+#
+# This drives the policy directly, so it exercises the script's own base-ref
+# re-assertion — defense in depth for a misconfigured or removed trigger filter.
+# In the deployed workflow the `branches: [main]` filter means an alternate-base
+# run is never dispatched at all, which is strictly safer: it also posts nothing.
+# What the workflow filter cannot do is un-publish a legitimate `main` success
+# from a shared head SHA; that inherited-visibility residual is documented in
+# AGENTS.md and is a property of commit statuses, not a gate decision.
+run_shared_head_sha_sequence() {
+  local name="only the main-targeting pull request may green a shared head SHA"
+  cases=$((cases + 1))
+
+  local work="$tmpdir/shared-head"
+  mkdir -p "$work"
+
+  local head_sha=5aaaaaaa00000000000000000000000000000001
+  local base_sha=5bbbbbbb00000000000000000000000000000002
+  local merge_base=5ccccccc00000000000000000000000000000003
+  local base_tree=5ddddddd00000000000000000000000000000004
+  local head_tree=5eeeeeee00000000000000000000000000000005
+
+  local compare_json
+  compare_json=$(jq -n --arg mb "$merge_base" '{merge_base_commit: {sha: $mb}}')
+
+  local permission_json
+  permission_json=$(jq -n \
+    '{permission:"admin", role_name:"admin", user:{login:"maintainer-jo"}}')
+
+  printf '{}' > "$work/blobs.json"
+  printf '{}' > "$work/blobs-b64.json"
+
+  run_shared_step() {
+    local step=$1 pr_number=$2 base_ref=$3
+    local event="$work/event-$step.json"
+
+    jq -n --arg head "$head_sha" --arg base "$base_sha" \
+      --arg base_ref "$base_ref" --argjson number "$pr_number" \
+      '{action: "labeled", sender: {login: "maintainer-jo", type: "User"},
+        label: {name: "darwin-e2e-verified"}, changes: {},
+        pull_request: {number: $number, state: "open",
+          head: {sha: $head, repo: {full_name: "contributor/fork"}},
+          base: {sha: $base, ref: $base_ref}}}' > "$event"
+
+    local live_pr_json
+    live_pr_json=$(jq -n --arg base_ref "$base_ref" \
+      --arg base_sha "$base_sha" --arg head_sha "$head_sha" \
+      '{state:"open", base:{ref:$base_ref, sha:$base_sha},
+        head:{sha:$head_sha, repo:{full_name:"contributor/fork"}}}')
+
+    (
+      PATH="$mock_bin:$PATH" \
+      GITHUB_EVENT_PATH="$event" \
+      GITHUB_REPOSITORY=bingosuite/bingo \
+      GITHUB_SERVER_URL=https://github.com \
+      GITHUB_RUN_ID=4242 \
+      DARWIN_GATE_DECISION_FILE="$work/decision-$step" \
+      MOCK_GH_LOG="$work/gh.log" \
+      MOCK_STATE_LOG="$work/states.log" \
+      MOCK_STATUS_LOG="$work/statuses.log" \
+      MOCK_TARGET_LOG="$work/targets.log" \
+      MOCK_LABELS_JSON='[{"name":"darwin-e2e-verified"}]' \
+      MOCK_COMPARE_JSON="$compare_json" \
+      MOCK_MERGE_BASE_SHA="$merge_base" \
+      MOCK_HEAD_SHA="$head_sha" \
+      MOCK_BASE_TREE_SHA="$base_tree" \
+      MOCK_HEAD_TREE_SHA="$head_tree" \
+      MOCK_BASE_TREE_ENTRIES='[]' \
+      MOCK_HEAD_TREE_ENTRIES='["internal/debugger/engine.go"]' \
+      MOCK_BASE_TREE_TRUNCATED=false \
+      MOCK_HEAD_TREE_TRUNCATED=false \
+      MOCK_BLOB_CONTENTS_FILE="$work/blobs.json" \
+      MOCK_BLOB_B64_FILE="$work/blobs-b64.json" \
+      MOCK_LIVE_PR_JSON="$live_pr_json" \
+      MOCK_PERMISSION_JSON="$permission_json" \
+      bash "$gate"
+    ) > "$work/out-$step.txt" 2>&1
+    printf '%s' $?
+  }
+
+  local rc_alt rc_main
+  rc_alt=$(run_shared_step 1 21 release-1.x)
+  rc_main=$(run_shared_step 2 17 main)
+
+  local ok=1
+  [ "$rc_alt" = "1" ] || {
+    fail "$name: the alternate-base pull request should fail (got $rc_alt)"
+    ok=0
+  }
+  [ "$rc_main" = "0" ] || {
+    fail "$name: the main pull request should succeed (got $rc_main)"
+    ok=0
+  }
+
+  local states
+  states=$(paste -sd, - < "$work/states.log")
+  if [ "$states" != "failure,pending,success" ]; then
+    fail "$name: expected 'failure,pending,success', got '$states'"
+    ok=0
+  fi
+
+  if ! grep -Fq "/statuses/$head_sha" "$work/gh.log"; then
+    fail "$name: both generations should address the same head SHA"
+    ok=0
+  fi
+
+  if grep -Fq "/git/trees/" "$work/out-1.txt"; then
+    fail "$name: the alternate-base generation should not inspect the diff"
+    ok=0
+  fi
+
+  [ "$ok" = "1" ] && pass "$name"
+}
+
+run_shared_head_sha_sequence
+
+# ---------------------------------------------------------------------------
+# Static contracts on the policy script and the workflows
+# ---------------------------------------------------------------------------
+
+check() {
   local name=$1
   shift
-
-  case_count=$((case_count + 1))
-  if ! "$@"; then
-    fail_case "$name" "workflow invariant not satisfied"
+  cases=$((cases + 1))
+  if "$@"; then
+    pass "$name"
+  else
+    fail "$name"
   fi
-  printf 'ok - %s\n' "$name"
 }
 
-trusted_is_base_controlled() {
-  grep -Eq '^[[:space:]]+pull_request_target:' "$trusted_workflow" &&
-    ! grep -Eq '^[[:space:]]+pull_request:' "$trusted_workflow"
+trusted_workflow_uses_pull_request_target() {
+  grep -q '^  pull_request_target:' "$workflow"
 }
 
-# The privileged job must never materialise a working tree, and the only code it
-# runs must be read from the base SHA, which a pull request cannot influence.
-# GitHub Actions '${{ }}' expressions are matched literally, not expanded.
-# shellcheck disable=SC2016
-trusted_runs_base_policy_only() {
-  ! grep -Eq 'uses:[[:space:]]*actions/checkout' "$trusted_workflow" &&
-    grep -Fq 'BASE_SHA: ${{ github.event.pull_request.base.sha }}' \
-      "$trusted_workflow" &&
-    grep -Fq 'contents/.github/scripts/darwin-verification-gate.sh?ref=$BASE_SHA' \
-      "$trusted_workflow" &&
-    ! grep -Fq 'github.event.pull_request.head.sha }}' "$trusted_workflow" &&
-    ! grep -Fq 'github.event.pull_request.head.ref' "$trusted_workflow"
+trusted_workflow_targets_main_only() {
+  # Statuses are SHA-global and the policy is fetched by SHA, so the trusted
+  # workflow must never run for a base branch an attacker can create.
+  awk '
+    /^  pull_request_target:/ {inside = 1; next}
+    inside && /^  [^ ]/ {inside = 0}
+    inside && /^    branches: \[main\]$/ {found = 1}
+    END {exit found ? 0 : 1}
+  ' "$workflow"
 }
 
+trusted_workflow_never_checks_out() {
+  ! grep -q 'actions/checkout' "$workflow"
+}
+
+# `go/build` decides what actually compiles, and only `.go` blobs get a content
+# scan, so every other extension it accepts must be caught by name. Shrinking
+# this list silently reopens the "untagged cgo wrapper + shim_darwin.sx" bypass.
+gate_covers_every_go_build_extension() {
+  local exts ext
+  exts=$(sed -n "s/^readonly darwin_native_exts='\(.*\)'$/\1/p" "$gate")
+  [ -n "$exts" ] || return 1
+
+  for ext in c cc cpp cxx m mm h hh hpp hxx f F for f90 s S sx swig swigcxx syso; do
+    case "|$exts|" in
+      *"|$ext|"*) ;;
+      *) return 1 ;;
+    esac
+  done
+
+  # Plain `.go` must NOT be in the bare-extension alternation: every Go file
+  # would gate and the content scan would become dead code.
+  case "|$exts|" in
+    *'|go|'*) return 1 ;;
+  esac
+
+  # ... but a `_darwin`/`_arm64`-suffixed `.go` file carries an implicit
+  # constraint and must still be caught by name.
+  grep -q '_(darwin|arm64)(_\[\^/\.\]+)\*\\\\\.(go|\$darwin_native_exts)' "$gate"
+}
+
+trusted_workflow_runs_trusted_policy_only() {
+  grep -q 'POLICY_SHA: \${{ github.workflow_sha }}' "$workflow" &&
+    grep -q 'darwin-verification-gate.sh?ref=\$POLICY_SHA' "$workflow" &&
+    ! grep -q 'github.event.pull_request.base.sha' "$workflow"
+}
+
+# The single highest-value guard for a privileged `pull_request_target` file:
+# one `${{ github.event.pull_request.title }}` inside a `run:` block is shell
+# injection with statuses:write and pull-requests:write. Untrusted values may
+# only enter through `env:`, where they are variables and not code.
+trusted_workflow_never_interpolates_into_run() {
+  awk '
+    /^ *run: *\|/ {inside = 1; indent = match($0, /[^ ]/); next}
+    inside {
+      here = match($0, /[^ ]/)
+      if ($0 !~ /^ *$/ && here <= indent) {inside = 0}
+    }
+    inside && /\$\{\{/ {bad = 1}
+    END {exit bad ? 1 : 0}
+  ' "$workflow"
+}
+
+# A job-level `permissions:` block overrides the workflow-level one, so the
+# top-level check alone is not sufficient.
+trusted_workflow_has_no_scope_override() {
+  [ "$(grep -c '^ *permissions:' "$workflow")" = "1" ] &&
+    grep -q '^permissions:' "$workflow"
+}
+
+# Dropping `unlabeled` would silently make verification withdrawal a no-op;
+# dropping `synchronize` would leave a new head SHA with no status at all.
 trusted_subscribes_to_gated_actions() {
-  grep -Fq 'types: [opened, synchronize, reopened, edited, labeled, unlabeled]' \
-    "$trusted_workflow"
+  local types action
+  types=$(grep -E '^ *types: \[' "$workflow")
+  [ -n "$types" ] || return 1
+  for action in opened synchronize reopened edited labeled unlabeled; do
+    case "$types" in
+      *"$action"*) ;;
+      *) return 1 ;;
+    esac
+  done
 }
 
-# Cancelling a run between its pending and final status can strand the required
-# head status on pending, so superseding must only ever drop still-queued runs.
-trusted_never_cancels_in_progress() {
-  ! grep -Eq 'cancel-in-progress:[[:space:]]*true' "$trusted_workflow" &&
-    grep -Eq 'cancel-in-progress:[[:space:]]*false' "$trusted_workflow"
+trusted_workflow_fails_closed_without_policy() {
+  grep -q 'missing-policy' "$workflow" &&
+    grep -q 'Trusted Darwin verification policy is unavailable' "$workflow"
 }
 
-unrelated_labels_are_isolated() {
-  grep -Fq "format('unrelated-{0}', github.run_id)" "$trusted_workflow" &&
-    grep -Fq "github.event.label.name != 'darwin-e2e-verified'" "$trusted_workflow" &&
-    grep -Fq "github.event.action == 'edited' && github.event.changes.base == null" \
-      "$trusted_workflow"
+trusted_workflow_never_cancels_in_progress() {
+  grep -q 'cancel-in-progress: false' "$workflow" &&
+    ! grep -q 'cancel-in-progress: true' "$workflow"
 }
 
-# GitHub Actions '${{ }}' expressions are matched literally, not expanded.
-# shellcheck disable=SC2016
-gating_events_share_one_group() {
-  grep -Fq 'darwin-verification-${{ github.event.pull_request.number }}' \
-    "$trusted_workflow"
+trusted_workflow_serializes_only_authoritative_events() {
+  grep -q "format('unrelated-{0}', github.run_id)" "$workflow" &&
+    grep -q "|| 'policy' }}" "$workflow"
 }
 
-trusted_fails_closed_without_decision() {
-  grep -Fq 'if: always()' "$trusted_workflow" &&
-    grep -Fq 'DARWIN_GATE_DECISION_FILE' "$trusted_workflow" &&
-    grep -Fq 'Darwin verification gate ended without a decision.' "$trusted_workflow"
+trusted_workflow_has_a_decision_fallback() {
+  grep -q 'if: always()' "$workflow" &&
+    grep -q 'Darwin verification gate ended without a decision' "$workflow"
 }
 
-head_tests_run_proposed_policy() {
-  grep -Eq '^[[:space:]]+pull_request:' "$head_test_workflow" &&
-    grep -Fq 'bash .github/scripts/darwin-verification-gate_test.sh' \
-      "$head_test_workflow"
+trusted_workflow_permissions_are_minimal() {
+  awk '
+    /^permissions:/ {inside = 1; next}
+    inside && /^[^ ]/ {inside = 0}
+    inside && /^  [a-z-]+:/ {
+      line = $0
+      sub(/^  /, "", line)
+      if (line != "contents: read" &&
+          line != "pull-requests: write" &&
+          line != "statuses: write") {
+        bad = 1
+      }
+    }
+    END {exit bad ? 1 : 0}
+  ' "$workflow"
 }
 
-head_tests_use_a_distinct_check_name() {
-  ! grep -Fq 'Darwin E2E verified' "$head_test_workflow"
+trusted_workflow_declares_advisory_posture() {
+  grep -qi 'advisory' "$workflow" &&
+    grep -q 'github-actions\[bot\]' "$workflow"
 }
 
-only_trusted_publishes_statuses() {
-  grep -Fq 'statuses: write' "$trusted_workflow" &&
-    ! grep -Eq 'statuses:[[:space:]]*write' "$head_test_workflow"
+trusted_workflow_has_no_merge_group_publisher() {
+  ! grep -q 'merge_group' "$workflow"
 }
 
-head_tests_cannot_write_pull_requests() {
-  ! grep -Eq 'pull-requests:[[:space:]]*write' "$head_test_workflow"
+policy_test_workflow_is_unprivileged() {
+  grep -q '^  pull_request:' "$policy_test_workflow" &&
+    ! grep -q 'pull_request_target' "$policy_test_workflow" &&
+    ! grep -q 'statuses: write' "$policy_test_workflow" &&
+    ! grep -q 'Darwin E2E verified' "$policy_test_workflow"
 }
 
-# Bash >= 4.4 propagates an ERR trap into command-substitution subshells, so an
-# unguarded $(...) publishes a duplicate status from the subshell before the
-# parent publishes its own. Every substitution below the trap must disarm it.
-# shellcheck disable=SC2016  # shell syntax is matched literally, not expanded.
-command_substitutions_disarm_the_err_trap() {
-  local body
-  body=$(awk '/^trap fail_closed ERR$/ {found = 1; next} found' "$gate")
-  [ -n "$body" ] || return 1
-
-  local offenders
-  offenders=$(printf '%s\n' "$body" | grep -F '$(' | grep -Fv '$(trap - ERR;' || true)
-  if [ -n "$offenders" ]; then
-    printf 'unguarded command substitution:\n%s\n' "$offenders" >&2
-    return 1
-  fi
-
-  # Backticks, process substitution and explicit subshells inherit the ERR trap
-  # exactly like '$( )' does, but carry no '$(' for the scan above to catch.
-  # Ban them outright so the guarded form stays the only way to spawn a subshell.
-  offenders=$(printf '%s\n' "$body" | grep -E '`|<\(|>\(' || true)
-  if [ -n "$offenders" ]; then
-    printf 'subshell form that cannot be guarded:\n%s\n' "$offenders" >&2
-    return 1
-  fi
+gate_binds_every_success_to_the_live_generation() {
+  awk '
+    /^[[:space:]]*#/ {next}
+    /^[[:space:]]*$/ {next}
+    {
+      if ($0 ~ /post_status success/ && prev !~ /require_current_generation/) {
+        bad = 1
+      }
+      prev = $0
+    }
+    END {exit bad ? 1 : 0}
+  ' "$gate"
 }
 
+gate_never_reads_prior_statuses() {
+  ! grep -q 'approval_ready' "$gate" &&
+    ! grep -Eq '/commits/[^"]*/statuses' "$gate"
+}
+
+gate_binds_authorization_to_the_event_actor() {
+  grep -q '\.sender\.login' "$gate" &&
+    grep -q '\.sender\.type' "$gate" &&
+    grep -q 'collaborators/\$actor_login/permission' "$gate" &&
+    grep -q 'require_authorized_labeler' "$gate"
+}
+
+gate_authorizes_before_publishing_success() {
+  # Per-site, not "the last one wins": a new success site added above the
+  # authorization call must fail this check.
+  local line last=0 authorized=0 sites=0
+  while read -r line; do
+    case "$line" in
+      *require_authorized_labeler) authorized=1 ;;
+      *"post_status success 'Darwin E2E verified"*)
+        sites=$((sites + 1))
+        [ "$authorized" = "1" ] || return 1
+        ;;
+    esac
+    last=1
+  done <<EOF
+$(grep -E "require_authorized_labeler\$|post_status success 'Darwin E2E verified" "$gate")
+EOF
+  [ "$last" = "1" ] && [ "$sites" -ge 1 ]
+}
+
+gate_never_publishes_success_from_an_unlabel() {
+  local arm withdraw
+  arm=$(grep -n '^  labeled | unlabeled)' "$gate" | head -1 | cut -d: -f1)
+  withdraw=$(grep -n "post_status failure 'Darwin verification was withdrawn" \
+    "$gate" | head -1 | cut -d: -f1)
+  [ -n "$arm" ] && [ -n "$withdraw" ] || return 1
+
+  # The unlabeled branch must terminate the arm before any success can be
+  # reached, so no `post_status success` may appear between them.
+  awk -v a="$arm" -v b="$withdraw" \
+    'NR > a && NR < b && /post_status success/ {bad = 1}
+     END {exit bad ? 1 : 0}' "$gate" || return 1
+
+  awk -v a="$withdraw" \
+    'NR > a && /^      exit 1$/ {found = 1; exit}
+     END {exit found ? 0 : 1}' "$gate"
+}
+
+# A force-push can change `/pulls/N/files` while the run is still publishing to
+# the event's old head SHA, so the diff must come from immutable tree objects.
 gate_uses_immutable_diff() {
-  grep -Fq 'compare/$base_sha...$head_sha' "$gate" &&
-    grep -Fq 'git/trees/$merge_base_tree_sha?recursive=1' "$gate" &&
-    grep -Fq 'git/trees/$head_tree_sha?recursive=1' "$gate" &&
-    ! grep -Fq '/pulls/$pr_number/files' "$gate"
+  grep -q 'git/trees/' "$gate" &&
+    grep -q 'recursive=1' "$gate" &&
+    grep -q 'compare/' "$gate" &&
+    ! grep -Eq 'pulls/[^"]*/files' "$gate"
 }
 
-gate_workflows_are_valid_yaml() {
-  python3 -c 'import sys, yaml
-for path in sys.argv[1:]:
-    with open(path) as handle:
-        yaml.safe_load(handle)' "$trusted_workflow" "$head_test_workflow"
+gate_enforces_the_required_base_ref() {
+  grep -q "required_base_ref='main'" "$gate" &&
+    grep -q 'base_ref" != "\$required_base_ref' "$gate"
 }
 
-assert_workflow "trusted workflow is base-controlled pull_request_target only" \
-  trusted_is_base_controlled
-assert_workflow "trusted workflow runs only base-SHA policy and never checks out" \
-  trusted_runs_base_policy_only
-assert_workflow "trusted workflow subscribes to every gated action" \
+gate_validates_tree_documents() {
+  grep -q 'validate_tree_document' "$gate" &&
+    grep -q 'truncated' "$gate" &&
+    grep -q '\^\[0-7\]{6}\$' "$gate"
+}
+
+gate_normalizes_byte_order_marks() {
+  grep -q 'efbbbf' "$gate" &&
+    grep -q 'tail -c +4' "$gate" &&
+    grep -q 'fffe\|feff' "$gate"
+}
+
+gate_gates_non_regular_tree_entries() {
+  grep -q 'irregular' "$gate" &&
+    grep -q '100755' "$gate" &&
+    grep -q '100644' "$gate"
+}
+
+gate_publishes_only_from_the_top_level_shell() {
+  # `set -E` propagates the ERR trap into command-substitution subshells, so an
+  # unguarded substitution below the guarded-region marker would publish a
+  # status from the subshell and then again from the parent. Every substitution
+  # must disarm the trap first. Full-line comments cannot execute, so they are
+  # excluded from the scan.
+  local region="$tmpdir/gate-region.sh"
+  awk '
+    /^# --- ERR-trap guarded region/ {inside = 1}
+    inside && !/^[[:space:]]*#/ {print}
+  ' "$gate" > "$region"
+
+  [ -s "$region" ] || return 1
+
+  # Count per line, not per matching line: `a=$(trap - ERR; x); b=$(y)` would
+  # survive a line-granular filter because the guarded substitution deletes the
+  # whole line from the scan.
+  local total guarded
+  total=$(grep -o '\$(' "$region" | wc -l | tr -d ' ')
+  guarded=$(grep -o '\$(trap - ERR;' "$region" | wc -l | tr -d ' ')
+  if [ "$total" != "$guarded" ]; then
+    printf 'unguarded command substitution in the ERR-trap region (%s of %s):\n' \
+      "$((total - guarded))" "$total" >&2
+    grep -n '\$(' "$region" >&2
+    return 1
+  fi
+
+  # Backticks, process substitution and explicit grouping subshells all inherit
+  # the ERR trap under `set -E` exactly like `$( )` does. The grouping form is
+  # anchored to command position so parentheses inside regexes and message
+  # strings — of which this script has many — are not false positives.
+  local banned='`|<\(|>\(|(^|[;&|{] *)\([ \t]*[a-z_]'
+  if grep -Eq "$banned" "$region"; then
+    printf 'banned subshell form in the ERR-trap region:\n' >&2
+    grep -En "$banned" "$region" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+gate_records_a_decision_for_every_final_status() {
+  awk '
+    /^record_decision\(\)/ {seen_record = 1}
+    /^post_status\(\)/ {inside = 1}
+    inside && /record_decision/ {calls = 1}
+    inside && /^}/ {inside = 0}
+    END {exit (seen_record && calls) ? 0 : 1}
+  ' "$gate"
+}
+
+check "trusted workflow uses pull_request_target" trusted_workflow_uses_pull_request_target
+check "trusted workflow targets main only" trusted_workflow_targets_main_only
+check "trusted workflow never checks out" trusted_workflow_never_checks_out
+check "trusted workflow never interpolates into run" \
+  trusted_workflow_never_interpolates_into_run
+check "trusted workflow has no job scope override" \
+  trusted_workflow_has_no_scope_override
+check "trusted workflow subscribes to gated actions" \
   trusted_subscribes_to_gated_actions
-assert_workflow "trusted workflow never cancels a run in progress" \
-  trusted_never_cancels_in_progress
-assert_workflow "unrelated label events cannot supersede a gating run" \
-  unrelated_labels_are_isolated
-assert_workflow "gating events share one per-pull-request concurrency group" \
-  gating_events_share_one_group
-assert_workflow "trusted workflow fails closed without a published decision" \
-  trusted_fails_closed_without_decision
-assert_workflow "unprivileged pull_request workflow tests proposed HEAD policy" \
-  head_tests_run_proposed_policy
-assert_workflow "untrusted policy test has a distinct check name" \
-  head_tests_use_a_distinct_check_name
-assert_workflow "only the trusted workflow may publish commit statuses" \
-  only_trusted_publishes_statuses
-assert_workflow "untrusted policy test cannot write pull requests" \
-  head_tests_cannot_write_pull_requests
-assert_workflow "command substitutions cannot double-publish a status" \
-  command_substitutions_disarm_the_err_trap
-assert_workflow "gate diff is bound to immutable event SHAs" \
-  gate_uses_immutable_diff
+check "gate uses immutable diff" gate_uses_immutable_diff
+check "gate covers every go/build native extension" \
+  gate_covers_every_go_build_extension
+check "trusted workflow runs trusted policy only" trusted_workflow_runs_trusted_policy_only
+check "trusted workflow fails closed without policy" trusted_workflow_fails_closed_without_policy
+check "trusted workflow never cancels in progress" trusted_workflow_never_cancels_in_progress
+check "trusted workflow serializes only authoritative events" trusted_workflow_serializes_only_authoritative_events
+check "trusted workflow has a decision fallback" trusted_workflow_has_a_decision_fallback
+check "trusted workflow permissions are minimal" trusted_workflow_permissions_are_minimal
+check "trusted workflow declares advisory posture" trusted_workflow_declares_advisory_posture
+check "trusted workflow has no merge_group publisher" trusted_workflow_has_no_merge_group_publisher
+check "policy test workflow is unprivileged" policy_test_workflow_is_unprivileged
+check "gate binds every success to the live generation" gate_binds_every_success_to_the_live_generation
+check "gate never reads prior statuses" gate_never_reads_prior_statuses
+check "gate binds authorization to the event actor" gate_binds_authorization_to_the_event_actor
+check "gate authorizes before publishing success" gate_authorizes_before_publishing_success
+check "gate never publishes success from an unlabel" gate_never_publishes_success_from_an_unlabel
+check "gate enforces the required base ref" gate_enforces_the_required_base_ref
+check "gate validates tree documents" gate_validates_tree_documents
+check "gate normalizes byte order marks" gate_normalizes_byte_order_marks
+check "gate gates non-regular tree entries" gate_gates_non_regular_tree_entries
+check "gate publishes only from the top level shell" gate_publishes_only_from_the_top_level_shell
+check "gate records a decision for every final status" gate_records_a_decision_for_every_final_status
 
-if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' 2>/dev/null; then
-  assert_workflow "gate workflows are valid YAML" gate_workflows_are_valid_yaml
-fi
-
-printf '1..%s\n' "$case_count"
+printf '\n%d cases, %d failures\n' "$cases" "$failures"
+[ "$failures" -eq 0 ]

--- a/.github/scripts/darwin-verification-gate_test.sh
+++ b/.github/scripts/darwin-verification-gate_test.sh
@@ -31,6 +31,23 @@ if [ "$1" != "api" ]; then
 fi
 
 case "$*" in
+  *"/commits/"*"/statuses?"*)
+    jq -n \
+      --arg state "$MOCK_PRIOR_STATUS_STATE" \
+      --arg creator "$MOCK_PRIOR_STATUS_CREATOR" \
+      --arg target "$MOCK_PRIOR_STATUS_TARGET" '
+        if $state == "" then
+          [[]]
+        else
+          [[{
+            context: "Darwin E2E verified",
+            state: $state,
+            creator: {login: $creator},
+            target_url: $target
+          }]]
+        end
+      '
+    ;;
   *"/statuses/"*)
     state=
     context=
@@ -52,20 +69,72 @@ case "$*" in
     done
     printf '%s|%s|%s\n' "$endpoint" "$state" "$context" >> "$MOCK_STATUS_LOG"
     ;;
-  *"/pulls/"*"/files?"*)
+  *"/compare/"*)
     if [ "$MOCK_DIFF_STATUS" -ne 0 ]; then
       echo "diff API failed" >&2
       exit "$MOCK_DIFF_STATUS"
     fi
-    # `--slurp` yields one array per fetched page; the gate must flatten them.
+    printf '%s\n' "$MOCK_MERGE_BASE_SHA"
+    ;;
+  *"/git/commits/"*)
+    case "$*" in
+      *"/git/commits/$MOCK_MERGE_BASE_SHA"*)
+        printf '%s\n' "$MOCK_BASE_TREE_SHA"
+        ;;
+      *"/git/commits/$MOCK_HEAD_SHA"*)
+        printf '%s\n' "$MOCK_HEAD_TREE_SHA"
+        ;;
+      *)
+        echo "Unexpected commit lookup: $*" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  *"/git/trees/"*)
+    paths='[]'
+    truncated=false
+    case "$*" in
+      *"/git/trees/$MOCK_BASE_TREE_SHA"*)
+        paths=$MOCK_BASE_PATHS_JSON
+        truncated=$MOCK_BASE_TREE_TRUNCATED
+        ;;
+      *"/git/trees/$MOCK_HEAD_TREE_SHA"*)
+        paths=$MOCK_CHANGED_PATHS_JSON
+        truncated=$MOCK_TREE_TRUNCATED
+        ;;
+      *)
+        echo "Unexpected tree lookup: $*" >&2
+        exit 2
+        ;;
+    esac
     jq -n \
-      --argjson filenames "$MOCK_CHANGED_PATHS_JSON" \
-      --argjson pages "$MOCK_PAGES" '
-        [$filenames[] | {filename: .}] as $files
-        | ((($files | length) + $pages - 1) / $pages | floor) as $size
-        | [range(0; $pages) | $files[(. * $size):((. + 1) * $size)]]
-        | map(select(length > 0))
+      --argjson paths "$paths" \
+      --argjson truncated "$truncated" '
+        {
+          truncated: $truncated,
+          tree: [
+            range(0; $paths | length) as $index
+            | {
+                mode: "100644",
+                path: $paths[$index],
+                sha: ($index | tostring),
+                type: "blob"
+              }
+          ]
+        }
       '
+    ;;
+  *"/git/blobs/"*)
+    path=
+    for arg in "$@"; do
+      case "$arg" in
+        repos/*/git/blobs/*) path=$arg ;;
+      esac
+    done
+    sha=${path##*/}
+    content=$(jq -r --arg sha "$sha" '.[$sha] // "package bingo\n"' \
+      <<< "$MOCK_BLOB_CONTENTS_JSON")
+    printf '%s' "$content" | base64
     ;;
   *"/issues/"*"/labels?"*)
     if [ "$MOCK_LABEL_STATUS" -ne 0 ]; then
@@ -101,17 +170,23 @@ fail_case() {
 
 # run_case NAME key=value...
 #
-# Keys: action, label, head_repo, path, paths_json, pages, has_label,
-# edit_status, diff_status, label_status, status_fail, declared_files,
-# exit, state, states, output, label_query, decision, gh_contains, gh_missing.
+# Keys: action, label, head_repo, path, paths_json, base_paths_json,
+# base_changed, tree_truncated, blob_contents_json, prior_status,
+# prior_creator, prior_target, has_label, edit_status, diff_status, label_status,
+# status_fail, exit, state, states, output, label_query, decision, gh_contains,
+# gh_missing.
 run_case() {
   local name=$1
   shift
 
   local action=opened label='' head_repo=contributor/fork
-  local path=entitlements.plist paths_json='' pages=1
+  local path=entitlements.plist paths_json='' base_paths_json='[]'
+  local base_changed=false base_tree_truncated=false tree_truncated=false
+  local blob_contents_json='{}'
+  local prior_status=failure prior_creator='github-actions[bot]'
+  local prior_target='https://github.com/bingosuite/bingo/actions/runs/122'
   local has_label=false edit_status=0 diff_status=0 label_status=0
-  local status_fail='' declared_files='' expect_exit=0 expect_state=none
+  local status_fail='' expect_exit=0 expect_state=none
   local expect_states=''
   local expect_output='' expect_label_query=any expect_decision=''
   local gh_contains='' gh_missing=''
@@ -126,13 +201,19 @@ run_case() {
       head_repo) head_repo=$value ;;
       path) path=$value ;;
       paths_json) paths_json=$value ;;
-      pages) pages=$value ;;
+      base_paths_json) base_paths_json=$value ;;
+      base_changed) base_changed=$value ;;
+      base_tree_truncated) base_tree_truncated=$value ;;
+      tree_truncated) tree_truncated=$value ;;
+      blob_contents_json) blob_contents_json=$value ;;
+      prior_status) prior_status=$value ;;
+      prior_creator) prior_creator=$value ;;
+      prior_target) prior_target=$value ;;
       has_label) has_label=$value ;;
       edit_status) edit_status=$value ;;
       diff_status) diff_status=$value ;;
       label_status) label_status=$value ;;
       status_fail) status_fail=$value ;;
-      declared_files) declared_files=$value ;;
       exit) expect_exit=$value ;;
       state) expect_state=$value ;;
       states) expect_states=$value ;;
@@ -153,14 +234,19 @@ run_case() {
   local decision_file="$tmpdir/decision-$case_id.txt"
   local head_sha
   head_sha=$(printf '%040x' "$case_id")
+  local base_sha
+  base_sha=$(printf 'f%039x' "$case_id")
+  local merge_base_sha
+  merge_base_sha=$(printf 'e%039x' "$case_id")
+  local base_tree_sha
+  base_tree_sha=$(printf 'c%039x' "$case_id")
+  local head_tree_sha
+  head_tree_sha=$(printf 'd%039x' "$case_id")
   local output
   local status=0
 
   if [ -z "$paths_json" ]; then
     paths_json=$(jq -n --arg path "$path" '[$path]')
-  fi
-  if [ -z "$declared_files" ]; then
-    declared_files=$(jq -n --argjson paths "$paths_json" '$paths | length')
   fi
   : > "$gh_log"
   : > "$status_log"
@@ -171,13 +257,22 @@ run_case() {
     --arg event_label "$label" \
     --arg head_repository "$head_repo" \
     --arg head_sha "$head_sha" \
-    --argjson changed_files "$declared_files" \
+    --arg base_sha "$base_sha" \
+    --argjson base_changed "$base_changed" \
+    --argjson changed_files "$(jq -n --argjson paths "$paths_json" '$paths | length')" \
     '{
       action: $action,
       label: {name: $event_label},
+      changes: (
+        if $base_changed
+        then {base: {ref: {from: "previous-base"}}}
+        else {}
+        end
+      ),
       pull_request: {
         number: 17,
         changed_files: $changed_files,
+        base: {sha: $base_sha},
         head: {sha: $head_sha, repo: {full_name: $head_repository}}
       }
     }' > "$event_path"
@@ -192,7 +287,17 @@ run_case() {
       MOCK_GH_LOG="$gh_log" \
       MOCK_STATUS_LOG="$status_log" \
       MOCK_CHANGED_PATHS_JSON="$paths_json" \
-      MOCK_PAGES="$pages" \
+      MOCK_BASE_PATHS_JSON="$base_paths_json" \
+      MOCK_BASE_TREE_TRUNCATED="$base_tree_truncated" \
+      MOCK_TREE_TRUNCATED="$tree_truncated" \
+      MOCK_MERGE_BASE_SHA="$merge_base_sha" \
+      MOCK_BASE_TREE_SHA="$base_tree_sha" \
+      MOCK_HEAD_TREE_SHA="$head_tree_sha" \
+      MOCK_HEAD_SHA="$head_sha" \
+      MOCK_BLOB_CONTENTS_JSON="$blob_contents_json" \
+      MOCK_PRIOR_STATUS_STATE="$prior_status" \
+      MOCK_PRIOR_STATUS_CREATOR="$prior_creator" \
+      MOCK_PRIOR_STATUS_TARGET="$prior_target" \
       MOCK_HAS_LABEL="$has_label" \
       MOCK_EDIT_STATUS="$edit_status" \
       MOCK_DIFF_STATUS="$diff_status" \
@@ -221,6 +326,17 @@ run_case() {
 
   if grep -Eq 'attacker-controlled|attacker/repository| 999 ' "$gh_log"; then
     fail_case "$name" "hostile environment reached gh" "$(cat "$gh_log")"
+  fi
+
+  if grep -Fq "/pulls/17/files" "$gh_log"; then
+    fail_case "$name" "gate consulted the live pull request file list" \
+      "$(cat "$gh_log")"
+  fi
+
+  if grep -Fq '|pending|' "$status_log" &&
+    ! grep -Fq "/compare/$base_sha...$head_sha" "$gh_log"; then
+    fail_case "$name" "gate did not bind its diff to event base/head SHAs" \
+      "$(cat "$gh_log")"
   fi
 
   if [ "$expect_label_query" = "true" ] &&
@@ -316,7 +432,7 @@ run_case "successful cleanup omits the stale-label recovery hint" \
   has_label=true edit_status=0 \
   exit=1 state=failure label_query=false decision=failure \
   gh_contains="--remove-label darwin-e2e-verified" \
-  output="then add the 'darwin-e2e-verified' label to verify this head"
+  output="then add the 'darwin-e2e-verified' label"
 
 run_case "reopened pull request fails current head" \
   action=reopened head_repo=contributor/fork path=entitlements.plist \
@@ -350,6 +466,18 @@ run_case "verified label publishes success to current head" \
   path=test/integration/debugger_e2e_darwin_arm64_test.go has_label=true \
   exit=0 state=success label_query=true decision=success \
   gh_missing="pr edit" output="verified locally"
+
+run_case "verified label cannot supersede an unevaluated head" \
+  action=labeled label=darwin-e2e-verified head_repo=contributor/fork \
+  path=entitlements.plist has_label=true prior_status='' \
+  exit=1 state=failure label_query=true decision=failure \
+  output="has not completed a trusted failing gate run"
+
+run_case "untrusted prior failure cannot authorize a verified label" \
+  action=labeled label=darwin-e2e-verified head_repo=contributor/fork \
+  path=entitlements.plist has_label=true prior_creator=octocat \
+  exit=1 state=failure label_query=true decision=failure \
+  output="has not completed a trusted failing gate run"
 
 run_case "verified label removal publishes failure" \
   action=unlabeled label=darwin-e2e-verified head_repo=contributor/fork \
@@ -410,52 +538,193 @@ needs-review' \
   exit=0 state=success label_query=true decision=success \
   output="verified locally"
 
+# --- pull request edits ------------------------------------------------------
+
+run_case "non-base pull request edit preserves the current status" \
+  action=edited base_changed=false head_repo=contributor/fork \
+  path=entitlements.plist \
+  exit=0 state=none decision=ignored gh_missing="statuses/" \
+  output="did not change the base"
+
+run_case "base retarget invalidates Darwin verification" \
+  action=edited base_changed=true head_repo=contributor/fork \
+  path=entitlements.plist has_label=true edit_status=1 \
+  exit=1 state=failure decision=failure label_query=false \
+  output="re-verification required"
+
 # --- path matching -----------------------------------------------------------
 
 run_case "non-Darwin synchronize publishes success" \
-  action=synchronize head_repo=contributor/fork path=internal/debugger/engine.go \
+  action=synchronize head_repo=contributor/fork path=internal/hub/hub.go \
   has_label=true edit_status=1 \
   exit=0 state=success label_query=false decision=success \
   output="No darwin-native code changed"
 
 run_case "near-match outside regex publishes success" \
-  action=opened head_repo=contributor/fork path=docs/backend_darwin_arm64.go \
+  action=opened head_repo=contributor/fork path=docs/backend-darwin-arm64.go \
   exit=0 state=success label_query=false decision=success \
   output="No darwin-native code changed"
+
+run_case "darwin GOOS suffix without arch still gates" \
+  action=opened head_repo=contributor/fork \
+  path=internal/debugger/backend_darwin.go \
+  exit=1 state=failure decision=failure output="verification required"
+
+run_case "darwin suffix in a new package still gates" \
+  action=opened head_repo=contributor/fork \
+  path=internal/hub/attach_darwin.go \
+  exit=1 state=failure decision=failure output="verification required"
+
+run_case "arm64 assembly in a new package still gates" \
+  action=opened head_repo=contributor/fork \
+  path=internal/hub/attach_arm64.s \
+  exit=1 state=failure decision=failure output="verification required"
+
+run_case "arm64 test suffix still gates" \
+  action=opened head_repo=contributor/fork \
+  path=internal/debugger/trap_arm64_test.go \
+  exit=1 state=failure decision=failure output="verification required"
+
+run_case "native source without platform suffix gates conservatively" \
+  action=opened head_repo=contributor/fork \
+  path=internal/debugger/machtrap.s \
+  exit=1 state=failure decision=failure output="verification required"
+
+darwin_constraint_blob=$(jq -n \
+  '{"0":"//go:build darwin && arm64 && bingonative\n\npackage debugger\n"}')
+run_case "darwin build constraint gates convention-free Go file" \
+  action=opened head_repo=contributor/fork \
+  path=internal/hub/machfix.go \
+  blob_contents_json="$darwin_constraint_blob" \
+  exit=1 state=failure decision=failure output="verification required"
+
+negated_constraint_blob=$(jq -n \
+  '{"0":"//go:build !linux && !windows\n\npackage debugger\n"}')
+run_case "negated platform constraint is evaluated as Darwin-only" \
+  action=opened head_repo=contributor/fork \
+  path=internal/hub/negated.go \
+  blob_contents_json="$negated_constraint_blob" \
+  exit=1 state=failure decision=failure output="verification required"
+
+legacy_constraint_blob=$(jq -n \
+  '{"0":"// +build darwin,arm64\n\npackage debugger\n"}')
+run_case "legacy Darwin build constraint still gates" \
+  action=opened head_repo=contributor/fork \
+  path=internal/hub/legacy.go \
+  blob_contents_json="$legacy_constraint_blob" \
+  exit=1 state=failure decision=failure output="verification required"
+
+cross_platform_constraint_blob=$(jq -n \
+  '{"0":"//go:build (linux && amd64) || (darwin && arm64)\n\npackage debugger\n"}')
+run_case "cross-platform build constraint gates conservatively" \
+  action=opened head_repo=contributor/fork \
+  path=internal/hub/crossplatform.go \
+  blob_contents_json="$cross_platform_constraint_blob" \
+  exit=1 state=failure decision=failure output="verification required"
+
+large_padding=$(awk 'BEGIN {
+  for (i = 0; i < 4000; i++) {
+    print "// padding padding padding padding padding"
+  }
+}')
+large_header=$(printf '//go:build darwin && arm64\n%s\npackage debugger\n' \
+  "$large_padding")
+large_constraint_blob=$(jq -n --arg content "$large_header" '{"0":$content}')
+run_case "large pre-package header cannot bypass build constraint detection" \
+  action=opened head_repo=contributor/fork \
+  path=internal/hub/largeheader.go \
+  blob_contents_json="$large_constraint_blob" \
+  exit=1 state=failure decision=failure output="verification required"
+
+decoy_constraint_blob=$(jq -n \
+  '{"0":"/*\n//go:build ignore\n*/\npackage debugger\n"}')
+run_case "constraint-like comment gates conservatively rather than false-green" \
+  action=opened head_repo=contributor/fork \
+  path=internal/hub/decoy.go \
+  blob_contents_json="$decoy_constraint_blob" \
+  exit=1 state=failure decision=failure output="verification required"
+
+run_case "existing Darwin probe constraint is gated" \
+  action=opened head_repo=contributor/fork \
+  path=internal/debugger/gcpreempt_probe_test.go \
+  blob_contents_json="$darwin_constraint_blob" \
+  exit=1 state=failure decision=failure output="verification required"
+
+run_case "ordinary Go change without Darwin constraint stays ungated" \
+  action=opened head_repo=contributor/fork \
+  path=internal/hub/hub.go \
+  exit=0 state=success decision=success output="No darwin-native code changed"
+
+run_case "runtime-dispatched debugger code always gates" \
+  action=opened head_repo=contributor/fork \
+  path=internal/debugger/dwarf.go \
+  exit=1 state=failure decision=failure output="verification required"
+
+run_case "integration suite entry point always gates" \
+  action=opened head_repo=contributor/fork \
+  path=test/integration/integration_suite_test.go \
+  exit=1 state=failure decision=failure output="verification required"
+
+run_case "Darwin verification recipe always gates" \
+  action=opened head_repo=contributor/fork path=justfile \
+  exit=1 state=failure decision=failure output="verification required"
+
+run_case "module graph changes always gate" \
+  action=opened head_repo=contributor/fork path=go.mod \
+  exit=1 state=failure decision=failure output="verification required"
 
 run_case "one Darwin file among many still gates" \
   action=opened head_repo=contributor/fork \
   paths_json='["README.md","internal/hub/hub.go","internal/debugger/backend_darwin_arm64.go","docs/x.md"]' \
   exit=1 state=failure decision=failure output="verification required"
 
-# --- PR files API integrity --------------------------------------------------
+# --- immutable tree diff integrity -------------------------------------------
 
-run_case "paginated file list is flattened and gated" \
+many_paths_json=$(jq -n \
+  '[range(0; 150) | "docs/generated-\(.).md"] + ["entitlements.plist"]')
+run_case "more than 100 changed files are evaluated immutably" \
   action=opened head_repo=contributor/fork \
-  paths_json='["a.md","b.md","c.md","entitlements.plist"]' pages=2 \
+  paths_json="$many_paths_json" \
   exit=1 state=failure decision=failure output="verification required"
 
-run_case "paginated non-Darwin file list publishes success" \
+run_case "multi-file non-Darwin tree diff publishes success" \
   action=opened head_repo=contributor/fork \
-  paths_json='["a.md","b.md","c.md","d.md","e.md","f.md"]' pages=3 \
+  paths_json='["a.md","b.md","c.md","d.md","e.md","f.md"]' \
   exit=0 state=success decision=success output="No darwin-native code changed"
 
-run_case "truncated PR files response fails closed" \
+run_case "truncated Git tree response fails closed" \
   action=opened head_repo=contributor/fork path=docs/readme.md \
-  declared_files=3001 \
+  tree_truncated=true \
   exit=1 state=failure decision=failure \
-  output="refusing an incomplete gate decision"
+  output="truncated or malformed tree"
 
-run_case "newline filename cannot hide truncated response" \
-  action=opened head_repo=contributor/fork path=$'000-padding\nextra-line' \
-  declared_files=2 \
-  exit=1 state=failure decision=failure output="returned 1 of 2 changed files"
-
-run_case "over-reported file list also fails closed" \
+run_case "truncated base tree cannot hide a Darwin deletion" \
   action=opened head_repo=contributor/fork \
-  paths_json='["a.md","b.md"]' declared_files=1 \
+  base_paths_json='["entitlements.plist","README.md"]' \
+  paths_json='["README.md"]' base_tree_truncated=true \
   exit=1 state=failure decision=failure \
-  output="refusing an incomplete gate decision"
+  output="truncated or malformed tree"
+
+run_case "control character filename fails closed" \
+  action=opened head_repo=contributor/fork \
+  path=$'000-padding\nentitlements.plist' \
+  exit=1 state=failure decision=failure output="verification required"
+
+run_case "empty immutable diff fails closed" \
+  action=opened head_repo=contributor/fork paths_json='[]' \
+  exit=1 state=failure decision=failure \
+  output="refusing an empty gate decision"
+
+run_case "deleting a Darwin file still requires verification" \
+  action=opened head_repo=contributor/fork \
+  base_paths_json='["entitlements.plist"]' paths_json='[]' \
+  exit=1 state=failure decision=failure output="verification required"
+
+run_case "deleting a convention-free Darwin constrained file is gated" \
+  action=opened head_repo=contributor/fork \
+  base_paths_json='["internal/hub/machfix.go"]' paths_json='[]' \
+  blob_contents_json="$darwin_constraint_blob" \
+  exit=1 state=failure decision=failure output="verification required"
 
 run_case "diff API failure replaces pending with failure" \
   action=opened head_repo=contributor/fork path=entitlements.plist \
@@ -490,9 +759,9 @@ run_case "unpublishable success degrades to failure" \
 # --- unsupported actions -----------------------------------------------------
 
 run_case "unsupported action refuses to decide" \
-  action=edited head_repo=contributor/fork path=entitlements.plist \
+  action=closed head_repo=contributor/fork path=entitlements.plist \
   exit=2 state=none decision=none gh_missing="statuses/" \
-  output="Unsupported pull_request_target action: edited"
+  output="Unsupported pull_request_target action: closed"
 
 run_status_persistence_sequence() {
   local name=$1
@@ -510,10 +779,18 @@ run_status_persistence_sequence() {
   local unrelated_event
   local first_status=0
   local second_status=0
+  local base_sha
+  local merge_base_sha
+  local base_tree_sha
+  local head_tree_sha
 
   case_count=$((case_count + 1))
   case_id=$case_count
   head_sha=$(printf '%040x' "$case_id")
+  base_sha=$(printf 'f%039x' "$case_id")
+  merge_base_sha=$(printf 'e%039x' "$case_id")
+  base_tree_sha=$(printf 'c%039x' "$case_id")
+  head_tree_sha=$(printf 'd%039x' "$case_id")
   gh_log="$tmpdir/sequence-gh-$case_id.log"
   status_log="$tmpdir/sequence-status-$case_id.log"
   first_event="$tmpdir/sequence-first-$case_id.json"
@@ -525,23 +802,27 @@ run_status_persistence_sequence() {
     --arg action "$first_action" \
     --arg event_label "$first_event_label" \
     --arg head_sha "$head_sha" \
+    --arg base_sha "$base_sha" \
     '{
       action: $action,
       label: {name: $event_label},
       pull_request: {
         number: 17,
         changed_files: 1,
+        base: {sha: $base_sha},
         head: {sha: $head_sha, repo: {full_name: "contributor/fork"}}
       }
     }' > "$first_event"
   jq -n \
     --arg head_sha "$head_sha" \
+    --arg base_sha "$base_sha" \
     '{
       action: "labeled",
       label: {name: "triage"},
       pull_request: {
         number: 17,
         changed_files: 1,
+        base: {sha: $base_sha},
         head: {sha: $head_sha, repo: {full_name: "contributor/fork"}}
       }
     }' > "$unrelated_event"
@@ -552,7 +833,17 @@ run_status_persistence_sequence() {
     MOCK_GH_LOG="$gh_log" \
     MOCK_STATUS_LOG="$status_log" \
     MOCK_CHANGED_PATHS_JSON='["entitlements.plist"]' \
-    MOCK_PAGES=1 \
+    MOCK_BASE_PATHS_JSON='[]' \
+    MOCK_BASE_TREE_TRUNCATED=false \
+    MOCK_TREE_TRUNCATED=false \
+    MOCK_MERGE_BASE_SHA="$merge_base_sha" \
+    MOCK_BASE_TREE_SHA="$base_tree_sha" \
+    MOCK_HEAD_TREE_SHA="$head_tree_sha" \
+    MOCK_HEAD_SHA="$head_sha" \
+    MOCK_BLOB_CONTENTS_JSON='{}' \
+    MOCK_PRIOR_STATUS_STATE=failure \
+    MOCK_PRIOR_STATUS_CREATOR='github-actions[bot]' \
+    MOCK_PRIOR_STATUS_TARGET='https://github.com/bingosuite/bingo/actions/runs/122' \
     MOCK_HAS_LABEL="$first_has_label" \
     MOCK_EDIT_STATUS="$first_edit_status" \
     MOCK_DIFF_STATUS=0 \
@@ -565,7 +856,17 @@ run_status_persistence_sequence() {
     MOCK_GH_LOG="$gh_log" \
     MOCK_STATUS_LOG="$status_log" \
     MOCK_CHANGED_PATHS_JSON='["entitlements.plist"]' \
-    MOCK_PAGES=1 \
+    MOCK_BASE_PATHS_JSON='[]' \
+    MOCK_BASE_TREE_TRUNCATED=false \
+    MOCK_TREE_TRUNCATED=false \
+    MOCK_MERGE_BASE_SHA="$merge_base_sha" \
+    MOCK_BASE_TREE_SHA="$base_tree_sha" \
+    MOCK_HEAD_TREE_SHA="$head_tree_sha" \
+    MOCK_HEAD_SHA="$head_sha" \
+    MOCK_BLOB_CONTENTS_JSON='{}' \
+    MOCK_PRIOR_STATUS_STATE=failure \
+    MOCK_PRIOR_STATUS_CREATOR='github-actions[bot]' \
+    MOCK_PRIOR_STATUS_TARGET='https://github.com/bingosuite/bingo/actions/runs/122' \
     MOCK_HAS_LABEL=true \
     MOCK_EDIT_STATUS=0 \
     MOCK_DIFF_STATUS=0 \
@@ -627,7 +928,7 @@ trusted_runs_base_policy_only() {
 }
 
 trusted_subscribes_to_gated_actions() {
-  grep -Fq 'types: [opened, synchronize, reopened, labeled, unlabeled]' \
+  grep -Fq 'types: [opened, synchronize, reopened, edited, labeled, unlabeled]' \
     "$trusted_workflow"
 }
 
@@ -640,7 +941,9 @@ trusted_never_cancels_in_progress() {
 
 unrelated_labels_are_isolated() {
   grep -Fq "format('unrelated-{0}', github.run_id)" "$trusted_workflow" &&
-    grep -Fq "github.event.label.name != 'darwin-e2e-verified'" "$trusted_workflow"
+    grep -Fq "github.event.label.name != 'darwin-e2e-verified'" "$trusted_workflow" &&
+    grep -Fq "github.event.action == 'edited' && github.event.changes.base == null" \
+      "$trusted_workflow"
 }
 
 # GitHub Actions '${{ }}' expressions are matched literally, not expanded.
@@ -701,6 +1004,13 @@ command_substitutions_disarm_the_err_trap() {
   fi
 }
 
+gate_uses_immutable_diff() {
+  grep -Fq 'compare/$base_sha...$head_sha' "$gate" &&
+    grep -Fq 'git/trees/$merge_base_tree_sha?recursive=1' "$gate" &&
+    grep -Fq 'git/trees/$head_tree_sha?recursive=1' "$gate" &&
+    ! grep -Fq '/pulls/$pr_number/files' "$gate"
+}
+
 gate_workflows_are_valid_yaml() {
   python3 -c 'import sys, yaml
 for path in sys.argv[1:]:
@@ -732,6 +1042,8 @@ assert_workflow "untrusted policy test cannot write pull requests" \
   head_tests_cannot_write_pull_requests
 assert_workflow "command substitutions cannot double-publish a status" \
   command_substitutions_disarm_the_err_trap
+assert_workflow "gate diff is bound to immutable event SHAs" \
+  gate_uses_immutable_diff
 
 if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' 2>/dev/null; then
   assert_workflow "gate workflows are valid YAML" gate_workflows_are_valid_yaml

--- a/.github/scripts/darwin-verification-gate_test.sh
+++ b/.github/scripts/darwin-verification-gate_test.sh
@@ -72,9 +72,13 @@ case "$*" in
       echo "label API failed" >&2
       exit "$MOCK_LABEL_STATUS"
     fi
-    if [ "$MOCK_HAS_LABEL" = "true" ]; then
-      printf '%s\n' darwin-e2e-verified
-    fi
+    # Anything other than true/false is emitted verbatim as the live label set,
+    # so a case can pin that only an exact match counts as verification.
+    case "$MOCK_HAS_LABEL" in
+      true) printf '%s\n' darwin-e2e-verified ;;
+      false) ;;
+      *) printf '%s\n' "$MOCK_HAS_LABEL" ;;
+    esac
     ;;
   *)
     echo "Unexpected gh api call: $*" >&2
@@ -389,6 +393,22 @@ run_case "verified-label prefix does not count as the verified label" \
   path=entitlements.plist has_label=true \
   exit=0 state=none label_query=false decision=ignored \
   output="existing head-SHA status remains authoritative"
+
+# The live-label read is the only path that can publish a green status, so a
+# label that merely contains the verified name must not satisfy it.
+run_case "a live label that only contains the verified name is not a match" \
+  action=labeled label=darwin-e2e-verified head_repo=contributor/fork \
+  path=entitlements.plist has_label=darwin-e2e-verified-2 \
+  exit=1 state=failure label_query=true decision=failure \
+  output="not currently present"
+
+run_case "the verified label counts among several live labels" \
+  action=labeled label=darwin-e2e-verified head_repo=contributor/fork \
+  path=entitlements.plist has_label='triage
+darwin-e2e-verified
+needs-review' \
+  exit=0 state=success label_query=true decision=success \
+  output="verified locally"
 
 # --- path matching -----------------------------------------------------------
 

--- a/.github/scripts/darwin-verification-gate_test.sh
+++ b/.github/scripts/darwin-verification-gate_test.sh
@@ -15,6 +15,10 @@ workflow="$repo_root/.github/workflows/darwin-verification-gate.yml"
 policy_test_workflow="$repo_root/.github/workflows/darwin-verification-policy-test.yml"
 
 tmpdir=$(mktemp -d)
+
+# Injected into every attacker-controlled field of the synthetic event.
+# A `gh` invocation carrying it means the gate consumed PR-authored text.
+untrusted_token='PRTEXTPOISON9f3a'
 trap 'rm -rf "$tmpdir"' EXIT
 
 failures=0
@@ -123,7 +127,7 @@ case "$*" in
     exit 0
     ;;
   *"/pulls/"*/*)
-    echo "mock: mutable pull request sub-resource is banned: $path" >&2
+    echo "mock: mutable pull request sub-resource is banned: $*" >&2
     exit 92
     ;;
   *"/pulls/"*)
@@ -296,6 +300,8 @@ run_case() {
   local gh_expect=''
   local gh_missing=''
   local expect_label_query=''
+  local pr_number=17
+  local head_tree_sha_override=''
 
   local kv key value
   for kv in "$@"; do
@@ -344,6 +350,8 @@ run_case() {
       gh_expect) gh_expect=$value ;;
       gh_missing) gh_missing=$value ;;
       expect_label_query) expect_label_query=$value ;;
+      pr_number) pr_number=$value ;;
+      head_tree_sha_override) head_tree_sha_override=$value ;;
       *)
         fail "$name: unknown harness key '$key'"
         return
@@ -396,15 +404,24 @@ run_case() {
     --arg actor "$actor" \
     --arg actor_type "$actor_type" \
     --argjson changes "$edited_changes" \
+    --arg poison "$untrusted_token" \
+    --argjson pr_number "$pr_number" \
     '{
       action: $action,
       sender: {login: $actor, type: $actor_type},
       label: {name: $label},
       changes: $changes,
       pull_request: {
-        number: 17,
+        number: $pr_number,
         state: "open",
-        head: {sha: $head, repo: {full_name: $head_repo}},
+        title: ($poison + "-title"),
+        body: ($poison + "-body"),
+        head: {
+          sha: $head,
+          ref: ($poison + "-branch"),
+          label: ($poison + "-label"),
+          repo: {full_name: $head_repo}
+        },
         base: {sha: $base, ref: $base_ref}
       }
     }' > "$event"
@@ -458,7 +475,7 @@ run_case() {
     MOCK_MERGE_BASE_SHA="$merge_base_sha" \
     MOCK_HEAD_SHA="$head_sha" \
     MOCK_BASE_TREE_SHA=$(printf 'da%038x' $((case_id * 2))) \
-    MOCK_HEAD_TREE_SHA=$(printf 'da%038x' $((case_id * 2 + 1))) \
+    MOCK_HEAD_TREE_SHA="${head_tree_sha_override:-$(printf 'da%038x' $((case_id * 2 + 1)))}" \
     MOCK_BASE_TREE_ENTRIES="$base_entries" \
     MOCK_HEAD_TREE_ENTRIES="$head_entries" \
     MOCK_BASE_TREE_TRUNCATED="$base_tree_truncated" \
@@ -556,8 +573,9 @@ run_case() {
     fail "$name: gate passed shell metacharacters to gh"
     ok=0
   fi
-  if [ -n "${CASE_UNTRUSTED_TOKEN:-}" ] &&
-    grep -Fq "$CASE_UNTRUSTED_TOKEN" "$work/gh.log"; then
+  # Every synthetic event carries this token in its title, body, head ref and
+  # head label — all attacker-controlled. None may ever reach the API surface.
+  if grep -Fq "$untrusted_token" "$work/gh.log"; then
     fail "$name: gate consumed untrusted pull request content"
     ok=0
   fi
@@ -595,6 +613,22 @@ func Noop() {}
 legacy_source='// +build darwin
 
 package debugger
+'
+
+# A cgo preamble makes a file platform-dependent with no explicit constraint.
+cgo_source='package debugger
+
+/*
+#cgo darwin LDFLAGS: -framework CoreFoundation
+*/
+import "C"
+'
+
+# A comment that merely mentions cgo must not gate.
+cgo_mention_source='package hub
+
+// The debugger uses #cgo directives on darwin, but this file does not.
+func Noop() {}
 '
 
 # A header long enough that a naive fixed-size prefix read would miss the
@@ -642,6 +676,22 @@ run_case "unsupported event actions publish nothing" \
 # ---------------------------------------------------------------------------
 # Blocker 1 + 5: trigger scope, base binding, SHA-global statuses
 # ---------------------------------------------------------------------------
+
+# Both of these values reach a URL path. Neither is PR-authored, but a
+# malformed one must be refused rather than pasted into a request.
+# jq -e exits 4 when the filter selects nothing; any non-zero exit before a
+# decision is recorded makes the workflow's always() fallback fail the head.
+run_case "a non-numeric pull request number is refused before any API call" \
+  pr_number='"17/../../evil"' \
+  expect_exit=4 expect_states='' expect_decision='' \
+  gh_missing='api'
+
+run_case "a malformed tree SHA is refused before the tree is fetched" \
+  head_entries='["internal/hub/hub.go"]' \
+  head_tree_sha_override='not-a-sha' \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='invalid tree SHA' \
+  gh_missing='/git/trees/'
 
 run_case "a pull request targeting another base is refused outright" \
   base_ref=release-1.x \
@@ -793,6 +843,24 @@ run_case "a legacy // +build constraint gates" \
   blob_contents="$(jq -n --arg src "$legacy_source" '{"0":$src}')" \
   expect_exit=1 expect_states='pending,failure' expect_decision=failure \
   expect_output='internal/hub/legacy.go'
+
+# A cgo preamble is platform-dependent with no explicit build constraint, so a
+# `#cgo darwin` directive must gate on its own.
+run_case "a cgo preamble gates a Go file with no build constraint" \
+  head_entries='["internal/hub/bridge.go"]' \
+  blob_contents="$(jq -n --arg src "$cgo_source" '{"0":$src}')" \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure \
+  expect_output='internal/hub/bridge.go'
+
+run_case "deleting a cgo file still gates" \
+  base_entries='["internal/hub/bridge.go"]' head_entries='[]' \
+  blob_contents="$(jq -n --arg src "$cgo_source" '{"0":$src}')" \
+  expect_exit=1 expect_states='pending,failure' expect_decision=failure
+
+run_case "merely mentioning cgo in prose does not gate" \
+  head_entries='["internal/hub/notes.go"]' \
+  blob_contents="$(jq -n --arg src "$cgo_mention_source" '{"0":$src}')" \
+  expect_exit=0 expect_states='pending,success' expect_decision=success
 
 run_case "an unconstrained Go file does not gate" \
   head_entries='["internal/hub/plain.go"]' \
@@ -1375,13 +1443,23 @@ trusted_workflow_runs_trusted_policy_only() {
 # injection with statuses:write and pull-requests:write. Untrusted values may
 # only enter through `env:`, where they are variables and not code.
 trusted_workflow_never_interpolates_into_run() {
+  # Covers all four shell-bearing forms an expression could reach: a `run:`
+  # block scalar (`|` or `>`), a single-line `run:`, and an `actions/github-script`
+  # `script:` block. `env:`/`concurrency:` interpolation stays allowed — those
+  # do not build a shell word.
   awk '
-    /^ *run: *\|/ {inside = 1; indent = match($0, /[^ ]/); next}
+    /^ *(run|script): *[|>][-+0-9]* *$/ {
+      inside = 1
+      indent = match($0, /[^ ]/)
+      next
+    }
     inside {
       here = match($0, /[^ ]/)
       if ($0 !~ /^ *$/ && here <= indent) {inside = 0}
     }
     inside && /\$\{\{/ {bad = 1}
+    # A single-line `run:`/`script:` value is a shell word on its own line.
+    !inside && /^ *(run|script): *[^|>]/ && /\$\{\{/ {bad = 1}
     END {exit bad ? 1 : 0}
   ' "$workflow"
 }
@@ -1532,6 +1610,19 @@ gate_uses_immutable_diff() {
     ! grep -Eq 'pulls/[^"]*/files' "$gate"
 }
 
+# The "gate never consumes PR-authored text" invariant is only meaningful while
+# the synthetic event actually carries the poison token in every field an
+# attacker controls. An earlier revision gated that check behind a per-case
+# variable no case ever set, making it silently vacuous.
+harness_poisons_every_attacker_controlled_field() {
+  local field
+  for field in title body ref label; do
+    grep -Eq "$field: \(\\\$poison \+" "$0" || return 1
+  done
+  grep -q '\--arg poison "\$untrusted_token"' "$0" &&
+    grep -q 'grep -Fq "\$untrusted_token" "\$work/gh.log"' "$0"
+}
+
 gate_enforces_the_required_base_ref() {
   grep -q "required_base_ref='main'" "$gate" &&
     grep -q 'base_ref" != "\$required_base_ref' "$gate"
@@ -1584,9 +1675,10 @@ gate_publishes_only_from_the_top_level_shell() {
 
   # Backticks, process substitution and explicit grouping subshells all inherit
   # the ERR trap under `set -E` exactly like `$( )` does. The grouping form is
-  # anchored to command position so parentheses inside regexes and message
-  # strings — of which this script has many — are not false positives.
-  local banned='`|<\(|>\(|(^|[;&|{] *)\([ \t]*[a-z_]'
+  # anchored to command position — line start, after a separator, or after a
+  # block keyword — so parentheses inside regexes and message strings, of which
+  # this script has many, are not false positives.
+  local banned='`|<\(|>\(|((^|[;&|{])[ \t]*|(^|[ \t;&|{])[ \t]*(then|else|do|elif|in)[ \t]+)\([ \t]*[A-Za-z_$]'
   if grep -Eq "$banned" "$region"; then
     printf 'banned subshell form in the ERR-trap region:\n' >&2
     grep -En "$banned" "$region" >&2
@@ -1616,6 +1708,8 @@ check "trusted workflow has no job scope override" \
 check "trusted workflow subscribes to gated actions" \
   trusted_subscribes_to_gated_actions
 check "gate uses immutable diff" gate_uses_immutable_diff
+check "harness poisons every attacker controlled field" \
+  harness_poisons_every_attacker_controlled_field
 check "gate covers every go/build native extension" \
   gate_covers_every_go_build_extension
 check "trusted workflow runs trusted policy only" trusted_workflow_runs_trusted_policy_only

--- a/.github/scripts/darwin-verification-gate_test.sh
+++ b/.github/scripts/darwin-verification-gate_test.sh
@@ -42,6 +42,14 @@ case "$*" in
         context=*) context=${arg#context=} ;;
       esac
     done
+    # Only successfully published statuses are logged, so the log is an exact
+    # record of what GitHub would show on the head SHA.
+    for failing in ${MOCK_STATUS_FAIL_STATES:-}; do
+      if [ "$failing" = "$state" ]; then
+        echo "status API failed for state $state" >&2
+        exit 1
+      fi
+    done
     printf '%s|%s|%s\n' "$endpoint" "$state" "$context" >> "$MOCK_STATUS_LOG"
     ;;
   *"/pulls/"*"/files?"*)
@@ -49,7 +57,15 @@ case "$*" in
       echo "diff API failed" >&2
       exit "$MOCK_DIFF_STATUS"
     fi
-    jq -n --arg filename "$MOCK_CHANGED_PATH" '[[{filename: $filename}]]'
+    # `--slurp` yields one array per fetched page; the gate must flatten them.
+    jq -n \
+      --argjson filenames "$MOCK_CHANGED_PATHS_JSON" \
+      --argjson pages "$MOCK_PAGES" '
+        [$filenames[] | {filename: .}] as $files
+        | ((($files | length) + $pages - 1) / $pages | floor) as $size
+        | [range(0; $pages) | $files[(. * $size):((. + 1) * $size)]]
+        | map(select(length > 0))
+      '
     ;;
   *"/issues/"*"/labels?"*)
     if [ "$MOCK_LABEL_STATUS" -ne 0 ]; then
@@ -70,47 +86,88 @@ chmod +x "$tmpdir/bin/gh"
 
 case_count=0
 
+fail_case() {
+  printf 'not ok - %s\n' "$1" >&2
+  shift
+  if [ "$#" -gt 0 ]; then
+    printf '%s\n' "$@" >&2
+  fi
+  exit 1
+}
+
+# run_case NAME key=value...
+#
+# Keys: action, label, head_repo, path, paths_json, pages, has_label,
+# edit_status, diff_status, label_status, status_fail, declared_files,
+# exit, state, states, output, label_query, decision, gh_contains, gh_missing.
 run_case() {
   local name=$1
-  local action=$2
-  local event_label=$3
-  local head_repository=$4
-  local changed_path=$5
-  local has_label=$6
-  local edit_status=$7
-  local expected_exit=$8
-  local expected_state=$9
-  local expected_output=${10}
-  local expected_label_query=${11}
-  local diff_status=${12:-0}
-  local label_status=${13:-0}
-  local declared_changed_files=${14:-}
-  local case_id
-  local event_path
-  local gh_log
-  local status_log
+  shift
+
+  local action=opened label='' head_repo=contributor/fork
+  local path=entitlements.plist paths_json='' pages=1
+  local has_label=false edit_status=0 diff_status=0 label_status=0
+  local status_fail='' declared_files='' expect_exit=0 expect_state=none
+  local expect_states=''
+  local expect_output='' expect_label_query=any expect_decision=''
+  local gh_contains='' gh_missing=''
+  local kv key value
+
+  for kv in "$@"; do
+    key=${kv%%=*}
+    value=${kv#*=}
+    case "$key" in
+      action) action=$value ;;
+      label) label=$value ;;
+      head_repo) head_repo=$value ;;
+      path) path=$value ;;
+      paths_json) paths_json=$value ;;
+      pages) pages=$value ;;
+      has_label) has_label=$value ;;
+      edit_status) edit_status=$value ;;
+      diff_status) diff_status=$value ;;
+      label_status) label_status=$value ;;
+      status_fail) status_fail=$value ;;
+      declared_files) declared_files=$value ;;
+      exit) expect_exit=$value ;;
+      state) expect_state=$value ;;
+      states) expect_states=$value ;;
+      output) expect_output=$value ;;
+      label_query) expect_label_query=$value ;;
+      decision) expect_decision=$value ;;
+      gh_contains) gh_contains=$value ;;
+      gh_missing) gh_missing=$value ;;
+      *) fail_case "$name" "unknown run_case key: $key" ;;
+    esac
+  done
+
+  case_count=$((case_count + 1))
+  local case_id=$case_count
+  local event_path="$tmpdir/event-$case_id.json"
+  local gh_log="$tmpdir/gh-$case_id.log"
+  local status_log="$tmpdir/status-$case_id.log"
+  local decision_file="$tmpdir/decision-$case_id.txt"
   local head_sha
+  head_sha=$(printf '%040x' "$case_id")
   local output
   local status=0
 
-  case_count=$((case_count + 1))
-  case_id=$case_count
-  event_path="$tmpdir/event-$case_id.json"
-  gh_log="$tmpdir/gh-$case_id.log"
-  status_log="$tmpdir/status-$case_id.log"
-  head_sha=$(printf '%040x' "$case_id")
-  if [ -z "$declared_changed_files" ]; then
-    declared_changed_files=$(printf '%s\n' "$changed_path" | wc -l | tr -d ' ')
+  if [ -z "$paths_json" ]; then
+    paths_json=$(jq -n --arg path "$path" '[$path]')
+  fi
+  if [ -z "$declared_files" ]; then
+    declared_files=$(jq -n --argjson paths "$paths_json" '$paths | length')
   fi
   : > "$gh_log"
   : > "$status_log"
+  rm -f "$decision_file"
 
   jq -n \
     --arg action "$action" \
-    --arg event_label "$event_label" \
-    --arg head_repository "$head_repository" \
+    --arg event_label "$label" \
+    --arg head_repository "$head_repo" \
     --arg head_sha "$head_sha" \
-    --argjson changed_files "$declared_changed_files" \
+    --argjson changed_files "$declared_files" \
     '{
       action: $action,
       label: {name: $event_label},
@@ -127,13 +184,16 @@ run_case() {
       GITHUB_REPOSITORY=bingosuite/bingo \
       GITHUB_SERVER_URL=https://github.com \
       GITHUB_RUN_ID=123 \
+      DARWIN_GATE_DECISION_FILE="$decision_file" \
       MOCK_GH_LOG="$gh_log" \
       MOCK_STATUS_LOG="$status_log" \
-      MOCK_CHANGED_PATH="$changed_path" \
+      MOCK_CHANGED_PATHS_JSON="$paths_json" \
+      MOCK_PAGES="$pages" \
       MOCK_HAS_LABEL="$has_label" \
       MOCK_EDIT_STATUS="$edit_status" \
       MOCK_DIFF_STATUS="$diff_status" \
       MOCK_LABEL_STATUS="$label_status" \
+      MOCK_STATUS_FAIL_STATES="$status_fail" \
       DARWIN_NATIVE_REGEX='^never-match$' \
       VERIFIED_LABEL=attacker-controlled \
       EVENT_ACTION=opened \
@@ -147,47 +207,75 @@ run_case() {
       bash "$gate" 2>&1
   ) || status=$?
 
-  if [ "$status" -ne "$expected_exit" ]; then
-    printf 'not ok - %s (status %s, expected %s)\n%s\n' \
-      "$name" "$status" "$expected_exit" "$output" >&2
-    exit 1
+  if [ "$status" -ne "$expect_exit" ]; then
+    fail_case "$name" "status $status, expected $expect_exit" "$output"
   fi
 
-  if ! grep -Fq "$expected_output" <<< "$output"; then
-    printf 'not ok - %s (missing output: %s)\n%s\n' \
-      "$name" "$expected_output" "$output" >&2
-    exit 1
+  if [ -n "$expect_output" ] && ! grep -Fq -- "$expect_output" <<< "$output"; then
+    fail_case "$name" "missing output: $expect_output" "$output"
   fi
 
   if grep -Eq 'attacker-controlled|attacker/repository| 999 ' "$gh_log"; then
-    printf 'not ok - %s (hostile environment reached gh)\n' "$name" >&2
-    exit 1
+    fail_case "$name" "hostile environment reached gh" "$(cat "$gh_log")"
   fi
 
-  if [ "$expected_label_query" = "true" ] &&
+  if [ "$expect_label_query" = "true" ] &&
     ! grep -Fq "/issues/17/labels?" "$gh_log"; then
-    printf 'not ok - %s (expected live label query)\n' "$name" >&2
-    exit 1
+    fail_case "$name" "expected live label query" "$(cat "$gh_log")"
   fi
 
-  if [ "$expected_label_query" = "false" ] &&
+  if [ "$expect_label_query" = "false" ] &&
     grep -Fq "/issues/17/labels?" "$gh_log"; then
-    printf 'not ok - %s (unexpected live label query)\n' "$name" >&2
-    exit 1
+    fail_case "$name" "unexpected live label query" "$(cat "$gh_log")"
   fi
 
-  if [ "$expected_state" = "none" ]; then
+  if [ -n "$gh_contains" ] && ! grep -Fq -- "$gh_contains" "$gh_log"; then
+    fail_case "$name" "expected gh call: $gh_contains" "$(cat "$gh_log")"
+  fi
+
+  if [ -n "$gh_missing" ] && grep -Fq -- "$gh_missing" "$gh_log"; then
+    fail_case "$name" "unexpected gh call: $gh_missing" "$(cat "$gh_log")"
+  fi
+
+  if [ "$expect_state" = "none" ]; then
     if [ -s "$status_log" ]; then
-      printf 'not ok - %s (unexpected head status)\n' "$name" >&2
-      exit 1
+      fail_case "$name" "unexpected head status" "$(cat "$status_log")"
     fi
   else
-    expected_status="repos/bingosuite/bingo/statuses/$head_sha|$expected_state|Darwin E2E verified"
+    local expected_status="repos/bingosuite/bingo/statuses/$head_sha|$expect_state|Darwin E2E verified"
     if [ "$(tail -n 1 "$status_log")" != "$expected_status" ]; then
-      printf 'not ok - %s (missing head-SHA status: %s)\n' \
-        "$name" "$expected_status" >&2
-      cat "$status_log" >&2
-      exit 1
+      fail_case "$name" "missing head-SHA status: $expected_status" \
+        "$(cat "$status_log")"
+    fi
+  fi
+
+  # Assert the exact published sequence, not just the terminal status: the head
+  # must move `pending` -> decision, and nothing may follow a decision.
+  local want_states=$expect_states
+  if [ -z "$want_states" ]; then
+    if [ "$expect_state" = "none" ]; then
+      want_states=''
+    else
+      want_states="pending,$expect_state"
+    fi
+  fi
+  [ "$want_states" = "none" ] && want_states=''
+  local actual_states
+  actual_states=$(cut -d'|' -f2 "$status_log" | paste -sd, -)
+  if [ "$actual_states" != "$want_states" ]; then
+    fail_case "$name" "status sequence '$actual_states', expected '$want_states'" \
+      "$(cat "$status_log")"
+  fi
+
+  local decision=''
+  if [ -f "$decision_file" ]; then
+    decision=$(tr -d '\n' < "$decision_file")
+  fi
+  if [ -n "$expect_decision" ]; then
+    local want=$expect_decision
+    [ "$want" = "none" ] && want=''
+    if [ "$decision" != "$want" ]; then
+      fail_case "$name" "decision '$decision', expected '$want'"
     fi
   fi
 
@@ -200,63 +288,191 @@ printf '%s\n' 'jobs: {gate: {steps: [{run: "exit 0"}]}}' \
 printf '%s\n' '#!/usr/bin/env bash' 'exit 0' \
   > "$tmpdir/hostile-head/.github/scripts/darwin-verification-gate.sh"
 
-run_case \
-  "fork workflow exit 0 cannot bypass trusted synchronize" \
-  synchronize "" contributor/fork internal/debugger/backend_darwin_arm64.go \
-  true 1 1 failure "public-fork GITHUB_TOKEN could not remove" false
-run_case \
-  "same-repository synchronize fails current head" \
-  synchronize "" bingosuite/bingo entitlements.plist \
-  false 0 1 failure "re-verification required" false
-run_case \
-  "reopened pull request fails current head" \
-  reopened "" contributor/fork entitlements.plist \
-  true 1 1 failure "re-verification required" false
-run_case \
-  "verified label publishes success to current head" \
-  labeled darwin-e2e-verified contributor/fork \
-  test/integration/debugger_e2e_darwin_arm64_test.go \
-  true 0 0 success "verified locally" true
-run_case \
-  "verified label removal publishes failure" \
-  unlabeled darwin-e2e-verified contributor/fork internal/debugger/trap_arm64.go \
-  false 0 1 failure "not currently present" true
-run_case \
-  "re-added verified label survives delayed unlabel event" \
-  unlabeled darwin-e2e-verified contributor/fork internal/debugger/trap_arm64.go \
-  true 0 0 success "verified locally" true
-run_case \
-  "unrelated label leaves prior status untouched" \
-  labeled triage contributor/fork entitlements.plist \
-  true 0 0 none "existing head-SHA status remains authoritative" false
-run_case \
-  "unrelated unlabel leaves prior status untouched" \
-  unlabeled triage contributor/fork entitlements.plist \
-  true 0 0 none "existing head-SHA status remains authoritative" false
-run_case \
-  "non-Darwin synchronize publishes success" \
-  synchronize "" contributor/fork internal/debugger/engine.go \
-  true 1 0 success "No darwin-native code changed" false
-run_case \
-  "opened Darwin change publishes failure" \
-  opened "" contributor/fork entitlements.plist \
-  false 0 1 failure "verification required" false
-run_case \
-  "near-match outside regex publishes success" \
-  opened "" contributor/fork docs/backend_darwin_arm64.go \
-  false 0 0 success "No darwin-native code changed" false
-run_case \
-  "diff API failure replaces pending with failure" \
-  opened "" contributor/fork entitlements.plist \
-  false 0 1 failure "diff API failed" false 1
-run_case \
-  "truncated PR files response fails closed" \
-  opened "" contributor/fork docs/readme.md \
-  false 0 1 failure "refusing an incomplete gate decision" false 0 0 3001
-run_case \
-  "newline filename cannot hide truncated response" \
-  opened "" contributor/fork $'000-padding\nextra-line' \
-  false 0 1 failure "returned 1 of 2 changed files" false 0 0 2
+# --- synchronize / reopened: always unverify the new head --------------------
+
+run_case "fork workflow exit 0 cannot bypass trusted synchronize" \
+  action=synchronize head_repo=contributor/fork \
+  path=internal/debugger/backend_darwin_arm64.go has_label=true edit_status=1 \
+  exit=1 state=failure label_query=false decision=failure \
+  output="public-fork GITHUB_TOKEN could not remove"
+
+run_case "same-repository synchronize fails current head" \
+  action=synchronize head_repo=bingosuite/bingo path=entitlements.plist \
+  exit=1 state=failure label_query=false decision=failure \
+  gh_contains="pr edit 17" output="re-verification required"
+
+run_case "same-repository cleanup denial warns without fork wording" \
+  action=synchronize head_repo=bingosuite/bingo path=entitlements.plist \
+  has_label=true edit_status=1 \
+  exit=1 state=failure label_query=false decision=failure \
+  output="The API could not remove"
+
+run_case "successful cleanup omits the stale-label recovery hint" \
+  action=synchronize head_repo=contributor/fork path=entitlements.plist \
+  has_label=true edit_status=0 \
+  exit=1 state=failure label_query=false decision=failure \
+  gh_contains="--remove-label darwin-e2e-verified" \
+  output="then add the 'darwin-e2e-verified' label to verify this head"
+
+run_case "reopened pull request fails current head" \
+  action=reopened head_repo=contributor/fork path=entitlements.plist \
+  has_label=true edit_status=1 \
+  exit=1 state=failure label_query=false decision=failure \
+  output="re-verification required"
+
+run_case "synchronize with a live verified label still fails closed" \
+  action=synchronize head_repo=contributor/fork \
+  path=internal/debugger/trap_arm64.go has_label=true edit_status=0 \
+  exit=1 state=failure label_query=false decision=failure \
+  output="re-verification required"
+
+# --- opened ------------------------------------------------------------------
+
+run_case "opened Darwin change publishes failure" \
+  action=opened head_repo=contributor/fork path=entitlements.plist \
+  exit=1 state=failure label_query=false decision=failure \
+  gh_missing="pr edit" output="verification required"
+
+run_case "opened Darwin change ignores a pre-existing label" \
+  action=opened head_repo=contributor/fork path=entitlements.plist \
+  has_label=true \
+  exit=1 state=failure label_query=false decision=failure \
+  output="verification required"
+
+# --- verified label add / remove ---------------------------------------------
+
+run_case "verified label publishes success to current head" \
+  action=labeled label=darwin-e2e-verified head_repo=contributor/fork \
+  path=test/integration/debugger_e2e_darwin_arm64_test.go has_label=true \
+  exit=0 state=success label_query=true decision=success \
+  gh_missing="pr edit" output="verified locally"
+
+run_case "verified label removal publishes failure" \
+  action=unlabeled label=darwin-e2e-verified head_repo=contributor/fork \
+  path=internal/debugger/trap_arm64.go has_label=false \
+  exit=1 state=failure label_query=true decision=failure \
+  output="not currently present"
+
+run_case "re-added verified label survives delayed unlabel event" \
+  action=unlabeled label=darwin-e2e-verified head_repo=contributor/fork \
+  path=internal/debugger/trap_arm64.go has_label=true \
+  exit=0 state=success label_query=true decision=success \
+  output="verified locally"
+
+run_case "removed verified label defeats a delayed label event" \
+  action=labeled label=darwin-e2e-verified head_repo=contributor/fork \
+  path=internal/debugger/trap_arm64.go has_label=false \
+  exit=1 state=failure label_query=true decision=failure \
+  output="not currently present"
+
+run_case "live label API failure fails closed" \
+  action=labeled label=darwin-e2e-verified head_repo=contributor/fork \
+  path=entitlements.plist has_label=true label_status=1 \
+  exit=1 state=failure decision=failure output="label API failed"
+
+# --- unrelated labels --------------------------------------------------------
+
+run_case "unrelated label leaves prior status untouched" \
+  action=labeled label=triage head_repo=contributor/fork \
+  path=entitlements.plist has_label=true \
+  exit=0 state=none label_query=false decision=ignored \
+  gh_missing="statuses/" output="existing head-SHA status remains authoritative"
+
+run_case "unrelated unlabel leaves prior status untouched" \
+  action=unlabeled label=triage head_repo=contributor/fork \
+  path=entitlements.plist has_label=true \
+  exit=0 state=none label_query=false decision=ignored \
+  output="existing head-SHA status remains authoritative"
+
+run_case "verified-label prefix does not count as the verified label" \
+  action=labeled label=darwin-e2e-verified-2 head_repo=contributor/fork \
+  path=entitlements.plist has_label=true \
+  exit=0 state=none label_query=false decision=ignored \
+  output="existing head-SHA status remains authoritative"
+
+# --- path matching -----------------------------------------------------------
+
+run_case "non-Darwin synchronize publishes success" \
+  action=synchronize head_repo=contributor/fork path=internal/debugger/engine.go \
+  has_label=true edit_status=1 \
+  exit=0 state=success label_query=false decision=success \
+  output="No darwin-native code changed"
+
+run_case "near-match outside regex publishes success" \
+  action=opened head_repo=contributor/fork path=docs/backend_darwin_arm64.go \
+  exit=0 state=success label_query=false decision=success \
+  output="No darwin-native code changed"
+
+run_case "one Darwin file among many still gates" \
+  action=opened head_repo=contributor/fork \
+  paths_json='["README.md","internal/hub/hub.go","internal/debugger/backend_darwin_arm64.go","docs/x.md"]' \
+  exit=1 state=failure decision=failure output="verification required"
+
+# --- PR files API integrity --------------------------------------------------
+
+run_case "paginated file list is flattened and gated" \
+  action=opened head_repo=contributor/fork \
+  paths_json='["a.md","b.md","c.md","entitlements.plist"]' pages=2 \
+  exit=1 state=failure decision=failure output="verification required"
+
+run_case "paginated non-Darwin file list publishes success" \
+  action=opened head_repo=contributor/fork \
+  paths_json='["a.md","b.md","c.md","d.md","e.md","f.md"]' pages=3 \
+  exit=0 state=success decision=success output="No darwin-native code changed"
+
+run_case "truncated PR files response fails closed" \
+  action=opened head_repo=contributor/fork path=docs/readme.md \
+  declared_files=3001 \
+  exit=1 state=failure decision=failure \
+  output="refusing an incomplete gate decision"
+
+run_case "newline filename cannot hide truncated response" \
+  action=opened head_repo=contributor/fork path=$'000-padding\nextra-line' \
+  declared_files=2 \
+  exit=1 state=failure decision=failure output="returned 1 of 2 changed files"
+
+run_case "over-reported file list also fails closed" \
+  action=opened head_repo=contributor/fork \
+  paths_json='["a.md","b.md"]' declared_files=1 \
+  exit=1 state=failure decision=failure \
+  output="refusing an incomplete gate decision"
+
+run_case "diff API failure replaces pending with failure" \
+  action=opened head_repo=contributor/fork path=entitlements.plist \
+  diff_status=1 \
+  exit=1 state=failure decision=failure output="diff API failed"
+
+# --- status API failures -----------------------------------------------------
+
+# A pending POST that fails aborts before any evaluation; the ERR trap still
+# publishes an explicit failure to the head.
+run_case "pending status failure still fails the head closed" \
+  action=opened head_repo=contributor/fork path=entitlements.plist \
+  status_fail=pending \
+  exit=1 state=failure states=failure decision=failure \
+  output="status API failed for state pending"
+
+# When even the fail-closed POST cannot be delivered, no decision is recorded and
+# the workflow guard step takes over.
+run_case "unpublishable failure records no decision" \
+  action=opened head_repo=contributor/fork path=entitlements.plist \
+  status_fail=failure \
+  exit=1 state=pending states=pending decision=none \
+  output="status API failed for state failure"
+
+# A success POST that fails must degrade to failure, never to silence.
+run_case "unpublishable success degrades to failure" \
+  action=synchronize head_repo=contributor/fork path=internal/hub/hub.go \
+  status_fail=success \
+  exit=1 state=failure states=pending,failure decision=failure \
+  output="status API failed for state success"
+
+# --- unsupported actions -----------------------------------------------------
+
+run_case "unsupported action refuses to decide" \
+  action=edited head_repo=contributor/fork path=entitlements.plist \
+  exit=2 state=none decision=none gh_missing="statuses/" \
+  output="Unsupported pull_request_target action: edited"
 
 run_status_persistence_sequence() {
   local name=$1
@@ -315,7 +531,8 @@ run_status_persistence_sequence() {
     GITHUB_REPOSITORY=bingosuite/bingo \
     MOCK_GH_LOG="$gh_log" \
     MOCK_STATUS_LOG="$status_log" \
-    MOCK_CHANGED_PATH=entitlements.plist \
+    MOCK_CHANGED_PATHS_JSON='["entitlements.plist"]' \
+    MOCK_PAGES=1 \
     MOCK_HAS_LABEL="$first_has_label" \
     MOCK_EDIT_STATUS="$first_edit_status" \
     MOCK_DIFF_STATUS=0 \
@@ -327,7 +544,8 @@ run_status_persistence_sequence() {
     GITHUB_REPOSITORY=bingosuite/bingo \
     MOCK_GH_LOG="$gh_log" \
     MOCK_STATUS_LOG="$status_log" \
-    MOCK_CHANGED_PATH=entitlements.plist \
+    MOCK_CHANGED_PATHS_JSON='["entitlements.plist"]' \
+    MOCK_PAGES=1 \
     MOCK_HAS_LABEL=true \
     MOCK_EDIT_STATUS=0 \
     MOCK_DIFF_STATUS=0 \
@@ -336,19 +554,14 @@ run_status_persistence_sequence() {
 
   if [ "$first_status" -ne "$expected_first_exit" ] ||
     [ "$second_status" -ne 0 ]; then
-    printf 'not ok - %s (event statuses %s/%s)\n' \
-      "$name" "$first_status" "$second_status" >&2
-    exit 1
+    fail_case "$name" "event statuses $first_status/$second_status"
   fi
 
   expected_status="repos/bingosuite/bingo/statuses/$head_sha|$expected_state|Darwin E2E verified"
   if [ "$(wc -l < "$status_log" | tr -d ' ')" -ne 2 ] ||
     [ "$(tail -n 1 "$status_log")" != "$expected_status" ]; then
-    printf 'not ok - %s (unrelated label changed the SHA-bound status)\n' \
-      "$name" >&2
-    cat "$status_log" >&2
-    cat "$gh_log" >&2
-    exit 1
+    fail_case "$name" "unrelated label changed the SHA-bound status" \
+      "$(cat "$status_log")" "$(cat "$gh_log")"
   fi
 
   printf 'ok - %s\n' "$name"
@@ -361,43 +574,112 @@ run_status_persistence_sequence \
   "verified head plus unrelated label preserves success" \
   labeled darwin-e2e-verified true 0 success 0
 
-case_count=$((case_count + 1))
-if ! grep -Eq '^[[:space:]]+pull_request_target:' "$trusted_workflow" ||
-  grep -Eq '^[[:space:]]+pull_request:' "$trusted_workflow"; then
-  echo "not ok - trusted workflow is base-controlled pull_request_target only" >&2
-  exit 1
-fi
-echo "ok - trusted workflow is base-controlled pull_request_target only"
+# Workflow invariants are asserted through named predicates rather than an
+# `eval`'d string so the checks stay statically analysable.
+assert_workflow() {
+  local name=$1
+  shift
 
-case_count=$((case_count + 1))
-if ! grep -Fq 'ref: ${{ github.event.pull_request.base.sha }}' "$trusted_workflow" ||
-  grep -Fq 'github.event.pull_request.head.sha }}' "$trusted_workflow"; then
-  echo "not ok - trusted workflow checks out only the base policy" >&2
-  exit 1
-fi
-echo "ok - trusted workflow checks out only the base policy"
+  case_count=$((case_count + 1))
+  if ! "$@"; then
+    fail_case "$name" "workflow invariant not satisfied"
+  fi
+  printf 'ok - %s\n' "$name"
+}
 
-case_count=$((case_count + 1))
-if ! grep -Eq '^[[:space:]]+pull_request:' "$head_test_workflow" ||
-  ! grep -Fq 'bash .github/scripts/darwin-verification-gate_test.sh' "$head_test_workflow"; then
-  echo "not ok - unprivileged pull_request workflow tests proposed HEAD policy" >&2
-  exit 1
-fi
-echo "ok - unprivileged pull_request workflow tests proposed HEAD policy"
+trusted_is_base_controlled() {
+  grep -Eq '^[[:space:]]+pull_request_target:' "$trusted_workflow" &&
+    ! grep -Eq '^[[:space:]]+pull_request:' "$trusted_workflow"
+}
 
-case_count=$((case_count + 1))
-if grep -Fq 'Darwin E2E verified' "$head_test_workflow"; then
-  echo "not ok - untrusted policy test can collide with required status context" >&2
-  exit 1
-fi
-echo "ok - untrusted policy test has a distinct check name"
+# GitHub Actions '${{ }}' expressions are matched literally, not expanded.
+# shellcheck disable=SC2016
+trusted_checks_out_base_only() {
+  grep -Fq 'ref: ${{ github.event.pull_request.base.sha }}' "$trusted_workflow" &&
+    ! grep -Fq 'github.event.pull_request.head.sha }}' "$trusted_workflow"
+}
 
-case_count=$((case_count + 1))
-if ! grep -Fq 'statuses: write' "$trusted_workflow" ||
-  grep -Eq 'statuses:[[:space:]]*write' "$head_test_workflow"; then
-  echo "not ok - only the trusted workflow may publish commit statuses" >&2
-  exit 1
+trusted_subscribes_to_gated_actions() {
+  grep -Fq 'types: [opened, synchronize, reopened, labeled, unlabeled]' \
+    "$trusted_workflow"
+}
+
+# Cancelling a run between its pending and final status can strand the required
+# head status on pending, so superseding must only ever drop still-queued runs.
+trusted_never_cancels_in_progress() {
+  ! grep -Eq 'cancel-in-progress:[[:space:]]*true' "$trusted_workflow" &&
+    grep -Eq 'cancel-in-progress:[[:space:]]*false' "$trusted_workflow"
+}
+
+unrelated_labels_are_isolated() {
+  grep -Fq "format('unrelated-{0}', github.run_id)" "$trusted_workflow" &&
+    grep -Fq "github.event.label.name != 'darwin-e2e-verified'" "$trusted_workflow"
+}
+
+# GitHub Actions '${{ }}' expressions are matched literally, not expanded.
+# shellcheck disable=SC2016
+gating_events_share_one_group() {
+  grep -Fq 'darwin-verification-${{ github.event.pull_request.number }}' \
+    "$trusted_workflow"
+}
+
+trusted_fails_closed_without_decision() {
+  grep -Fq 'if: always()' "$trusted_workflow" &&
+    grep -Fq 'DARWIN_GATE_DECISION_FILE' "$trusted_workflow" &&
+    grep -Fq 'Darwin verification gate ended without a decision.' "$trusted_workflow"
+}
+
+head_tests_run_proposed_policy() {
+  grep -Eq '^[[:space:]]+pull_request:' "$head_test_workflow" &&
+    grep -Fq 'bash .github/scripts/darwin-verification-gate_test.sh' \
+      "$head_test_workflow"
+}
+
+head_tests_use_a_distinct_check_name() {
+  ! grep -Fq 'Darwin E2E verified' "$head_test_workflow"
+}
+
+only_trusted_publishes_statuses() {
+  grep -Fq 'statuses: write' "$trusted_workflow" &&
+    ! grep -Eq 'statuses:[[:space:]]*write' "$head_test_workflow"
+}
+
+head_tests_cannot_write_pull_requests() {
+  ! grep -Eq 'pull-requests:[[:space:]]*write' "$head_test_workflow"
+}
+
+gate_workflows_are_valid_yaml() {
+  python3 -c 'import sys, yaml
+for path in sys.argv[1:]:
+    with open(path) as handle:
+        yaml.safe_load(handle)' "$trusted_workflow" "$head_test_workflow"
+}
+
+assert_workflow "trusted workflow is base-controlled pull_request_target only" \
+  trusted_is_base_controlled
+assert_workflow "trusted workflow checks out only the base policy" \
+  trusted_checks_out_base_only
+assert_workflow "trusted workflow subscribes to every gated action" \
+  trusted_subscribes_to_gated_actions
+assert_workflow "trusted workflow never cancels a run in progress" \
+  trusted_never_cancels_in_progress
+assert_workflow "unrelated label events cannot supersede a gating run" \
+  unrelated_labels_are_isolated
+assert_workflow "gating events share one per-pull-request concurrency group" \
+  gating_events_share_one_group
+assert_workflow "trusted workflow fails closed without a published decision" \
+  trusted_fails_closed_without_decision
+assert_workflow "unprivileged pull_request workflow tests proposed HEAD policy" \
+  head_tests_run_proposed_policy
+assert_workflow "untrusted policy test has a distinct check name" \
+  head_tests_use_a_distinct_check_name
+assert_workflow "only the trusted workflow may publish commit statuses" \
+  only_trusted_publishes_statuses
+assert_workflow "untrusted policy test cannot write pull requests" \
+  head_tests_cannot_write_pull_requests
+
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' 2>/dev/null; then
+  assert_workflow "gate workflows are valid YAML" gate_workflows_are_valid_yaml
 fi
-echo "ok - only the trusted workflow may publish commit statuses"
 
 printf '1..%s\n' "$case_count"

--- a/.github/workflows/darwin-verification-gate.yml
+++ b/.github/workflows/darwin-verification-gate.yml
@@ -37,11 +37,6 @@ jobs:
     timeout-minutes: 5
     env:
       GH_TOKEN: ${{ github.token }}
-      VERIFIED_LABEL: darwin-e2e-verified
-      # Paths whose runtime behaviour only runs on real darwin/arm64 hardware and
-      # therefore can't be exercised by any CI job. Keep in sync with the darwin
-      # files under internal/debugger, the darwin E2E spec, and entitlements.
-      DARWIN_NATIVE_REGEX: '^(internal/debugger/.*_darwin_.*|internal/debugger/trap_arm64\.go|test/integration/.*_darwin_.*_test\.go|entitlements\.plist)$'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -54,63 +49,15 @@ jobs:
           if [ -r .github/scripts/darwin-verification-gate_test.sh ]; then
             bash .github/scripts/darwin-verification-gate_test.sh
           else
-            echo "Trusted base predates the gate script; the gate step will use its fail-closed bootstrap."
-          fi
-
-      - name: Remove stale verification label on new commits
-        id: stale-verification
-        if: github.event.action == 'synchronize'
-        env:
-          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-          if output=$(gh pr edit "$PR_NUMBER" --repo "$REPOSITORY" \
-            --remove-label "$VERIFIED_LABEL" 2>&1); then
-            echo "status=cleared" >> "$GITHUB_OUTPUT"
-            echo "Cleared '$VERIFIED_LABEL' if present — new commits require re-verification."
-          else
-            exit_code=$?
-            echo "status=failed" >> "$GITHUB_OUTPUT"
-            if [ "$IS_FORK" = "true" ]; then
-              echo "::warning title=Stale Darwin verification label not removed::The public-fork GITHUB_TOKEN is read-only, so '$VERIFIED_LABEL' could not be removed (exit $exit_code). The gate will fail closed; remove or toggle the stale label, then re-add it to verify this head."
-            else
-              echo "::warning title=Stale Darwin verification label not removed::The API failed to remove '$VERIFIED_LABEL' (exit $exit_code). The gate will fail closed; remove or toggle the stale label, then re-add it to verify this head."
-            fi
-            printf '%s\n' "$output" >&2
+            echo "Trusted base predates the gate script; the gate will fail closed."
           fi
 
       - name: Require local darwin E2E verification when darwin-native code changes
-        env:
-          EVENT_ACTION: ${{ github.event.action }}
-          LABEL_CLEANUP: ${{ steps.stale-verification.outputs.status }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          gh pr diff "$PR_NUMBER" --repo "$REPOSITORY" --name-only > changed.txt
-
           if [ ! -r .github/scripts/darwin-verification-gate.sh ]; then
-            echo "Changed files in this PR:"
-            sed 's/^/  /' changed.txt
-            echo
-            if grep -Eq "$DARWIN_NATIVE_REGEX" changed.txt; then
-              echo "::error title=Darwin E2E verification policy unavailable::The trusted base does not contain the gate script, so this Darwin-native change fails closed."
-              exit 1
-            fi
-            echo "No darwin-native code changed; gate not required."
-            exit 0
+            echo "::error title=Darwin E2E verification policy unavailable::The trusted base does not contain the gate script, so the gate cannot safely evaluate this pull request."
+            exit 1
           fi
 
-          has_label=
-          if [ "$EVENT_ACTION" != "synchronize" ]; then
-            has_label=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json labels \
-              -q "[.labels[].name] | any(. == \"$VERIFIED_LABEL\")")
-          fi
-
-          EVENT_ACTION="$EVENT_ACTION" \
-            CHANGED_FILES=changed.txt \
-            HAS_VERIFIED_LABEL="$has_label" \
-            LABEL_CLEANUP="${LABEL_CLEANUP:-not-run}" \
-            bash .github/scripts/darwin-verification-gate.sh
+          bash .github/scripts/darwin-verification-gate.sh

--- a/.github/workflows/darwin-verification-gate.yml
+++ b/.github/workflows/darwin-verification-gate.yml
@@ -1,62 +1,57 @@
 name: Darwin verification gate
 
-# The darwin/arm64 low-level backend (ptrace + Mach) cannot be *executed* on
-# GitHub-hosted macOS runners: Apple's Sonoma (macOS 14) security model blocks
-# task_for_pid there even with the debugger entitlement, so the real backend
-# never runs in CI (see .github/workflows/debugger-e2e.yml — the darwin E2E jobs
-# only compile + codesign on hosted runners).
+# This workflow is the trusted enforcement path for darwin/arm64 changes that
+# cannot execute on GitHub-hosted runners. `pull_request_target` loads this YAML
+# from the base branch. It checks out only the base SHA policy script, never PR
+# head code, then posts the "Darwin E2E verified" status explicitly to the PR
+# head SHA. The workflow's own check belongs to the base SHA and is not the
+# branch-protection signal.
 #
-# This gate closes that hole with a human-in-the-loop check: when a PR modifies
-# darwin-native code whose runtime behaviour can only be validated on real Apple
-# Silicon, it requires a maintainer to run `just e2e-darwin` locally, confirm it
-# passes, and add the `darwin-e2e-verified` label to the PR. The gate is a
-# no-op (green) for PRs that don't touch that code.
-#
-# On every `synchronize` (new commits pushed), the current head is unverified by
-# definition: a prior verification only covers the commits it was run against.
-# The workflow best-effort removes the stale label for same-repository PRs, but
-# public-fork tokens are read-only and may leave it in place. The synchronize run
-# therefore fails closed without consulting the live label. Removing/toggling
-# and then re-adding the label triggers `unlabeled`/`labeled` runs that evaluate
-# the live label and revalidate the same head without another push.
-# To actually block merges, mark "Darwin E2E verified" as a required status
-# check in branch protection.
+# A separate unprivileged `pull_request` workflow runs the proposed HEAD policy
+# tests. Those tests are useful review feedback but are not enforcement because
+# a fork can modify both that workflow and its test code.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 permissions:
   contents: read
   pull-requests: write
+  statuses: write
+
+concurrency:
+  group: darwin-verification-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
-  darwin-e2e-verified:
-    name: Darwin E2E verified
+  publish-darwin-verification:
+    name: Publish Darwin verification status
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    env:
-      GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out trusted gate policy
+        uses: actions/checkout@v4
         with:
-          # The gate must never execute a fork-modified copy of its own policy.
           ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: .github/scripts/darwin-verification-gate.sh
+          sparse-checkout-cone-mode: false
           persist-credentials: false
 
-      - name: Test Darwin verification gate decision
-        run: |
-          if [ -r .github/scripts/darwin-verification-gate_test.sh ]; then
-            bash .github/scripts/darwin-verification-gate_test.sh
-          else
-            echo "Trusted base predates the gate script; the gate will fail closed."
-          fi
-
-      - name: Require local darwin E2E verification when darwin-native code changes
+      - name: Evaluate and publish Darwin verification
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           if [ ! -r .github/scripts/darwin-verification-gate.sh ]; then
-            echo "::error title=Darwin E2E verification policy unavailable::The trusted base does not contain the gate script, so the gate cannot safely evaluate this pull request."
+            head_sha=$(jq -er '.pull_request.head.sha' "$GITHUB_EVENT_PATH")
+            run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$head_sha" \
+              -f state=failure \
+              -f context='Darwin E2E verified' \
+              -f description='Trusted Darwin verification policy is unavailable.' \
+              -f target_url="$run_url" >/dev/null
+            echo "::error title=Darwin E2E verification policy unavailable::The trusted base does not contain the gate script, so this head fails closed."
             exit 1
           fi
 

--- a/.github/workflows/darwin-verification-gate.yml
+++ b/.github/workflows/darwin-verification-gate.yml
@@ -20,9 +20,18 @@ permissions:
   pull-requests: write
   statuses: write
 
+# Runs are serialized per pull request and are NEVER cancelled. Cancellation
+# terminates the job between the pending status and the final one, and a killed
+# runner cannot be relied on to run its cleanup, so an interrupted run can strand
+# the required head status on `pending` forever. Superseding therefore happens
+# only while a run is still queued, where it has posted nothing.
+#
+# Unrelated label events are routed to a per-run group so they can never queue
+# behind — or cancel a queued — `synchronize`/`reopened`/verified-label run. Only
+# events that are authoritative for the current head share the `policy` group.
 concurrency:
-  group: darwin-verification-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: darwin-verification-${{ github.event.pull_request.number }}-${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name != 'darwin-e2e-verified' && format('unrelated-{0}', github.run_id) || 'policy' }}
+  cancel-in-progress: false
 
 jobs:
   publish-darwin-verification:
@@ -41,6 +50,7 @@ jobs:
       - name: Evaluate and publish Darwin verification
         env:
           GH_TOKEN: ${{ github.token }}
+          DARWIN_GATE_DECISION_FILE: ${{ runner.temp }}/darwin-gate-decision
         run: |
           set -euo pipefail
           if [ ! -r .github/scripts/darwin-verification-gate.sh ]; then
@@ -51,8 +61,37 @@ jobs:
               -f context='Darwin E2E verified' \
               -f description='Trusted Darwin verification policy is unavailable.' \
               -f target_url="$run_url" >/dev/null
+            printf '%s\n' missing-policy > "$DARWIN_GATE_DECISION_FILE"
             echo "::error title=Darwin E2E verification policy unavailable::The trusted base does not contain the gate script, so this head fails closed."
             exit 1
           fi
 
           bash .github/scripts/darwin-verification-gate.sh
+
+      # The gate posts `pending` before it can decide. If the job is interrupted
+      # (cancellation, timeout, runner loss) between those points, the required
+      # head status would stay `pending` and block the PR forever. `always()`
+      # also runs on cancellation, so this best-effort step replaces a
+      # never-resolved `pending` with an explicit failure.
+      - name: Fail closed when no decision was published
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DARWIN_GATE_DECISION_FILE: ${{ runner.temp }}/darwin-gate-decision
+        run: |
+          set -euo pipefail
+          if [ -s "$DARWIN_GATE_DECISION_FILE" ]; then
+            printf 'Darwin verification gate decided: %s\n' \
+              "$(cat "$DARWIN_GATE_DECISION_FILE")"
+            exit 0
+          fi
+
+          head_sha=$(jq -er '.pull_request.head.sha' "$GITHUB_EVENT_PATH")
+          run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$head_sha" \
+            -f state=failure \
+            -f context='Darwin E2E verified' \
+            -f description='Darwin verification gate ended without a decision.' \
+            -f target_url="$run_url" >/dev/null
+          echo "::error title=Darwin E2E verification incomplete::The gate did not publish a decision for this head, so it fails closed."
+          exit 1

--- a/.github/workflows/darwin-verification-gate.yml
+++ b/.github/workflows/darwin-verification-gate.yml
@@ -1,12 +1,34 @@
 name: Darwin verification gate
 
-# This workflow is the trusted enforcement path for darwin/arm64 changes that
+# This workflow is the trusted evaluation path for darwin/arm64 changes that
 # cannot execute on GitHub-hosted runners. `pull_request_target` loads this YAML
 # from the base branch. It performs NO repository checkout at all: it fetches the
-# single policy script from the base SHA through the contents API, so there is no
-# working tree that could ever hold PR head or merge content. It then posts the
-# "Darwin E2E verified" status explicitly to the PR head SHA. The workflow's own
-# check belongs to the base SHA and is not the branch-protection signal.
+# single policy script from `github.workflow_sha` through the contents API, so
+# there is no working tree that could ever hold PR head or merge content. It then
+# posts the "Darwin E2E verified" status explicitly to the PR head SHA. The
+# workflow's own check belongs to the base SHA and is not the enforcement signal.
+#
+# ADVISORY STATUS, NOT AN AUTHENTICATED ONE. Every workflow in this repository
+# runs as the same `github-actions[bot]` identity, and the repository's default
+# Actions token permission is write, so a pull-request-authored workflow can post
+# or overwrite the same "Darwin E2E verified" context on the same head SHA.
+# Branch protection binds a status to an App, not to a workflow, so it cannot
+# distinguish this gate from any other Actions writer. Turning the merge queue
+# off does NOT change that. Treat this status as a review aid; genuine
+# enforcement needs either a distinct trusted GitHub App as the status source or
+# native required-review/CODEOWNERS approval, which IS attributable to a human.
+#
+# The trigger is restricted to `main` because the policy is fetched by SHA and
+# statuses are SHA-global: without the filter, a writer could open a pull request
+# against an unprotected branch they control and have this privileged job execute
+# a policy script of their choosing. The policy re-asserts the same scope itself
+# as defense in depth, but under this filter that check is unreachable.
+#
+# A consequence of the filter: this status asserts "verified relative to `main`"
+# about a HEAD COMMIT, not about a pull request. A success is therefore inherited
+# by any other pull request sharing that head SHA — including one on a different
+# base whose diff was never evaluated, since the gate never runs there. Do not
+# consume this context as verification on any base other than `main`.
 #
 # A separate unprivileged `pull_request` workflow runs the proposed HEAD policy
 # tests. Those tests are useful review feedback but are not enforcement because
@@ -14,6 +36,7 @@ name: Darwin verification gate
 
 on:
   pull_request_target:
+    branches: [main]
     types: [opened, synchronize, reopened, edited, labeled, unlabeled]
 
 permissions:
@@ -41,20 +64,24 @@ jobs:
     timeout-minutes: 5
     steps:
       # No checkout: the only code this privileged job runs is the policy script
-      # read from the base SHA, which a pull request cannot influence. Fetching
-      # it through the contents API keeps the workspace empty, so head or merge
-      # content can never appear on disk.
+      # read from `github.workflow_sha` — the commit this very workflow file was
+      # loaded from, which for `pull_request_target` is a base-branch commit and
+      # which a pull request cannot influence. The event's `base.sha` is NOT used
+      # as the policy ref: it is whatever branch the PR targets, and only the
+      # `branches: [main]` filter plus this trusted ref keep an attacker-chosen
+      # base out of the privileged execution path. Fetching through the contents
+      # API keeps the workspace empty, so head or merge content never hits disk.
       - name: Evaluate and publish Darwin verification
         env:
           GH_TOKEN: ${{ github.token }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          POLICY_SHA: ${{ github.workflow_sha }}
           DARWIN_GATE_DECISION_FILE: ${{ runner.temp }}/darwin-gate-decision
         run: |
           set -euo pipefail
 
-          case "$BASE_SHA" in
+          case "$POLICY_SHA" in
             '' | *[!0-9a-fA-F]*)
-              echo "Refusing to fetch policy at a non-SHA base ref." >&2
+              echo "Refusing to fetch policy at a non-SHA trusted ref." >&2
               exit 1
               ;;
           esac
@@ -62,7 +89,7 @@ jobs:
           policy="$RUNNER_TEMP/darwin-verification-gate.sh"
           fetched=true
           gh api \
-            "repos/$GITHUB_REPOSITORY/contents/.github/scripts/darwin-verification-gate.sh?ref=$BASE_SHA" \
+            "repos/$GITHUB_REPOSITORY/contents/.github/scripts/darwin-verification-gate.sh?ref=$POLICY_SHA" \
             --jq '.content' | base64 -d > "$policy" || fetched=false
 
           if [ "$fetched" != true ] || [ ! -s "$policy" ]; then

--- a/.github/workflows/darwin-verification-gate.yml
+++ b/.github/workflows/darwin-verification-gate.yml
@@ -14,7 +14,7 @@ name: Darwin verification gate
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -31,7 +31,7 @@ permissions:
 # behind — or cancel a queued — `synchronize`/`reopened`/verified-label run. Only
 # events that are authoritative for the current head share the `policy` group.
 concurrency:
-  group: darwin-verification-${{ github.event.pull_request.number }}-${{ (github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name != 'darwin-e2e-verified' && format('unrelated-{0}', github.run_id) || 'policy' }}
+  group: darwin-verification-${{ github.event.pull_request.number }}-${{ ((((github.event.action == 'labeled' || github.event.action == 'unlabeled') && github.event.label.name != 'darwin-e2e-verified') || (github.event.action == 'edited' && github.event.changes.base == null)) && format('unrelated-{0}', github.run_id)) || 'policy' }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/darwin-verification-gate.yml
+++ b/.github/workflows/darwin-verification-gate.yml
@@ -12,13 +12,13 @@ name: Darwin verification gate
 # passes, and add the `darwin-e2e-verified` label to the PR. The gate is a
 # no-op (green) for PRs that don't touch that code.
 #
-# On every `synchronize` (new commits pushed) the `darwin-e2e-verified` label is
-# automatically removed: a prior verification only covers the commits it was
-# run against, so it must not silently carry forward onto unverified code. The
-# gate then re-evaluates the (now-current) label state in the same run, rather
-# than trusting the stale `github.event.pull_request.labels` payload, since that
-# payload predates the removal step. It also re-runs on `labeled`/`unlabeled` so
-# adding the label back flips the check to green without needing a new push.
+# On every `synchronize` (new commits pushed), the current head is unverified by
+# definition: a prior verification only covers the commits it was run against.
+# The workflow best-effort removes the stale label for same-repository PRs, but
+# public-fork tokens are read-only and may leave it in place. The synchronize run
+# therefore fails closed without consulting the live label. Removing/toggling
+# and then re-adding the label triggers `unlabeled`/`labeled` runs that evaluate
+# the live label and revalidate the same head without another push.
 # To actually block merges, mark "Darwin E2E verified" as a required status
 # check in branch protection.
 
@@ -43,50 +43,74 @@ jobs:
       # files under internal/debugger, the darwin E2E spec, and entitlements.
       DARWIN_NATIVE_REGEX: '^(internal/debugger/.*_darwin_.*|internal/debugger/trap_arm64\.go|test/integration/.*_darwin_.*_test\.go|entitlements\.plist)$'
     steps:
+      - uses: actions/checkout@v4
+        with:
+          # The gate must never execute a fork-modified copy of its own policy.
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Test Darwin verification gate decision
+        run: |
+          if [ -r .github/scripts/darwin-verification-gate_test.sh ]; then
+            bash .github/scripts/darwin-verification-gate_test.sh
+          else
+            echo "Trusted base predates the gate script; the gate step will use its fail-closed bootstrap."
+          fi
+
       - name: Remove stale verification label on new commits
+        id: stale-verification
         if: github.event.action == 'synchronize'
+        env:
+          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          pr='${{ github.event.pull_request.number }}'
-          if gh pr edit "$pr" --repo "${{ github.repository }}" --remove-label "$VERIFIED_LABEL" 2>/dev/null; then
-            echo "Removed '$VERIFIED_LABEL' label — new commits require re-verification."
+          if output=$(gh pr edit "$PR_NUMBER" --repo "$REPOSITORY" \
+            --remove-label "$VERIFIED_LABEL" 2>&1); then
+            echo "status=cleared" >> "$GITHUB_OUTPUT"
+            echo "Cleared '$VERIFIED_LABEL' if present — new commits require re-verification."
           else
-            echo "'$VERIFIED_LABEL' label was not present — nothing to remove."
+            exit_code=$?
+            echo "status=failed" >> "$GITHUB_OUTPUT"
+            if [ "$IS_FORK" = "true" ]; then
+              echo "::warning title=Stale Darwin verification label not removed::The public-fork GITHUB_TOKEN is read-only, so '$VERIFIED_LABEL' could not be removed (exit $exit_code). The gate will fail closed; remove or toggle the stale label, then re-add it to verify this head."
+            else
+              echo "::warning title=Stale Darwin verification label not removed::The API failed to remove '$VERIFIED_LABEL' (exit $exit_code). The gate will fail closed; remove or toggle the stale label, then re-add it to verify this head."
+            fi
+            printf '%s\n' "$output" >&2
           fi
 
       - name: Require local darwin E2E verification when darwin-native code changes
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_CLEANUP: ${{ steps.stale-verification.outputs.status }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
-          pr='${{ github.event.pull_request.number }}'
-          gh pr diff "$pr" --repo "${{ github.repository }}" --name-only > changed.txt
-          echo "Changed files in this PR:"
-          sed 's/^/  /' changed.txt
+          gh pr diff "$PR_NUMBER" --repo "$REPOSITORY" --name-only > changed.txt
 
-          if grep -Eq "$DARWIN_NATIVE_REGEX" changed.txt; then
+          if [ ! -r .github/scripts/darwin-verification-gate.sh ]; then
+            echo "Changed files in this PR:"
+            sed 's/^/  /' changed.txt
             echo
-            echo "Darwin-native (CI-unexecutable) files changed:"
-            grep -E "$DARWIN_NATIVE_REGEX" changed.txt | sed 's/^/  /'
-            darwin_changed=true
-          else
-            darwin_changed=false
-          fi
-
-          echo
-          if [ "$darwin_changed" != "true" ]; then
-            echo "No darwin-native code changed — gate not required. ✅"
+            if grep -Eq "$DARWIN_NATIVE_REGEX" changed.txt; then
+              echo "::error title=Darwin E2E verification policy unavailable::The trusted base does not contain the gate script, so this Darwin-native change fails closed."
+              exit 1
+            fi
+            echo "No darwin-native code changed; gate not required."
             exit 0
           fi
 
-          # Re-fetch the current label state live rather than trusting
-          # github.event.pull_request.labels, which is a snapshot from before
-          # this run (and predates the removal step above on `synchronize`).
-          has_label=$(gh pr view "$pr" --repo "${{ github.repository }}" --json labels \
-            -q "[.labels[].name] | any(. == \"$VERIFIED_LABEL\")")
-
-          if [ "$has_label" = "true" ]; then
-            echo "'$VERIFIED_LABEL' label present — darwin backend verified locally. ✅"
-            exit 0
+          has_label=
+          if [ "$EVENT_ACTION" != "synchronize" ]; then
+            has_label=$(gh pr view "$PR_NUMBER" --repo "$REPOSITORY" --json labels \
+              -q "[.labels[].name] | any(. == \"$VERIFIED_LABEL\")")
           fi
 
-          echo "::error title=Darwin E2E verification required::This PR changes darwin-native debugger code that cannot be executed on GitHub-hosted runners. Run 'just e2e-darwin' locally on Apple Silicon, confirm it passes, then add the '${VERIFIED_LABEL}' label to this PR."
-          exit 1
+          EVENT_ACTION="$EVENT_ACTION" \
+            CHANGED_FILES=changed.txt \
+            HAS_VERIFIED_LABEL="$has_label" \
+            LABEL_CLEANUP="${LABEL_CLEANUP:-not-run}" \
+            bash .github/scripts/darwin-verification-gate.sh

--- a/.github/workflows/darwin-verification-gate.yml
+++ b/.github/workflows/darwin-verification-gate.yml
@@ -2,10 +2,11 @@ name: Darwin verification gate
 
 # This workflow is the trusted enforcement path for darwin/arm64 changes that
 # cannot execute on GitHub-hosted runners. `pull_request_target` loads this YAML
-# from the base branch. It checks out only the base SHA policy script, never PR
-# head code, then posts the "Darwin E2E verified" status explicitly to the PR
-# head SHA. The workflow's own check belongs to the base SHA and is not the
-# branch-protection signal.
+# from the base branch. It performs NO repository checkout at all: it fetches the
+# single policy script from the base SHA through the contents API, so there is no
+# working tree that could ever hold PR head or merge content. It then posts the
+# "Darwin E2E verified" status explicitly to the PR head SHA. The workflow's own
+# check belongs to the base SHA and is not the branch-protection signal.
 #
 # A separate unprivileged `pull_request` workflow runs the proposed HEAD policy
 # tests. Those tests are useful review feedback but are not enforcement because
@@ -39,21 +40,32 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out trusted gate policy
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
-          sparse-checkout: .github/scripts/darwin-verification-gate.sh
-          sparse-checkout-cone-mode: false
-          persist-credentials: false
-
+      # No checkout: the only code this privileged job runs is the policy script
+      # read from the base SHA, which a pull request cannot influence. Fetching
+      # it through the contents API keeps the workspace empty, so head or merge
+      # content can never appear on disk.
       - name: Evaluate and publish Darwin verification
         env:
           GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           DARWIN_GATE_DECISION_FILE: ${{ runner.temp }}/darwin-gate-decision
         run: |
           set -euo pipefail
-          if [ ! -r .github/scripts/darwin-verification-gate.sh ]; then
+
+          case "$BASE_SHA" in
+            '' | *[!0-9a-fA-F]*)
+              echo "Refusing to fetch policy at a non-SHA base ref." >&2
+              exit 1
+              ;;
+          esac
+
+          policy="$RUNNER_TEMP/darwin-verification-gate.sh"
+          fetched=true
+          gh api \
+            "repos/$GITHUB_REPOSITORY/contents/.github/scripts/darwin-verification-gate.sh?ref=$BASE_SHA" \
+            --jq '.content' | base64 -d > "$policy" || fetched=false
+
+          if [ "$fetched" != true ] || [ ! -s "$policy" ]; then
             head_sha=$(jq -er '.pull_request.head.sha' "$GITHUB_EVENT_PATH")
             run_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
             gh api --method POST "repos/$GITHUB_REPOSITORY/statuses/$head_sha" \
@@ -66,7 +78,7 @@ jobs:
             exit 1
           fi
 
-          bash .github/scripts/darwin-verification-gate.sh
+          bash "$policy"
 
       # The gate posts `pending` before it can decide. If the job is interrupted
       # (cancellation, timeout, runner loss) between those points, the required

--- a/.github/workflows/darwin-verification-policy-test.yml
+++ b/.github/workflows/darwin-verification-policy-test.yml
@@ -1,0 +1,27 @@
+name: Darwin verification policy tests
+
+# This unprivileged workflow deliberately tests the proposed PR version of the
+# policy. It is not the trusted gate and must never publish its required status.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  policy-tests:
+    name: Darwin gate policy tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Test proposed Darwin verification policy
+        run: |
+          bash -n \
+            .github/scripts/darwin-verification-gate.sh \
+            .github/scripts/darwin-verification-gate_test.sh
+          bash .github/scripts/darwin-verification-gate_test.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1491,6 +1491,14 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   absent. This converts an interrupted run into a failing head status instead of
   a permanently pending one.
 
+  **Only the top-level shell may publish.** `set -E` propagates the policy's ERR
+  trap into command-substitution subshells, so an unguarded `$(...)` that fails
+  publishes a status from the subshell and then again from the parent (the
+  subshell's "already posted" flag cannot propagate back out). Every `$(...)`
+  below the trap installation disarms it with `$(trap - ERR; …)`, and a contract
+  test enforces that statically — the runtime symptom only reproduces on the
+  runner's bash 5, not on macOS's bash 3.2.
+
 Build/test commands:
 
 ```sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1428,14 +1428,19 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   E2E verified" check fails until the label is present; it re-runs on
   `labeled`/`unlabeled` so adding the label flips it green without a new push,
   and is a green no-op for PRs that don't touch those paths. On `synchronize`
-  (new commits pushed) the workflow removes the `darwin-e2e-verified` label
-  itself before evaluating the gate — a verification only covers the commits
-  it was run against, so it must not silently carry forward onto new,
-  unverified commits — then re-checks the label live via `gh pr view` rather
-  than the stale `github.event.pull_request.labels` payload, since that
-  payload predates the removal. This needs `pull-requests: write` permission
-  (not just `read`). Mark it a required status check in branch protection to
-  actually block merges.
+  (new commits pushed), the current head is always unverified: the workflow
+  best-effort removes `darwin-e2e-verified` for same-repository PRs, but public
+  fork `pull_request` tokens are read-only and may leave the stale label in
+  place. The synchronize run therefore warns on cleanup failure and fails
+  closed without consulting or accepting the live label. A maintainer can
+  remove/toggle the stale label and re-add it; the resulting `unlabeled` and
+  `labeled` runs evaluate the live label and revalidate that same head. Keep
+  this on the unprivileged `pull_request` trigger and execute the gate script
+  from the explicitly checked-out base SHA, never the fork-modified merge tree;
+  if that trusted base predates the script, the inline bootstrap passes only
+  non-Darwin changes and fails Darwin changes closed. Do not run untrusted PR
+  code via `pull_request_target`. Mark it a required status check in branch
+  protection to actually block merges.
 
 Build/test commands:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1437,10 +1437,16 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   `labeled` runs evaluate the live label and revalidate that same head. Keep
   this on the unprivileged `pull_request` trigger and execute the gate script
   from the explicitly checked-out base SHA, never the fork-modified merge tree;
-  if that trusted base predates the script, the inline bootstrap passes only
-  non-Darwin changes and fails Darwin changes closed. Do not run untrusted PR
-  code via `pull_request_target`. Mark it a required status check in branch
-  protection to actually block merges.
+  the trusted script owns the label name, path regex, event parsing, diff, and
+  live-label query rather than accepting policy or decision inputs from the
+  fork-modifiable workflow environment. If that trusted base predates the
+  script, fail the gate unconditionally. Do not run untrusted PR code via
+  `pull_request_target`. Mark it a required status check in branch protection
+  to actually block merges. Reopening a PR invalidates verification just like a
+  push, because commits can be added while the PR is closed. On Darwin-changing
+  PRs, only adding/removing `darwin-e2e-verified` may resolve a label-triggered
+  run; unrelated label events fail closed so a stale label left by denied fork
+  cleanup cannot reactivate the check.
 
 Build/test commands:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1427,8 +1427,25 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   changes, `justfile`, entitlements, the module graph, repo-wide platform suffixes
   and native sources, plus explicit Go build constraints. The "Darwin
   E2E verified" **commit status is posted explicitly to the PR head SHA** and
-  Darwin-native heads fail until the label is present. `pull_request_target` is
-  a requirement here, not a preference: a
+  Darwin-native heads fail until the label is present.
+
+  **Advisory, not authoritative — read this before relying on the status.**
+  This repository's default Actions permissions are write, and *every* same-repo
+  workflow runs under the single `github-actions[bot]` identity. Any workflow a
+  PR author adds can therefore write the same `Darwin E2E verified` context on
+  any SHA, and branch protection cannot distinguish "which workflow" produced an
+  Actions status — the app binding is per-app, not per-workflow. So this status
+  is a **review aid and audit trail, not a cryptographically enforceable gate**,
+  and it is deliberately not a required check. Do not describe it as tamper-proof
+  and do not "fix" it by disabling the merge queue: queue state is orthogonal to
+  the shared-identity problem. Real enforcement needs either a **distinct trusted
+  GitHub App** publishing its own status context (which branch protection *can*
+  bind to), an org-required workflow (unavailable here), or native
+  required-review/CODEOWNERS if the human review itself is the enforcement. The
+  hardening below removes every attack that does not require an attacker to add
+  a status-writing workflow; it cannot remove that one.
+
+  `pull_request_target` is a requirement here, not a preference: a
   fork-triggered `pull_request` run gets a read-only `GITHUB_TOKEN` (it can
   neither publish the head status nor clear a stale label) and it executes
   workflow YAML taken from the PR head, so a fork could simply rewrite the gate
@@ -1436,11 +1453,23 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   token and base-controlled policy. The usual argument against
   `pull_request_target` — a privileged token combined with untrusted code — is
   eliminated by never checking out or executing head content.
+
+  **Trigger scope and policy source are both pinned to trusted refs.** The
+  trigger is filtered to `branches: [main]`, and the policy script is fetched at
+  **`${{ github.workflow_sha }}`** — the SHA of the commit the running workflow
+  file came from — *not* at `github.event.pull_request.base.sha`. Without both,
+  a same-repo writer could push an unprotected branch carrying a malicious
+  `.github/scripts/darwin-verification-gate.sh`, open a PR against it, and have
+  that attacker-authored policy executed with `pull-requests: write` +
+  `statuses: write`. Never reintroduce an event-derived policy ref, and never
+  widen the branch filter.
+
   The `pull_request_target` workflow and its own job run against the
   base SHA, so that job is deliberately NOT the merge gate. The trusted workflow
   performs **no checkout at all**: it reads the single policy script from the
-  base SHA through the contents API, so no working tree exists that could hold
-  PR head or merge content, and it reads PR metadata/labels through GitHub APIs. Do
+  trusted workflow SHA through the contents API, so no working tree exists that
+  could hold PR head or merge content, and it reads PR metadata/labels through
+  GitHub APIs. Do
   not add `actions/checkout`, or any step that executes head code, consumes head
   artifacts, or builds a shell command from PR content, to this privileged
   workflow. Changed paths are computed from the immutable event base/head SHAs:
@@ -1448,7 +1477,10 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   are structurally diffed by path/mode/type/blob SHA. Never return to the live
   PR-files endpoint — a force-push can change that response while the run still
   publishes to the event's old head SHA. A missing/empty diff or a Git-tree
-  `truncated` response fails closed; path matching stays inside JSON (Git permits
+  `truncated` response fails closed; **both** trees are independently schema-
+  validated before the diff (array shape, non-empty string `path`, six-octal
+  `mode`, `type` ∈ blob/tree/commit, hex `sha` on non-tree entries) and any
+  malformed document fails closed; path matching stays inside JSON (Git permits
   newlines in filenames). The selector is deliberately conservative: repo-wide
   implicit `_darwin*`/`_arm64*` source suffixes, every changed native source
   (`c`/C++/headers/Obj-C/assembly/syso), control-character paths, and any changed
@@ -1456,6 +1488,23 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   This deliberately over-gates Linux/cross-platform constraints rather than
   guessing an incomplete tag universe. `edited` base-retarget events invalidate
   verification; unrelated PR edits preserve the current SHA-bound status.
+
+  **Non-regular tree entries are always gated.** A changed `.go` *symlink*
+  (mode `120000`) stores only its link text, so scanning its blob can never see
+  the Darwin constraint in the file it resolves to; a gitlink/submodule
+  (`type: commit`) has no blob at all. Every changed entry whose mode is not
+  `100644`/`100755` or whose type is not `blob` — on **either** side, so both
+  additions and deletions count — forces verification and is itemized in the
+  log. Only regular blobs are content-scanned.
+
+  **A UTF-8 BOM does not hide a build constraint.** Go 1.25 strips a single
+  leading BOM before parsing, so `\xEF\xBB\xBF//go:build darwin` is a *live*
+  constraint that an anchored `grep` on the raw bytes would miss. The blob
+  scanner reads the first four bytes with `od`, drops exactly one leading UTF-8
+  BOM before matching, and treats a UTF-16 BOM (`fffe`/`feff`) as
+  "gate, don't guess". Blob responses that are not decodable base64, or whose
+  encoding/content fields are missing or wrongly typed, fail closed — never
+  "assume no constraint". This applies to added *and* deleted blobs.
 
   A separate unprivileged
   [.github/workflows/darwin-verification-policy-test.yml](.github/workflows/darwin-verification-policy-test.yml)
@@ -1465,20 +1514,61 @@ side `chan error` — every debugger outcome, failures included, rides the singl
 
   On `synchronize`, `reopened`, or base-changing `edited`, the trusted policy
   best-effort removes `darwin-e2e-verified` and posts failure to the new/current
-  head regardless of label cleanup success. A successful `labeled` event for
-  that exact label posts success to that head; removing it posts failure, with
-  both events re-reading live label state so a remove/re-add race settles to the
-  current truth. A label addition may publish success only after the same head
-  already has a trusted failing gate status; otherwise it fails and asks the
-  maintainer to toggle again. This prevents a queued label event from superseding
-  the still-pending `synchronize` run that would have invalidated the new head.
-  Unrelated label events post nothing, preserving either a legitimate success
-  or a stale-cleanup failure already bound to the same head SHA. Relevant runs
+  head regardless of label cleanup success.
+
+  **Only an authorized human `labeled` event may assert verification.** Success
+  requires, in order: the event action is exactly `labeled` for exactly
+  `darwin-e2e-verified`; the label is still present in live PR metadata; the
+  event **sender** is a `User` (not a bot/app) whose login passes a shape check
+  before it is interpolated into an API path; and
+  `GET /repos/{owner}/{repo}/collaborators/{login}/permission` reports
+  `admin`, `maintain`, or `write` for that exact login. The gate **never** reads
+  prior commit statuses as a readiness signal — the previous `approval_ready`
+  handshake was removed because any same-repo workflow can seed the status it
+  was reading, which made it a self-signed approval. An `unlabeled` event for
+  the verified label **always** publishes failure for a head that needs
+  verification, and never consults live label state: a remove/re-add race must
+  be settled by a *fresh authorized `labeled` event*, not by an unlabel run
+  noticing the label came back. (A head with **no** Darwin-native change is
+  short-circuited to `success` by the scope check before any label arm runs —
+  there is nothing to withdraw, and the same live-generation binding still
+  applies. Both behaviors are pinned by cases in the contract suite so the
+  distinction cannot drift.) Unrelated label
+  events post nothing, preserving either a legitimate success
+  or a stale-cleanup failure already bound to the same head SHA.
+
+  **Every success is bound to the live PR generation.** Commit statuses are
+  SHA-global: two PRs can share one head commit, and a status published for one
+  is visible to the other. So immediately before **each** `post_status success`
+  the gate re-reads live PR metadata and requires that the PR is still `open`,
+  its base ref is still exactly `main`, its live base SHA and head SHA still
+  equal the event's, and the head repo is unchanged. A retarget mid-run, a
+  force-push (including head ABA), a close, or a delayed run from an older event
+  therefore fails closed instead of greening a commit whose context has moved.
+  The policy also re-asserts `base.ref == main` itself rather than trusting the
+  trigger filter — defense in depth for a future misconfiguration, and the only
+  thing that would refuse an alternate-base run before it posted `pending`.
+  Under the deployed `branches: [main]` filter that path is unreachable, because
+  such a run is never dispatched at all.
+
+  **Residual, by design: this status is main-only and is inherited, not
+  scoped.** A commit status belongs to a SHA, not to a pull request, so a
+  success legitimately published for a `main` PR is also *visible* on any other
+  PR that shares that head commit — including one targeting a different base,
+  whose diff against a different merge base may contain Darwin changes that were
+  never verified. No PR-scoped decision can revoke a SHA-scoped signal, and the
+  `branches: [main]` filter means the gate never runs (and so never re-evaluates
+  or overwrites) on those PRs. Therefore: read `Darwin E2E verified` as an
+  assertion about a **head commit relative to `main`**, and do not consume it as
+  verification on any other base. Cross-base assurance needs a PR-scoped
+  mechanism (a trusted App check, or human review), not this status.
+
+  Relevant runs
   post `pending` before evaluation, serialize per PR, and post failure on
   API/decision errors so an old success cannot survive a reopened/error window.
   A status counts as published only when the API accepted it, so a failed POST
   never records a decision.
-  If the base policy cannot be fetched, the trusted workflow posts failure
+  If the trusted policy cannot be fetched, the trusted workflow posts failure
   inline.
   Keep permissions limited to API reads, PR-label cleanup, and
   head commit statuses; never expose secrets or execute untrusted code through
@@ -1497,15 +1587,16 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   serialized per-PR `policy` group. Unrelated labels and non-base edits get a
   per-run group so they can neither queue behind nor displace a queued gating
   run. A verified-label event that replaces a queued `synchronize` still cannot
-  pass: it requires the same head's prior trusted failure, which the superseded
-  run never posted.
+  pass: the live-generation check re-reads the PR, so a head that moved after
+  the label was applied fails closed.
 
   **A run must publish a decision or fail closed.** The gate records its
   terminal outcome (`success`, `failure`, or `ignored`) to
   `DARWIN_GATE_DECISION_FILE`, and a final `if: always()` workflow step — which
   also runs on cancellation — posts an explicit failure when that marker is
   absent. This converts an interrupted run into a failing head status instead of
-  a permanently pending one.
+  a permanently pending one. An unrecognized event action exits without a
+  decision on purpose, so that fallback fails the head closed.
 
   **Only the top-level shell may publish.** `set -E` propagates the policy's ERR
   trap into command-substitution subshells, so an unguarded `$(...)` that fails
@@ -1515,16 +1606,26 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   test enforces that statically — the runtime symptom only reproduces on the
   runner's bash 5, not on macOS's bash 3.2.
 
-  **Merge-queue limitation:** the active default-branch merge queue evaluates
+  **Merge-queue posture:** the active default-branch merge queue evaluates
   required checks on synthetic merge-group SHAs, while this trusted workflow
-  posts only to PR head SHAs. Do not require `Darwin E2E verified` while that
-  queue is active: a missing group status would time out every queue entry, and
-  an Actions-only group publisher is not a safe fix because merge-group content
-  includes PR-authored workflow YAML that can write the same GitHub Actions
-  status context. Keep this status advisory unless the merge queue is disabled,
-  or implement group enforcement with a distinct trusted GitHub App whose status
-  source can be required separately. Current branch protection/rulesets do not
-  require the context, so the present impact remains advisory.
+  posts only to PR head SHAs. Do not require `Darwin E2E verified`: a missing
+  group status would time out every queue entry, and an Actions-only
+  `merge_group` publisher is not a safe fix because merge-group content includes
+  PR-authored workflow YAML that runs with a base-repo write token under the
+  same `github-actions[bot]` identity and can forge or overwrite the context.
+  **Disabling the merge queue does not make this status authentic** — the
+  shared-identity problem above is independent of it. Enforcement requires a
+  distinct trusted GitHub App (or another status source branch protection can
+  bind separately), or replacing the status with native required review /
+  CODEOWNERS. Current branch protection/rulesets do not require the context, so
+  the gate is explicitly advisory.
+
+  The policy's adversarial contract suite lives in
+  [.github/scripts/darwin-verification-gate_test.sh](.github/scripts/darwin-verification-gate_test.sh)
+  and must stay runnable on both macOS bash 3.2 and Linux bash 5 with no new
+  tooling. It mocks `gh` end to end (compare/tree/blob/PR/permission/status
+  APIs) and poisons the commit-status *read* endpoint so any regression that
+  reintroduces status-as-readiness fails loudly.
 
 Build/test commands:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1437,10 +1437,12 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   eliminated by never checking out or executing head content.
   The `pull_request_target` workflow and its own job run against the
   base SHA, so that job is deliberately NOT the merge gate. The trusted workflow
-  checks out only the exact base SHA policy script, never the PR head or merge
-  tree, and reads PR files/labels through GitHub APIs. Do not add any step that
-  executes head code, consumes head artifacts, or builds a shell command from PR
-  content in this privileged workflow. The PR-files REST endpoint hard-caps its
+  performs **no checkout at all**: it reads the single policy script from the
+  base SHA through the contents API, so no working tree exists that could hold
+  PR head or merge content, and it reads PR files/labels through GitHub APIs. Do
+  not add `actions/checkout`, or any step that executes head code, consumes head
+  artifacts, or builds a shell command from PR content, to this privileged
+  workflow. The PR-files REST endpoint hard-caps its
   response at 3,000 files, so the policy cross-checks the returned count against
   the event's `pull_request.changed_files` and fails closed on any mismatch.
   Count and path matching operate on the slurped JSON arrays, never line-oriented
@@ -1463,8 +1465,9 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   API/decision errors so an old success cannot survive a reopened/error window.
   A status counts as published only when the API accepted it, so a failed POST
   never records a decision.
-  If the base policy is missing, the trusted workflow posts failure inline.
-  Keep permissions limited to base checkout/API reads, PR-label cleanup, and
+  If the base policy cannot be fetched, the trusted workflow posts failure
+  inline.
+  Keep permissions limited to API reads, PR-label cleanup, and
   head commit statuses; never expose secrets or execute untrusted code through
   `pull_request_target`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1442,8 +1442,9 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   GitHub App** publishing its own status context (which branch protection *can*
   bind to), an org-required workflow (unavailable here), or native
   required-review/CODEOWNERS if the human review itself is the enforcement. The
-  hardening below removes every attack that does not require an attacker to add
-  a status-writing workflow; it cannot remove that one.
+  hardening below closes every bypass found in review that does not require an
+  attacker to add a status-writing workflow; it cannot close that one, and no
+  audit can prove the list exhaustive.
 
   `pull_request_target` is a requirement here, not a preference: a
   fork-triggered `pull_request` run gets a read-only `GITHUB_TOKEN` (it can
@@ -1489,15 +1490,35 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   This deliberately over-gates Linux/cross-platform constraints rather than
   guessing an incomplete tag universe.
 
+  **PR-authored text is never consumed.** The gate reads only structural fields
+  from the event (numbers, SHAs, refs, the sender login, the label name) and
+  never the title, body, head branch name, or head label — all of which an
+  attacker sets freely and any of which could otherwise reach a shell word or an
+  API path. The contract suite injects a poison token into every one of those
+  fields on **every** synthetic event and fails the case if the token appears in
+  any `gh` invocation. A separate static contract asserts the harness still
+  injects it and still asserts on it, because an earlier revision gated that
+  check behind a per-case variable no case ever set — making it silently vacuous.
+
   **Only `.go` blobs are content-scanned, so everything else must be caught by
-  name.** The native-source extension list is exactly what `go/build` compiles —
-  `c cc cpp cxx m mm h hh hpp hxx f F for f90 s S sx swig swigcxx syso` — and a
-  contract test asserts it stays complete. Shrinking it reopens a real bypass:
+  name.** The native-source extension list covers every extension `go/build`
+  compiles — `c cc cpp cxx m h hh hpp hxx f F for f90 s S sx swig swigcxx syso`
+  — plus `.mm`, which Go itself does not accept but which is conventional for
+  Objective-C++ and therefore gated anyway. A contract test asserts the list
+  stays complete. Shrinking it reopens a real bypass:
   an untagged cgo wrapper plus a darwin-only `shim_darwin.sx` ships machine code
   the gate never looked at. Plain `.go` is deliberately **absent** from that
   bare-extension list (every Go change would gate and the constraint scan would
   become dead code) but **present** in the `_darwin`/`_arm64` suffix
   alternation, where the filename itself is the constraint.
+
+  **A `.go` blob also gates on a cgo preamble**, not just on `//go:build` /
+  `// +build`. A `#cgo darwin LDFLAGS: …` directive — bare inside the `/* … */`
+  block before `import "C"`, or as a `// #cgo …` line comment — makes the file
+  platform-dependent with no explicit constraint anywhere in it. A bare `#cgo`
+  at the start of a line is not valid Go outside such a comment, so the anchored
+  match cannot false-positive; prose that merely mentions `#cgo` mid-line does
+  not gate. Both behaviours are pinned by cases.
   `edited` base-retarget events invalidate
   verification; unrelated PR edits preserve the current SHA-bound status.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1425,28 +1425,38 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   runtime behaviour only runs on real Apple Silicon — matched by regex over
   `internal/debugger/*_darwin_*`, `internal/debugger/trap_arm64.go`,
   `test/integration/*_darwin_*_test.go`, and `entitlements.plist`. The "Darwin
-  E2E verified" check fails until the label is present; it re-runs on
-  `labeled`/`unlabeled` so adding the label flips it green without a new push,
-  and is a green no-op for PRs that don't touch those paths. On `synchronize`
-  (new commits pushed), the current head is always unverified: the workflow
-  best-effort removes `darwin-e2e-verified` for same-repository PRs, but public
-  fork `pull_request` tokens are read-only and may leave the stale label in
-  place. The synchronize run therefore warns on cleanup failure and fails
-  closed without consulting or accepting the live label. A maintainer can
-  remove/toggle the stale label and re-add it; the resulting `unlabeled` and
-  `labeled` runs evaluate the live label and revalidate that same head. Keep
-  this on the unprivileged `pull_request` trigger and execute the gate script
-  from the explicitly checked-out base SHA, never the fork-modified merge tree;
-  the trusted script owns the label name, path regex, event parsing, diff, and
-  live-label query rather than accepting policy or decision inputs from the
-  fork-modifiable workflow environment. If that trusted base predates the
-  script, fail the gate unconditionally. Do not run untrusted PR code via
-  `pull_request_target`. Mark it a required status check in branch protection
-  to actually block merges. Reopening a PR invalidates verification just like a
-  push, because commits can be added while the PR is closed. On Darwin-changing
-  PRs, only adding/removing `darwin-e2e-verified` may resolve a label-triggered
-  run; unrelated label events fail closed so a stale label left by denied fork
-  cleanup cannot reactivate the check.
+  E2E verified" **commit status is posted explicitly to the PR head SHA** and
+  fails until the label is present; it is the status to require in branch
+  protection. The `pull_request_target` workflow and its own job run against the
+  base SHA, so that job is deliberately NOT the merge gate. The trusted workflow
+  checks out only the exact base SHA policy script, never the PR head or merge
+  tree, and reads PR files/labels through GitHub APIs. Do not add any step that
+  executes head code, consumes head artifacts, or builds a shell command from PR
+  content in this privileged workflow. The PR-files REST endpoint hard-caps its
+  response at 3,000 files, so the policy cross-checks the returned count against
+  the event's `pull_request.changed_files` and fails closed on any mismatch.
+  Count and path matching operate on the slurped JSON arrays, never line-oriented
+  filename output (Git permits newlines in filenames).
+
+  A separate unprivileged
+  [.github/workflows/darwin-verification-policy-test.yml](.github/workflows/darwin-verification-policy-test.yml)
+  runs the proposed HEAD script/tests on `pull_request` with a read-only token
+  and a distinct check name. It is review feedback only: a fork can modify that
+  workflow, so it never publishes the required status.
+
+  On `synchronize` or `reopened`, the trusted policy best-effort removes
+  `darwin-e2e-verified` and posts failure to the new/current head regardless of
+  label cleanup success. A successful `labeled` event for that exact label posts
+  success to that head; removing it posts failure, with both events re-reading
+  live label state so a remove/re-add race settles to the current truth.
+  Unrelated label events post nothing, preserving either a legitimate success
+  or a stale-cleanup failure already bound to the same head SHA. Relevant runs
+  post `pending` before evaluation, serialize per PR, and post failure on
+  API/decision errors so an old success cannot survive a reopened/error window.
+  If the base policy is missing, the trusted workflow posts failure inline.
+  Keep permissions limited to base checkout/API reads, PR-label cleanup, and
+  head commit statuses; never expose secrets or execute untrusted code through
+  `pull_request_target`.
 
 Build/test commands:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1427,7 +1427,15 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   `test/integration/*_darwin_*_test.go`, and `entitlements.plist`. The "Darwin
   E2E verified" **commit status is posted explicitly to the PR head SHA** and
   fails until the label is present; it is the status to require in branch
-  protection. The `pull_request_target` workflow and its own job run against the
+  protection. `pull_request_target` is a requirement here, not a preference: a
+  fork-triggered `pull_request` run gets a read-only `GITHUB_TOKEN` (it can
+  neither publish the head status nor clear a stale label) and it executes
+  workflow YAML taken from the PR head, so a fork could simply rewrite the gate
+  to pass. Only a base-controlled `pull_request_target` run has both a write
+  token and base-controlled policy. The usual argument against
+  `pull_request_target` — a privileged token combined with untrusted code — is
+  eliminated by never checking out or executing head content.
+  The `pull_request_target` workflow and its own job run against the
   base SHA, so that job is deliberately NOT the merge gate. The trusted workflow
   checks out only the exact base SHA policy script, never the PR head or merge
   tree, and reads PR files/labels through GitHub APIs. Do not add any step that
@@ -1453,10 +1461,35 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   or a stale-cleanup failure already bound to the same head SHA. Relevant runs
   post `pending` before evaluation, serialize per PR, and post failure on
   API/decision errors so an old success cannot survive a reopened/error window.
+  A status counts as published only when the API accepted it, so a failed POST
+  never records a decision.
   If the base policy is missing, the trusted workflow posts failure inline.
   Keep permissions limited to base checkout/API reads, PR-label cleanup, and
   head commit statuses; never expose secrets or execute untrusted code through
   `pull_request_target`.
+
+  **Never cancel a gate run.** Because every relevant run publishes `pending`
+  before it can decide, cancelling one mid-flight can strand the required head
+  status on `pending` forever — a killed runner is not a reliable place to
+  recover. So `cancel-in-progress` is **`false`**, which limits superseding to
+  runs that are still queued and have therefore published nothing. Do not
+  reintroduce `cancel-in-progress: true`.
+
+  **Concurrency grouping is part of the policy.** Only events that are
+  authoritative for the current head (`opened`, `synchronize`, `reopened`, and
+  `darwin-e2e-verified` label add/remove) share the serialized per-PR `policy`
+  group. Unrelated label events get a per-run group so they can neither queue
+  behind nor displace a queued gating run. That isolation is what makes queued
+  supersession safe: every event that can replace a queued `synchronize` either
+  performs the same stale-label cleanup itself (`synchronize`/`reopened`) or is
+  a deliberate human assertion about the current head (verified-label events).
+
+  **A run must publish a decision or fail closed.** The gate records its
+  terminal outcome (`success`, `failure`, or `ignored`) to
+  `DARWIN_GATE_DECISION_FILE`, and a final `if: always()` workflow step — which
+  also runs on cancellation — posts an explicit failure when that marker is
+  absent. This converts an interrupted run into a failing head status instead of
+  a permanently pending one.
 
 Build/test commands:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1483,10 +1483,22 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   malformed document fails closed; path matching stays inside JSON (Git permits
   newlines in filenames). The selector is deliberately conservative: repo-wide
   implicit `_darwin*`/`_arm64*` source suffixes, every changed native source
-  (`c`/C++/headers/Obj-C/assembly/syso), control-character paths, and any changed
+  that `go/build` compiles (C, C++, Obj-C, Fortran, assembly incl. `.sx`, SWIG,
+  `.syso`), control-character paths, and any changed
   Go blob containing an explicit build-constraint line all require verification.
   This deliberately over-gates Linux/cross-platform constraints rather than
-  guessing an incomplete tag universe. `edited` base-retarget events invalidate
+  guessing an incomplete tag universe.
+
+  **Only `.go` blobs are content-scanned, so everything else must be caught by
+  name.** The native-source extension list is exactly what `go/build` compiles —
+  `c cc cpp cxx m mm h hh hpp hxx f F for f90 s S sx swig swigcxx syso` — and a
+  contract test asserts it stays complete. Shrinking it reopens a real bypass:
+  an untagged cgo wrapper plus a darwin-only `shim_darwin.sx` ships machine code
+  the gate never looked at. Plain `.go` is deliberately **absent** from that
+  bare-extension list (every Go change would gate and the constraint scan would
+  become dead code) but **present** in the `_darwin`/`_arm64` suffix
+  alternation, where the filename itself is the constraint.
+  `edited` base-retarget events invalidate
   verification; unrelated PR edits preserve the current SHA-bound status.
 
   **Non-regular tree entries are always gated.** A changed `.go` *symlink*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1420,14 +1420,15 @@ side `chan error` — every debugger outcome, failures included, rides the singl
 - **Darwin verification gate**
   ([.github/workflows/darwin-verification-gate.yml](.github/workflows/darwin-verification-gate.yml)):
   because the darwin backend can't be executed in CI, this human-in-the-loop
-  check requires a maintainer to run `just e2e-darwin` locally and add the
-  `darwin-e2e-verified` PR label whenever a PR touches darwin-native code whose
-  runtime behaviour only runs on real Apple Silicon — matched by regex over
-  `internal/debugger/*_darwin_*`, `internal/debugger/trap_arm64.go`,
-  `test/integration/*_darwin_*_test.go`, and `entitlements.plist`. The "Darwin
+  check requires a maintainer to run the **trusted base branch's**
+  `e2e-darwin` recipe against the PR head on Apple Silicon, review any PR changes
+  to that recipe, and add the `darwin-e2e-verified` label. The conservative
+  coverage floor includes all `internal/debugger/` and `test/integration/`
+  changes, `justfile`, entitlements, the module graph, repo-wide platform suffixes
+  and native sources, plus explicit Go build constraints. The "Darwin
   E2E verified" **commit status is posted explicitly to the PR head SHA** and
-  fails until the label is present; it is the status to require in branch
-  protection. `pull_request_target` is a requirement here, not a preference: a
+  Darwin-native heads fail until the label is present. `pull_request_target` is
+  a requirement here, not a preference: a
   fork-triggered `pull_request` run gets a read-only `GITHUB_TOKEN` (it can
   neither publish the head status nor clear a stale label) and it executes
   workflow YAML taken from the PR head, so a fork could simply rewrite the gate
@@ -1439,14 +1440,22 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   base SHA, so that job is deliberately NOT the merge gate. The trusted workflow
   performs **no checkout at all**: it reads the single policy script from the
   base SHA through the contents API, so no working tree exists that could hold
-  PR head or merge content, and it reads PR files/labels through GitHub APIs. Do
+  PR head or merge content, and it reads PR metadata/labels through GitHub APIs. Do
   not add `actions/checkout`, or any step that executes head code, consumes head
   artifacts, or builds a shell command from PR content, to this privileged
-  workflow. The PR-files REST endpoint hard-caps its
-  response at 3,000 files, so the policy cross-checks the returned count against
-  the event's `pull_request.changed_files` and fails closed on any mismatch.
-  Count and path matching operate on the slurped JSON arrays, never line-oriented
-  filename output (Git permits newlines in filenames).
+  workflow. Changed paths are computed from the immutable event base/head SHAs:
+  the compare API resolves their merge base, then recursive Git-tree snapshots
+  are structurally diffed by path/mode/type/blob SHA. Never return to the live
+  PR-files endpoint — a force-push can change that response while the run still
+  publishes to the event's old head SHA. A missing/empty diff or a Git-tree
+  `truncated` response fails closed; path matching stays inside JSON (Git permits
+  newlines in filenames). The selector is deliberately conservative: repo-wide
+  implicit `_darwin*`/`_arm64*` source suffixes, every changed native source
+  (`c`/C++/headers/Obj-C/assembly/syso), control-character paths, and any changed
+  Go blob containing an explicit build-constraint line all require verification.
+  This deliberately over-gates Linux/cross-platform constraints rather than
+  guessing an incomplete tag universe. `edited` base-retarget events invalidate
+  verification; unrelated PR edits preserve the current SHA-bound status.
 
   A separate unprivileged
   [.github/workflows/darwin-verification-policy-test.yml](.github/workflows/darwin-verification-policy-test.yml)
@@ -1454,11 +1463,15 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   and a distinct check name. It is review feedback only: a fork can modify that
   workflow, so it never publishes the required status.
 
-  On `synchronize` or `reopened`, the trusted policy best-effort removes
-  `darwin-e2e-verified` and posts failure to the new/current head regardless of
-  label cleanup success. A successful `labeled` event for that exact label posts
-  success to that head; removing it posts failure, with both events re-reading
-  live label state so a remove/re-add race settles to the current truth.
+  On `synchronize`, `reopened`, or base-changing `edited`, the trusted policy
+  best-effort removes `darwin-e2e-verified` and posts failure to the new/current
+  head regardless of label cleanup success. A successful `labeled` event for
+  that exact label posts success to that head; removing it posts failure, with
+  both events re-reading live label state so a remove/re-add race settles to the
+  current truth. A label addition may publish success only after the same head
+  already has a trusted failing gate status; otherwise it fails and asks the
+  maintainer to toggle again. This prevents a queued label event from superseding
+  the still-pending `synchronize` run that would have invalidated the new head.
   Unrelated label events post nothing, preserving either a legitimate success
   or a stale-cleanup failure already bound to the same head SHA. Relevant runs
   post `pending` before evaluation, serialize per PR, and post failure on
@@ -1479,13 +1492,13 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   reintroduce `cancel-in-progress: true`.
 
   **Concurrency grouping is part of the policy.** Only events that are
-  authoritative for the current head (`opened`, `synchronize`, `reopened`, and
-  `darwin-e2e-verified` label add/remove) share the serialized per-PR `policy`
-  group. Unrelated label events get a per-run group so they can neither queue
-  behind nor displace a queued gating run. That isolation is what makes queued
-  supersession safe: every event that can replace a queued `synchronize` either
-  performs the same stale-label cleanup itself (`synchronize`/`reopened`) or is
-  a deliberate human assertion about the current head (verified-label events).
+  authoritative for the current head (`opened`, `synchronize`, `reopened`,
+  base-changing `edited`, and `darwin-e2e-verified` label add/remove) share the
+  serialized per-PR `policy` group. Unrelated labels and non-base edits get a
+  per-run group so they can neither queue behind nor displace a queued gating
+  run. A verified-label event that replaces a queued `synchronize` still cannot
+  pass: it requires the same head's prior trusted failure, which the superseded
+  run never posted.
 
   **A run must publish a decision or fail closed.** The gate records its
   terminal outcome (`success`, `failure`, or `ignored`) to
@@ -1501,6 +1514,17 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   below the trap installation disarms it with `$(trap - ERR; …)`, and a contract
   test enforces that statically — the runtime symptom only reproduces on the
   runner's bash 5, not on macOS's bash 3.2.
+
+  **Merge-queue limitation:** the active default-branch merge queue evaluates
+  required checks on synthetic merge-group SHAs, while this trusted workflow
+  posts only to PR head SHAs. Do not require `Darwin E2E verified` while that
+  queue is active: a missing group status would time out every queue entry, and
+  an Actions-only group publisher is not a safe fix because merge-group content
+  includes PR-authored workflow YAML that can write the same GitHub Actions
+  status context. Keep this status advisory unless the merge queue is disabled,
+  or implement group enforcement with a distinct trusted GitHub App whose status
+  source can be required separately. Current branch protection/rulesets do not
+  require the context, so the present impact remains advisory.
 
 Build/test commands:
 


### PR DESCRIPTION
## Summary

- replace fork-modifiable `pull_request` enforcement with a main-only, base-controlled `pull_request_target` workflow
- fetch policy from trusted `${{ github.workflow_sha }}` with no checkout, head execution, or artifacts
- bind decisions to live PR generation and immutable merge-base/head Git trees
- require an authorized human `labeled` event; never treat another Actions status as approval readiness and never succeed from `unlabeled`
- fail closed on stale cleanup, retarget/force-push races, malformed trees, BOM constraints, symlinks/gitlinks, native/cgo coverage, and API/status failures
- keep proposed HEAD policy tests read-only and non-authoritative

## Security posture

> [!IMPORTANT]
> **`Darwin E2E verified` is advisory and non-authoritative under current repository settings.** Same-repository workflows share the GitHub Actions identity and may write the same status context, so App binding cannot authenticate this workflow.
>
> The active merge queue is also not safely enforceable through Actions alone. Disabling it only removes synthetic merge-group SHAs; it does not fix same-repository spoofing. Safe enforcement requires a distinct trusted GitHub App/status source, an organization-required workflow if available, or native required-review/CODEOWNERS if human review is the enforcement mechanism.

## Trust and coverage

- `pull_request_target` is restricted to `main`; executable policy comes from `${{ github.workflow_sha }}`.
- Immediately before every success, live metadata must still show the exact open `main` PR generation: unchanged base/head SHAs and head repository.
- Success requires the exact live label and a human event sender with `write`, `maintain`, or `admin` permission.
- Changed paths come from independently validated immutable Git trees, never mutable `/pulls/{n}/files` data.
- Conservative coverage includes debugger and integration-harness code, `justfile`, entitlements, module graph, platform suffixes, all native extensions, explicit Go/cgo constraints, BOMs, control-character paths, and non-regular tree entries.
- Relevant runs are never canceled in progress; terminal decisions are recorded only after GitHub accepts them, with an `always()` failure backstop.

## Verification

- **172 cases**, 0 failures under Bash 3.2.57 and Bash 5.3.15
- exact-head Linux policy run **31346856241** passed on the pre-restack head
- all workflow YAML parses
- `go vet -tags bingonative ./...`
- `go test -tags bingonative -race ./...`
- native `just e2e-darwin` on Apple Silicon: **22/22 specs passed**, 0 failed (251.6s), including the darwin-only `hygiene` port-right check (task send refs `base:1` → `after:1`)
- three max-effort adversarial security reviews; all findings remediated, with no exploitable bypass or documentation overclaim remaining

### Restack onto current `main`

Rebased from merge-base `0509b53bfc44da889e152ee20f56ce3663882c65` onto `1f16c666b9ad682c0a12d5324fcaf4afb280cbdc`; head moved `8be155b1c8196a9826d0faaa2a1b8b621e8578ac` → `746b67bbbab262e0b6b376705b7b23f684e76569`.

- zero conflicts; all 13 commits preserved 1:1 in order
- `git range-diff` reports every commit `=` (unchanged); all 13 per-commit `patch-id --stable` values are byte-identical
- aggregate delta `patch-id` unchanged: `edf24f4489b86c4042ed5bd94f2f41bbb071c76c`
- `git diff --name-status` identical (same 5 paths); the four policy/workflow blobs are byte-identical to the pre-restack head
- `AGENTS.md` differs from the pre-restack head only by `main`'s #147 churn-watchdog paragraph; every change from this PR is intact
- #137 (`justfile` host-aware Darwin recipes) and #147 (`churn_watchdog_test.go`, `debugger_e2e_common_test.go`) blobs are byte-identical to `main` — nothing merged was reverted or weakened

## Residuals

- Statuses are SHA-global; success means “verified relative to `main`” for that commit.
- This bootstrap PR cannot run the new authoritative `pull_request_target` path because `main` still has the old trigger. The read-only HEAD policy workflow validates it until merge.
- The former #146 flake (`StepOver #199`, normal exit at 181.362s against the then-fixed 180s churn watchdog) is resolved in the new base: #147 scales the watchdog from `BINGO_E2E_CHURN_ITERS`. No debugger or E2E-harness code is changed here.
- This PR's delta touches no path in the gate's own Darwin-native scope (only `.github/**` and `AGENTS.md`), so the policy short-circuits this head to `success` without requiring a `darwin-e2e-verified` label.

Fixes #154