### PR TITLE
fix(dap): reconcile joined session lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -695,11 +695,21 @@ of issue #32). Constructors accept a nil logger and fall back to
 
 ## Hub seq stream — why one counter
 
-The hub re-stamps every outbound event with its own atomic `seq` counter. The
-engine has its own seq, and the hub also synthesises events (errors,
-confirmations like `BreakpointSet`). If clients saw both streams interleaved,
-they'd see two overlapping monotonic sequences and couldn't detect drops.
-**Always go through `h.seq.Add(1)` before broadcasting.**
+The hub re-stamps every outbound event with its own `seq` counter. The engine
+has its own seq, and the hub also synthesises events (errors, confirmations like
+`BreakpointSet`). If clients saw both streams interleaved, they'd see two
+overlapping monotonic sequences and couldn't detect drops.
+
+**`broadcast` is the only sequence-allocation path.** Its `outboundMu` covers
+sequence assignment, marshal, and nonblocking `deliver` to the registry
+snapshot, so every connected client sees the same frames in the same order.
+Managed `AddClient` takes that same lock across registry admission and a
+**broadcast** `EventSessionState`; existing clients therefore learn the new
+client count without a phantom gap, and the join state is the new client's
+first frame. Do not unicast an allocated sequence, reuse `seq` without
+incrementing it, or route join state through `Run` (which may be blocked in the
+suspended wait). `shutdown` also takes `outboundMu` before registry teardown so
+admission plus its initial state enqueue cannot interleave with closure.
 
 ## Restart — hub-level, not engine-level
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -708,8 +708,21 @@ Managed `AddClient` takes that same lock across registry admission and a
 client count without a phantom gap, and the join state is the new client's
 first frame. Do not unicast an allocated sequence, reuse `seq` without
 incrementing it, or route join state through `Run` (which may be blocked in the
-suspended wait). `shutdown` also takes `outboundMu` before registry teardown so
-admission plus its initial state enqueue cannot interleave with closure.
+suspended wait).
+
+Lifecycle events and their state transitions are one outbound critical section:
+`BreakpointHit`/`Panic`/`Stepped`/`Paused` is broadcast, state becomes
+`suspended`, then `EventSessionState` is broadcast; `ProcessExited` follows the
+same event → `exited` → state-event order, including when it arrives inside the
+suspended wait loop. `AddClient` cannot enter between those operations. A
+joiner is therefore either admitted before the lifecycle event and receives it,
+or admitted after the transition and receives the new state in its welcome —
+never a stale welcome after missing the event. The locked helpers exist to
+avoid re-entering `outboundMu`; do not split this pair back into separate
+`broadcast` and `transitionState` calls.
+
+`shutdown` also takes `outboundMu` before registry teardown so admission plus
+its initial state enqueue cannot interleave with closure.
 
 ## Restart — hub-level, not engine-level
 
@@ -1075,12 +1088,17 @@ session.
   `awaitingWelcome=true` to translate it.
 - `initialized` fires immediately (the target image is already loaded, so
   breakpoints resolve right away — there is no entry stop to wait for).
-- `onSessionState` (`events.go`) consumes that welcome **once** (gated on
-  `awaitingWelcome`): `suspended`→`suspended=true` + `stopped reason=pause` (tid
-  defaults to 1 — the engine inspects the currently-stopped goroutine regardless
-  of the DAP threadId); `exited`→`terminated`; idle/running→nothing. For the
-  normal launch/attach path `awaitingWelcome` is never set, so it is a no-op
-  there (the entry stop drives the initial state instead).
+- `onSessionState` (`events.go`) keeps reconciling state for the lifetime of a
+  **joined** connection, not just its welcome. `suspended` emits
+  `stopped reason=pause` only on a running→suspended adapter transition (tid
+  defaults to 1 before any real stop); `exited` emits `terminated` once; idle
+  and running clear the adapter's suspended flag without fabricating
+  `continued`. A real `BreakpointHit`/`Stepped`/`Paused`/`Panic` sets
+  `joinedState=suspended` before the following state frame, so reconciliation
+  does not duplicate its `stopped` even if a zero-latency client has already
+  sent Continue/Step and optimistically cleared the separate `suspended` flag.
+  Normal launch/attach connections have `joining=false`, so their
+  entry/configurationDone handshake remains the sole initial-state path.
 - `onConfigurationDone`'s `joining` branch responds to the attach but does NOT
   `pendingContinues++`, resume, or fabricate an entry stop.
 
@@ -1092,11 +1110,11 @@ reason=step; `EventBreakpointHit`→`stopped` reason=breakpoint;
 `EventProcessExited`→`exited`(code)+`terminated`; `EventOutput`→`output`;
 `EventRestarted`→delayed `restart` response; `EventEvaluate`→`evaluate` response
 (correlated via `evalQ`, NOT a stop — see below); `EventSessionState`→ignored on
-the launch/attach path, but consumed **once** as the initial state on the join
-path (see *Joining an existing session*); `EventGoroutineSnapshot`→**deliberately
-ignored** (WebSocket-only concurrency stream with no DAP equivalent; translating
-it would corrupt the `threads`→`EventGoroutines` FIFO — see the goroutine
-snapshot section).
+the launch/attach path, but continuously reconciled on the join path (see
+*Joining an existing session*); `EventGoroutineSnapshot`→**deliberately ignored**
+(WebSocket-only concurrency stream with no DAP equivalent; translating it would
+corrupt the `threads`→`EventGoroutines` FIFO — see the goroutine snapshot
+section).
 
 `EventContinued` → DAP `continued` **only for out-of-band resumes**. The Handler
 increments `pendingContinues` before enqueuing its OWN continue and decrements it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1097,6 +1097,9 @@ session.
   `joinedState=suspended` before the following state frame, so reconciliation
   does not duplicate its `stopped` even if a zero-latency client has already
   sent Continue/Step and optimistically cleared the separate `suspended` flag.
+  `EventRestarted` begins a new process lifecycle only after relaunch succeeds,
+  resetting the termination latch so the next exit emits `terminated` once
+  without reopening duplicates for the previous exit.
   Normal launch/attach connections have `joining=false`, so their
   entry/configurationDone handshake remains the sole initial-state path.
 - `onConfigurationDone`'s `joining` branch responds to the attach but does NOT

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1097,9 +1097,11 @@ session.
   `joinedState=suspended` before the following state frame, so reconciliation
   does not duplicate its `stopped` even if a zero-latency client has already
   sent Continue/Step and optimistically cleared the separate `suspended` flag.
