### PR TITLE
fix(hub): prevent ordinary command loss

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,16 @@ normal `running` state transition and event ordering. A rejected auto-continue
 broadcasts `EventError`, remains in the suspended wait loop, and re-arms a full
 30-minute interval so client retries stay serviceable without a hot retry loop.
 
+Ordinary-command admission is lossless while the originating client remains
+connected. When bounded `cmdCh` is full, `injectCommand` backpressures that
+client's read pump for up to five seconds while also selecting on hub shutdown
+and the client's disconnect signal. If capacity never frees, the hub removes
+and closes that client rather than silently dropping the command. This is
+load-bearing for DAP's id-less confirmation FIFOs: a logged drop would leave a
+pending request forever and shift every later confirmation, while a synthetic
+`EventError` for an unadmitted tail could resolve the wrong FIFO head. The
+lossy, capacity-one `resumeCh` is the deliberate exception described below.
+
 A successful `Continue` emits a **non-suspending** `EventContinued` from the
 engine (`engine.Continue` → `emitContinued`) before the process runs free. It is
 not in the suspending set and does not gate the hub — it's a fire-and-forget
@@ -1040,7 +1050,10 @@ slow-client eviction. There is deliberately no DAP-awareness anywhere in
   `cmdOut chan []byte` of marshalled bingo `Command`s produced by the DAP read
   loop; returns `io.EOF` on Close. **cmdOut-priority:** a non-blocking check of
   `cmdOut` precedes the `{cmdOut | done}` select, so a `Kill` enqueued right
-  before `Close` (disconnect-terminate) is still handed off before EOF.
+  before `Close` (disconnect-terminate) is still handed off before EOF. The hub
+  may backpressure this read pump while its ordinary-command queue is full;
+  `cmdOut` stays bounded, and Handler `Close` unblocks both `ReadMessage` and a
+  DAP producer waiting to enqueue.
 - `Serve()` (its own goroutine, one per connection): the DAP read loop —
   `godap.ReadProtocolMessage` → `dispatchRequest`. Runs the handshake state
   machine, enqueues bingo commands, and answers non-hub requests directly.
@@ -1213,6 +1226,12 @@ documented caveat. Fixing it properly needs correlation ids in the bingo protoco
 — deferred. Resume/step/breakpoint-hit events are broadcast to all clients and
 need no correlation, so multi-driver continue/step is fine; only the id-less
 confirmation requests are affected.
+
+The hub's reliable ordinary-command admission is a prerequisite for these
+FIFOs: it either executes each admitted command in order or closes the whole DAP
+connection on sustained overload. Never replace overload eviction with an
+uncorrelated bingo error event — the adapter cannot identify a dropped tail
+slot, so such an event could consume the wrong FIFO head.
 
 **setBreakpoints is replace-all** (`breakpoints.go`): diff the requested lines
 for a source against `bpByFile` — clear removed, set new, keep unchanged — and

--- a/internal/dap/handler.go
+++ b/internal/dap/handler.go
@@ -19,9 +19,9 @@ import (
 )
 
 // cmdBufferSize bounds the queue of bingo commands awaiting the hub's read
