### PR TITLE
fix(debugger): expand sibling pointer aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -539,8 +539,10 @@ are detected by a `mach_msg` receive loop.
   `interface {}` / `error` self-reference.
 - **Bounds & fallback (never error the stop):** `maxValueDepth=4`,
   `maxChildren=100` (overflow appended as a synthetic `… N more` node),
-  pointer-deref depth `1`, `maxStringBytes≈256`, and a **visited-address cycle
-  guard** (pointer targets) so self-referential structures can't infinite-loop.
+  pointer-deref depth `1`, `maxStringBytes≈256`, and an **active recursion-path
+  cycle guard** for pointer targets. Pointer addresses are removed as each
+  subtree unwinds, so self-referential structures terminate without suppressing
+  later sibling aliases to the same non-cyclic target.
   Those are *per-path* caps; on top of them a **shared global ceiling**
   (`maxTotalNodes=10000`, `maxTotalBytes=256 KiB`) is threaded through `formatCtx`
   and debited once per `formatNode` and by every read. Without it a

--- a/internal/debugger/values.go
+++ b/internal/debugger/values.go
@@ -21,7 +21,7 @@ import (
 // erroring the stop. See AGENTS.md → DWARF reader notes.
 
 // Bounds on the eager tree. The per-node depth (maxValueDepth) and per-aggregate
-// width (maxChildren) caps plus the visited-address cycle guard stop any single
+// width (maxChildren) caps plus the active-pointer cycle guard stop any single
 // path from running away, but a collection-of-collections is still bounded only
 // by their product (e.g. [][][][]int ≈ maxChildren⁴ nodes, each doing its own
 // ReadMemory). maxTotalNodes/maxTotalBytes add a SHARED ceiling across the whole
@@ -64,15 +64,17 @@ const (
 )
 
 // formatCtx carries the per-inspection state shared across the whole recursive
-// walk. b and visited are shared; depth/ptrDepth are passed by value so a
-// sibling's recursion budget is independent. nodesLeft and bytesLeft are the
-// shared GLOBAL ceiling (see the bounds block): decremented once per formatNode
-// and by each read, so a collection-of-collections can't fan out unboundedly.
+// walk. activePointers contains only the current recursion path; entries are
+// removed while unwinding so sibling aliases expand independently. depth and
+// ptrDepth are passed by value so a sibling's recursion budget is independent.
+// nodesLeft and bytesLeft are the shared GLOBAL ceiling (see the bounds block):
+// decremented once per formatNode and by each read, so a
+// collection-of-collections can't fan out unboundedly.
 type formatCtx struct {
-	b         Backend
-	visited   map[uint64]bool // addresses whose formatting has begun (cycle guard)
-	nodesLeft int             // remaining nodes for this inspection (shared)
-	bytesLeft int             // remaining bytes to read for this inspection (shared)
+	b              Backend
+	activePointers map[uint64]bool
+	nodesLeft      int // remaining nodes for this inspection (shared)
+	bytesLeft      int // remaining bytes to read for this inspection (shared)
 }
 
 // read fetches n bytes at addr like readMem, additionally debiting the shared
@@ -91,10 +93,25 @@ func (ctx *formatCtx) budgetExhausted() bool {
 	return ctx.nodesLeft <= 0 || ctx.bytesLeft <= 0
 }
 
+// enterPointer claims addr for the current recursion path. A rejected claim
+// returns no cleanup function, so a cycle cannot remove its ancestor's entry.
+func (ctx *formatCtx) enterPointer(addr uint64) (leave func(), ok bool) {
+	if ctx.activePointers[addr] {
+		return nil, false
+	}
+	ctx.activePointers[addr] = true
+	return func() { delete(ctx.activePointers, addr) }, true
+}
+
 // formatTyped renders the value of type typ stored at addr into a bounded
 // protocol.Variable tree rooted at name.
 func (r *dwarfReader) formatTyped(b Backend, name string, typ dwarf.Type, addr uint64) protocol.Variable {
-	ctx := &formatCtx{b: b, visited: map[uint64]bool{}, nodesLeft: maxTotalNodes, bytesLeft: maxTotalBytes}
+	ctx := &formatCtx{
+		b:              b,
+		activePointers: map[uint64]bool{},
+		nodesLeft:      maxTotalNodes,
+		bytesLeft:      maxTotalBytes,
+	}
 	return r.formatNode(name, typ, addr, 0, 0, ctx)
 }
 
@@ -218,13 +235,17 @@ func (r *dwarfReader) formatPointer(out *protocol.Variable, t *dwarf.PtrType, ad
 	}
 	out.Value = fmt.Sprintf("0x%x", p)
 	// One bounded dereference as a child, guarded against cycles and budget.
-	if ptrDepth >= maxPtrDeref || depth >= maxValueDepth || ctx.visited[p] {
+	if ptrDepth >= maxPtrDeref || depth >= maxValueDepth {
 		return
 	}
 	if _, ok := t.Type.(*dwarf.VoidType); ok {
 		return // unsafe.Pointer — nothing typed to deref
 	}
-	ctx.visited[p] = true
+	leave, ok := ctx.enterPointer(p)
+	if !ok {
+		return
+	}
+	defer leave()
 	child := r.formatNode("*"+out.Name, t.Type, p, depth+1, ptrDepth+1, ctx)
 	out.Children = []protocol.Variable{child}
 }

--- a/internal/debugger/values_test.go
+++ b/internal/debugger/values_test.go
@@ -2,6 +2,8 @@ package debugger
 
 import (
 	"debug/dwarf"
+	"encoding/binary"
+	"errors"
 	"testing"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
@@ -23,6 +25,47 @@ func (readableBackend) SetRegisters(int, Registers) error     { return nil }
 func (readableBackend) Threads() ([]int, error)               { return []int{1}, nil }
 func (readableBackend) Wait() (StopEvent, error)              { return StopEvent{}, nil }
 
+type valueMemoryBackend struct {
+	readableBackend
+	mem map[uint64]byte
+}
+
+func newValueMemoryBackend() *valueMemoryBackend {
+	return &valueMemoryBackend{mem: make(map[uint64]byte)}
+}
+
+func (b *valueMemoryBackend) ReadMemory(addr uint64, dst []byte) error {
+	for i := range dst {
+		value, ok := b.mem[addr+uint64(i)]
+		if !ok {
+			return errors.New("unreadable memory")
+		}
+		dst[i] = value
+	}
+	return nil
+}
+
+func (b *valueMemoryBackend) seedUint64(addr, value uint64) {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, value)
+	for i := range buf {
+		b.mem[addr+uint64(i)] = buf[i]
+	}
+}
+
+func testIntType() *dwarf.IntType {
+	return &dwarf.IntType{BasicType: dwarf.BasicType{
+		CommonType: dwarf.CommonType{ByteSize: 8, Name: "int"},
+	}}
+}
+
+func testPointerType(name string, target dwarf.Type) *dwarf.PtrType {
+	return &dwarf.PtrType{
+		CommonType: dwarf.CommonType{ByteSize: 8, Name: name},
+		Type:       target,
+	}
+}
+
 func countNodes(v protocol.Variable) int {
 	n := 1
 	for i := range v.Children {
@@ -43,12 +86,137 @@ func hasTruncationNode(v protocol.Variable) bool {
 	return false
 }
 
+func TestFormatTypedExpandsSiblingPointerAliases(t *testing.T) {
+	intType := testIntType()
+	ptrType := testPointerType("*int", intType)
+	pairType := &dwarf.StructType{
+		CommonType: dwarf.CommonType{ByteSize: 16, Name: "pair"},
+		StructName: "pair",
+		Kind:       "struct",
+		Field: []*dwarf.StructField{
+			{Name: "Left", Type: ptrType, ByteOffset: 0},
+			{Name: "Right", Type: ptrType, ByteOffset: 8},
+		},
+	}
+	backend := newValueMemoryBackend()
+	backend.seedUint64(0x1000, 0x2000)
+	backend.seedUint64(0x1008, 0x2000)
+	backend.seedUint64(0x2000, 42)
+
+	root := (&dwarfReader{}).formatTyped(backend, "pair", pairType, 0x1000)
+
+	if len(root.Children) != 2 {
+		t.Fatalf("pair children = %d, want 2", len(root.Children))
+	}
+	for _, pointer := range root.Children {
+		if len(pointer.Children) != 1 {
+			t.Errorf("%s children = %d, want 1", pointer.Name, len(pointer.Children))
+			continue
+		}
+		if got := pointer.Children[0].Value; got != "42" {
+			t.Errorf("%s pointee = %q, want 42", pointer.Name, got)
+		}
+	}
+}
+
+func TestFormatCtxPointerPathOwnership(t *testing.T) {
+	ctx := &formatCtx{activePointers: make(map[uint64]bool)}
+
+	leaveAncestor, ok := ctx.enterPointer(0x2000)
+	if !ok {
+		t.Fatal("first pointer entry was rejected")
+	}
+	if leaveCycle, ok := ctx.enterPointer(0x2000); ok || leaveCycle != nil {
+		t.Fatal("cycle entry must not own ancestor cleanup")
+	}
+	if !ctx.activePointers[0x2000] {
+		t.Fatal("rejected cycle entry removed its ancestor")
+	}
+
+	leaveAncestor()
+	leaveAlias, ok := ctx.enterPointer(0x2000)
+	if !ok {
+		t.Fatal("sibling alias was rejected after ancestor unwound")
+	}
+	leaveAlias()
+}
+
+func TestFormatTypedPointerCyclesRemainBounded(t *testing.T) {
+	t.Run("self cycle", func(t *testing.T) {
+		nodeType := &dwarf.StructType{
+			CommonType: dwarf.CommonType{ByteSize: 8, Name: "node"},
+			StructName: "node",
+			Kind:       "struct",
+		}
+		nodePtr := testPointerType("*node", nodeType)
+		nodeType.Field = []*dwarf.StructField{
+			{Name: "Next", Type: nodePtr, ByteOffset: 0},
+		}
+		backend := newValueMemoryBackend()
+		backend.seedUint64(0x1000, 0x2000)
+		backend.seedUint64(0x2000, 0x2000)
+
+		root := (&dwarfReader{}).formatTyped(backend, "head", nodePtr, 0x1000)
+
+		if total := countNodes(root); total > 4 {
+			t.Fatalf("self-cycle node count = %d, want <= 4", total)
+		}
+	})
+
+	t.Run("mutual cycle", func(t *testing.T) {
+		leftType := &dwarf.StructType{
+			CommonType: dwarf.CommonType{ByteSize: 8, Name: "leftNode"},
+			StructName: "leftNode",
+			Kind:       "struct",
+		}
+		rightType := &dwarf.StructType{
+			CommonType: dwarf.CommonType{ByteSize: 8, Name: "rightNode"},
+			StructName: "rightNode",
+			Kind:       "struct",
+		}
+		leftType.Field = []*dwarf.StructField{
+			{Name: "Right", Type: testPointerType("*rightNode", rightType), ByteOffset: 0},
+		}
+		rightType.Field = []*dwarf.StructField{
+			{Name: "Left", Type: testPointerType("*leftNode", leftType), ByteOffset: 0},
+		}
+		backend := newValueMemoryBackend()
+		backend.seedUint64(0x2000, 0x3000)
+		backend.seedUint64(0x3000, 0x2000)
+
+		root := (&dwarfReader{}).formatTyped(backend, "left", leftType, 0x2000)
+
+		if total := countNodes(root); total > 5 {
+			t.Fatalf("mutual-cycle node count = %d, want <= 5", total)
+		}
+	})
+}
+
+func TestFormatTypedUnreadablePointerTarget(t *testing.T) {
+	backend := newValueMemoryBackend()
+	backend.seedUint64(0x1000, 0x2000)
+
+	root := (&dwarfReader{}).formatTyped(
+		backend,
+		"value",
+		testPointerType("*int", testIntType()),
+		0x1000,
+	)
+
+	if len(root.Children) != 1 {
+		t.Fatalf("pointer children = %d, want 1", len(root.Children))
+	}
+	if got, want := root.Children[0].Value, "<unreadable: unreadable memory>"; got != want {
+		t.Errorf("unreadable pointee = %q, want %q", got, want)
+	}
+}
+
 // TestFormatTypedBudget guards the shared per-inspection node/byte ceiling: a
 // pathologically wide, deep aggregate ([100][100][100][100]int, ~10^8 potential
 // nodes) must be truncated to O(maxTotalNodes) with a truncation node present,
 // so one Locals/Evaluate request can never wedge the single-threaded engine loop.
 func TestFormatTypedBudget(t *testing.T) {
-	intT := &dwarf.IntType{BasicType: dwarf.BasicType{CommonType: dwarf.CommonType{ByteSize: 8, Name: "int"}}}
+	intT := testIntType()
 	arr := func(elem dwarf.Type, count int64) *dwarf.ArrayType {
 		return &dwarf.ArrayType{Type: elem, Count: count}
 	}


### PR DESCRIPTION
## Summary

- treat pointer-cycle tracking as an active recursion path instead of root-wide alias deduplication
- preserve eager children for sibling aliases while retaining the existing depth, dereference, node, and byte bounds
- cover sibling aliases, path ownership, self/mutual cycles, and unreadable pointees; document the invariant in AGENTS.md

## Validation

- `go test -tags bingonative -race ./internal/debugger ./internal/dap`
- `go vet -tags bingonative ./internal/debugger ./internal/dap`

Fixes #165