-  `EventRestarted` begins a new process lifecycle only after relaunch succeeds,
-  resetting the termination latch so the next exit emits `terminated` once
-  without reopening duplicates for the previous exit.
+  A hub-observed `exited`/`idle`→`running` transition begins a fresh Launch
+  lifecycle (including one driven by another client), resetting the termination
+  latch exactly once for the new process; duplicate `running` frames in that
+  lifecycle do not. `EventRestarted` supplies the equivalent successful-relaunch
+  boundary for restart-from-suspended, where the previous state is not terminal.
   Normal launch/attach connections have `joining=false`, so their
   entry/configurationDone handshake remains the sole initial-state path.
 - `onConfigurationDone`'s `joining` branch responds to the attach but does NOT

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -249,12 +249,12 @@ type ErrorPayload struct {
 
 // internal/hub/hub.go
 func (h *Hub) broadcastError(kind protocol.CommandKind, err error) {
-    evt, e := protocol.NewEvent(protocol.EventError, h.seq.Add(1), protocol.ErrorPayload{
+    evt, e := protocol.NewEvent(protocol.EventError, 0, protocol.ErrorPayload{
         Command: kind,
         Message: err.Error(),
     })
     if e != nil {
-        h.log.Error("failed to marshal error event", "err", e)
+        h.log.Error("failed to marshal error event", "err", e, "cause", err)
         return
     }
     h.broadcast(evt)
@@ -267,6 +267,10 @@ version before hub injection, send that connection a close-1002 frame naming
 the expected and received versions, and disconnect it. Broadcasting an
 `EventError` would expose one client's malformed input to innocent clients and
 consume a shared hub sequence number for a connection-local failure.
+
+`broadcast` assigns the hub sequence while holding the outbound lock, then
+marshals and delivers the frame in that same order. Event constructors must not
+allocate or reuse hub sequence numbers themselves.
 
 ### On error message content
 

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -66,6 +66,10 @@ func (h *Handler) onSessionState(evt protocol.Event) {
 	h.awaitingWelcome = false
 	previousState := h.joinedState
 	h.joinedState = p.State
+	if p.State == protocol.StateRunning &&
+		(previousState == protocol.StateExited || previousState == protocol.StateIdle) {
+		h.terminated = false
+	}
 	tid := h.curThreadID
 	if tid == 0 {
 		// No stop event has been seen yet on a freshly-joined suspended session,

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -42,19 +42,16 @@ func (h *Handler) translateEvent(evt protocol.Event) {
 	case protocol.EventError:
 		h.onError(evt)
 	case protocol.EventSessionState:
-		// For a JOINING connection, the hub's welcome state seeds the joiner's
-		// initial DAP state. For the normal launch/attach path it is
-		// informational (the entry stop drives the initial state instead).
+		// Joined connections use state both for their welcome and to reconcile a
+		// lifecycle event missed during admission. The normal launch/attach
+		// handshake remains driven by its entry stop.
 		h.onSessionState(evt)
 	}
 }
 
-// onSessionState consumes the hub's welcome EventSessionState for a JOINING
-// connection, reflecting the shared session's current run state as the joiner's
-// initial DAP state: a `stopped` if already suspended, `terminated` if already
-// exited, nothing while idle/running. It fires at most once (gated on
-// awaitingWelcome) and is a no-op for the normal launch/attach path, where
-// awaitingWelcome is never set.
+// onSessionState reconciles the shared lifecycle only for a connection that
+// joined an existing session. Keeping later states authoritative closes an
+// admission race without disturbing the launch/attach configuration handshake.
 func (h *Handler) onSessionState(evt protocol.Event) {
 	var p protocol.SessionStatePayload
 	if err := protocol.DecodeEventPayload(evt, &p); err != nil {
@@ -62,11 +59,13 @@ func (h *Handler) onSessionState(evt protocol.Event) {
 	}
 
 	h.mu.Lock()
-	if !h.awaitingWelcome {
+	if !h.joining {
 		h.mu.Unlock()
 		return
 	}
 	h.awaitingWelcome = false
+	previousState := h.joinedState
+	h.joinedState = p.State
 	tid := h.curThreadID
 	if tid == 0 {
 		// No stop event has been seen yet on a freshly-joined suspended session,
@@ -77,11 +76,21 @@ func (h *Handler) onSessionState(evt protocol.Event) {
 	}
 	switch p.State {
 	case protocol.StateSuspended:
+		if previousState == protocol.StateSuspended || h.terminated {
+			h.mu.Unlock()
+			return
+		}
+		h.resetVarsLocked()
 		h.suspended = true
 		h.mu.Unlock()
 		h.sendStopped("pause", tid)
 	case protocol.StateExited:
 		h.suspended = false
+		if previousState == protocol.StateExited || h.terminated {
+			h.mu.Unlock()
+			return
+		}
+		h.terminated = true
 		h.mu.Unlock()
 		h.send(&godap.TerminatedEvent{Event: h.event("terminated")})
 	default:
@@ -124,6 +133,9 @@ func (h *Handler) onStop(evt protocol.Event) {
 	restarting := h.restarting
 	stopOnEntry := h.stopOnEntry
 	h.curThreadID = tid
+	if h.joining {
+		h.joinedState = protocol.StateSuspended
+	}
 
 	// The first stop after Launch/Attach is the entry stop: fire `initialized`
 	// (breakpoints can now resolve against the loaded image) but withhold the
@@ -162,6 +174,9 @@ func (h *Handler) onStop(evt protocol.Event) {
 func (h *Handler) onContinued() {
 	h.mu.Lock()
 	tid := h.curThreadID
+	if h.joining {
+		h.joinedState = protocol.StateRunning
+	}
 	if h.pendingContinues > 0 {
 		// Our own resume — suppress; DAP already implied continuation via the
 		// continue/step response.
@@ -187,10 +202,17 @@ func (h *Handler) onProcessExited(evt protocol.Event) {
 
 	h.mu.Lock()
 	h.suspended = false
+	if h.joining {
+		h.joinedState = protocol.StateExited
+	}
+	sendTerminated := !h.terminated
+	h.terminated = true
 	h.mu.Unlock()
 
 	h.send(&godap.ExitedEvent{Event: h.event("exited"), Body: godap.ExitedEventBody{ExitCode: p.ExitCode}})
-	h.send(&godap.TerminatedEvent{Event: h.event("terminated")})
+	if sendTerminated {
+		h.send(&godap.TerminatedEvent{Event: h.event("terminated")})
+	}
 }
 
 func (h *Handler) onOutput(evt protocol.Event) {

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -372,6 +372,7 @@ func (h *Handler) onRestarted() {
 	h.mu.Lock()
 	seq := h.restartReqSeq
 	h.restartReqSeq = 0
+	h.terminated = false
 	h.mu.Unlock()
 
 	if seq != 0 {

--- a/internal/dap/handler.go
+++ b/internal/dap/handler.go
@@ -74,6 +74,7 @@ type Handler struct {
 	launching   bool
 	restarting  bool
 	suspended   bool
+	terminated  bool
 	stopOnEntry bool
 	attached    bool
 
@@ -81,11 +82,14 @@ type Handler struct {
 	// attach with a `session` argument and no pid) rather than launching or
 	// attaching to a debuggee. A joiner never enqueues Launch/Attach and never
 	// auto-continues at configurationDone — it must not disturb the run state of
-	// a session other clients are already driving. awaitingWelcome is set until
-	// the hub's welcome EventSessionState is consumed to reflect the session's
-	// current state (a `stopped` if already suspended).
+	// a session other clients are already driving. awaitingWelcome tracks
+	// whether the initial state has arrived; later state frames still reconcile
+	// lifecycle gaps for joiners. joinedState tracks hub-observed lifecycle
+	// separately from suspended, which requests clear optimistically before the
+	// hub confirms a resume.
 	joining         bool
 	awaitingWelcome bool
+	joinedState     protocol.SessionState
 
 	startReqSeq   int
 	startCmd      string

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -43,6 +43,18 @@ func (r *cmdRecorder) kinds() []protocol.CommandKind {
 	return out
 }
 
+func (r *cmdRecorder) count(kind protocol.CommandKind) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := 0
+	for _, cmd := range r.cmds {
+		if cmd.Kind == kind {
+			count++
+		}
+	}
+	return count
+}
+
 // waitForCommand polls until a command of kind appears or the deadline passes.
 func (r *cmdRecorder) waitForCommand(t *testing.T, kind protocol.CommandKind) protocol.Command {
 	t.Helper()
@@ -60,6 +72,18 @@ func (r *cmdRecorder) waitForCommand(t *testing.T, kind protocol.CommandKind) pr
 	}
 	t.Fatalf("timed out waiting for command %s; saw %v", kind, r.kinds())
 	return protocol.Command{}
+}
+
+func (r *cmdRecorder) waitForCommandCount(t *testing.T, kind protocol.CommandKind, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if r.count(kind) >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d %s commands; saw %d", want, kind, r.count(kind))
 }
 
 type fakeSession struct {
@@ -1064,5 +1088,100 @@ func TestLaunchSessionStateDoesNotBypassConfigurationDone(t *testing.T) {
 	}
 
 	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateSuspended})
+	expectNoDAPMessage(t, hh)
+}
+
+func TestLaunchRestartEmitsTerminatedForEachExit(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+
+	hh.inject(protocol.EventProcessExited, protocol.ProcessExitedPayload{ExitCode: 11})
+	firstExit := recvType[*godap.ExitedEvent](hh)
+	if firstExit.Body.ExitCode != 11 {
+		t.Fatalf("first exit code = %d, want 11", firstExit.Body.ExitCode)
+	}
+	_ = recvType[*godap.TerminatedEvent](hh)
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != restartSeq {
+		t.Fatalf("restart response seq = %d, want %d", restarted.RequestSeq, restartSeq)
+	}
+
+	continueCount := hh.cmds.count(protocol.CmdContinue)
+	hh.inject(protocol.EventStepped, protocol.SteppedPayload{Goroutine: protocol.Goroutine{ID: 2}})
+	hh.cmds.waitForCommandCount(t, protocol.CmdContinue, continueCount+1)
+	hh.inject(protocol.EventContinued, protocol.ContinuedPayload{})
+
+	hh.inject(protocol.EventProcessExited, protocol.ProcessExitedPayload{ExitCode: 22})
+	secondExit := recvType[*godap.ExitedEvent](hh)
+	if secondExit.Body.ExitCode != 22 {
+		t.Fatalf("second exit code = %d, want 22", secondExit.Body.ExitCode)
+	}
+	_ = recvType[*godap.TerminatedEvent](hh)
+}
+
+func TestJoinRestartResetsTerminationForNextExit(t *testing.T) {
+	hh := startJoinWithoutWelcome(t)
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateExited})
+	_ = recvType[*godap.TerminatedEvent](hh)
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateExited})
+	expectNoDAPMessage(t, hh)
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateRunning})
+	expectNoDAPMessage(t, hh)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != restartSeq {
+		t.Fatalf("restart response seq = %d, want %d", restarted.RequestSeq, restartSeq)
+	}
+
+	continueCount := hh.cmds.count(protocol.CmdContinue)
+	hh.inject(protocol.EventStepped, protocol.SteppedPayload{Goroutine: protocol.Goroutine{ID: 3}})
+	hh.cmds.waitForCommandCount(t, protocol.CmdContinue, continueCount+1)
+	hh.inject(protocol.EventContinued, protocol.ContinuedPayload{})
+
+	hh.inject(protocol.EventProcessExited, protocol.ProcessExitedPayload{ExitCode: 33})
+	exited := recvType[*godap.ExitedEvent](hh)
+	if exited.Body.ExitCode != 33 {
+		t.Fatalf("exit code = %d, want 33", exited.Body.ExitCode)
+	}
+	_ = recvType[*godap.TerminatedEvent](hh)
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateExited})
+	expectNoDAPMessage(t, hh)
+}
+
+func TestJoinedObserverRestartResetsTerminationForNextExit(t *testing.T) {
+	hh := startJoinWithoutWelcome(t)
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateExited})
+	_ = recvType[*godap.TerminatedEvent](hh)
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateRunning})
+	expectNoDAPMessage(t, hh)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	expectNoDAPMessage(t, hh)
+
+	hh.inject(protocol.EventStepped, protocol.SteppedPayload{Goroutine: protocol.Goroutine{ID: 4}})
+	_ = recvType[*godap.StoppedEvent](hh)
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateSuspended})
+	expectNoDAPMessage(t, hh)
+	hh.inject(protocol.EventContinued, protocol.ContinuedPayload{})
+	_ = recvType[*godap.ContinuedEvent](hh)
+
+	hh.inject(protocol.EventProcessExited, protocol.ProcessExitedPayload{ExitCode: 44})
+	exited := recvType[*godap.ExitedEvent](hh)
+	if exited.Body.ExitCode != 44 {
+		t.Fatalf("exit code = %d, want 44", exited.Body.ExitCode)
+	}
+	_ = recvType[*godap.TerminatedEvent](hh)
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateExited})
 	expectNoDAPMessage(t, hh)
 }

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -268,6 +268,17 @@ func recvType[T godap.Message](hh *harness) T {
 	return zero
 }
 