-// pump. The pump drains it promptly (injectCommand is a channel send), so a
-// small buffer is plenty; it exists mainly so the DAP read loop never blocks
-// while a burst of setBreakpoints commands is enqueued.
+// pump. It absorbs normal setBreakpoints bursts while the hub applies its own
+// bounded backpressure; persistent hub overload closes the handler and unblocks
+// enqueue through done.
 const cmdBufferSize = 64
 
 // dapWriteTimeout bounds a single socket write so a DAP client that stops

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -2,6 +2,7 @@ package dap
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -12,6 +13,7 @@ import (
 
 	godap "github.com/google/go-dap"
 
+	"github.com/bingosuite/bingo/internal/debugger"
 	"github.com/bingosuite/bingo/internal/hub"
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
@@ -153,6 +155,92 @@ func (p *fakeProvider) CreateSession() (Session, error) {
 func (p *fakeProvider) GetSession(string) (Session, bool) {
 	return p.sess, p.sess != nil
 }
+
+type hubProvider struct {
+	session Session
+}
+
+func (p *hubProvider) CreateSession() (Session, error) {
+	return p.session, nil
+}
+
+func (p *hubProvider) GetSession(id string) (Session, bool) {
+	return p.session, p.session != nil && p.session.SessionID() == id
+}
+
+type gatedBreakpointDebugger struct {
+	events chan protocol.Event
+	gate   chan struct{}
+
+	started     chan struct{}
+	startOnce   sync.Once
+	releaseOnce sync.Once
+
+	mu       sync.Mutex
+	setLines []int
+}
+
+func newGatedBreakpointDebugger() *gatedBreakpointDebugger {
+	return &gatedBreakpointDebugger{
+		events:  make(chan protocol.Event, 1),
+		gate:    make(chan struct{}),
+		started: make(chan struct{}),
+	}
+}
+
+func (d *gatedBreakpointDebugger) release() {
+	d.releaseOnce.Do(func() { close(d.gate) })
+}
+
+func (d *gatedBreakpointDebugger) setCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.setLines)
+}
+
+func (d *gatedBreakpointDebugger) Launch(string, []string, []string) error {
+	d.events <- protocol.MustEvent(protocol.EventStepped, 1,
+		protocol.SteppedPayload{Goroutine: protocol.Goroutine{ID: 1}})
+	return nil
+}
+
+func (*gatedBreakpointDebugger) Attach(int, string) error { return nil }
+func (*gatedBreakpointDebugger) Kill() error              { return nil }
+func (d *gatedBreakpointDebugger) SetBreakpoint(file string, line int) (protocol.Breakpoint, error) {
+	d.startOnce.Do(func() { close(d.started) })
+	<-d.gate
+	d.mu.Lock()
+	d.setLines = append(d.setLines, line)
+	d.mu.Unlock()
+	return protocol.Breakpoint{
+		ID:       line,
+		Location: protocol.Location{File: file, Line: line},
+	}, nil
+}
+func (*gatedBreakpointDebugger) ClearBreakpoint(int) error { return nil }
+func (*gatedBreakpointDebugger) Continue() error           { return nil }
+func (*gatedBreakpointDebugger) StepOver() error           { return nil }
+func (*gatedBreakpointDebugger) StepInto() error           { return nil }
+func (*gatedBreakpointDebugger) StepOut() error            { return nil }
+func (*gatedBreakpointDebugger) Pause() error              { return nil }
+func (*gatedBreakpointDebugger) Locals(int) ([]protocol.Variable, error) {
+	return nil, nil
+}
+func (*gatedBreakpointDebugger) Evaluate(int, string) (protocol.Variable, error) {
+	return protocol.Variable{}, nil
+}
+func (*gatedBreakpointDebugger) StackFrames() ([]protocol.Frame, error) {
+	return nil, nil
+}
+func (*gatedBreakpointDebugger) Goroutines() ([]protocol.Goroutine, error) {
+	return nil, nil
+}
+func (*gatedBreakpointDebugger) GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error) {
+	return protocol.GoroutineSnapshotPayload{}, nil
+}
+func (d *gatedBreakpointDebugger) Events() <-chan protocol.Event { return d.events }
+
+var _ debugger.Debugger = (*gatedBreakpointDebugger)(nil)
 
 func TestStartSessionRejectsClosedHub(t *testing.T) {
 	serverConn, clientConn := net.Pipe()
@@ -781,6 +869,108 @@ func TestRestartPreservesBreakpointCorrelationQueues(t *testing.T) {
 	if len(h.clearQ) != 1 || h.clearQ[0] != 73 {
 		t.Fatalf("clearQ changed across restart: %v", h.clearQ)
 	}
+}
+
+func TestSetBreakpointsBurstThroughHubPreservesFIFO(t *testing.T) {
+	dbg := newGatedBreakpointDebugger()
+	defer dbg.release()
+
+	session := hub.NewSession("sess-burst", func() debugger.Debugger { return dbg }, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	go session.Run(ctx)
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-session.Done():
+		case <-time.After(2 * time.Second):
+			t.Error("hub did not stop")
+		}
+	})
+
+	hh := newHarnessProvider(t, &hubProvider{session: session}, &cmdRecorder{})
+	hh.sendReq("initialize", initArgs())
+	_ = recvType[*godap.InitializeResponse](hh)
+
+	launchSeq := hh.sendReq("launch", &godap.LaunchRequest{
+		Arguments: json.RawMessage(`{"program":"/bin/x","stopOnEntry":true}`),
+	})
+	_ = recvType[*godap.InitializedEvent](hh)
+
+	const breakpointCount = 98
+	requested := make([]godap.SourceBreakpoint, breakpointCount)
+	for i := range requested {
+		requested[i] = godap.SourceBreakpoint{Line: i + 1}
+	}
+	setSeq := hh.sendReq("setBreakpoints", &godap.SetBreakpointsRequest{
+		Arguments: godap.SetBreakpointsArguments{
+			Source:      godap.Source{Path: "/x/main.go", Name: "main.go"},
+			Breakpoints: requested,
+		},
+	})
+
+	select {
+	case <-dbg.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first SetBreakpoint did not reach the debugger")
+	}
+
+	// The handler processes requests serially. With 98 commands and a 64-slot
+	// cmdOut, this response proves the hub read pump consumed enough commands to
+	// saturate its 32-slot queue while the first debugger call remained gated.
+	hh.sendReq("scopes", &godap.ScopesRequest{
+		Arguments: godap.ScopesArguments{FrameId: 1},
+	})
+	_ = recvType[*godap.ScopesResponse](hh)
+
+	dbg.release()
+
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	if resp.RequestSeq != setSeq {
+		t.Fatalf("setBreakpoints request seq = %d, want %d", resp.RequestSeq, setSeq)
+	}
+	if len(resp.Body.Breakpoints) != breakpointCount {
+		t.Fatalf("got %d breakpoints, want %d", len(resp.Body.Breakpoints), breakpointCount)
+	}
+	for i, bp := range resp.Body.Breakpoints {
+		wantLine := i + 1
+		if !bp.Verified || bp.Id != wantLine || bp.Line != wantLine {
+			t.Fatalf("breakpoint %d = %+v, want verified line/id %d", i, bp, wantLine)
+		}
+	}
+	if got := dbg.setCount(); got != breakpointCount {
+		t.Fatalf("SetBreakpoint calls = %d, want %d", got, breakpointCount)
+	}
+
+	requested = append(requested, godap.SourceBreakpoint{Line: 1000})
+	nextSeq := hh.sendReq("setBreakpoints", &godap.SetBreakpointsRequest{
+		Arguments: godap.SetBreakpointsArguments{
+			Source:      godap.Source{Path: "/x/main.go", Name: "main.go"},
+			Breakpoints: requested,
+		},
+	})
+	next := recvType[*godap.SetBreakpointsResponse](hh)
+	if next.RequestSeq != nextSeq {
+		t.Fatalf("next setBreakpoints request seq = %d, want %d", next.RequestSeq, nextSeq)
+	}
+	last := next.Body.Breakpoints[len(next.Body.Breakpoints)-1]
+	if !last.Verified || last.Id != 1000 || last.Line != 1000 {
+		t.Fatalf("next breakpoint = %+v, want verified line/id 1000", last)
+	}
+
+	hh.handler.mu.Lock()
+	pendingSets := len(hh.handler.setQ)
+	hh.handler.mu.Unlock()
+	if pendingSets != 0 {
+		t.Fatalf("pending set FIFO entries = %d, want 0", pendingSets)
+	}
+
+	hh.sendReq("configurationDone", &godap.ConfigurationDoneRequest{})
+	_ = recvType[*godap.ConfigurationDoneResponse](hh)
+	launch := recvType[*godap.LaunchResponse](hh)
+	if launch.RequestSeq != launchSeq {
+		t.Fatalf("launch request seq = %d, want %d", launch.RequestSeq, launchSeq)
+	}
+	_ = recvType[*godap.StoppedEvent](hh)
 }
 
 func TestStackTraceAndVariablesCorrelation(t *testing.T) {

--- a/internal/hub/admission_test.go
+++ b/internal/hub/admission_test.go
@@ -1,0 +1,204 @@
+package hub
+
+import (
+	"encoding/json"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+type admissionConn struct {
+	command   []byte
+	firstRead chan struct{}
+	closed    chan struct{}
+	readOnce  sync.Once
+	closeOnce sync.Once
+}
+
+func newAdmissionConn(command protocol.Command) *admissionConn {
+	data, _ := json.Marshal(command)
+	return &admissionConn{
+		command:   data,
+		firstRead: make(chan struct{}),
+		closed:    make(chan struct{}),
+	}
+}
+
+func (c *admissionConn) ReadMessage() (int, []byte, error) {
+	first := false
+	c.readOnce.Do(func() {
+		first = true
+		close(c.firstRead)
+	})
+	if first {
+		return TextMessage, c.command, nil
+	}
+	<-c.closed
+	return 0, nil, io.EOF
+}
+
+func (*admissionConn) WriteMessage(int, []byte) error    { return nil }
+func (*admissionConn) SetReadLimit(int64)                {}
+func (*admissionConn) SetReadDeadline(time.Time) error   { return nil }
+func (*admissionConn) SetWriteDeadline(time.Time) error  { return nil }
+func (*admissionConn) SetPongHandler(func(string) error) {}
+func (c *admissionConn) Close() error {
+	c.closeOnce.Do(func() { close(c.closed) })
+	return nil
+}
+
+func TestBlockedCommandAdmissionUnblocksReadPump(t *testing.T) {
+	tests := []struct {
+		name string
+		stop func(*Hub, *Client)
+	}{
+		{
+			name: "client teardown",
+			stop: func(h *Hub, c *Client) {
+				h.removeClient(c)
+			},
+		},
+		{
+			name: "hub shutdown",
+			stop: func(h *Hub, _ *Client) {
+				h.shutdown()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newHub(nil)
+			for i := 0; i < cap(h.cmdCh); i++ {
+				h.cmdCh <- clientCommand{cmd: protocol.Command{Kind: protocol.CmdPause}}
+			}
+
+			conn := newAdmissionConn(protocol.Command{
+				Version: protocol.Version,
+				Kind:    protocol.CmdPause,
+			})
+			client := newClient(conn, h, nil)
+			if !h.registry.add(client) {
+				t.Fatal("client was not admitted")
+			}
+
+			if tt.name == "client teardown" {
+				keepalive := newClient(newAdmissionConn(protocol.Command{}), h, nil)
+				if !h.registry.add(keepalive) {
+					t.Fatal("keepalive client was not admitted")
+				}
+			}
+
+			readPumpDone := make(chan struct{})
+			go func() {
+				client.readPump()
+				close(readPumpDone)
+			}()
+
+			select {
+			case <-conn.firstRead:
+			case <-time.After(time.Second):
+				t.Fatal("read pump did not read the command")
+			}
+			select {
+			case <-readPumpDone:
+				t.Fatal("read pump returned before blocked admission was released")
+			case <-time.After(20 * time.Millisecond):
+			}
+
+			tt.stop(h, client)
+
+			select {
+			case <-readPumpDone:
+			case <-time.After(time.Second):
+				t.Fatal("blocked read pump did not exit")
+			}
+			h.shutdown()
+		})
+	}
+}
+
+func TestCommandAdmissionTimeoutEvictsClient(t *testing.T) {
+	h := newHub(nil)
+	h.commandAdmissionTimeout = 20 * time.Millisecond
+	for i := 0; i < cap(h.cmdCh); i++ {
+		h.cmdCh <- clientCommand{cmd: protocol.Command{Kind: protocol.CmdPause}}
+	}
+
+	conn := newAdmissionConn(protocol.Command{})
+	client := newClient(conn, h, nil)
+	if !h.registry.add(client) {
+		t.Fatal("client was not admitted")
+	}
+
+	admitted := h.injectCommand(client, protocol.Command{
+		Version: protocol.Version,
+		Kind:    protocol.CmdPause,
+	})
+	if admitted {
+		t.Fatal("command was admitted despite a persistently full queue")
+	}
+	if got := h.registry.count(); got != 0 {
+		t.Fatalf("client count = %d, want 0 after overload eviction", got)
+	}
+	select {
+	case <-client.disconnected:
+	default:
+		t.Fatal("overloaded client was not marked disconnected")
+	}
+	select {
+	case <-conn.closed:
+	default:
+		t.Fatal("overloaded client connection was not closed")
+	}
+	select {
+	case <-h.shutdownCh:
+	case <-time.After(time.Second):
+		t.Fatal("last-client eviction did not shut down the hub")
+	}
+}
+
+func TestKillAdmissionWaitsForCapacity(t *testing.T) {
+	h := newHub(nil)
+	for i := 0; i < cap(h.cmdCh); i++ {
+		h.cmdCh <- clientCommand{cmd: protocol.Command{Kind: protocol.CmdPause}}
+	}
+
+	client := newClient(newAdmissionConn(protocol.Command{}), h, nil)
+	admitted := make(chan bool, 1)
+	go func() {
+		admitted <- h.injectCommand(client, protocol.Command{
+			Version: protocol.Version,
+			Kind:    protocol.CmdKill,
+		})
+	}()
+
+	select {
+	case <-admitted:
+		t.Fatal("Kill admission returned while the command queue was full")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	<-h.cmdCh
+	select {
+	case ok := <-admitted:
+		if !ok {
+			t.Fatal("Kill admission was canceled after capacity became available")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Kill admission did not resume when capacity became available")
+	}
+
+	foundKill := false
+	for len(h.cmdCh) > 0 {
+		if cc := <-h.cmdCh; cc.cmd.Kind == protocol.CmdKill {
+			foundKill = true
+		}
+	}
+	if !foundKill {
+		t.Fatal("admitted Kill was not queued")
+	}
+}

--- a/internal/hub/client.go
+++ b/internal/hub/client.go
@@ -45,11 +45,13 @@ type Client struct {
 	hub  *Hub
 	log  *slog.Logger
 
-	// send is closed exactly once — by the registry on shutdown, or by
-	// deliver() on buffer overflow. sendMu guards close-vs-send races.
-	send   chan []byte
-	sendMu sync.Mutex
-	closed bool
+	// send and disconnected are closed together exactly once — by registry
+	// teardown, explicit eviction, or deliver() on buffer overflow. sendMu
+	// guards close-vs-send races.
+	send         chan []byte
+	disconnected chan struct{}
+	sendMu       sync.Mutex
+	closed       bool
 
 	// writeMu serialises the normal write pump with a protocol close emitted by
 	// the read pump when an incompatible peer must be rejected immediately.
@@ -61,20 +63,26 @@ func newClient(conn WSConn, h *Hub, log *slog.Logger) *Client {
 		log = slog.Default()
 	}
 	return &Client{
-		conn: conn,
-		hub:  h,
-		send: make(chan []byte, 256),
-		log:  log,
+		conn:         conn,
+		hub:          h,
+		send:         make(chan []byte, 256),
+		disconnected: make(chan struct{}),
+		log:          log,
 	}
 }
 
 func (c *Client) closeSend() {
 	c.sendMu.Lock()
 	defer c.sendMu.Unlock()
+	c.closeSendLocked()
+}
+
+func (c *Client) closeSendLocked() {
 	if c.closed {
 		return
 	}
 	c.closed = true
+	close(c.disconnected)
 	close(c.send)
 }
 
@@ -84,6 +92,7 @@ func (c *Client) writePump() {
 	ticker := time.NewTicker(pingInterval)
 	defer func() {
 		ticker.Stop()
+		c.closeSend()
 		_ = c.conn.Close()
 	}()
 
@@ -171,7 +180,9 @@ func (c *Client) readPump() {
 			return
 		}
 
-		c.hub.injectCommand(c, cmd)
+		if !c.hub.injectCommand(c, cmd) {
+			return
+		}
 	}
 }
 
@@ -188,8 +199,7 @@ func (c *Client) deliver(msg []byte) bool {
 		return true
 	default:
 		c.log.Warn("send buffer full — evicting slow client")
-		c.closed = true
-		close(c.send)
+		c.closeSendLocked()
 		return false
 	}
 }

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -19,7 +19,11 @@ import (
 
 var ErrHubClosed = errors.New("hub is shutting down")
 
-const defaultSuspendTimeout = 30 * time.Minute
+const (
+	commandQueueSize               = 32
+	defaultCommandAdmissionTimeout = 5 * time.Second
+	defaultSuspendTimeout          = 30 * time.Minute
+)
 
 // suspendingEvents pause the hub and require a resuming command before the
 // process is allowed to continue. EventPaused is included: a Pause request
@@ -71,8 +75,11 @@ type Hub struct {
 	stateMu sync.RWMutex
 	state   protocol.SessionState
 
-	// cmdCh: non-resuming commands from client read-pumps to the main loop.
-	cmdCh chan clientCommand
+	// cmdCh carries non-resuming commands from client read-pumps to the main
+	// loop. Producers apply bounded backpressure rather than dropping commands;
+	// commandAdmissionTimeout bounds how long one client may wait for capacity.
+	cmdCh                   chan clientCommand
+	commandAdmissionTimeout time.Duration
 
 	// resumeCh: capacity 1, first-write-wins. Extras dropped in injectCommand.
 	resumeCh chan protocol.Command
@@ -117,14 +124,15 @@ func newHub(log *slog.Logger) *Hub {
 		log = slog.Default()
 	}
 	return &Hub{
-		registry:           newRegistry(),
-		cmdCh:              make(chan clientCommand, 32),
-		resumeCh:           make(chan protocol.Command, 1),
-		suspendTimeout:     defaultSuspendTimeout,
-		shutdownCh:         make(chan struct{}),
-		done:               make(chan struct{}),
-		log:                log,
-		restartBreakpoints: make(map[int]protocol.Location),
+		registry:                newRegistry(),
+		cmdCh:                   make(chan clientCommand, commandQueueSize),
+		commandAdmissionTimeout: defaultCommandAdmissionTimeout,
+		resumeCh:                make(chan protocol.Command, 1),
+		suspendTimeout:          defaultSuspendTimeout,
+		shutdownCh:              make(chan struct{}),
+		done:                    make(chan struct{}),
+		log:                     log,
+		restartBreakpoints:      make(map[int]protocol.Location),
 	}
 }
 
@@ -683,22 +691,50 @@ func (h *Hub) handleRestart(cmd protocol.Command) {
 }
 
 // injectCommand is called by client read-pumps. Resuming commands (Continue,
-// Step*) go to resumeCh to directly unblock a suspended hub; everything else —
-// including Kill and Pause, which must act while the process is running — goes
-// to cmdCh, drained by Run's main loop and the suspended wait loop alike.
-func (h *Hub) injectCommand(_ *Client, cmd protocol.Command) {
+// Step*) retain their first-writer-wins semantics. Ordinary commands apply
+// bounded backpressure so a live client is never left with silently missing
+// commands; persistent overload evicts that client instead.
+func (h *Hub) injectCommand(c *Client, cmd protocol.Command) bool {
 	if resumingCommands[cmd.Kind] {
 		select {
 		case h.resumeCh <- cmd:
+		case <-h.shutdownCh:
+			return false
+		case <-c.disconnected:
+			return false
 		default:
 			// First writer wins; later resumers are dropped.
 		}
-		return
+		return true
 	}
+
+	cc := clientCommand{cmd: cmd}
 	select {
-	case h.cmdCh <- clientCommand{cmd: cmd}:
+	case h.cmdCh <- cc:
+		return true
+	case <-h.shutdownCh:
+		return false
+	case <-c.disconnected:
+		return false
 	default:
-		h.log.Warn("command queue full — dropping", "kind", cmd.Kind)
+	}
+
+	timeout := time.NewTimer(h.commandAdmissionTimeout)
+	defer timeout.Stop()
+
+	select {
+	case h.cmdCh <- cc:
+		return true
+	case <-h.shutdownCh:
+		return false
+	case <-c.disconnected:
+		return false
+	case <-timeout.C:
+		h.log.Warn("command admission timed out — evicting client",
+			"kind", cmd.Kind, "timeout", h.commandAdmissionTimeout)
+		h.removeClient(c)
+		_ = c.conn.Close()
+		return false
 	}
 }
 

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -31,6 +31,9 @@ type fakeDebugger struct {
 	attachErr        error
 	setBPResult      protocol.Breakpoint
 	setBPErr         error
+	setBPGate        chan struct{}
+	setBPStarted     chan struct{}
+	setBPStartOnce   sync.Once
 	clearBPErr       error
 	continueErr      error
 	emitContinued    bool
@@ -94,6 +97,12 @@ func (f *fakeDebugger) ClearBreakpoint(id int) error {
 }
 func (f *fakeDebugger) SetBreakpoint(file string, line int) (protocol.Breakpoint, error) {
 	f.record("SetBreakpoint")
+	if f.setBPStarted != nil {
+		f.setBPStartOnce.Do(func() { close(f.setBPStarted) })
+	}
+	if f.setBPGate != nil {
+		<-f.setBPGate
+	}
 	return f.setBPResult, f.setBPErr
 }
 func (f *fakeDebugger) Locals(fi int) ([]protocol.Variable, error) {
@@ -144,11 +153,15 @@ type fakeWSWrite struct {
 }
 
 func newFakeWSConn() *fakeWSConn {
+	return newFakeWSConnWithOutgoingBuffer(32)
+}
+
+func newFakeWSConnWithOutgoingBuffer(size int) *fakeWSConn {
 	return &fakeWSConn{
 		// Large buffer so WriteMessage (called from the hub's event loop)
 		// never blocks if a test doesn't drain — blocking would deadlock.
 		incoming: make(chan []byte, 256),
-		outgoing: make(chan []byte, 32),
+		outgoing: make(chan []byte, size),
 	}
 }
 
@@ -701,6 +714,61 @@ var _ = Describe("Hub", func() {
 			conn.inject(mustCommand(protocol.CmdKill, struct{}{}))
 			Eventually(fd.recordedCalls, "500ms", "10ms").
 				Should(ContainElement("Kill"))
+		})
+	})
+
+	Describe("ordinary command admission", func() {
+		It("executes a burst larger than cmdCh capacity without losing Kill", func() {
+			conn := newFakeWSConnWithOutgoingBuffer(1)
+			mustAddClient(h, conn)
+
+			fd.setBPGate = make(chan struct{})
+			fd.setBPStarted = make(chan struct{})
+			var releaseOnce sync.Once
+			release := func() {
+				releaseOnce.Do(func() { close(fd.setBPGate) })
+			}
+			DeferCleanup(release)
+
+			const breakpointCount = 48
+			conn.inject(mustCommand(protocol.CmdSetBreakpoint,
+				protocol.SetBreakpointPayload{File: "main.go", Line: 1}))
+			select {
+			case <-fd.setBPStarted:
+			case <-time.After(500 * time.Millisecond):
+				Fail("first SetBreakpoint did not reach the debugger")
+			}
+
+			burstSent := make(chan struct{})
+			go func() {
+				defer close(burstSent)
+				for line := 2; line <= breakpointCount; line++ {
+					conn.inject(mustCommand(protocol.CmdSetBreakpoint,
+						protocol.SetBreakpointPayload{File: "main.go", Line: line}))
+				}
+				conn.inject(mustCommand(protocol.CmdKill, struct{}{}))
+			}()
+
+			select {
+			case <-burstSent:
+				Fail("burst bypassed backpressure while the debugger was gated")
+			case <-time.After(100 * time.Millisecond):
+			}
+
+			release()
+			select {
+			case <-burstSent:
+			case <-time.After(2 * time.Second):
+				Fail("command producer remained blocked after debugger release")
+			}
+
+			Eventually(func() int {
+				return countCalls(fd.recordedCalls(), "SetBreakpoint")
+			}, "2s", "10ms").Should(Equal(breakpointCount))
+			Eventually(func() int {
+				return countCalls(fd.recordedCalls(), "Kill")
+			}, "2s", "10ms").Should(Equal(1))
+			Expect(h.ClientCount()).To(Equal(1))
 		})
 	})
 


### PR DESCRIPTION
## Summary

- replace silent `cmdCh` drops with bounded, disconnect-aware backpressure for every ordinary command
- evict and close only the originating client after five seconds of sustained overload, while preserving `resumeCh` first-writer-wins behavior
- add a per-client disconnect signal so blocked admission exits cleanly on client teardown, write failure, or hub shutdown
- cover high-count hub admission, queued `Kill`, overload eviction, read-pump teardown, and a real DAP→hub 98-breakpoint burst with a follow-up FIFO-alignment request
- document the ordinary-command delivery and DAP FIFO invariant in `AGENTS.md`

The pre-fix regression reproduced deterministically with only 33 of 48 breakpoints executed and the trailing `Kill` dropped while the connection stayed live.

## Validation

- `go test -race -tags bingonative ./internal/hub/... ./internal/dap/... ./internal/server/... ./pkg/client/... -count=1`
- `go vet -tags bingonative ./...`
- `go test -tags bingonative ./... -count=1`
- hub high-count admission regression: 20/20 race-enabled focused runs
- DAP 98-breakpoint FIFO regression: 20/20 race-enabled focused runs

Fixes #160