### PR TITLE
fix(vscode): preserve webview focus on rerender

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -919,7 +919,7 @@ target metadata, architecture, mode, and entitlements.
 The extension package version is the installed-runtime upgrade boundary:
 material shipped behavior changes must bump both `package.json` and the lockfile
 or VS Code can retain an older bundle under the same identity. The manifest test
-and package verifier pin the current version (**0.3.1**) in source and VSIX
+and package verifier pin the current version (**0.3.2**) in source and VSIX
 metadata.
 The root Run and Debug dropdown exposes exactly two `"type":"bingo"` choices:
 launch one of five progressive examples through a `pickString`, and join a
@@ -1010,7 +1010,14 @@ the 500-node rendering cap, re-lays out each match with at most four ancestors,
 and resets fit so a deep or previously capped match cannot remain invisible.
 Empty results keep Fit/zoom callbacks safe even without an SVG scene. SVG
 treeitems carry `aria-level`, sibling position/size, selection, and parent
-context; arrow navigation moves DOM focus with selection.
+context; arrow navigation moves DOM focus with selection. Full-root model
+rerenders preserve focus through bounded literal identities for the session
+selector and controls, the two static element IDs, and numeric goroutine IDs,
+but only when `document.hasFocus()` was true before replacement; a blurred
+webview must never reclaim focus from the editor, and an identity absent from
+the new render is a no-op. Rebuilding the selector can still close its native
+open popup; preserving that transient browser UI would require an incremental
+renderer and is intentionally outside this invariant.
 
 ### Handshake (Delve-style, VS Code-compatible)
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -20,8 +20,9 @@ just vscode-install
 ```
 
 This builds, verifies, and installs `dist/bingo-<platform>.vsix`. The graphical
-concurrency view debuted in 0.3.0; **0.3.1** adds capability-safe managed-server
-reuse and is the minimum supported version. Rerun the command to update, then run
+concurrency view debuted in 0.3.0; 0.3.1 added capability-safe managed-server
+reuse, and **0.3.2** preserves keyboard focus across telemetry rerenders without
+pulling focus back from the editor. Rerun the command to update, then run
 **Developer: Reload Window** once so the active extension host loads the new
 bundle. Package without installing with `just vscode-package`. Uninstall with:
 

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bingo",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bingo",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "ws": "8.18.3"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "bingo",
   "displayName": "bingo Debugger",
   "description": "Debug Go concurrency with bingo's DAP adapter and live goroutine visualization.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "publisher": "bingosuite",
   "license": "MIT",
   "private": true,

--- a/editors/vscode/scripts/verify-package.mjs
+++ b/editors/vscode/scripts/verify-package.mjs
@@ -13,7 +13,7 @@ import { spawnSync } from "node:child_process";
 import { currentTarget } from "./platform.mjs";
 
 const target = currentTarget();
-const expectedExtensionVersion = "0.3.1";
+const expectedExtensionVersion = "0.3.2";
 const vsix = fileURLToPath(
   new URL(`../../../dist/bingo-${target}.vsix`, import.meta.url),
 );

--- a/editors/vscode/src/webviewApp.ts
+++ b/editors/vscode/src/webviewApp.ts
@@ -9,6 +9,25 @@ export interface WebviewHost {
 }
 
 const svgNamespace = "http://www.w3.org/2000/svg";
+const focusSelectors = {
+  "session-selector": '[data-focus="session-selector"]',
+  refresh: '[data-focus="refresh"]',
+  "copy-snapshot": '[data-focus="copy-snapshot"]',
+  fit: '[data-focus="fit"]',
+  "zoom-out": '[data-focus="zoom-out"]',
+  "zoom-in": '[data-focus="zoom-in"]',
+} as const;
+const focusIDSelectors = {
+  "bingo-goroutine-filter": "#bingo-goroutine-filter",
+  "concurrency-tree": "#concurrency-tree",
+} as const;
+
+type FocusToken = keyof typeof focusSelectors;
+type FocusID = keyof typeof focusIDSelectors;
+type FocusIdentity =
+  | { readonly kind: "control"; readonly token: FocusToken }
+  | { readonly kind: "id"; readonly id: FocusID }
+  | { readonly kind: "goroutine"; readonly id: number };
 
 export function mountConcurrencyView(
   document: Document,
@@ -22,7 +41,10 @@ export function mountConcurrencyView(
   let transform = { x: 20, y: 20, scale: 1 };
 
   return (model, generation = 1) => {
-    const focused = focusIdentity(document.activeElement);
+    const documentWasFocused = document.hasFocus();
+    const focused = documentWasFocused
+      ? focusIdentity(document.activeElement)
+      : undefined;
     root.replaceChildren();
     root.className = "app";
     root.setAttribute("aria-live", "polite");
@@ -49,7 +71,9 @@ export function mountConcurrencyView(
             },
           }),
     );
-    restoreFocus(root, focused);
+    if (documentWasFocused) {
+      restoreFocus(root, focused);
+    }
     host.postMessage({
       type: "rendered",
       generation,
@@ -80,6 +104,7 @@ function header(
   if (model.sessions.length > 0) {
     const selector = document.createElement("select");
     selector.className = "session-selector";
+    selector.dataset.focus = "session-selector";
     selector.setAttribute("aria-label", "Active bingo debug session");
     for (const item of model.sessions) {
       const option = document.createElement("option");
@@ -151,10 +176,10 @@ function renderSession(
   search.placeholder = "Filter goroutines";
   search.value = state.query;
   search.setAttribute("aria-label", "Filter goroutines");
-  const refresh = button(document, "Refresh", () => {
+  const refresh = button(document, "Refresh", "refresh", () => {
     host.postMessage({ type: "refresh" });
   });
-  const copy = button(document, "Copy snapshot", () => {
+  const copy = button(document, "Copy snapshot", "copy-snapshot", () => {
     host.postMessage({ type: "copySnapshot" });
   });
   toolbar.append(search, refresh, copy);
@@ -232,14 +257,14 @@ function renderGraph(
   const scene = document.createElementNS(svgNamespace, "g");
   const controls = document.createElement("div");
   controls.className = "graph-controls";
-  const fit = button(document, "Fit", () => {
+  const fit = button(document, "Fit", "fit", () => {
     currentTransform = { x: 20, y: 20, scale: 1 };
     state.setTransform(currentTransform);
     updateTransform();
   });
-  const zoomIn = button(document, "+", () => zoom(1.15));
+  const zoomIn = button(document, "+", "zoom-in", () => zoom(1.15));
   zoomIn.setAttribute("aria-label", "Zoom in");
-  const zoomOut = button(document, "−", () => zoom(0.85));
+  const zoomOut = button(document, "−", "zoom-out", () => zoom(0.85));
   zoomOut.setAttribute("aria-label", "Zoom out");
   controls.append(fit, zoomOut, zoomIn);
   panel.append(controls);
@@ -647,11 +672,13 @@ function callout(
 function button(
   document: Document,
   label: string,
+  focusToken: FocusToken,
   action: () => void,
 ): HTMLButtonElement {
   const element = document.createElement("button");
   element.type = "button";
   element.textContent = label;
+  element.dataset.focus = focusToken;
   element.addEventListener("click", action);
   return element;
 }
@@ -696,22 +723,49 @@ function goroutineLabel(goroutine: {
     .join(" ");
 }
 
-function focusIdentity(element: Element | null | undefined): string {
+function focusIdentity(
+  element: Element | null | undefined,
+): FocusIdentity | undefined {
   if (element === null || element === undefined) {
-    return "";
+    return undefined;
   }
-  if (element.id.length > 0) {
-    return `#${element.id}`;
+  const token = element.getAttribute("data-focus");
+  if (token !== null && isFocusToken(token)) {
+    return { kind: "control", token };
   }