+func expectNoDAPMessage(t *testing.T, hh *harness) {
+	t.Helper()
+	_ = hh.client.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	defer func() { _ = hh.client.SetReadDeadline(time.Time{}) }()
+	if _, err := hh.reader.Peek(1); err == nil {
+		t.Fatal("unexpected DAP message")
+	} else if nerr, ok := err.(net.Error); !ok || !nerr.Timeout() {
+		t.Fatalf("peek for unexpected DAP message: %v", err)
+	}
+}
+
 // inject delivers a bingo event to the handler as the hub write pump would.
 func (hh *harness) inject(kind protocol.EventKind, payload any) {
 	hh.t.Helper()
@@ -307,6 +318,16 @@ func (hh *harness) doHandshake(t *testing.T) {
 	hh.cmds.waitForCommand(t, protocol.CmdContinue)
 	// Suppress our own continue.
 	hh.inject(protocol.EventContinued, protocol.ContinuedPayload{})
+}
+
+func startJoinWithoutWelcome(t *testing.T) *harness {
+	t.Helper()
+	hh := newHarness(t)
+	hh.sendReq("initialize", initArgs())
+	_ = recvType[*godap.InitializeResponse](hh)
+	hh.sendReq("attach", &godap.AttachRequest{Arguments: json.RawMessage(`{"session":"sess-test"}`)})
+	_ = recvType[*godap.InitializedEvent](hh)
+	return hh
 }
 
 func TestLaunchAnnouncesManagedSessionAfterClientAttach(t *testing.T) {
@@ -857,4 +878,191 @@ func TestJoinExistingSuspendedSession(t *testing.T) {
 	hh.sendReq("continue", &godap.ContinueRequest{})
 	_ = recvType[*godap.ContinueResponse](hh)
 	hh.cmds.waitForCommand(t, protocol.CmdContinue)
+}
+
+func TestJoinReconcilesRunningThenSuspended(t *testing.T) {
+	hh := startJoinWithoutWelcome(t)
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateRunning})
+	expectNoDAPMessage(t, hh)
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateSuspended})
+	stopped := recvType[*godap.StoppedEvent](hh)
+	if stopped.Body.Reason != "pause" {
+		t.Fatalf("stopped reason = %q, want pause", stopped.Body.Reason)
+	}
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateSuspended})
+	expectNoDAPMessage(t, hh)
+}
+
+func TestJoinReconcilesDuplicateSuspendedStateOnce(t *testing.T) {
+	hh := startJoinWithoutWelcome(t)
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateSuspended})
+	_ = recvType[*godap.StoppedEvent](hh)
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateSuspended})
+	expectNoDAPMessage(t, hh)
+}
+
+func TestJoinReconcilesRunningThenExited(t *testing.T) {
+	hh := startJoinWithoutWelcome(t)
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateRunning})
+	expectNoDAPMessage(t, hh)
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateExited})
+	_ = recvType[*godap.TerminatedEvent](hh)
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateExited})
+	expectNoDAPMessage(t, hh)
+}
+
+func TestJoinStateDoesNotDuplicateDebuggerStops(t *testing.T) {
+	cases := []struct {
+		name    string
+		kind    protocol.EventKind
+		payload any
+		reason  string
+	}{
+		{
+			name:    "breakpoint",
+			kind:    protocol.EventBreakpointHit,
+			payload: protocol.BreakpointHitPayload{Goroutine: protocol.Goroutine{ID: 7}},
+			reason:  "breakpoint",
+		},
+		{
+			name:    "step",
+			kind:    protocol.EventStepped,
+			payload: protocol.SteppedPayload{Goroutine: protocol.Goroutine{ID: 8}},
+			reason:  "step",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hh := startJoinWithoutWelcome(t)
+			hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateRunning})
+			expectNoDAPMessage(t, hh)
+
+			hh.inject(tc.kind, tc.payload)
+			stopped := recvType[*godap.StoppedEvent](hh)
+			if stopped.Body.Reason != tc.reason {
+				t.Fatalf("stopped reason = %q, want %s", stopped.Body.Reason, tc.reason)
+			}
+
+			hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateSuspended})
+			expectNoDAPMessage(t, hh)
+		})
+	}
+}
+
+func TestJoinStateDoesNotRestopAfterOptimisticResume(t *testing.T) {
+	cases := []struct {
+		name        string
+		commandKind protocol.CommandKind
+		send        func(*harness)
+	}{
+		{
+			name:        "continue",
+			commandKind: protocol.CmdContinue,
+			send: func(hh *harness) {
+				hh.sendReq("continue", &godap.ContinueRequest{})
+				_ = recvType[*godap.ContinueResponse](hh)
+			},
+		},
+		{
+			name:        "step",
+			commandKind: protocol.CmdStepOver,
+			send: func(hh *harness) {
+				hh.sendReq("next", &godap.NextRequest{Arguments: godap.NextArguments{ThreadId: 4}})
+				_ = recvType[*godap.NextResponse](hh)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hh := startJoinWithoutWelcome(t)
+			hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateRunning})
+			expectNoDAPMessage(t, hh)
+
+			hh.inject(protocol.EventBreakpointHit,
+				protocol.BreakpointHitPayload{Goroutine: protocol.Goroutine{ID: 4}})
+			_ = recvType[*godap.StoppedEvent](hh)
+
+			tc.send(hh)
+			hh.cmds.waitForCommand(t, tc.commandKind)
+
+			// The state frame paired with the stop can arrive after the client
+			// has already requested a resume. It confirms the stop already
+			// observed; it must not pause the adapter again.
+			hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateSuspended})
+			expectNoDAPMessage(t, hh)
+		})
+	}
+}
+
+func TestJoinStateDoesNotDuplicateProcessExit(t *testing.T) {
+	hh := startJoinWithoutWelcome(t)
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateRunning})
+	expectNoDAPMessage(t, hh)
+
+	hh.inject(protocol.EventProcessExited, protocol.ProcessExitedPayload{ExitCode: 17})
+	exited := recvType[*godap.ExitedEvent](hh)
+	if exited.Body.ExitCode != 17 {
+		t.Fatalf("exit code = %d, want 17", exited.Body.ExitCode)
+	}
+	_ = recvType[*godap.TerminatedEvent](hh)
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateExited})
+	expectNoDAPMessage(t, hh)
+}
+
+func TestJoinRunningAndIdleStatesClearSuspensionSilently(t *testing.T) {
+	for _, state := range []protocol.SessionState{protocol.StateRunning, protocol.StateIdle} {
+		t.Run(string(state), func(t *testing.T) {
+			hh := startJoinWithoutWelcome(t)
+			hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateSuspended})
+			_ = recvType[*godap.StoppedEvent](hh)
+
+			hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: state})
+			expectNoDAPMessage(t, hh)
+
+			hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateSuspended})
+			_ = recvType[*godap.StoppedEvent](hh)
+		})
+	}
+}
+
+func TestLaunchSessionStateDoesNotBypassConfigurationDone(t *testing.T) {
+	hh := newHarness(t)
+	hh.sendReq("initialize", initArgs())
+	_ = recvType[*godap.InitializeResponse](hh)
+
+	launchSeq := hh.sendReq("launch", &godap.LaunchRequest{
+		Arguments: json.RawMessage(`{"program":"/bin/x","stopOnEntry":true}`),
+	})
+	hh.cmds.waitForCommand(t, protocol.CmdLaunch)
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateRunning})
+	hh.inject(protocol.EventStepped, protocol.SteppedPayload{Goroutine: protocol.Goroutine{ID: 9}})
+	_ = recvType[*godap.InitializedEvent](hh)
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateSuspended})
+	expectNoDAPMessage(t, hh)
+
+	hh.sendReq("configurationDone", &godap.ConfigurationDoneRequest{})
+	_ = recvType[*godap.ConfigurationDoneResponse](hh)
+	launch := recvType[*godap.LaunchResponse](hh)
+	if launch.RequestSeq != launchSeq {
+		t.Fatalf("launch response seq = %d, want %d", launch.RequestSeq, launchSeq)
+	}
+	stopped := recvType[*godap.StoppedEvent](hh)
+	if stopped.Body.Reason != "entry" {
+		t.Fatalf("stopped reason = %q, want entry", stopped.Body.Reason)
+	}
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateSuspended})
+	expectNoDAPMessage(t, hh)
 }

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -1185,3 +1185,49 @@ func TestJoinedObserverRestartResetsTerminationForNextExit(t *testing.T) {
 	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateExited})
 	expectNoDAPMessage(t, hh)
 }
