### PR TITLE
fix(debugger): scope bare globals to frame package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1570,16 +1570,29 @@ are detected by a `mach_msg` receive loop.
   child-DIE read errors propagate instead of becoming a truncated success.
 - `EvaluateName` resolves a **single variable name only** (no dotted paths /
   indexing / arithmetic): a local or parameter in the subprogram containing the
-  frame PC first. A bare global then prefers the frame package identified by
-  `debug/dwarf.Reader.SeekPC` on the unslid PC and scans direct globals across
-  every CU with that same `DW_AT_name` (Go and assembly can emit separate CUs
-  for one package); if CU lookup or that scoped search fails, it falls back to
-  the whole-image exact/package-suffix scan for cross-package convenience.
-  Qualified names skip package preference. Generic shape code is emitted in the
-  instantiating CU, so its bare globals follow that CU rather than the generic's
-  defining package; use explicit qualification instead of function-name
-  heuristics. Global locations remain `DW_OP_addr` only. Backs the WebSocket
-  `CmdEvaluate`/`EventEvaluate` and the DAP `evaluate` request.
+  frame PC first. A bare global then prefers the **logical code package at that
+  PC**, not merely the physical CU returned by `debug/dwarf.Reader.SeekPC`:
+  inside inlined code it uses the deepest containing
+  `DW_TAG_inlined_subroutine`'s `DW_AT_abstract_origin`; otherwise it uses the
+  same qualified subprogram name reported as `Frame.Function`. The function's
+  package is matched against exact known CU `DW_AT_name` identities (never split
+  heuristically), then direct globals are scanned across every CU with that
+  package name because Go and assembly can emit separate CUs. This also handles
+  generic shape code emitted in an instantiating package's physical CU while
+  retaining the defining package in its qualified subprogram name.
+  `SeekPC` always receives the unslid PC. If the inline origin is missing,
+  malformed, or ambiguous, the logical function cannot be matched to a known
+  package, or the scoped global is absent, lookup conservatively falls back to
+  the whole-image exact/package-suffix scan for cross-package convenience
+  rather than confidently choosing the physical CU. Qualified names skip
+  package preference. Global locations remain `DW_OP_addr` only.
+  Bingo does not synthesize inline stack frames: at an inline-body PC,
+  `Frame.Function` can still name the physical caller while `Frame.Location`
+  points into the inlined source; bare globals follow that deepest inline
+  lexical scope. Locals remain those of the physical subprogram because inline
+  frames/locals are not synthesized, so local and bare-global scope can differ
+  at such a PC. Backs the WebSocket `CmdEvaluate`/`EventEvaluate` and the DAP
+  `evaluate` request.
 - **`DW_OP_fbreg` locals resolve against the CFA, not a fixed FP offset** — this
   is why [frame.go](internal/debugger/frame.go) exists. Go compiles every
   function's `DW_AT_frame_base` to `DW_OP_call_frame_cfa`, so a local at

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1570,9 +1570,16 @@ are detected by a `mach_msg` receive loop.
   child-DIE read errors propagate instead of becoming a truncated success.
 - `EvaluateName` resolves a **single variable name only** (no dotted paths /
   indexing / arithmetic): a local or parameter in the subprogram containing the
-  frame PC first, then a package-level global via `globalVar` (matches the exact
-  DWARF name or a package-qualified `pkg.name` suffix, `DW_OP_addr` only). Backs
-  the WebSocket `CmdEvaluate`/`EventEvaluate` and the DAP `evaluate` request.
+  frame PC first. A bare global then prefers the frame package identified by
+  `debug/dwarf.Reader.SeekPC` on the unslid PC and scans direct globals across
+  every CU with that same `DW_AT_name` (Go and assembly can emit separate CUs
+  for one package); if CU lookup or that scoped search fails, it falls back to
+  the whole-image exact/package-suffix scan for cross-package convenience.
+  Qualified names skip package preference. Generic shape code is emitted in the
+  instantiating CU, so its bare globals follow that CU rather than the generic's
+  defining package; use explicit qualification instead of function-name
+  heuristics. Global locations remain `DW_OP_addr` only. Backs the WebSocket
+  `CmdEvaluate`/`EventEvaluate` and the DAP `evaluate` request.
 - **`DW_OP_fbreg` locals resolve against the CFA, not a fixed FP offset** — this
   is why [frame.go](internal/debugger/frame.go) exists. Go compiles every
   function's `DW_AT_frame_base` to `DW_OP_call_frame_cfa`, so a local at