-  const goid = (element as HTMLElement | SVGElement).dataset.goid;
-  if (goid !== undefined) {
-    return `[data-goid="${goid}"]`;
+  if (isFocusID(element.id)) {
+    return { kind: "id", id: element.id };
   }
-  return "";
+  const goid = element.getAttribute("data-goid");
+  if (goid !== null) {
+    const id = Number(goid);
+    if (Number.isSafeInteger(id) && id > 0) {
+      return { kind: "goroutine", id };
+    }
+  }
+  return undefined;
 }
 
-function restoreFocus(root: HTMLElement, identity: string): void {
-  if (identity.length > 0) {
-    root.querySelector<HTMLElement | SVGElement>(identity)?.focus();
+function restoreFocus(
+  root: HTMLElement,
+  identity: FocusIdentity | undefined,
+): void {
+  if (identity === undefined) {
+    return;
   }
+  const selector =
+    identity.kind === "control"
+      ? focusSelectors[identity.token]
+      : identity.kind === "id"
+        ? focusIDSelectors[identity.id]
+        : `[data-goid="${String(identity.id)}"]`;
+  root.querySelector<HTMLElement | SVGElement>(selector)?.focus();
+}
+
+function isFocusToken(value: string): value is FocusToken {
+  return Object.prototype.hasOwnProperty.call(focusSelectors, value);
+}
+
+function isFocusID(value: string): value is FocusID {
+  return Object.prototype.hasOwnProperty.call(focusIDSelectors, value);
 }

--- a/editors/vscode/test/manifest.test.ts
+++ b/editors/vscode/test/manifest.test.ts
@@ -12,7 +12,7 @@ const manifest = requireRecord(
 const contributes = requireRecord(manifest.contributes);
 const debuggers = requireArray(contributes.debuggers);
 const debuggerContribution = requireRecord(debuggers[0]);
-const expectedExtensionVersion = "0.3.1";
+const expectedExtensionVersion = "0.3.2";
 
 describe("extension manifest", () => {
   it("versions the managed-server runtime as an installable upgrade", () => {

--- a/editors/vscode/test/webviewDom.test.ts
+++ b/editors/vscode/test/webviewDom.test.ts
@@ -7,6 +7,50 @@ import { toSessionViewModel } from "../src/model.js";
 import { mountConcurrencyView } from "../src/webviewApp.js";
 import { goroutine, snapshot, thread } from "./fixtures.js";
 
+const activeElements = new WeakMap<Document, Element>();
+const focusedDocuments = new WeakMap<Document, boolean>();
+
+function testDOM() {
+  const { document, window } = parseHTML(
+    "<html><body><div id=app></div></body></html>",
+  );
+  const focus = function (this: HTMLElement | SVGElement): void {
+    activeElements.set(this.ownerDocument, this);
+    focusedDocuments.set(this.ownerDocument, true);
+  };
+  for (const prototype of [
+    window.HTMLElement.prototype,
+    window.SVGElement.prototype,
+  ]) {
+    Object.defineProperty(prototype, "focus", {
+      configurable: true,
+      value: focus,
+    });
+  }
+
+  const documentPrototype = Object.getPrototypeOf(document) as object;
+  Object.defineProperty(documentPrototype, "activeElement", {
+    configurable: true,
+    get(this: Document): Element | null {
+      return activeElements.get(this) ?? null;
+    },
+  });
+  Object.defineProperty(documentPrototype, "hasFocus", {
+    configurable: true,
+    value(this: Document): boolean {
+      return focusedDocuments.get(this) ?? false;
+    },
+  });
+
+  return {
+    document,
+    window,
+    setDocumentFocused: (focused: boolean): void => {
+      focusedDocuments.set(document, focused);
+    },
+  };
+}
+
 function model(
   patch: Partial<SessionModel> = {},
 ): ConcurrencyViewModel {
@@ -39,9 +83,34 @@ function model(
   };
 }
 
+function multiSessionModel(
+  activeDebugSessionId = "debug",
+  revision = 1,
+): ConcurrencyViewModel {
+  const base = model();
+  const first = base.sessions[0];
+  if (first === undefined) {
+    throw new Error("test model requires a session");
+  }
+  return {
+    ...base,
+    revision,
+    activeDebugSessionId,
+    sessions: [
+      first,
+      {
+        ...first,
+        debugSessionId: "debug-2",
+        debugSessionName: "Level 2",
+        sessionId: "session-2",
+      },
+    ],
+  };
+}
+
 describe("concurrency webview DOM", () => {
   it("renders nodes, edges, threads, inspector, lifecycle, and accessibility", () => {
-    const { document } = parseHTML("<html><body><div id=app></div></body></html>");
+    const { document } = testDOM();
     const messages: Record<string, unknown>[] = [];
     const render = mountConcurrencyView(document, {
       postMessage(message) {
@@ -77,7 +146,7 @@ describe("concurrency webview DOM", () => {
   });
 
   it("filters and selects through DOM events", () => {
-    const { document, window } = parseHTML("<html><body><div id=app></div></body></html>");
+    const { document, window } = testDOM();
     const messages: Record<string, unknown>[] = [];
     mountConcurrencyView(document, { postMessage: (message) => messages.push(message) })(model());
     const search = document.querySelector<HTMLInputElement>('input[type="search"]')!;
@@ -88,10 +157,134 @@ describe("concurrency webview DOM", () => {
     assert.deepEqual(messages.at(-1), { type: "selectGoroutine", id: 2 });
   });
 
-  it("moves DOM focus with keyboard tree selection", () => {
-    const { document, window } = parseHTML(
-      "<html><body><div id=app></div></body></html>",
+  it("preserves session selector focus across selection rerenders", () => {
+    const { document, window } = testDOM();
+    const messages: Record<string, unknown>[] = [];
+    const render = mountConcurrencyView(document, {
+      postMessage: (message) => messages.push(message),
+    });
+    render(multiSessionModel());
+    const before = document.querySelector<HTMLSelectElement>(
+      '[data-focus="session-selector"]',
     );
+    assert.ok(before);
+    before.focus();
+    const options = before.querySelectorAll<HTMLOptionElement>("option");
+    const firstOption = options[0];
+    const secondOption = options[1];
+    assert.ok(firstOption);
+    assert.ok(secondOption);
+    firstOption.selected = false;
+    secondOption.selected = true;
+    before.dispatchEvent(new window.Event("change"));
+    assert.deepEqual(messages.at(-1), {
+      type: "selectSession",
+      id: "debug-2",
+    });
+
+    render(multiSessionModel("debug-2", 2));
+    const after = document.querySelector<HTMLSelectElement>(
+      '[data-focus="session-selector"]',
+    );
+    assert.ok(after);
+    assert.notEqual(after, before);
+    assert.equal(document.activeElement, after);
+  });
+
+  it("preserves every toolbar control across model revisions", () => {
+    const { document } = testDOM();
+    const render = mountConcurrencyView(document, { postMessage() {} });
+    render(model());
+    const tokens = [
+      "refresh",
+      "copy-snapshot",
+      "fit",
+      "zoom-out",
+      "zoom-in",
+    ] as const;
+
+    let revision = 2;
+    for (const token of tokens) {
+      const before = document.querySelector<HTMLButtonElement>(
+        `[data-focus="${token}"]`,
+      );
+      assert.ok(before);
+      before.focus();
+      render({ ...model(), revision });
+      revision += 1;
+      const after = document.querySelector<HTMLButtonElement>(
+        `[data-focus="${token}"]`,
+      );
+      assert.ok(after);
+      assert.notEqual(after, before);
+      assert.equal(document.activeElement, after);
+    }
+  });
+
+  it("retains search, viewport, and tree-node focus behavior", () => {
+    const { document } = testDOM();
+    const render = mountConcurrencyView(document, { postMessage() {} });
+    render(model());
+    const selectors = [
+      "#bingo-goroutine-filter",
+      "#concurrency-tree",
+      '[data-goid="1"]',
+    ] as const;
+
+    let revision = 2;
+    for (const selector of selectors) {
+      const before = document.querySelector<HTMLElement | SVGElement>(selector);
+      assert.ok(before);
+      before.focus();
+      render({ ...model(), revision });
+      revision += 1;
+      const after = document.querySelector<HTMLElement | SVGElement>(selector);
+      assert.ok(after);
+      assert.notEqual(after, before);
+      assert.equal(document.activeElement, after);
+    }
+  });
+
+  it("does not restore focus when the webview document is blurred", () => {
+    const { document, setDocumentFocused } = testDOM();
+    const render = mountConcurrencyView(document, { postMessage() {} });
+    render(model());
+    const before = document.querySelector<HTMLInputElement>(
+      "#bingo-goroutine-filter",
+    );
+    assert.ok(before);
+    before.focus();
+    setDocumentFocused(false);
+
+    render({ ...model(), revision: 2 });
+    const after = document.querySelector<HTMLInputElement>(
+      "#bingo-goroutine-filter",
+    );
+    assert.ok(after);
+    assert.notEqual(after, before);
+    assert.equal(document.activeElement, before);
+  });
+
+  it("does nothing when the focused control is absent after rendering", () => {
+    const { document } = testDOM();
+    const render = mountConcurrencyView(document, { postMessage() {} });
+    render(multiSessionModel());
+    const before = document.querySelector<HTMLSelectElement>(
+      '[data-focus="session-selector"]',
+    );
+    assert.ok(before);
+    before.focus();
+
+    render({ revision: 2, activeDebugSessionId: "", sessions: [] });
+    assert.equal(
+      document.querySelector('[data-focus="session-selector"]'),
+      null,
+    );
+    assert.equal(document.activeElement, before);
+  });
+
+  it("moves DOM focus with keyboard tree selection", () => {
+    const { document, window } = testDOM();
     const messages: Record<string, unknown>[] = [];
     mountConcurrencyView(document, {
       postMessage: (message) => messages.push(message),
@@ -107,17 +300,6 @@ describe("concurrency webview DOM", () => {
         return querySelector(selector);
       },
     });
-    let focused = "";
-    Object.defineProperty(first, "focus", {
-      value: () => {
-        focused = "1";
-      },
-    });
-    Object.defineProperty(second, "focus", {
-      value: () => {
-        focused = "2";
-      },
-    });
     first.focus();
     const event = new window.Event("keydown", {
       bubbles: true,
@@ -126,7 +308,7 @@ describe("concurrency webview DOM", () => {
     Object.defineProperty(event, "key", { value: "ArrowDown" });
     first.dispatchEvent(event);
 
-    assert.equal(focused, "2");
+    assert.equal(document.activeElement, second);
     assert.equal(selectorCalls, 1);
     assert.deepEqual(messages.at(-1), {
       type: "selectGoroutine",
@@ -135,7 +317,7 @@ describe("concurrency webview DOM", () => {
   });
 
   it("keeps matching descendants connected to visible ancestors", () => {
-    const { document, window } = parseHTML("<html><body><div id=app></div></body></html>");
+    const { document, window } = testDOM();
     const nested = snapshot([
       goroutine(1, 0, { current: true }),
       goroutine(2, 1),
@@ -152,7 +334,7 @@ describe("concurrency webview DOM", () => {
   });
 
   it("describes cycle-normalized roots without claiming their parent is absent", () => {
-    const { document } = parseHTML("<html><body><div id=app></div></body></html>");
+    const { document } = testDOM();
     mountConcurrencyView(document, { postMessage() {} })(
       model({
         snapshot: snapshot([
@@ -170,7 +352,7 @@ describe("concurrency webview DOM", () => {
   });
 
   it("finds, compacts, and fits matches beyond the rendering cap", () => {
-    const { document, window } = parseHTML("<html><body><div id=app></div></body></html>");
+    const { document, window } = testDOM();
     const goroutines = [goroutine(1, 0, { current: true })];
     for (let id = 2; id <= 1000; id += 1) {
       goroutines.push(
@@ -208,9 +390,7 @@ describe("concurrency webview DOM", () => {
   });
 
   it("keeps fit and zoom controls safe for an empty filter result", () => {
-    const { document, window } = parseHTML(
-      "<html><body><div id=app></div></body></html>",
-    );
+    const { document, window } = testDOM();
     mountConcurrencyView(document, { postMessage() {} })(model());
     const search = document.querySelector<HTMLInputElement>(
       'input[type="search"]',
@@ -241,7 +421,7 @@ describe("concurrency webview DOM", () => {
   });
 
   it("renders empty and error states", () => {
-    const { document } = parseHTML("<html><body><div id=app></div></body></html>");
+    const { document } = testDOM();
     const render = mountConcurrencyView(document, { postMessage() {} });
     render({ revision: 1, activeDebugSessionId: "", sessions: [] });
     assert.match(document.body.textContent, /Start a bingo debug session/);
@@ -251,7 +431,7 @@ describe("concurrency webview DOM", () => {
   });
 
   it("keeps hostile tracee strings inert", () => {
-    const { document } = parseHTML("<html><body><div id=app></div></body></html>");
+    const { document } = testDOM();
     const hostile = '<img src=x onerror="globalThis.pwned=true">';
     const snap = snapshot([goroutine(1, 0, { waitReason: hostile, current: true })]);
     mountConcurrencyView(document, { postMessage() {} })(


### PR DESCRIPTION
## Stack

**Layer 2 atop #134.** This PR intentionally targets `xsachax-fix-vscode-keyboard-navigation`; #134 remains the lower performance-only layer.

## Summary

- give the session selector and Refresh, Copy, Fit, Zoom out, and Zoom in controls bounded literal focus identities
- preserve those controls plus the existing search, viewport, and goroutine-node focus across full-root model rerenders
- gate restoration on the webview document having focus before replacement so telemetry cannot pull focus back from the editor
- treat a missing replacement control as a no-op and retain the full-root renderer; an open native select popup may still close on rebuild
- replace linkedom's inert focus behavior with a prototype-level `activeElement`/`hasFocus` shim and cover selector traversal, every button, existing identities, blur, and absent targets
- bump the shipped VS Code extension boundary from 0.3.1 to 0.3.2 and update the manifest/package verifier and agent invariant

## Validation

- `npm --prefix editors/vscode run check`
- `npm --prefix editors/vscode run test:integration`
- `npm --prefix editors/vscode run package:reproducible`
- `npm --prefix editors/vscode run package:verify`
- `npm --prefix editors/vscode run smoke:server`

Fixes #169