+
+func TestJoinedObserverFreshLaunchStartsNewLifecycle(t *testing.T) {
+	hh := startJoinWithoutWelcome(t)
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateRunning})
+	expectNoDAPMessage(t, hh)
+
+	hh.inject(protocol.EventProcessExited, protocol.ProcessExitedPayload{ExitCode: 55})
+	firstExit := recvType[*godap.ExitedEvent](hh)
+	if firstExit.Body.ExitCode != 55 {
+		t.Fatalf("first exit code = %d, want 55", firstExit.Body.ExitCode)
+	}
+	_ = recvType[*godap.TerminatedEvent](hh)
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateExited})
+	expectNoDAPMessage(t, hh)
+
+	// Another client launches a fresh process through the same managed hub.
+	// No EventRestarted is emitted for this exited→idle→running path.
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateIdle})
+	expectNoDAPMessage(t, hh)
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateIdle})
+	expectNoDAPMessage(t, hh)
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateRunning})
+	expectNoDAPMessage(t, hh)
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateRunning})
+	expectNoDAPMessage(t, hh)
+
+	// The new epoch must also restore state-only stop reconciliation.
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateSuspended})
+	stopped := recvType[*godap.StoppedEvent](hh)
+	if stopped.Body.Reason != "pause" {
+		t.Fatalf("stopped reason = %q, want pause", stopped.Body.Reason)
+	}
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateSuspended})
+	expectNoDAPMessage(t, hh)
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateRunning})
+	expectNoDAPMessage(t, hh)
+
+	hh.inject(protocol.EventProcessExited, protocol.ProcessExitedPayload{ExitCode: 66})
+	secondExit := recvType[*godap.ExitedEvent](hh)
+	if secondExit.Body.ExitCode != 66 {
+		t.Fatalf("second exit code = %d, want 66", secondExit.Body.ExitCode)
+	}
+	_ = recvType[*godap.TerminatedEvent](hh)
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{State: protocol.StateExited})
+	expectNoDAPMessage(t, hh)
+}

