### PR TITLE
fix(hub): preserve timeout resume state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,12 @@ The hub blocks after broadcasting any of these "suspending" events until a
 While suspended, **non-resuming** commands (`SetBreakpoint`, `Locals`, …) are
 still executed immediately — the process is paused, so it's safe.
 
+The 30-minute safety timeout synthesizes a versioned `CmdContinue` and uses the
+same `executeCommand` path as a client resume. Success therefore performs the
+normal `running` state transition and event ordering. A rejected auto-continue
+broadcasts `EventError`, remains in the suspended wait loop, and re-arms a full
+30-minute interval so client retries stay serviceable without a hot retry loop.
+
 A successful `Continue` emits a **non-suspending** `EventContinued` from the
 engine (`engine.Continue` → `emitContinued`) before the process runs free. It is
 not in the suspending set and does not gate the hub — it's a fire-and-forget

--- a/internal/hub/export_test.go
+++ b/internal/hub/export_test.go
@@ -1,0 +1,9 @@
+// Exposes internal symbols to hub_test. Compiled only during `go test`.
+package hub
+
+import "time"
+
+// ExportedSetSuspendTimeout must be called before Run starts.
+func ExportedSetSuspendTimeout(h *Hub, timeout time.Duration) {
+	h.suspendTimeout = timeout
+}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -19,6 +19,8 @@ import (
 
 var ErrHubClosed = errors.New("hub is shutting down")
 
+const defaultSuspendTimeout = 30 * time.Minute
+
 // suspendingEvents pause the hub and require a resuming command before the
 // process is allowed to continue. EventPaused is included: a Pause request
 // halts the tracee and suspends it exactly like a breakpoint hit, just
@@ -80,6 +82,10 @@ type Hub struct {
 	// resumeCh: capacity 1, first-write-wins. Extras dropped in injectCommand.
 	resumeCh chan protocol.Command
 
+	// Immutable after Run starts; tests shorten it per hub to exercise the
+	// safety-resume path without a mutable process-wide setting.
+	suspendTimeout time.Duration
+
 	// seq is the single counter for ALL outbound events. The hub re-stamps
 	// debugger events with this counter, so clients see one monotonic stream
 	// and can detect gaps. The engine has its own seq.
@@ -119,6 +125,7 @@ func newHub(log *slog.Logger) *Hub {
 		registry:           newRegistry(),
 		cmdCh:              make(chan clientCommand, 32),
 		resumeCh:           make(chan protocol.Command, 1),
+		suspendTimeout:     defaultSuspendTimeout,
 		shutdownCh:         make(chan struct{}),
 		done:               make(chan struct{}),
 		log:                log,
@@ -283,7 +290,7 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 
 	h.log.Info("suspended — waiting for resuming command", "event", evt.Kind)
 
-	timeout := time.NewTimer(30 * time.Minute)
+	timeout := time.NewTimer(h.suspendTimeout)
 	defer timeout.Stop()
 
 	for {
@@ -344,13 +351,18 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 			}
 
 		case <-timeout.C:
-			h.log.Warn("30-minute suspend timeout — auto-continuing")
-			if h.dbg != nil {
-				if err := h.dbg.Continue(); err != nil {
-					h.log.Warn("auto-continue failed", "err", err)
-				}
+			h.log.Warn("suspend timeout — auto-continuing", "timeout", h.suspendTimeout)
+			h.executeCommand(protocol.Command{
+				Version: protocol.Version,
+				Kind:    protocol.CmdContinue,
+			})
+			if h.State() != protocol.StateSuspended {
+				return
 			}
-			return
+			// A rejected safety resume must leave the same retry path available
+			// as a rejected client resume. Re-arm from now so failures do not
+			// collapse into a hot retry loop.
+			timeout.Reset(h.suspendTimeout)
 		}
 	}
 }

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -33,6 +33,7 @@ type fakeDebugger struct {
 	setBPErr         error
 	clearBPErr       error
 	continueErr      error
+	emitContinued    bool
 	stepOverErr      error
 	stepIntoErr      error
 	stepOutErr       error
@@ -75,8 +76,14 @@ func (f *fakeDebugger) Attach(pid int, binaryPath string) error {
 	f.record("Attach")
 	return f.attachErr
 }
-func (f *fakeDebugger) Kill() error     { f.record("Kill"); return nil }
-func (f *fakeDebugger) Continue() error { f.record("Continue"); return f.continueErr }
+func (f *fakeDebugger) Kill() error { f.record("Kill"); return nil }
+func (f *fakeDebugger) Continue() error {
+	f.record("Continue")
+	if f.continueErr == nil && f.emitContinued {
+		f.push(protocol.MustEvent(protocol.EventContinued, 0, protocol.ContinuedPayload{}))
+	}
+	return f.continueErr
+}
 func (f *fakeDebugger) StepOver() error { f.record("StepOver"); return f.stepOverErr }
 func (f *fakeDebugger) StepInto() error { f.record("StepInto"); return f.stepIntoErr }
 func (f *fakeDebugger) StepOut() error  { f.record("StepOut"); return f.stepOutErr }
@@ -933,6 +940,112 @@ func countCalls(calls []string, name string) int {
 	}
 	return n
 }
+
+func newManagedTimeoutHub(timeout time.Duration) (*fakeDebugger, *hub.Hub, *fakeWSConn, context.CancelFunc) {
+	fd := newFakeDebugger()
+	managed := hub.NewSession("timeout-session", func() debugger.Debugger { return fd }, nil)
+	hub.ExportedSetSuspendTimeout(managed, timeout)
+	cancel := runHub(managed)
+	conn := newFakeWSConn()
+	mustAddClient(managed, conn)
+	waitForEventKind(conn, protocol.EventSessionState, nil)
+	launchManaged(conn, fd, "timeout-target")
+	return fd, managed, conn, cancel
+}
+
+var _ = Describe("Suspend safety timeout", func() {
+	It("uses the normal resume state and event path after auto-continue succeeds", func() {
+		const timeout = 50 * time.Millisecond
+		fd, managed, conn, cancel := newManagedTimeoutHub(timeout)
+		defer func() {
+			cancel()
+			Eventually(managed.Done(), "500ms", "10ms").Should(BeClosed())
+		}()
+		fd.emitContinued = true
+
+		fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+		waitForEventKind(conn, protocol.EventBreakpointHit, nil)
+		var suspended protocol.SessionStatePayload
+		waitForEventKind(conn, protocol.EventSessionState, &suspended)
+		Expect(suspended.State).To(Equal(protocol.StateSuspended))
+
+		runningEvent, ok := recvEvent(conn)
+		Expect(ok).To(BeTrue())
+		Expect(runningEvent.Kind).To(Equal(protocol.EventSessionState))
+		var running protocol.SessionStatePayload
+		Expect(protocol.DecodeEventPayload(runningEvent, &running)).To(Succeed())
+		Expect(running.State).To(Equal(protocol.StateRunning))
+
+		continued, ok := recvEvent(conn)
+		Expect(ok).To(BeTrue())
+		Expect(continued.Kind).To(Equal(protocol.EventContinued))
+		Expect(continued.Seq).To(BeNumerically(">", runningEvent.Seq))
+		Expect(managed.State()).To(Equal(protocol.StateRunning))
+		Consistently(func() int {
+			return countCalls(fd.recordedCalls(), "Continue")
+		}, 2*timeout, 5*time.Millisecond).Should(Equal(1))
+	})
+
+	It("reports a rejected auto-continue and still accepts a client retry", func() {
+		const timeout = 50 * time.Millisecond
+		fd, managed, conn, cancel := newManagedTimeoutHub(timeout)
+		defer func() {
+			cancel()
+			Eventually(managed.Done(), "500ms", "10ms").Should(BeClosed())
+		}()
+		fd.continueErr = errors.New("reinstall failed")
+		fd.emitContinued = true
+
+		fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+		waitForEventKind(conn, protocol.EventBreakpointHit, nil)
+		waitForEventKind(conn, protocol.EventSessionState, nil)
+
+		var commandErr protocol.ErrorPayload
+		waitForEventKind(conn, protocol.EventError, &commandErr)
+		Expect(commandErr.Command).To(Equal(protocol.CmdContinue))
+		Expect(managed.State()).To(Equal(protocol.StateSuspended))
+		Expect(countCalls(fd.recordedCalls(), "Continue")).To(Equal(1))
+
+		fd.continueErr = nil
+		conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
+
+		var running protocol.SessionStatePayload
+		waitForEventKind(conn, protocol.EventSessionState, &running)
+		Expect(running.State).To(Equal(protocol.StateRunning))
+		waitForEventKind(conn, protocol.EventContinued, nil)
+		Expect(managed.State()).To(Equal(protocol.StateRunning))
+		Expect(countCalls(fd.recordedCalls(), "Continue")).To(Equal(2))
+	})
+
+	It("re-arms the full interval after each rejected auto-continue", func() {
+		const timeout = 120 * time.Millisecond
+		fd, managed, conn, cancel := newManagedTimeoutHub(timeout)
+		defer func() {
+			cancel()
+			Eventually(managed.Done(), "500ms", "10ms").Should(BeClosed())
+		}()
+		fd.continueErr = errors.New("still suspended")
+
+		fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+		waitForEventKind(conn, protocol.EventBreakpointHit, nil)
+		waitForEventKind(conn, protocol.EventSessionState, nil)
+		waitForEventKind(conn, protocol.EventError, nil)
+
+		Consistently(func() int {
+			return countCalls(fd.recordedCalls(), "Continue")
+		}, timeout/2, 5*time.Millisecond).Should(Equal(1))
+
+		waitForEventKind(conn, protocol.EventError, nil)
+		Expect(countCalls(fd.recordedCalls(), "Continue")).To(Equal(2))
+		Consistently(func() int {
+			return countCalls(fd.recordedCalls(), "Continue")
+		}, timeout/2, 5*time.Millisecond).Should(Equal(2))
+		Expect(managed.State()).To(Equal(protocol.StateSuspended))
+	})
+})
 
 var _ = Describe("Restart", func() {
 	var fd *fakeDebugger


### PR DESCRIPTION
## Summary

- route the 30-minute suspend safety auto-continue through a versioned `CmdContinue` and the existing command dispatcher
- keep rejected auto-continues in the suspended wait loop, broadcast their `EventError`, and re-arm the full safety interval
- add a per-hub test seam plus deterministic managed-session coverage for state/event ordering, client retry recovery, and bounded retry cadence
- document the timeout resume invariant in `AGENTS.md`

## Tests

- `go test -tags bingonative -race ./internal/hub/... ./internal/server/... ./internal/dap/...`
- 20/20 focused timeout race runs
- 20/20 randomized full hub race runs (seeds 1-20)
- `go vet -tags bingonative ./...`

Fixes #158