--- a/internal/debugger/debugger.go
+++ b/internal/debugger/debugger.go
@@ -71,9 +71,9 @@ type Debugger interface {
 	Locals(frameIndex int) ([]protocol.Variable, error)
 
 	// Evaluate resolves a single variable NAME in the given frame (local or
-	// parameter, then a frame-package global, then a whole-image fallback) to
-	// its bounded typed tree. Name-only: no dotted paths, indexing, or
-	// arithmetic. Non-suspending, non-resuming.
+	// parameter, then a global from the logical code package at the frame PC,
+	// then a whole-image fallback) to its bounded typed tree. Name-only: no
+	// dotted paths, indexing, or arithmetic. Non-suspending, non-resuming.
 	Evaluate(frameIndex int, name string) (protocol.Variable, error)
 
 	StackFrames() ([]protocol.Frame, error)

--- a/internal/debugger/debugger.go
+++ b/internal/debugger/debugger.go
@@ -71,8 +71,9 @@ type Debugger interface {
 	Locals(frameIndex int) ([]protocol.Variable, error)
 
 	// Evaluate resolves a single variable NAME in the given frame (local or
-	// parameter, then a package global) to its bounded typed tree. Name-only:
-	// no dotted paths, indexing, or arithmetic. Non-suspending, non-resuming.
+	// parameter, then a frame-package global, then a whole-image fallback) to
+	// its bounded typed tree. Name-only: no dotted paths, indexing, or
+	// arithmetic. Non-suspending, non-resuming.
 	Evaluate(frameIndex int, name string) (protocol.Variable, error)
 
 	StackFrames() ([]protocol.Frame, error)

--- a/internal/debugger/dwarf.go
+++ b/internal/debugger/dwarf.go
@@ -42,6 +42,12 @@ type dwarfReader struct {
 	funcIndexOnce sync.Once
 	funcIndex     []funcRange
 
+	// packageNames is the de-duplicated set of DW_AT_name values from compile
+	// units, longest first. Matching a qualified function name against known CU
+	// identities avoids guessing where an import path ends.
+	packageNamesOnce sync.Once
+	packageNames     []string
+
 	// cacheMu guards the lazily-populated runtime-introspection caches below.
 	// Struct layouts and variable addresses never change for a loaded image, so
 	// each is resolved from DWARF at most once. Inspection already runs on the
@@ -430,9 +436,9 @@ func (r *dwarfReader) LocalsForFrame(b Backend, pc, frameBase uint64) ([]protoco
 // EvaluateName resolves a single variable name — no dotted paths, indexing, or
 // arithmetic (those belong to the later expression-evaluator PR). It first looks
 // for a local or parameter in the subprogram containing pc. A bare global then
-// prefers the frame's package before falling back to the whole image; qualified
-// globals use the whole-image lookup directly. The result is the same bounded
-// typed tree LocalsForFrame produces.
+// prefers the logical code package at pc before falling back to the whole image;
+// qualified globals use the whole-image lookup directly. The result is the same
+// bounded typed tree LocalsForFrame produces.
 func (r *dwarfReader) EvaluateName(b Backend, pc, frameBase uint64, name string) (protocol.Variable, error) {
 	entries, err := r.subprogramVars(pc)
 	if err != nil {
@@ -676,8 +682,9 @@ func (r *dwarfReader) varAddress(entry *dwarf.Entry, frameBase uint64) (uint64, 
 }
 
 // globalVar resolves a package-level variable to its address and type. Bare
-// names prefer globals from the frame's package; explicit qualified names and
-// degraded CU lookups retain the whole-binary exact-or-suffix behavior.
+// names prefer globals from the logical code package at pc; explicit qualified
+// names and degraded scope lookups retain the whole-binary exact-or-suffix
+// behavior.
 func (r *dwarfReader) globalVar(pc uint64, name string) (uint64, dwarf.Type, bool) {
 	if !strings.Contains(name, ".") {
 		if packageName, ok := r.packageForPC(pc); ok {
@@ -689,17 +696,176 @@ func (r *dwarfReader) globalVar(pc uint64, name string) (uint64, dwarf.Type, boo
 	return r.globalVarAnywhere(name)
 }
 
-// packageForPC uses DWARF's range-aware CU lookup rather than inferring package
-// ownership from a function name. Any lookup failure deliberately degrades to
-// the legacy whole-binary global search.
+// packageForPC identifies the package whose code is executing at pc. The
+// physical CU alone is insufficient: an inline body keeps its abstract
+// origin's lexical package, and generic shape functions can be emitted in the
+// instantiating package's CU. Any ambiguous or malformed scope degrades to the
+// legacy whole-binary global search.
 func (r *dwarfReader) packageForPC(pc uint64) (string, bool) {
 	dwarfPC := uint64(int64(pc) - r.slide)
-	cu, err := r.data.Reader().SeekPC(dwarfPC)
-	if err != nil || cu == nil {
+	rd := r.data.Reader()
+	if _, err := rd.SeekPC(dwarfPC); err != nil {
 		return "", false
 	}
-	name, ok := cu.Val(dwarf.AttrName).(string)
-	return name, ok && name != ""
+
+	function, hasInline, ok := r.inlinedFunctionAt(rd, dwarfPC)
+	if !ok {
+		return "", false
+	}
+	if !hasInline {
+		function = r.functionAt(pc)
+	}
+	if function == "" {
+		return "", false
+	}
+	return r.packageForFunction(function)
+}
+
+// inlinedFunctionAt returns the deepest inline abstract-origin function that
+// contains dwarfPC. hasInline distinguishes an ordinary physical frame from an
+// inline scope whose origin could not be resolved safely.
+func (r *dwarfReader) inlinedFunctionAt(rd *dwarf.Reader, dwarfPC uint64) (name string, hasInline, ok bool) {
+	for {
+		entry, err := rd.Next()
+		if err != nil || entry == nil {
+			return "", false, false
+		}
+		if entry.Tag == 0 {
+			return "", false, true
+		}
+		if entry.Tag != dwarf.TagSubprogram {
+			if entry.Children {
+				rd.SkipChildren()
+			}
+			continue
+		}
+		ranges, err := r.data.Ranges(entry)
+		if err != nil {
+			return "", false, false
+		}
+		if !rangesContainPC(ranges, dwarfPC) {
+			rd.SkipChildren()
+			continue
+		}
+		if !entry.Children {
+			return "", false, true
+		}
+		return r.inlinedFunctionInSubprogram(rd, dwarfPC)
+	}
+}
+
+func (r *dwarfReader) inlinedFunctionInSubprogram(rd *dwarf.Reader, dwarfPC uint64) (name string, hasInline, ok bool) {
+	depth := 0
+	bestDepth := -1
+	for {
+		entry, err := rd.Next()
+		if err != nil || entry == nil {
+			return "", hasInline, false
+		}
+		if entry.Tag == 0 {
+			if depth == 0 {
+				break
+			}
+			depth--
+			continue
+		}
+
+		entryDepth := depth
+		if entry.Tag == dwarf.TagInlinedSubroutine {
+			ranges, err := r.data.Ranges(entry)
+			if err != nil {
+				return "", true, false
+			}
+			if rangesContainPC(ranges, dwarfPC) {
+				hasInline = true
+				originName, resolved := r.abstractOriginName(entry)
+				switch {
+				case entryDepth > bestDepth:
+					bestDepth = entryDepth
+					name = originName
+					ok = resolved
+				case entryDepth == bestDepth && (!resolved || !ok || originName != name):
+					ok = false
+				}
+			}
+		}
+		if entry.Children {
+			depth++
+		}
+	}
+	if !hasInline {
+		return "", false, true
+	}
+	return name, true, ok && name != ""
+}
+
+func rangesContainPC(ranges [][2]uint64, pc uint64) bool {
+	for _, pcs := range ranges {
+		if pcs[0] <= pc && pc < pcs[1] {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *dwarfReader) abstractOriginName(entry *dwarf.Entry) (string, bool) {
+	offset, ok := entry.Val(dwarf.AttrAbstractOrigin).(dwarf.Offset)
+	for range 8 {
+		if !ok {
+			return "", false
+		}
+		rd := r.data.Reader()
+		rd.Seek(offset)
+		origin, err := rd.Next()
+		if err != nil || origin == nil {
+			return "", false
+		}
+		if name, _ := origin.Val(dwarf.AttrName).(string); name != "" {
+			return name, true
+		}
+		offset, ok = origin.Val(dwarf.AttrAbstractOrigin).(dwarf.Offset)
+		if !ok {
+			offset, ok = origin.Val(dwarf.AttrSpecification).(dwarf.Offset)
+		}
+	}
+	return "", false
+}
+
+func (r *dwarfReader) packageForFunction(function string) (string, bool) {
+	r.packageNamesOnce.Do(r.buildPackageNames)
+	for _, packageName := range r.packageNames {
+		if strings.HasPrefix(function, packageName+".") {
+			return packageName, true
+		}
+	}
+	return "", false
+}
+
+func (r *dwarfReader) buildPackageNames() {
+	seen := make(map[string]struct{})
+	rd := r.data.Reader()
+	for {
+		entry, err := rd.Next()
+		if err != nil || entry == nil {
+			break
+		}
+		if entry.Tag != dwarf.TagCompileUnit {
+			continue
+		}
+		if name, _ := entry.Val(dwarf.AttrName).(string); name != "" {
+			if _, ok := seen[name]; !ok {
+				seen[name] = struct{}{}
+				r.packageNames = append(r.packageNames, name)
+			}
+		}
+		rd.SkipChildren()
+	}
+	sort.Slice(r.packageNames, func(i, j int) bool {
+		if len(r.packageNames[i]) != len(r.packageNames[j]) {
+			return len(r.packageNames[i]) > len(r.packageNames[j])
+		}
+		return r.packageNames[i] < r.packageNames[j]
+	})
 }
 
 // globalVarInPackage scans every CU with the same package identity. Go assembly

--- a/internal/debugger/dwarf.go
+++ b/internal/debugger/dwarf.go
@@ -429,9 +429,10 @@ func (r *dwarfReader) LocalsForFrame(b Backend, pc, frameBase uint64) ([]protoco
 
 // EvaluateName resolves a single variable name — no dotted paths, indexing, or
 // arithmetic (those belong to the later expression-evaluator PR). It first looks
-// for a local or parameter in the subprogram containing pc, then falls back to a
-// package-level global. The result is the same bounded typed tree LocalsForFrame
-// produces.
+// for a local or parameter in the subprogram containing pc. A bare global then
+// prefers the frame's package before falling back to the whole image; qualified
+// globals use the whole-image lookup directly. The result is the same bounded
+// typed tree LocalsForFrame produces.
 func (r *dwarfReader) EvaluateName(b Backend, pc, frameBase uint64, name string) (protocol.Variable, error) {
 	entries, err := r.subprogramVars(pc)
 	if err != nil {
@@ -442,7 +443,7 @@ func (r *dwarfReader) EvaluateName(b Backend, pc, frameBase uint64, name string)
 			return r.formatEntry(b, child, name, frameBase), nil
 		}
 	}
-	if addr, typ, ok := r.globalVar(name); ok {
+	if addr, typ, ok := r.globalVar(pc, name); ok {
 		return r.formatTyped(b, name, typ, addr), nil
 	}
 	return protocol.Variable{}, fmt.Errorf("no variable named %q in scope", name)
@@ -674,10 +675,84 @@ func (r *dwarfReader) varAddress(entry *dwarf.Entry, frameBase uint64) (uint64, 
 	}
 }
 
-// globalVar resolves a package-level variable to its address and type. It
-// matches either the exact DWARF name or a package-qualified "pkg.name" so a
-// caller can pass a bare "name". Mirrors resolveVarAddr but also returns type.
-func (r *dwarfReader) globalVar(name string) (uint64, dwarf.Type, bool) {
+// globalVar resolves a package-level variable to its address and type. Bare
+// names prefer globals from the frame's package; explicit qualified names and
+// degraded CU lookups retain the whole-binary exact-or-suffix behavior.
+func (r *dwarfReader) globalVar(pc uint64, name string) (uint64, dwarf.Type, bool) {
+	if !strings.Contains(name, ".") {
+		if packageName, ok := r.packageForPC(pc); ok {
+			if addr, typ, found := r.globalVarInPackage(packageName, name); found {
+				return addr, typ, true
+			}
+		}
+	}
+	return r.globalVarAnywhere(name)
+}
+
+// packageForPC uses DWARF's range-aware CU lookup rather than inferring package
+// ownership from a function name. Any lookup failure deliberately degrades to
+// the legacy whole-binary global search.
+func (r *dwarfReader) packageForPC(pc uint64) (string, bool) {
+	dwarfPC := uint64(int64(pc) - r.slide)
+	cu, err := r.data.Reader().SeekPC(dwarfPC)
+	if err != nil || cu == nil {
+		return "", false
+	}
+	name, ok := cu.Val(dwarf.AttrName).(string)
+	return name, ok && name != ""
+}
+
+// globalVarInPackage scans every CU with the same package identity. Go assembly
+// and Go source may contribute separate CUs for one package, while only the Go
+// CU carries its package variables.
+func (r *dwarfReader) globalVarInPackage(packageName, name string) (uint64, dwarf.Type, bool) {
+	rd := r.data.Reader()
+	for {
+		entry, err := rd.Next()
+		if err != nil || entry == nil {
+			return 0, nil, false
+		}
+		if entry.Tag != dwarf.TagCompileUnit {
+			continue
+		}
+		cuName, _ := entry.Val(dwarf.AttrName).(string)
+		if cuName != packageName {
+			rd.SkipChildren()
+			continue
+		}
+		if addr, typ, ok := r.directGlobalVar(rd, name); ok {
+			return addr, typ, true
+		}
+	}
+}
+
+// directGlobalVar reads only a CU's immediate children so local variables cannot
+// shadow package globals.
+func (r *dwarfReader) directGlobalVar(rd *dwarf.Reader, name string) (uint64, dwarf.Type, bool) {
+	for {
+		entry, err := rd.Next()
+		if err != nil || entry == nil || entry.Tag == 0 {
+			return 0, nil, false
+		}
+		if entry.Tag == dwarf.TagVariable {
+			n, _ := entry.Val(dwarf.AttrName).(string)
+			if n == name || strings.HasSuffix(n, "."+name) {
+				loc, ok := entry.Val(dwarf.AttrLocation).([]byte)
+				if ok && len(loc) >= 9 && loc[0] == 0x03 {
+					addr := uint64(int64(binary.LittleEndian.Uint64(loc[1:9])) + r.slide)
+					return addr, r.varType(entry), true
+				}
+			}
+		}
+		if entry.Children {
+			rd.SkipChildren()
+		}
+	}
+}
+
+// globalVarAnywhere preserves the original cross-package convenience lookup:
+// the first exact DWARF name or ".name" suffix match.
+func (r *dwarfReader) globalVarAnywhere(name string) (uint64, dwarf.Type, bool) {
 	rd := r.data.Reader()
 	for {
 		entry, err := rd.Next()

--- a/internal/debugger/dwarf_global_test.go
+++ b/internal/debugger/dwarf_global_test.go
@@ -20,12 +20,16 @@ go 1.25
 
 import (
 	"example.com/scopedglobals/asmfixture"
+	"example.com/scopedglobals/generic"
+	"example.com/scopedglobals/inline"
 	"example.com/scopedglobals/left"
 	"example.com/scopedglobals/right"
 )
 
 var buildVersion = "v1.2.3"
 var initValue string
+var Collide = "main"
+var GenGlobal = "main"
 
 func init() {
 	initValue = buildVersion
@@ -49,10 +53,20 @@ func makeClosure() func() string {
 	}
 }
 
+//go:noinline
+func inlineFrame() string {
+	return inline.Small()
+}
+
+//go:noinline
+func genericFrame() string {
+	return generic.Identity("value")
+}
+
 var closure = makeClosure()
 
 func main() {
-	println(frame(), receiver{}.method(), closure(), left.Frame(), right.Frame(), right.Fallback(), asmfixture.Read(), initValue)
+	println(frame(), receiver{}.method(), closure(), inlineFrame(), genericFrame(), left.Frame(), right.Frame(), right.Fallback(), asmfixture.Read(), initValue)
 }
 `,
 	"left/left.go": `package left
@@ -95,6 +109,30 @@ func Read() string {
 
 TEXT ·AssemblyFrame(SB),NOSPLIT,$0-0
 	RET
+`,
+	"generic/generic.go": `package generic
+
+var GenGlobal = "generic"
+
+//go:noinline
+func Identity[T any](value T) T {
+	if GenGlobal == "" {
+		panic("missing generic global")
+	}
+	return value
+}
+`,
+	"inline/inline.go": `package inline
+
+var Collide = "inline"
+
+func Small() string {
+	value := Collide
+	if len(value) == 0 {
+		return "missing"
+	}
+	return value
+}
 `,
 }
 
@@ -162,6 +200,76 @@ func subprogramPC(t *testing.T, r *dwarfReader, suffix string) uint64 {
 	}
 	t.Fatalf("no subprogram ending in %q; names include %v", suffix, names)
 	return 0
+}
+
+func subprogramPCContaining(t *testing.T, r *dwarfReader, fragment string) uint64 {
+	t.Helper()
+	rd := r.data.Reader()
+	for {
+		entry, err := rd.Next()
+		if err != nil {
+			t.Fatalf("scan subprograms: %v", err)
+		}
+		if entry == nil {
+			break
+		}
+		if entry.Tag != dwarf.TagSubprogram {
+			continue
+		}
+		name, _ := entry.Val(dwarf.AttrName).(string)
+		if !strings.Contains(name, fragment) {
+			continue
+		}
+		lowPC, ok := entry.Val(dwarf.AttrLowpc).(uint64)
+		if ok {
+			return uint64(int64(lowPC) + r.slide)
+		}
+	}
+	t.Fatalf("no subprogram containing %q", fragment)
+	return 0
+}
+
+func inlinedSubprogramPC(t *testing.T, r *dwarfReader, originSuffix string) uint64 {
+	t.Helper()
+	rd := r.data.Reader()
+	for {
+		entry, err := rd.Next()
+		if err != nil {
+			t.Fatalf("scan inlined subprograms: %v", err)
+		}
+		if entry == nil {
+			break
+		}
+		if entry.Tag != dwarf.TagInlinedSubroutine {
+			continue
+		}
+		name, ok := r.abstractOriginName(entry)
+		if !ok || !strings.HasSuffix(name, originSuffix) {
+			continue
+		}
+		ranges, err := r.data.Ranges(entry)
+		if err != nil {
+			t.Fatalf("read inline ranges for %q: %v", name, err)
+		}
+		if len(ranges) > 0 {
+			return uint64(int64(ranges[0][0]) + r.slide)
+		}
+	}
+	t.Fatalf("no inlined subprogram ending in %q", originSuffix)
+	return 0
+}
+
+func physicalPackageForPC(t *testing.T, r *dwarfReader, pc uint64) string {
+	t.Helper()
+	cu, err := r.data.Reader().SeekPC(uint64(int64(pc) - r.slide))
+	if err != nil {
+		t.Fatalf("SeekPC(%#x): %v", pc, err)
+	}
+	name, _ := cu.Val(dwarf.AttrName).(string)
+	if name == "" {
+		t.Fatalf("CU containing %#x has no package name", pc)
+	}
+	return name
 }
 
 func exactGlobalAddress(t *testing.T, r *dwarfReader, name string) uint64 {
@@ -246,5 +354,48 @@ func TestPackageForPCUsesRuntimeSlide(t *testing.T) {
 	}
 	if pc < uint64(r.slide) {
 		t.Fatalf("test fixture PC %#x does not include slide %#x", pc, r.slide)
+	}
+}
+
+func TestEvaluateNameUsesLogicalCodePackage(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		gcflags   string
+		optimized bool
+	}{
+		{name: "optimized", optimized: true},
+		{name: "no_optimize_no_inline", gcflags: "all=-N -l"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := buildScopedGlobalsFixture(t, tc.gcflags)
+
+			genericPC := subprogramPCContaining(t, r, "/generic.Identity[")
+			genericLocation := r.locationForPC(genericPC)
+			if want := scopedGlobalsModule + "/generic.Identity["; !strings.Contains(genericLocation.Function, want) {
+				t.Fatalf("generic Frame.Function = %q, want function containing %q", genericLocation.Function, want)
+			}
+			if got := physicalPackageForPC(t, r, genericPC); got != "main" {
+				t.Fatalf("generic physical CU = %q, want main to exercise instantiator-CU regression", got)
+			}
+			assertEvaluatesGlobal(t, r, genericPC, "GenGlobal", scopedGlobalsModule+"/generic.GenGlobal")
+
+			var inlinePC uint64
+			if tc.optimized {
+				inlinePC = inlinedSubprogramPC(t, r, "/inline.Small")
+				inlineLocation := r.locationForPC(inlinePC)
+				if inlineLocation.Function != "main.inlineFrame" {
+					t.Fatalf("inline Frame.Function = %q, want physical main.inlineFrame", inlineLocation.Function)
+				}
+				if !strings.HasSuffix(inlineLocation.File, "/inline/inline.go") {
+					t.Fatalf("inline current-PC file = %q, want inline/inline.go", inlineLocation.File)
+				}
+				if got := physicalPackageForPC(t, r, inlinePC); got != "main" {
+					t.Fatalf("inline physical CU = %q, want main to exercise caller-CU regression", got)
+				}
+			} else {
+				inlinePC = subprogramPC(t, r, "/inline.Small")
+			}
+			assertEvaluatesGlobal(t, r, inlinePC, "Collide", scopedGlobalsModule+"/inline.Collide")
+		})
 	}
 }

--- a/internal/debugger/dwarf_global_test.go
+++ b/internal/debugger/dwarf_global_test.go
@@ -1,0 +1,250 @@
+package debugger
+
+import (
+	"debug/dwarf"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const scopedGlobalsModule = "example.com/scopedglobals"
+
+var scopedGlobalsFiles = map[string]string{
+	"go.mod": `module example.com/scopedglobals
+
+go 1.25
+`,
+	"main.go": `package main
+
+import (
+	"example.com/scopedglobals/asmfixture"
+	"example.com/scopedglobals/left"
+	"example.com/scopedglobals/right"
+)
+
+var buildVersion = "v1.2.3"
+var initValue string
+
+func init() {
+	initValue = buildVersion
+}
+
+//go:noinline
+func frame() string {
+	return buildVersion
+}
+
+type receiver struct{}
+
+//go:noinline
+func (receiver) method() string {
+	return buildVersion
+}
+
+func makeClosure() func() string {
+	return func() string {
+		return buildVersion
+	}
+}
+
+var closure = makeClosure()
+
+func main() {
+	println(frame(), receiver{}.method(), closure(), left.Frame(), right.Frame(), right.Fallback(), asmfixture.Read(), initValue)
+}
+`,
+	"left/left.go": `package left
+
+var BuildVersion = "left"
+
+//go:noinline
+func Frame() string {
+	return BuildVersion
+}
+`,
+	"right/right.go": `package right
+
+var BuildVersion = "right"
+var FallbackOnly = "fallback"
+
+//go:noinline
+func Frame() string {
+	return BuildVersion
+}
+
+//go:noinline
+func Fallback() string {
+	return FallbackOnly
+}
+`,
+	"asmfixture/asmfixture.go": `package asmfixture
+
+var BuildVersion = "assembly"
+
+func AssemblyFrame()
+
+//go:noinline
+func Read() string {
+	AssemblyFrame()
+	return BuildVersion
+}
+`,
+	"asmfixture/frame.s": `#include "textflag.h"
+
+TEXT ·AssemblyFrame(SB),NOSPLIT,$0-0
+	RET
+`,
+}
+
+func buildScopedGlobalsFixture(t *testing.T, gcflags string) *dwarfReader {
+	t.Helper()
+	root := t.TempDir()
+	for name, contents := range scopedGlobalsFiles {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create fixture directory: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+			t.Fatalf("write fixture %s: %v", name, err)
+		}
+	}
+
+	binaryPath := filepath.Join(root, "fixture")
+	args := []string{"build", "-o", binaryPath}
+	if gcflags != "" {
+		args = append(args, "-gcflags="+gcflags)
+	}
+	args = append(args, ".")
+	cmd := exec.Command("go", args...)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build scoped-global fixture: %v\n%s", err, out)
+	}
+
+	reader, err := openDWARF(binaryPath)
+	if err != nil {
+		t.Fatalf("open fixture DWARF: %v", err)
+	}
+	reader.slide = 0x12345000
+	return reader
+}
+
+func subprogramPC(t *testing.T, r *dwarfReader, suffix string) uint64 {
+	t.Helper()
+	rd := r.data.Reader()
+	var names []string
+	for {
+		entry, err := rd.Next()
+		if err != nil {
+			t.Fatalf("scan subprograms: %v", err)
+		}
+		if entry == nil {
+			break
+		}
+		if entry.Tag != dwarf.TagSubprogram {
+			continue
+		}
+		name, _ := entry.Val(dwarf.AttrName).(string)
+		if name != "" && len(names) < 100 &&
+			(strings.Contains(name, "main") || strings.Contains(name, scopedGlobalsModule)) {
+			names = append(names, name)
+		}
+		if !strings.HasSuffix(name, suffix) {
+			continue
+		}
+		lowPC, ok := entry.Val(dwarf.AttrLowpc).(uint64)
+		if ok {
+			return uint64(int64(lowPC) + r.slide)
+		}
+	}
+	t.Fatalf("no subprogram ending in %q; names include %v", suffix, names)
+	return 0
+}
+
+func exactGlobalAddress(t *testing.T, r *dwarfReader, name string) uint64 {
+	t.Helper()
+	addr := r.resolveVarAddr(name)
+	if addr == 0 {
+		t.Fatalf("no exact global %q", name)
+	}
+	return addr
+}
+
+func assertEvaluatesGlobal(t *testing.T, r *dwarfReader, pc uint64, query, exact string) {
+	t.Helper()
+	got, err := r.EvaluateName(readableBackend{}, pc, 0, query)
+	if err != nil {
+		t.Fatalf("EvaluateName(%#x, %q): %v", pc, query, err)
+	}
+	want := exactGlobalAddress(t, r, exact)
+	if got.Address != want {
+		t.Fatalf("EvaluateName(%#x, %q) address = %#x, want %s at %#x",
+			pc, query, got.Address, exact, want)
+	}
+}
+
+func TestEvaluateNamePrefersFramePackageGlobals(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		gcflags string
+	}{
+		{name: "optimized"},
+		{name: "no_optimize_no_inline", gcflags: "all=-N -l"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := buildScopedGlobalsFixture(t, tc.gcflags)
+
+			mainPC := subprogramPC(t, r, "main.frame")
+			leftPC := subprogramPC(t, r, "/left.Frame")
+			rightPC := subprogramPC(t, r, "/right.Frame")
+			methodPC := subprogramPC(t, r, "main.receiver.method")
+			closurePC := subprogramPC(t, r, "makeClosure.func1")
+			initPC := subprogramPC(t, r, "main.init.0")
+			assemblyPC := subprogramPC(t, r, "/asmfixture.AssemblyFrame")
+
+			t.Run("runtime collision", func(t *testing.T) {
+				assertEvaluatesGlobal(t, r, mainPC, "buildVersion", "main.buildVersion")
+			})
+			t.Run("same name in two packages", func(t *testing.T) {
+				assertEvaluatesGlobal(t, r, leftPC, "BuildVersion", scopedGlobalsModule+"/left.BuildVersion")
+				assertEvaluatesGlobal(t, r, rightPC, "BuildVersion", scopedGlobalsModule+"/right.BuildVersion")
+			})
+			t.Run("method closure and init frames", func(t *testing.T) {
+				assertEvaluatesGlobal(t, r, methodPC, "buildVersion", "main.buildVersion")
+				assertEvaluatesGlobal(t, r, closurePC, "buildVersion", "main.buildVersion")
+				assertEvaluatesGlobal(t, r, initPC, "buildVersion", "main.buildVersion")
+			})
+			t.Run("assembly CU shares package globals", func(t *testing.T) {
+				assertEvaluatesGlobal(t, r, assemblyPC, "BuildVersion", scopedGlobalsModule+"/asmfixture.BuildVersion")
+			})
+			t.Run("cross package fallback", func(t *testing.T) {
+				assertEvaluatesGlobal(t, r, leftPC, "FallbackOnly", scopedGlobalsModule+"/right.FallbackOnly")
+				assertEvaluatesGlobal(t, r, ^uint64(0), "FallbackOnly", scopedGlobalsModule+"/right.FallbackOnly")
+			})
+			t.Run("qualified names stay exact", func(t *testing.T) {
+				assertEvaluatesGlobal(t, r, mainPC, "main.buildVersion", "main.buildVersion")
+				assertEvaluatesGlobal(t, r, mainPC, scopedGlobalsModule+"/left.BuildVersion", scopedGlobalsModule+"/left.BuildVersion")
+				assertEvaluatesGlobal(t, r, mainPC, "runtime.buildVersion", "runtime.buildVersion")
+			})
+		})
+	}
+}
+
+func TestPackageForPCUsesRuntimeSlide(t *testing.T) {
+	r := buildScopedGlobalsFixture(t, "")
+	pc := subprogramPC(t, r, "/right.Frame")
+
+	got, ok := r.packageForPC(pc)
+	if !ok {
+		t.Fatal("packageForPC did not resolve a slid runtime PC")
+	}
+	if want := scopedGlobalsModule + "/right"; got != want {
+		t.Fatalf("packageForPC(%#x) = %q, want %q", pc, got, want)
+	}
+	if pc < uint64(r.slide) {
+		t.Fatalf("test fixture PC %#x does not include slide %#x", pc, r.slide)
+	}
+}

--- a/internal/debugger/dwarf_global_test.go
+++ b/internal/debugger/dwarf_global_test.go
@@ -66,7 +66,7 @@ func genericFrame() string {
 var closure = makeClosure()
 
 func main() {
-	println(frame(), receiver{}.method(), closure(), inlineFrame(), genericFrame(), left.Frame(), right.Frame(), right.Fallback(), asmfixture.Read(), initValue)
+	println(frame(), receiver{}.method(), closure(), inlineFrame(), genericFrame(), left.Frame(), right.Frame(), right.Fallback(), asmfixture.Read(), initValue, Collide, GenGlobal)
 }
 `,
 	"left/left.go": `package left
@@ -294,6 +294,15 @@ func assertEvaluatesGlobal(t *testing.T, r *dwarfReader, pc uint64, query, exact
 	}
 }
 
+func assertDistinctGlobalCollision(t *testing.T, r *dwarfReader, first, second string) {
+	t.Helper()
+	firstAddr := exactGlobalAddress(t, r, first)
+	secondAddr := exactGlobalAddress(t, r, second)
+	if firstAddr == secondAddr {
+		t.Fatalf("collision globals %q and %q share address %#x", first, second, firstAddr)
+	}
+}
+
 func TestEvaluateNamePrefersFramePackageGlobals(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
@@ -369,33 +378,40 @@ func TestEvaluateNameUsesLogicalCodePackage(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r := buildScopedGlobalsFixture(t, tc.gcflags)
 
-			genericPC := subprogramPCContaining(t, r, "/generic.Identity[")
-			genericLocation := r.locationForPC(genericPC)
-			if want := scopedGlobalsModule + "/generic.Identity["; !strings.Contains(genericLocation.Function, want) {
-				t.Fatalf("generic Frame.Function = %q, want function containing %q", genericLocation.Function, want)
-			}
-			if got := physicalPackageForPC(t, r, genericPC); got != "main" {
-				t.Fatalf("generic physical CU = %q, want main to exercise instantiator-CU regression", got)
-			}
-			assertEvaluatesGlobal(t, r, genericPC, "GenGlobal", scopedGlobalsModule+"/generic.GenGlobal")
+			assertDistinctGlobalCollision(t, r, "main.Collide", scopedGlobalsModule+"/inline.Collide")
+			assertDistinctGlobalCollision(t, r, "main.GenGlobal", scopedGlobalsModule+"/generic.GenGlobal")
 
-			var inlinePC uint64
-			if tc.optimized {
-				inlinePC = inlinedSubprogramPC(t, r, "/inline.Small")
-				inlineLocation := r.locationForPC(inlinePC)
-				if inlineLocation.Function != "main.inlineFrame" {
-					t.Fatalf("inline Frame.Function = %q, want physical main.inlineFrame", inlineLocation.Function)
+			t.Run("generic shape", func(t *testing.T) {
+				genericPC := subprogramPCContaining(t, r, "/generic.Identity[")
+				genericLocation := r.locationForPC(genericPC)
+				if want := scopedGlobalsModule + "/generic.Identity["; !strings.Contains(genericLocation.Function, want) {
+					t.Fatalf("generic Frame.Function = %q, want function containing %q", genericLocation.Function, want)
 				}
-				if !strings.HasSuffix(inlineLocation.File, "/inline/inline.go") {
-					t.Fatalf("inline current-PC file = %q, want inline/inline.go", inlineLocation.File)
+				if got := physicalPackageForPC(t, r, genericPC); got != "main" {
+					t.Fatalf("generic physical CU = %q, want main to exercise instantiator-CU regression", got)
 				}
-				if got := physicalPackageForPC(t, r, inlinePC); got != "main" {
-					t.Fatalf("inline physical CU = %q, want main to exercise caller-CU regression", got)
+				assertEvaluatesGlobal(t, r, genericPC, "GenGlobal", scopedGlobalsModule+"/generic.GenGlobal")
+			})
+
+			t.Run("inlined function", func(t *testing.T) {
+				var inlinePC uint64
+				if tc.optimized {
+					inlinePC = inlinedSubprogramPC(t, r, "/inline.Small")
+					inlineLocation := r.locationForPC(inlinePC)
+					if inlineLocation.Function != "main.inlineFrame" {
+						t.Fatalf("inline Frame.Function = %q, want physical main.inlineFrame", inlineLocation.Function)
+					}
+					if !strings.HasSuffix(inlineLocation.File, "/inline/inline.go") {
+						t.Fatalf("inline current-PC file = %q, want inline/inline.go", inlineLocation.File)
+					}
+					if got := physicalPackageForPC(t, r, inlinePC); got != "main" {
+						t.Fatalf("inline physical CU = %q, want main to exercise caller-CU regression", got)
+					}
+				} else {
+					inlinePC = subprogramPC(t, r, "/inline.Small")
 				}
-			} else {
-				inlinePC = subprogramPC(t, r, "/inline.Small")
-			}
-			assertEvaluatesGlobal(t, r, inlinePC, "Collide", scopedGlobalsModule+"/inline.Collide")
+				assertEvaluatesGlobal(t, r, inlinePC, "Collide", scopedGlobalsModule+"/inline.Collide")
+			})
 		})
 	}
 }

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -475,9 +475,10 @@ func (e *engine) Locals(frameIndex int) ([]protocol.Variable, error) {
 }
 
 // Evaluate resolves a single variable NAME in the given frame (local/parameter
-// first, then a package global) and returns its bounded typed tree. It is
-// non-suspending and non-resuming — like Locals, it only reads a suspended
-// tracee. Expression parsing (dotted paths, indexing, arithmetic) is a later PR.
+// first, then a frame-package global, then a whole-image fallback) and returns
+// its bounded typed tree. It is non-suspending and non-resuming — like Locals,
+// it only reads a suspended tracee. Expression parsing (dotted paths, indexing,
+// arithmetic) is a later PR.
 func (e *engine) Evaluate(frameIndex int, name string) (protocol.Variable, error) {
 	var result protocol.Variable
 	err := e.dispatch(func() error {

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -475,10 +475,10 @@ func (e *engine) Locals(frameIndex int) ([]protocol.Variable, error) {
 }
 
 // Evaluate resolves a single variable NAME in the given frame (local/parameter
-// first, then a frame-package global, then a whole-image fallback) and returns
-// its bounded typed tree. It is non-suspending and non-resuming — like Locals,
-// it only reads a suspended tracee. Expression parsing (dotted paths, indexing,
-// arithmetic) is a later PR.
+// first, then a global from the logical code package at the frame PC, then a
+// whole-image fallback) and returns its bounded typed tree. It is non-suspending
+// and non-resuming — like Locals, it only reads a suspended tracee. Expression
+// parsing (dotted paths, indexing, arithmetic) is a later PR.
 func (e *engine) Evaluate(frameIndex int, name string) (protocol.Variable, error) {
 	var result protocol.Variable
 	err := e.dispatch(func() error {

--- a/pkg/protocol/payload.go
+++ b/pkg/protocol/payload.go
@@ -240,8 +240,12 @@ type LocalsPayloadCmd struct {
 // EvaluatePayloadCmd asks the debugger to resolve a single variable NAME in a
 // stack frame (FrameIndex 0 is innermost). This is name-only: no dotted paths,
 // indexing, or arithmetic — those belong to a later expression-evaluator PR.
-// A local or parameter of the frame is resolved first; failing that, a
-// package-level global of the same name. Answered with EventEvaluate.
+// A local or parameter is resolved first. A bare global then prefers the
+// frame's DWARF compilation-unit package before falling back to the whole
+// image; a qualified global uses the whole-image lookup directly. Generic shape
+// code is scoped to the instantiating CU, so explicit qualification may be
+// needed to inspect a global from the package that defined the generic.
+// Answered with EventEvaluate.
 type EvaluatePayloadCmd struct {
 	FrameIndex int    `json:"frameIndex"`
 	Name       string `json:"name"`

--- a/pkg/protocol/payload.go
+++ b/pkg/protocol/payload.go
@@ -241,10 +241,9 @@ type LocalsPayloadCmd struct {
 // stack frame (FrameIndex 0 is innermost). This is name-only: no dotted paths,
 // indexing, or arithmetic — those belong to a later expression-evaluator PR.
 // A local or parameter is resolved first. A bare global then prefers the
-// frame's DWARF compilation-unit package before falling back to the whole
-// image; a qualified global uses the whole-image lookup directly. Generic shape
-// code is scoped to the instantiating CU, so explicit qualification may be
-// needed to inspect a global from the package that defined the generic.
+// logical code package at the frame PC (including inline abstract origins and
+// generic functions emitted in another package's CU) before falling back to the
+// whole image; a qualified global uses the whole-image lookup directly.
 // Answered with EventEvaluate.
 type EvaluatePayloadCmd struct {
 	FrameIndex int    `json:"frameIndex"`


### PR DESCRIPTION
## Summary

- prefer bare globals from the **logical code package at the selected frame PC**, then retain the existing whole-image fallback
- resolve optimized inline bodies through the deepest containing `DW_TAG_inlined_subroutine` and its `DW_AT_abstract_origin`
- resolve ordinary and generic shape frames through the same qualified subprogram name bingo reports as `Frame.Function`, rather than trusting the physical compilation unit where the compiler emitted the code
- match that function against exact known CU `DW_AT_name` identities, then search direct globals across every CU for that package so Go and assembly CUs cooperate
- fall back conservatively when inline metadata is missing, malformed, ambiguous, or cannot be mapped to a known package; explicit qualified lookup and runtime-introspection helpers remain unchanged
- keep protocol 1.4 and its wire types unchanged

Bingo still does not synthesize inline stack frames. At an inline-body PC, `Frame.Function` and locals remain those of the physical caller while the source location and bare-global lexical package follow the deepest inline origin.

## Restack proof

Restacked the accepted three-commit series onto exact `origin/main` `02e76b531a2a2bb034c5ae63786e2244b1b87180`:

- `16856121ce337243350d98f1a376d17710ec9c19` → `7d6b280a8b417cd374b5e2d364d9f865cea00239`
- `f15e366cea0ab341e158af4576161552b6d17d24` → `9169b6998cd4daf7e8eda242e97c9b25491351f4`
- `1f222fdaf07fc362e3e6f0096817625e9afa4c89` → `0bfac5b141703a7fe7607ee0a32857149891ace4`

Stable patch IDs match commit-by-commit when scoped to implementation/tests/protocol, and the normalized combined implementation/test/protocol diff is identical. `range-diff` differs only where the same AGENTS.md guidance lands after current main's newer scoped-DIE documentation.

## Regression coverage

Real optimized and `all=-N -l` fixtures cover:

- `main.buildVersion` versus `runtime.buildVersion`
- same-named globals in two ordinary packages
- methods, closures, init functions, and a package split across Go and assembly CUs
- cross-package and unknown-PC fallback
- explicit `main`, package-path, and `runtime` qualification
- nonzero ASLR slide handling
- an actually inlined cross-package `inline.Small` body whose physical CU and displayed function are `main`, but whose colliding bare global resolves to `inline.Collide`
- a generic `Identity` shape whose physical CU is the instantiating `main` package, but whose qualified frame function and colliding global belong to the defining generic package

The fixture keeps both competing main-package globals live and asserts all exact DWARF globals have distinct addresses. Replacing the logical selector with the prior physical-`SeekPC` CU rule fails independently for optimized generic, optimized inline, and `-N -l` generic cases.

## Validation

- `gofmt` and `go tool goimports`
- `go test -tags bingonative -race -count=1 ./internal/debugger ./internal/dap ./pkg/protocol`
- `go test -tags bingonative -race -count=1 ./...`
- `go vet -tags bingonative ./...`
- `go vet -tags 'e2e bingonative' ./test/integration`
- Linux-context `golangci-lint run` — 0 issues
- linux/amd64 cross-builds for the server plus integration and debugger E2E test binaries
- signed native Darwin `inspect` subset — 2 passed
- full signed native Darwin `just e2e-darwin` on published exact head `0bfac5b141703a7fe7607ee0a32857149891ace4` — 24 passed, 1 intentional heavy skip
- independent high-confidence review — no findings

Fixes #166