--- a/internal/hub/export_test.go
+++ b/internal/hub/export_test.go
@@ -1,0 +1,8 @@
+// Exposes internal synchronization points to hub_test. Compiled only during tests.
+package hub
+
+import "github.com/bingosuite/bingo/pkg/protocol"
+
+func (h *Hub) ExportedSetEventTransitionHook(hook func(protocol.EventKind, protocol.SessionState)) {
+	h.eventTransitionHook = hook
+}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -85,6 +85,10 @@ type Hub struct {
 	outboundMu sync.Mutex
 	seq        uint64
 
+	// Tests use this to hold the otherwise-unobservable event/state boundary
+	// while outboundMu is locked; production leaves it nil.
+	eventTransitionHook func(protocol.EventKind, protocol.SessionState)
+
 	// shutdownOnce: Kill and registry teardown must happen exactly once,
 	// even when ctx.Done() and last-client-disconnect race.
 	shutdownOnce sync.Once
@@ -271,13 +275,13 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 		h.drainResumeCh()
 	}
 
-	h.broadcast(evt)
-
 	switch evt.Kind {
 	case protocol.EventBreakpointHit, protocol.EventPanic, protocol.EventStepped, protocol.EventPaused:
-		h.transitionState(protocol.StateSuspended)
+		h.broadcastWithStateTransition(evt, protocol.StateSuspended)
 	case protocol.EventProcessExited:
-		h.transitionState(protocol.StateExited)
+		h.broadcastWithStateTransition(evt, protocol.StateExited)
+	default:
+		h.broadcast(evt)
 	}
 
 	if !suspending {
@@ -309,11 +313,11 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 				}
 				return
 			}
-			h.broadcast(nextEvt)
 			if nextEvt.Kind == protocol.EventProcessExited {
-				h.transitionState(protocol.StateExited)
+				h.broadcastWithStateTransition(nextEvt, protocol.StateExited)
 				return
 			}
+			h.broadcast(nextEvt)
 
 		case cmd := <-h.resumeCh:
 			h.log.Info("resuming", "command", cmd.Kind)
@@ -610,28 +614,50 @@ func (h *Hub) drainResumeCh() {
 	}
 }
 
-// transitionState updates state and, for managed sessions, broadcasts.
+// transitionState updates state and, for managed sessions, broadcasts while
+// serializing the write with client admission.
 func (h *Hub) transitionState(newState protocol.SessionState) {
+	h.outboundMu.Lock()
+	old, changed := h.transitionStateLocked(newState)
+	h.outboundMu.Unlock()
+
+	if changed {
+		h.log.Info("state transition", "from", old, "to", newState)
+	}
+}
+
+// broadcastWithStateTransition prevents a join from landing after a lifecycle
+// event's fan-out but before its state becomes authoritative. The debugger
+// event stays first on the wire, followed by EventSessionState.
+func (h *Hub) broadcastWithStateTransition(evt protocol.Event, newState protocol.SessionState) {
+	h.outboundMu.Lock()
+	h.broadcastLocked(evt)
+	if h.eventTransitionHook != nil {
+		h.eventTransitionHook(evt.Kind, newState)
+	}
+	old, changed := h.transitionStateLocked(newState)
+	h.outboundMu.Unlock()
+
+	if changed {
+		h.log.Info("state transition", "from", old, "to", newState)
+	}
+}
+
+// transitionStateLocked requires outboundMu.
+func (h *Hub) transitionStateLocked(newState protocol.SessionState) (protocol.SessionState, bool) {
 	h.stateMu.Lock()
 	old := h.state
 	if old == newState {
 		h.stateMu.Unlock()
-		return
+		return old, false
 	}
 	h.state = newState
 	h.stateMu.Unlock()
 
-	h.log.Info("state transition", "from", old, "to", newState)
-
 	if h.sessionID != "" {
-		h.broadcastSessionState()
+		h.broadcastSessionStateLocked()
 	}
-}
-
-func (h *Hub) broadcastSessionState() {
-	h.outboundMu.Lock()
-	defer h.outboundMu.Unlock()
-	h.broadcastSessionStateLocked()
+	return old, true
 }
 
 func (h *Hub) broadcastSessionStateLocked() {

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"sort"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/bingosuite/bingo/internal/debugger"
@@ -80,10 +79,11 @@ type Hub struct {
 	// resumeCh: capacity 1, first-write-wins. Extras dropped in injectCommand.
 	resumeCh chan protocol.Command
 
-	// seq is the single counter for ALL outbound events. The hub re-stamps
-	// debugger events with this counter, so clients see one monotonic stream
-	// and can detect gaps. The engine has its own seq.
-	seq atomic.Uint64
+	// outboundMu keeps admission, sequence allocation, marshal, and delivery in
+	// one order. deliver is nonblocking, so the lock is never held across socket
+	// I/O. The engine has its own seq; broadcastLocked re-stamps every event.
+	outboundMu sync.Mutex
+	seq        uint64
 
 	// shutdownOnce: Kill and registry teardown must happen exactly once,
 	// even when ctx.Done() and last-client-disconnect race.
@@ -215,17 +215,21 @@ func (h *Hub) setDbg(d debugger.Debugger) {
 // hub after its one-shot shutdown has completed.
 func (h *Hub) AddClient(conn WSConn, log *slog.Logger) (*Client, error) {
 	c := newClient(conn, h, log)
+
+	h.outboundMu.Lock()
 	if !h.registry.add(c) {
+		h.outboundMu.Unlock()
 		_ = conn.Close()
 		return nil, ErrHubClosed
 	}
+	if h.sessionID != "" {
+		h.broadcastSessionStateLocked()
+	}
+	h.outboundMu.Unlock()
+
 	go c.writePump()
 	go c.readPump()
 	h.log.Info("client connected", "total", h.registry.count())
-
-	if h.sessionID != "" {
-		h.sendStateTo(c)
-	}
 
 	return c, nil
 }
@@ -267,7 +271,6 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 		h.drainResumeCh()
 	}
 
-	evt.Seq = h.seq.Add(1)
 	h.broadcast(evt)
 
 	switch evt.Kind {
@@ -306,7 +309,6 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 				}
 				return
 			}
-			nextEvt.Seq = h.seq.Add(1)
 			h.broadcast(nextEvt)
 			if nextEvt.Kind == protocol.EventProcessExited {
 				h.transitionState(protocol.StateExited)
@@ -429,7 +431,6 @@ func (h *Hub) executeCommand(cmd protocol.Command) {
 	}
 
 	if result.event != nil {
-		result.event.Seq = h.seq.Add(1)
 		h.broadcast(*result.event)
 	}
 }
@@ -568,7 +569,7 @@ func (h *Hub) handleRestart(cmd protocol.Command) {
 	}
 	h.restartBreakpoints = newBreakpoints
 
-	evt, err := protocol.NewEvent(protocol.EventRestarted, h.seq.Add(1), protocol.RestartedPayload{
+	evt, err := protocol.NewEvent(protocol.EventRestarted, 0, protocol.RestartedPayload{
 		Program:     program,
 		Breakpoints: installed,
 		Discarded:   discarded,
@@ -628,11 +629,17 @@ func (h *Hub) transitionState(newState protocol.SessionState) {
 }
 
 func (h *Hub) broadcastSessionState() {
+	h.outboundMu.Lock()
+	defer h.outboundMu.Unlock()
+	h.broadcastSessionStateLocked()
+}
+
+func (h *Hub) broadcastSessionStateLocked() {
 	h.stateMu.RLock()
 	state := h.state
 	h.stateMu.RUnlock()
 
-	evt, err := protocol.NewEvent(protocol.EventSessionState, h.seq.Add(1), protocol.SessionStatePayload{
+	evt, err := protocol.NewEvent(protocol.EventSessionState, 0, protocol.SessionStatePayload{
 		SessionID: h.sessionID,
 		State:     state,
 		Clients:   h.registry.count(),
@@ -641,40 +648,24 @@ func (h *Hub) broadcastSessionState() {
 		h.log.Error("failed to create session state event", "err", err)
 		return
 	}
-	h.broadcast(evt)
-}
-
-// sendStateTo delivers the current state to a single client (welcome message).
-func (h *Hub) sendStateTo(c *Client) {
-	h.stateMu.RLock()
-	state := h.state
-	h.stateMu.RUnlock()
-
-	evt, err := protocol.NewEvent(protocol.EventSessionState, h.seq.Add(1), protocol.SessionStatePayload{
-		SessionID: h.sessionID,
-		State:     state,
-		Clients:   h.registry.count(),
-	})
-	if err != nil {
-		h.log.Error("failed to create welcome state event", "err", err)
-		return
-	}
-	wire, err := protocol.MarshalEvent(evt)
-	if err != nil {
-		h.log.Error("failed to marshal welcome state event", "err", err)
-		return
-	}
-	if !c.deliver(wire) {
-		h.removeClient(c)
-	}
+	h.broadcastLocked(evt)
 }
 
 func (h *Hub) broadcast(evt protocol.Event) {
+	h.outboundMu.Lock()
+	defer h.outboundMu.Unlock()
+	h.broadcastLocked(evt)
+}
+
+func (h *Hub) broadcastLocked(evt protocol.Event) {
+	nextSeq := h.seq + 1
+	evt.Seq = nextSeq
 	wire, err := protocol.MarshalEvent(evt)
 	if err != nil {
 		h.log.Error("marshal event failed", "err", err)
 		return
 	}
+	h.seq = nextSeq
 	for _, c := range h.registry.snapshot() {
 		if !c.deliver(wire) {
 			h.removeClient(c)
@@ -683,7 +674,7 @@ func (h *Hub) broadcast(evt protocol.Event) {
 }
 
 func (h *Hub) broadcastError(kind protocol.CommandKind, err error) {
-	evt, e := protocol.NewEvent(protocol.EventError, h.seq.Add(1), protocol.ErrorPayload{
+	evt, e := protocol.NewEvent(protocol.EventError, 0, protocol.ErrorPayload{
 		Command: kind,
 		Message: err.Error(),
 	})
@@ -700,7 +691,9 @@ func (h *Hub) shutdown() {
 	h.shutdownOnce.Do(func() {
 		h.log.Info("hub shutting down")
 		close(h.shutdownCh)
+		h.outboundMu.Lock()
 		h.registry.closeAll()
+		h.outboundMu.Unlock()
 		// shutdown may run on a non-Run goroutine (go h.shutdown() from
 		// removeClient), so snapshot dbg under dbgMu to avoid racing a
 		// mid-flight Launch/Restart on the Run goroutine.

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -424,6 +424,161 @@ var _ = Describe("Hub", func() {
 	})
 
 	Describe("event sequence numbers", func() {
+		It("keeps existing clients on the managed-session sequence stream when another client joins", func() {
+			managedFD := newFakeDebugger()
+			managed := hub.NewSession("session", func() debugger.Debugger { return managedFD }, nil)
+			cancelManaged := runHub(managed)
+			defer cancelManaged()
+
+			conn1 := newFakeWSConn()
+			mustAddClient(managed, conn1)
+			first, ok := recvEvent(conn1)
+			Expect(ok).To(BeTrue())
+			Expect(first.Kind).To(Equal(protocol.EventSessionState))
+			Expect(first.Seq).To(Equal(uint64(1)))
+
+			conn2 := newFakeWSConn()
+			mustAddClient(managed, conn2)
+
+			existingState, ok := recvEvent(conn1)
+			Expect(ok).To(BeTrue())
+			joiningState, ok := recvEvent(conn2)
+			Expect(ok).To(BeTrue())
+			Expect(existingState.Kind).To(Equal(protocol.EventSessionState))
+			Expect(joiningState.Kind).To(Equal(protocol.EventSessionState))
+			Expect(existingState.Seq).To(Equal(first.Seq + 1))
+			Expect(joiningState.Seq).To(Equal(existingState.Seq))
+		})
+
+		It("serializes concurrent joins and broadcasts into contiguous client streams", func() {
+			managedFD := newFakeDebugger()
+			managed := hub.NewSession("session", func() debugger.Debugger { return managedFD }, nil)
+			cancelManaged := runHub(managed)
+			defer cancelManaged()
+
+			const (
+				joiners = 24
+				outputs = 64
+			)
+
+			conns := make([]*fakeWSConn, joiners+1)
+			conns[0] = newFakeWSConn()
+			mustAddClient(managed, conns[0])
+			welcome, ok := recvEvent(conns[0])
+			Expect(ok).To(BeTrue())
+			Expect(welcome.Seq).To(Equal(uint64(1)))
+
+			conns[0].inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "stress"}))
+			running, ok := recvEvent(conns[0])
+			Expect(ok).To(BeTrue())
+			Expect(running.Kind).To(Equal(protocol.EventSessionState))
+			Expect(running.Seq).To(Equal(welcome.Seq + 1))
+
+			start := make(chan struct{})
+			addErrs := make(chan error, joiners)
+			var joins sync.WaitGroup
+			joins.Add(joiners)
+			for i := 1; i <= joiners; i++ {
+				conns[i] = newFakeWSConn()
+				go func(conn *fakeWSConn) {
+					defer joins.Done()
+					<-start
+					_, err := managed.AddClient(conn, nil)
+					addErrs <- err
+				}(conns[i])
+			}
+
+			emitted := make(chan struct{})
+			go func() {
+				<-start
+				for i := 0; i < outputs; i++ {
+					managedFD.push(protocol.MustEvent(protocol.EventOutput, uint64(i+1),
+						protocol.OutputPayload{Content: fmt.Sprintf("output-%d", i)}))
+				}
+				close(emitted)
+			}()
+
+			close(start)
+			joins.Wait()
+			for i := 0; i < joiners; i++ {
+				Expect(<-addErrs).NotTo(HaveOccurred())
+			}
+			Eventually(emitted, "2s").Should(BeClosed())
+
+			managedFD.push(protocol.MustEvent(protocol.EventOutput, 1,
+				protocol.OutputPayload{Content: "sentinel"}))
+
+			for i, conn := range conns {
+				previous := uint64(0)
+				if i == 0 {
+					previous = running.Seq
+				} else {
+					first, ok := recvEvent(conn)
+					Expect(ok).To(BeTrue(), "client %d did not receive its join state", i)
+					Expect(first.Kind).To(Equal(protocol.EventSessionState))
+					Expect(first.Seq).To(BeNumerically(">=", uint64(1)))
+					previous = first.Seq
+				}
+
+				for {
+					evt, ok := recvEvent(conn)
+					Expect(ok).To(BeTrue(), "client %d stream ended before sentinel", i)
+					Expect(evt.Seq).To(Equal(previous+1),
+						"client %d received a non-contiguous stream", i)
+					previous = evt.Seq
+
+					if evt.Kind != protocol.EventOutput {
+						continue
+					}
+					var payload protocol.OutputPayload
+					Expect(protocol.DecodeEventPayload(evt, &payload)).To(Succeed())
+					if payload.Content == "sentinel" {
+						break
+					}
+				}
+			}
+		})
+
+		It("admits a client while Run is waiting for a suspended-session resume", func() {
+			managedFD := newFakeDebugger()
+			managed := hub.NewSession("session", func() debugger.Debugger { return managedFD }, nil)
+			cancelManaged := runHub(managed)
+			defer cancelManaged()
+
+			conn1 := newFakeWSConn()
+			mustAddClient(managed, conn1)
+			_, _ = recvEvent(conn1)
+			conn1.inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "paused"}))
+			_, _ = recvEvent(conn1)
+
+			managedFD.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+			waitForEventKind(conn1, protocol.EventBreakpointHit, nil)
+			suspended, ok := recvEvent(conn1)
+			Expect(ok).To(BeTrue())
+			Expect(suspended.Kind).To(Equal(protocol.EventSessionState))
+
+			conn2 := newFakeWSConn()
+			addResult := make(chan error, 1)
+			go func() {
+				_, err := managed.AddClient(conn2, nil)
+				addResult <- err
+			}()
+			Eventually(addResult, "500ms").Should(Receive(BeNil()))
+
+			existingState, ok := recvEvent(conn1)
+			Expect(ok).To(BeTrue())
+			joiningState, ok := recvEvent(conn2)
+			Expect(ok).To(BeTrue())
+			Expect(existingState.Seq).To(Equal(suspended.Seq + 1))
+			Expect(joiningState.Seq).To(Equal(existingState.Seq))
+
+			var payload protocol.SessionStatePayload
+			Expect(protocol.DecodeEventPayload(joiningState, &payload)).To(Succeed())
+			Expect(payload.State).To(Equal(protocol.StateSuspended))
+			Expect(payload.Clients).To(Equal(2))
+		})
+
 		It("assigns strictly increasing hub-managed seq to all outbound events", func() {
 			conn := newFakeWSConn()
 			_, err := h.AddClient(conn, nil)

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -241,6 +241,28 @@ func closeFakeWS(conn *fakeWSConn) {
 	ExpectWithOffset(1, conn.Close()).To(Succeed())
 }
 
+func newRunningManagedHub() (*hub.Hub, *fakeDebugger, *fakeWSConn, context.CancelFunc) {
+	fd := newFakeDebugger()
+	managed := hub.NewSession("session", func() debugger.Debugger { return fd }, nil)
+	cancel := runHub(managed)
+	conn := newFakeWSConn()
+	mustAddClient(managed, conn)
+
+	welcome, ok := recvEvent(conn)
+	ExpectWithOffset(1, ok).To(BeTrue())
+	ExpectWithOffset(1, welcome.Kind).To(Equal(protocol.EventSessionState))
+
+	conn.inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "race"}))
+	running, ok := recvEvent(conn)
+	ExpectWithOffset(1, ok).To(BeTrue())
+	ExpectWithOffset(1, running.Kind).To(Equal(protocol.EventSessionState))
+	var state protocol.SessionStatePayload
+	ExpectWithOffset(1, protocol.DecodeEventPayload(running, &state)).To(Succeed())
+	ExpectWithOffset(1, state.State).To(Equal(protocol.StateRunning))
+
+	return managed, fd, conn, cancel
+}
+
 var _ = Describe("Hub", func() {
 
 	var (
@@ -577,6 +599,219 @@ var _ = Describe("Hub", func() {
 			Expect(protocol.DecodeEventPayload(joiningState, &payload)).To(Succeed())
 			Expect(payload.State).To(Equal(protocol.StateSuspended))
 			Expect(payload.Clients).To(Equal(2))
+		})
+
+		It("holds admission across lifecycle event and state transition", func() {
+			cases := []struct {
+				name        string
+				kind        protocol.EventKind
+				payload     any
+				targetState protocol.SessionState
+			}{
+				{
+					name:        "suspend",
+					kind:        protocol.EventBreakpointHit,
+					payload:     protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}},
+					targetState: protocol.StateSuspended,
+				},
+				{
+					name:        "exit",
+					kind:        protocol.EventProcessExited,
+					payload:     protocol.ProcessExitedPayload{ExitCode: 12},
+					targetState: protocol.StateExited,
+				},
+			}
+
+			for _, tc := range cases {
+				By(tc.name)
+				managed, managedFD, existing, cancelManaged := newRunningManagedHub()
+				reached := make(chan struct{}, 1)
+				release := make(chan struct{})
+				var releaseOnce sync.Once
+				releaseTransition := func() {
+					releaseOnce.Do(func() { close(release) })
+				}
+				defer func() {
+					releaseTransition()
+					cancelManaged()
+					Eventually(managed.Done(), "500ms", "10ms").Should(BeClosed())
+				}()
+
+				managed.ExportedSetEventTransitionHook(func(kind protocol.EventKind, state protocol.SessionState) {
+					if kind != tc.kind || state != tc.targetState {
+						return
+					}
+					reached <- struct{}{}
+					<-release
+				})
+
+				managedFD.push(protocol.MustEvent(tc.kind, 1, tc.payload))
+				Eventually(reached, "500ms", "10ms").Should(Receive())
+
+				event, ok := recvEvent(existing)
+				Expect(ok).To(BeTrue())
+				Expect(event.Kind).To(Equal(tc.kind))
+
+				joining := newFakeWSConn()
+				joinStarted := make(chan struct{})
+				joinResult := make(chan error, 1)
+				go func() {
+					close(joinStarted)
+					_, err := managed.AddClient(joining, nil)
+					joinResult <- err
+				}()
+				<-joinStarted
+				Consistently(joinResult, "100ms", "10ms").ShouldNot(Receive(),
+					"admission completed inside the event/state critical section")
+
+				releaseTransition()
+				Eventually(joinResult, "500ms", "10ms").Should(Receive(BeNil()))
+
+				stateEvent, ok := recvEvent(existing)
+				Expect(ok).To(BeTrue())
+				Expect(stateEvent.Kind).To(Equal(protocol.EventSessionState))
+				Expect(stateEvent.Seq).To(Equal(event.Seq + 1))
+				var state protocol.SessionStatePayload
+				Expect(protocol.DecodeEventPayload(stateEvent, &state)).To(Succeed())
+				Expect(state.State).To(Equal(tc.targetState))
+
+				welcome, ok := recvEvent(joining)
+				Expect(ok).To(BeTrue())
+				Expect(welcome.Kind).To(Equal(protocol.EventSessionState))
+				Expect(protocol.DecodeEventPayload(welcome, &state)).To(Succeed())
+				Expect(state.State).To(Equal(tc.targetState))
+			}
+		})
+
+		It("holds admission across ProcessExited while waiting for a resume", func() {
+			managed, managedFD, existing, cancelManaged := newRunningManagedHub()
+			defer func() {
+				cancelManaged()
+				Eventually(managed.Done(), "500ms", "10ms").Should(BeClosed())
+			}()
+
+			managedFD.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+			stop, ok := recvEvent(existing)
+			Expect(ok).To(BeTrue())
+			Expect(stop.Kind).To(Equal(protocol.EventBreakpointHit))
+			suspended, ok := recvEvent(existing)
+			Expect(ok).To(BeTrue())
+			Expect(suspended.Kind).To(Equal(protocol.EventSessionState))
+
+			reached := make(chan struct{}, 1)
+			release := make(chan struct{})
+			var releaseOnce sync.Once
+			releaseTransition := func() {
+				releaseOnce.Do(func() { close(release) })
+			}
+			defer releaseTransition()
+			managed.ExportedSetEventTransitionHook(func(kind protocol.EventKind, state protocol.SessionState) {
+				if kind != protocol.EventProcessExited || state != protocol.StateExited {
+					return
+				}
+				reached <- struct{}{}
+				<-release
+			})
+
+			managedFD.push(protocol.MustEvent(protocol.EventProcessExited, 2,
+				protocol.ProcessExitedPayload{ExitCode: 23}))
+			Eventually(reached, "500ms", "10ms").Should(Receive())
+
+			exited, ok := recvEvent(existing)
+			Expect(ok).To(BeTrue())
+			Expect(exited.Kind).To(Equal(protocol.EventProcessExited))
+
+			joining := newFakeWSConn()
+			joinStarted := make(chan struct{})
+			joinResult := make(chan error, 1)
+			go func() {
+				close(joinStarted)
+				_, err := managed.AddClient(joining, nil)
+				joinResult <- err
+			}()
+			<-joinStarted
+			Consistently(joinResult, "100ms", "10ms").ShouldNot(Receive())
+
+			releaseTransition()
+			Eventually(joinResult, "500ms", "10ms").Should(Receive(BeNil()))
+
+			stateEvent, ok := recvEvent(existing)
+			Expect(ok).To(BeTrue())
+			Expect(stateEvent.Kind).To(Equal(protocol.EventSessionState))
+			Expect(stateEvent.Seq).To(Equal(exited.Seq + 1))
+			var state protocol.SessionStatePayload
+			Expect(protocol.DecodeEventPayload(stateEvent, &state)).To(Succeed())
+			Expect(state.State).To(Equal(protocol.StateExited))
+
+			welcome, ok := recvEvent(joining)
+			Expect(ok).To(BeTrue())
+			Expect(welcome.Kind).To(Equal(protocol.EventSessionState))
+			Expect(protocol.DecodeEventPayload(welcome, &state)).To(Succeed())
+			Expect(state.State).To(Equal(protocol.StateExited))
+		})
+
+		It("never exposes a stale running welcome without the lifecycle event under racing admission", func() {
+			const iterations = 100
+
+			for i := 0; i < iterations; i++ {
+				managed, managedFD, _, cancelManaged := newRunningManagedHub()
+				joining := newFakeWSConn()
+				joinResult := make(chan error, 1)
+				start := make(chan struct{})
+
+				kind := protocol.EventBreakpointHit
+				payload := any(protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}})
+				targetState := protocol.StateSuspended
+				if i%2 == 1 {
+					kind = protocol.EventProcessExited
+					payload = protocol.ProcessExitedPayload{ExitCode: i}
+					targetState = protocol.StateExited
+				}
+
+				go func() {
+					<-start
+					_, err := managed.AddClient(joining, nil)
+					joinResult <- err
+				}()
+				go func() {
+					<-start
+					managedFD.push(protocol.MustEvent(kind, 1, payload))
+				}()
+				close(start)
+
+				Eventually(joinResult, "500ms", "10ms").Should(Receive(BeNil()))
+
+				sawRunning := false
+				sawLifecycle := false
+				sawTarget := false
+				for attempts := 0; attempts < 3 && !sawTarget; attempts++ {
+					evt, ok := recvEvent(joining)
+					Expect(ok).To(BeTrue(), "iteration %d ended before %s", i, targetState)
+					switch evt.Kind {
+					case kind:
+						sawLifecycle = true
+					case protocol.EventSessionState:
+						var state protocol.SessionStatePayload
+						Expect(protocol.DecodeEventPayload(evt, &state)).To(Succeed())
+						switch state.State {
+						case protocol.StateRunning:
+							sawRunning = true
+						case targetState:
+							sawTarget = true
+						}
+					}
+				}
+
+				Expect(sawTarget).To(BeTrue(), "iteration %d never observed %s", i, targetState)
+				if sawRunning {
+					Expect(sawLifecycle).To(BeTrue(),
+						"iteration %d received stale running state without %s", i, kind)
+				}
+
+				cancelManaged()
+				Eventually(managed.Done(), "500ms", "10ms").Should(BeClosed())
+			}
 		})
 
 		It("assigns strictly increasing hub-managed seq to all outbound events", func() {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -33,17 +33,22 @@ func serverOrigin(ts *httptest.Server) string {
 }
 
 func recvState(conn *websocket.Conn) (protocol.SessionStatePayload, error) {
+	_, payload, err := recvStateEvent(conn)
+	return payload, err
+}
+
+func recvStateEvent(conn *websocket.Conn) (protocol.Event, protocol.SessionStatePayload, error) {
 	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
 	_, msg, err := conn.ReadMessage()
 	if err != nil {
-		return protocol.SessionStatePayload{}, err
+		return protocol.Event{}, protocol.SessionStatePayload{}, err
 	}
-	var evt protocol.Event
-	if err := json.Unmarshal(msg, &evt); err != nil {
-		return protocol.SessionStatePayload{}, err
+	evt, err := protocol.UnmarshalEvent(msg)
+	if err != nil {
+		return protocol.Event{}, protocol.SessionStatePayload{}, err
 	}
 	var p protocol.SessionStatePayload
-	return p, protocol.DecodeEventPayload(evt, &p)
+	return evt, p, protocol.DecodeEventPayload(evt, &p)
 }
 
 func closeWS(conn *websocket.Conn) {
@@ -190,6 +195,11 @@ var _ = Describe("Server", func() {
 				_, err = recvState(good)
 				Expect(err).NotTo(HaveOccurred())
 
+				// A join broadcasts session state to every client, so the
+				// existing connection has that frame queued ahead of the close.
+				_, err = recvState(bad)
+				Expect(err).NotTo(HaveOccurred())
+
 				cmd := protocol.Command{
 					Version: "999.0",
 					Kind:    protocol.CmdSetBreakpoint,
@@ -232,17 +242,24 @@ var _ = Describe("Server", func() {
 				conn1, _, err := websocket.DefaultDialer.Dial(toWS(ts, "/ws?create"), nil)
 				Expect(err).NotTo(HaveOccurred())
 				defer closeWS(conn1)
-				p1, _ := recvState(conn1)
+				first, p1, err := recvStateEvent(conn1)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(first.Seq).To(BeNumerically(">=", uint64(1)))
 
 				conn2, _, err := websocket.DefaultDialer.Dial(
 					toWS(ts, "/ws?session="+p1.SessionID), nil)
 				Expect(err).NotTo(HaveOccurred())
 				defer closeWS(conn2)
 
-				p2, err := recvState(conn2)
+				existing, pExisting, err := recvStateEvent(conn1)
 				Expect(err).NotTo(HaveOccurred())
+				joining, p2, err := recvStateEvent(conn2)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pExisting).To(Equal(p2))
 				Expect(p2.SessionID).To(Equal(p1.SessionID))
 				Expect(p2.Clients).To(Equal(2))
+				Expect(existing.Seq).To(Equal(first.Seq + 1))
+				Expect(joining.Seq).To(Equal(existing.Seq))
 			})
 
 			It("closes the connection when the session does not exist", func() {


### PR DESCRIPTION
## Stack

Layer 2 atop #141. Review and merge #141 first; this PR intentionally targets `xsachax-fix-hub-sequence-stream`, not `main`.

## Summary

- hold `outboundMu` across suspending/exiting event fan-out, the state write, and the following `EventSessionState`, preserving event-then-state wire order
- cover `ProcessExited` both in the outer hub loop and while the hub is waiting for a suspended-session resume
- keep joined DAP handlers reconciled with later session states without duplicate `stopped`/`terminated` events, including a fast Continue/Step between a stop and its paired state frame
- begin a new joined-adapter lifecycle on either a successful `EventRestarted` or an observed `exited`/`idle`→`running` fresh launch, including launches driven by another client
- preserve duplicate state suppression within one lifecycle while restoring stop and termination reconciliation for each new process
- document the lifecycle/admission and process-epoch invariants in `AGENTS.md`

## Testing

- `go test -tags bingonative -race -count=1 ./internal/hub/... ./internal/dap/... ./internal/server/...`
- `go vet -tags bingonative ./internal/hub/... ./internal/dap/... ./internal/server/...`
- focused hub transition races repeated 10 times with Ginkgo (`100` admission races per run)
- focused DAP join-state regressions repeated 20 times under `-race`
- owner, requesting-joiner, and passive-joiner restart/exit lifecycle regressions repeated 20 times under `-race`
- joined observer exit→idle→fresh running→stop→exit lifecycle repeated 20 times under `-race`

Fixes #159