### PR TITLE
fix(dap): gate variable cache expansion on suspended state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1141,6 +1141,13 @@ breakpoint the process is currently parked on re-arms it through the engine's
 step-off path (see the clearbp spec), so the e2e continue-to-exit uses a
 no-breakpoint target, not a clear-then-continue.
 
+`bpByFile` keeps the stable DAP id separate from the debugger's internal id.
+After `EventRestarted`, reconcile its exact source-path/line keys from
+`RestartedPayload` before replying: retained entries adopt the fresh debugger
+id, while discarded entries are removed and emit a `breakpoint` changed event
+with their prior DAP id and `verified:false`. Do not reset `setQ`/`clearQ`;
+those FIFOs still own any in-flight confirmations.
+
 ### Server wiring + multi-client discovery
 
 `internal/server` implements `dap.Provider` (`dapProvider`): `CreateSession` →

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1034,6 +1034,15 @@ context; arrow navigation moves DOM focus with selection.
    (`pendingContinues++`). Restart reuses a `restarting` flag so the post-restart
    entry `EventStepped` is treated as a fresh entry.
 
+`restartReqSeq` separately gates only an unanswered DAP restart. A second
+request before `EventRestarted`/`EventError` is rejected without enqueueing
+another destructive `CmdRestart`; once the response is sent, a new restart is
+allowed even if the prior process's entry stop has not arrived yet. In that
+race, `onStop` suppresses the superseded entry while a newer `restartReqSeq` is
+pending and preserves `restarting` for the replacement process. This relies on
+the hub/client FIFO ordering each restart's `EventRestarted` before its own
+entry `EventStepped`.
+
 ### Joining an existing session (no relaunch)
 
 A DAP `attach` carrying a `session` argument and **no** `pid` means "join an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2903,10 +2903,12 @@ reason=step; `EventBreakpointHit`→`stopped` reason=breakpoint;
 `EventPanic`→reason=exception; `EventPaused`→reason=pause;
 `EventProcessExited`→`exited`(code)+`terminated`; `EventOutput`→`output`;
 `EventRestarted`→delayed `restart` response; `EventEvaluate`→`evaluate` response
-(correlated via `evalQ`, NOT a stop — see below); `EventSessionState`→sends
-nothing on the launch/attach path (only recorded as the session's lifecycle
-state, which gates resume-rejection resync), but consumed **once** as the initial
-state on the join path (see *Joining an existing session*);
+(correlated via `evalQ`, NOT a stop — see below); `EventSessionState`→sends no
+DAP message on the launch/attach path, but records lifecycle state for
+resume-rejection resync and clears the suspended view on `running` (the managed
+hub's propagation path for a successful out-of-band step, which emits no
+`EventContinued`); it is consumed **once** as the initial state on the join path
+(see *Joining an existing session*);
 `EventGoroutineSnapshot`→**deliberately
 ignored** (WebSocket-only concurrency stream with no DAP equivalent; translating
 it would corrupt the `threads`→`EventGoroutines` FIFO — see the goroutine
@@ -3008,11 +3010,22 @@ a fresh `variablesReference` from `varRefBase` (`1<<16`) upward via `allocVarRef
 and caches the node's DAP children under it in `varCache` (`ref→[]godap.Variable`).
 Child refs start above `varRefBase` so they never collide with a frame-root ref
 (a scope's reference == `frameIndex+1`, bounded by the max stack depth), letting
-`onVariables` tell them apart by magnitude: a ref in `varCache` is served
-synchronously (no round-trip); anything else is a frame-root ref that enqueues
-`CmdLocals`. The cache reflects ONE memory snapshot, so `resetVarsLocked` clears
-`varCache`/`nextVarRef` on every stop (`onStop`) — a child ref from a prior
-suspension is stale and must not expand.
+`onVariables` tell them apart by magnitude. A cached child ref is served
+synchronously (no round-trip) only while the Handler believes the process is
+suspended; a child-range cache miss is rejected rather than reinterpreted as a
+frame root. An observed resume suppresses the still-resident cache until the
+next stop, where `resetVarsLocked` clears `varCache`/`nextVarRef` before the new
+snapshot is built. For an out-of-band Continue, the translated `EventContinued`
+propagates that running state to the adapter. Steps deliberately emit no
+`EventContinued`, so a managed session's `EventSessionState(running)` provides
+the equivalent suppression while the step executes; the resulting
+`EventStepped` is the next-stop reset.
+
+Do **not** eagerly clear the cache on Continue/Step. Those requests clear the
+suspended view optimistically, but a synchronously rejected resume never moved
+the process; `failResume` restores the same suspension without routing through
+`onStop`, so the same cached snapshot is still valid and must expand again. A
+genuine later stop is the invalidation boundary.
 
 **`evaluate` is name-only.** `onEvaluate` sends `CmdEvaluate{FrameIndex, Name}`
 (Expression = the bare variable name; the `context` field — watch/hover/repl — is

--- a/internal/dap/breakpoints.go
+++ b/internal/dap/breakpoints.go
@@ -35,21 +35,21 @@ func (h *Handler) onSetBreakpoints(req *godap.SetBreakpointsRequest) {
 	h.mu.Lock()
 	current := h.bpByFile[file]
 	if current == nil {
-		current = make(map[int]int)
+		current = make(map[int]breakpointState)
 		h.bpByFile[file] = current
 	}
 
 	// Clear breakpoints no longer requested.
-	for line, id := range current {
+	for line, state := range current {
 		if desired[line] {
 			continue
 		}
 		delete(current, line)
-		if id == 0 {
+		if state.debuggerID == 0 {
 			continue // never confirmed; nothing to clear on the debugger
 		}
-		h.clearQ = append(h.clearQ, id)
-		if cmd, err := marshalCommand(protocol.CmdClearBreakpoint, protocol.ClearBreakpointPayload{ID: id}); err == nil {
+		h.clearQ = append(h.clearQ, state.debuggerID)
+		if cmd, err := marshalCommand(protocol.CmdClearBreakpoint, protocol.ClearBreakpointPayload{ID: state.debuggerID}); err == nil {
 			clears = append(clears, cmd)
 		}
 	}
@@ -59,13 +59,13 @@ func (h *Handler) onSetBreakpoints(req *godap.SetBreakpointsRequest) {
 		slot := &bpSlot{req: reqObj, file: file, line: b.Line}
 		reqObj.slots = append(reqObj.slots, slot)
 
-		if id, ok := current[b.Line]; ok && id != 0 {
+		if state, ok := current[b.Line]; ok && state.debuggerID != 0 {
 			slot.resolved = true
-			slot.bp = godap.Breakpoint{Id: id, Verified: true, Line: b.Line, Source: &src}
+			slot.bp = godap.Breakpoint{Id: state.dapID, Verified: true, Line: b.Line, Source: &src}
 			continue
 		}
 
-		current[b.Line] = 0 // pending sentinel, replaced on confirmation
+		current[b.Line] = breakpointState{} // pending sentinel, replaced on confirmation
 		h.setQ = append(h.setQ, slot)
 		if cmd, err := marshalCommand(protocol.CmdSetBreakpoint, protocol.SetBreakpointPayload{File: file, Line: b.Line}); err == nil {
 			sets = append(sets, cmd)

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -38,7 +38,7 @@ func (h *Handler) translateEvent(evt protocol.Event) {
 		// want goroutine data use the threads request; the rich snapshot is a
 		// WebSocket-only concurrency-visualization stream.
 	case protocol.EventRestarted:
-		h.onRestarted()
+		h.onRestarted(evt)
 	case protocol.EventError:
 		h.onError(evt)
 	case protocol.EventSessionState:
@@ -215,7 +215,10 @@ func (h *Handler) onBreakpointSet(evt protocol.Event) {
 		slot := h.setQ[0]
 		h.setQ = h.setQ[1:]
 		if lines := h.bpByFile[slot.file]; lines != nil {
-			lines[slot.line] = p.Breakpoint.ID
+			lines[slot.line] = breakpointState{
+				dapID:      p.Breakpoint.ID,
+				debuggerID: p.Breakpoint.ID,
+			}
 		}
 		slot.resolved = true
 		slot.bp = godap.Breakpoint{
@@ -346,15 +349,61 @@ func (h *Handler) onEvaluated(evt protocol.Event) {
 	})
 }
 
-func (h *Handler) onRestarted() {
+func (h *Handler) onRestarted(evt protocol.Event) {
+	var p protocol.RestartedPayload
+	decoded := protocol.DecodeEventPayload(evt, &p) == nil
+
 	h.mu.Lock()
 	seq := h.restartReqSeq
 	h.restartReqSeq = 0
+	var discarded []godap.Breakpoint
+	if decoded {
+		discarded = h.reconcileRestartBreakpointsLocked(p)
+	}
 	h.mu.Unlock()
 
+	for _, bp := range discarded {
+		h.send(&godap.BreakpointEvent{
+			Event: h.event("breakpoint"),
+			Body: godap.BreakpointEventBody{
+				Reason:     "changed",
+				Breakpoint: bp,
+			},
+		})
+	}
 	if seq != 0 {
 		h.send(&godap.RestartResponse{Response: h.response(seq, "restart")})
 	}
+}
+
+func (h *Handler) reconcileRestartBreakpointsLocked(p protocol.RestartedPayload) []godap.Breakpoint {
+	for _, bp := range p.Breakpoints {
+		lines := h.bpByFile[bp.Location.File]
+		state, ok := lines[bp.Location.Line]
+		if !ok || state.debuggerID == 0 {
+			continue
+		}
+		state.debuggerID = bp.ID
+		lines[bp.Location.Line] = state
+	}
+
+	discarded := make([]godap.Breakpoint, 0, len(p.Discarded))
+	for _, dropped := range p.Discarded {
+		lines := h.bpByFile[dropped.Location.File]
+		state, ok := lines[dropped.Location.Line]
+		if !ok || state.debuggerID == 0 {
+			continue
+		}
+		delete(lines, dropped.Location.Line)
+		discarded = append(discarded, godap.Breakpoint{
+			Id:       state.dapID,
+			Verified: false,
+			Message:  dropped.Reason,
+			Source:   dapSource(dropped.Location),
+			Line:     dropped.Location.Line,
+		})
+	}
+	return discarded
 }
 
 // onError routes a bingo EventError to the DAP request it corresponds to,

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -43,8 +43,8 @@ func (h *Handler) translateEvent(evt protocol.Event) {
 		h.onError(evt)
 	case protocol.EventSessionState:
 		// For a JOINING connection, the hub's welcome state seeds the joiner's
-		// initial DAP state. For the normal launch/attach path it is
-		// informational (the entry stop drives the initial state instead).
+		// initial DAP state. Later running states also propagate successful
+		// out-of-band steps, which intentionally emit no EventContinued.
 		h.onSessionState(evt)
 	}
 }
@@ -57,10 +57,10 @@ func (h *Handler) translateEvent(evt protocol.Event) {
 // awaitingWelcome) and is a no-op for the normal launch/attach path, where
 // awaitingWelcome is never set.
 //
-// Outside that welcome, the state is only recorded — with one exception: idle
-// and exited mean the process is gone (a failed relaunch leaves a managed
-// session idle), so a stale suspended view is dropped. Nothing is sent; process
-// death is already reported by EventProcessExited.
+// Outside that welcome, running clears the suspended view so an out-of-band
+// step cannot leave inspection enabled while the process executes. Idle and
+// exited clear it because the process is gone. Nothing is sent: steps do not map
+// to DAP continued, and process death is already reported by EventProcessExited.
 func (h *Handler) onSessionState(evt protocol.Event) {
 	var p protocol.SessionStatePayload
 	if err := protocol.DecodeEventPayload(evt, &p); err != nil {
@@ -70,7 +70,7 @@ func (h *Handler) onSessionState(evt protocol.Event) {
 	h.mu.Lock()
 	h.sessionState = p.State
 	if !h.awaitingWelcome {
-		if h.sessionEndedLocked() {
+		if p.State == protocol.StateRunning || h.sessionEndedLocked() {
 			h.suspended = false
 		}
 		h.mu.Unlock()

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -138,6 +138,13 @@ func (h *Handler) onStop(evt protocol.Event) {
 
 	// The first Stepped after a Restart is the new process's entry stop.
 	if restarting && evt.Kind == protocol.EventStepped {
+		if h.restartReqSeq != 0 {
+			// EventRestarted precedes its process's entry in the hub/client FIFO.
+			// A pending newer response makes this the superseded process's entry;
+			// preserve the latch for the replacement process.
+			h.mu.Unlock()
+			return
+		}
 		h.restarting = false
 		if stopOnEntry {
 			h.suspended = true

--- a/internal/dap/handler.go
+++ b/internal/dap/handler.go
@@ -99,11 +99,13 @@ type Handler struct {
 	// Suspend/resume (EventContinued).
 	pendingContinues int
 
-	// Breakpoint bookkeeping. bpByFile maps file -> requested line -> bingo
-	// breakpoint id (0 = set enqueued, awaiting confirmation). setQ/clearQ are
-	// FIFOs of in-flight confirmations, correlated to the hub's ordered
-	// event stream (valid while the DAP client is the sole breakpoint driver).
-	bpByFile map[string]map[int]int
+	// Breakpoint bookkeeping. bpByFile maps file -> requested line -> DAP and
+	// debugger identities. The two diverge after Restart: DAP identity remains
+	// stable while the fresh debugger assigns a new internal id.
+	// setQ/clearQ are FIFOs of in-flight confirmations, correlated to the hub's
+	// ordered event stream (valid while the DAP client is the sole breakpoint
+	// driver).
+	bpByFile map[string]map[int]breakpointState
 	setQ     []*bpSlot
 	clearQ   []int
 
@@ -139,6 +141,11 @@ type bpSlot struct {
 	line     int
 	resolved bool
 	bp       godap.Breakpoint
+}
+
+type breakpointState struct {
+	dapID      int
+	debuggerID int
 }
 
 // bpRequest collects the slots of a single setBreakpoints request; its response
@@ -194,7 +201,7 @@ func NewHandler(conn net.Conn, provider Provider, log *slog.Logger) *Handler {
 		log:      log,
 		cmdOut:   make(chan []byte, cmdBufferSize),
 		done:     make(chan struct{}),
-		bpByFile: make(map[string]map[int]int),
+		bpByFile: make(map[string]map[int]breakpointState),
 		varCache: make(map[int][]godap.Variable),
 	}
 }

--- a/internal/dap/handler.go
+++ b/internal/dap/handler.go
@@ -153,7 +153,8 @@ type Handler struct {
 	// (buildVarTree) and read synchronously by a follow-up variables request.
 	// nextVarRef allocates those child refs from varRefBase upward. Both reset
 	// at every stop — the tree reflects one memory snapshot, so refs from a
-	// prior suspension are stale.
+	// prior suspension are stale. Since the reset happens at the next stop,
+	// onVariables also gates cache hits on the current suspended state.
 	varCache   map[int][]godap.Variable
 	nextVarRef int
 }

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -83,6 +83,32 @@ func (r *cmdRecorder) waitForCommands(t *testing.T, kind protocol.CommandKind, c
 	return nil
 }
 
+func (r *cmdRecorder) count(kind protocol.CommandKind) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := 0
+	for _, cmd := range r.cmds {
+		if cmd.Kind == kind {
+			count++
+		}
+	}
+	return count
+}
+
+func (r *cmdRecorder) requireNoAdditionalCommands(t *testing.T, kind protocol.CommandKind, expected int) {
+	t.Helper()
+	deadline := time.Now().Add(50 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if got := r.count(kind); got != expected {
+			t.Fatalf("%s command count = %d, want %d throughout quiet period; saw %v", kind, got, expected, r.kinds())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if got := r.count(kind); got != expected {
+		t.Fatalf("%s command count = %d, want %d after quiet period; saw %v", kind, got, expected, r.kinds())
+	}
+}
+
 type fakeSession struct {
 	id      string
 	cmds    *cmdRecorder
@@ -777,15 +803,43 @@ func TestRestartRejectsOverlappingRequest(t *testing.T) {
 	if rejected.RequestSeq != secondSeq || rejected.Success || rejected.Message != "restart already in progress" {
 		t.Fatalf("overlapping restart response = %+v, want immediate error for request %d", rejected.Response, secondSeq)
 	}
-	if commands := hh.cmds.waitForCommands(t, protocol.CmdRestart, 1); len(commands) != 1 {
-		t.Fatalf("restart commands = %d, want exactly 1", len(commands))
-	}
+	hh.cmds.waitForCommands(t, protocol.CmdRestart, 1)
+	hh.cmds.requireNoAdditionalCommands(t, protocol.CmdRestart, 1)
 
 	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
 	restarted := recvType[*godap.RestartResponse](hh)
 	if restarted.RequestSeq != firstSeq || !restarted.Success {
 		t.Fatalf("restart response = %+v, want success for original request %d", restarted.Response, firstSeq)
 	}
+}
+
+func TestRestartAfterSuccessSupersedesPendingEntry(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+
+	firstSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	first := recvType[*godap.RestartResponse](hh)
+	if first.RequestSeq != firstSeq || !first.Success {
+		t.Fatalf("first restart response = %+v, want success for request %d", first.Response, firstSeq)
+	}
+
+	secondSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommands(t, protocol.CmdRestart, 2)
+
+	continues := hh.cmds.count(protocol.CmdContinue)
+	hh.inject(protocol.EventStepped, protocol.SteppedPayload{Goroutine: protocol.Goroutine{ID: 1}})
+	hh.cmds.requireNoAdditionalCommands(t, protocol.CmdContinue, continues)
+
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	second := recvType[*godap.RestartResponse](hh)
+	if second.RequestSeq != secondSeq || !second.Success {
+		t.Fatalf("second restart response = %+v, want success for request %d", second.Response, secondSeq)
+	}
+	hh.inject(protocol.EventStepped, protocol.SteppedPayload{Goroutine: protocol.Goroutine{ID: 2}})
+	hh.cmds.waitForCommands(t, protocol.CmdContinue, continues+1)
+	hh.inject(protocol.EventContinued, protocol.ContinuedPayload{})
 }
 
 func TestRestartErrorAllowsRetry(t *testing.T) {

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -613,13 +613,8 @@ func TestSetBreakpointsDiffAndFIFO(t *testing.T) {
 	hh.cmds.waitForCommand(t, protocol.CmdClearBreakpoint)
 }
 
-func TestRestartReconcilesBreakpointCache(t *testing.T) {
-	hh := newHarness(t)
-	hh.doHandshake(t)
-	hh.inject(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{Goroutine: protocol.Goroutine{ID: 1}})
-	_ = recvType[*godap.StoppedEvent](hh)
-
-	source := godap.Source{Path: "/x/main.go", Name: "main.go"}
+func seedRestartBreakpointCache(t *testing.T, hh *harness, source godap.Source) {
+	t.Helper()
 	hh.sendReq("setBreakpoints", &godap.SetBreakpointsRequest{Arguments: godap.SetBreakpointsArguments{
 		Source:      source,
 		Breakpoints: []godap.SourceBreakpoint{{Line: 10}, {Line: 20}},
@@ -632,21 +627,23 @@ func TestRestartReconcilesBreakpointCache(t *testing.T) {
 		Breakpoint: protocol.Breakpoint{ID: 42, Location: protocol.Location{File: source.Path, Line: 20}},
 	})
 	initial := recvType[*godap.SetBreakpointsResponse](hh)
-	if got := []int{initial.Body.Breakpoints[0].Id, initial.Body.Breakpoints[1].Id}; got[0] != 41 || got[1] != 42 {
-		t.Fatalf("initial breakpoint ids = %v, want [41 42]", got)
+	requireBreakpointIDs(t, initial, 41, 42)
+}
+
+func requireBreakpointIDs(t *testing.T, response *godap.SetBreakpointsResponse, want ...int) {
+	t.Helper()
+	if len(response.Body.Breakpoints) != len(want) {
+		t.Fatalf("breakpoint count = %d, want %d", len(response.Body.Breakpoints), len(want))
 	}
+	for i, id := range want {
+		if response.Body.Breakpoints[i].Id != id {
+			t.Fatalf("breakpoint ids = %+v, want %v", response.Body.Breakpoints, want)
+		}
+	}
+}
 
-	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
-	hh.cmds.waitForCommand(t, protocol.CmdRestart)
-	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{
-		Breakpoints: []protocol.Breakpoint{
-			{ID: 101, Location: protocol.Location{File: source.Path, Line: 10}},
-		},
-		Discarded: []protocol.DiscardedBreakpoint{
-			{Location: protocol.Location{File: source.Path, Line: 20}, Reason: "no such line"},
-		},
-	})
-
+func receiveRestartResult(t *testing.T, hh *harness, restartSeq int) *godap.BreakpointEvent {
+	t.Helper()
 	var changed *godap.BreakpointEvent
 	var restarted *godap.RestartResponse
 	for range 2 {
@@ -663,6 +660,11 @@ func TestRestartReconcilesBreakpointCache(t *testing.T) {
 	if changed == nil {
 		t.Fatal("discarded breakpoint did not emit a breakpoint event")
 	}
+	return changed
+}
+
+func requireDiscardedBreakpointEvent(t *testing.T, changed *godap.BreakpointEvent) {
+	t.Helper()
 	if changed.Body.Reason != "changed" ||
 		changed.Body.Breakpoint.Id != 42 ||
 		changed.Body.Breakpoint.Verified ||
@@ -670,7 +672,10 @@ func TestRestartReconcilesBreakpointCache(t *testing.T) {
 		changed.Body.Breakpoint.Message != "no such line" {
 		t.Fatalf("discarded breakpoint event = %+v", changed.Body)
 	}
+}
 
+func requireRestartBreakpointCache(t *testing.T, hh *harness, source godap.Source) {
+	t.Helper()
 	hh.handler.mu.Lock()
 	retained := hh.handler.bpByFile[source.Path][10]
 	_, droppedStillCached := hh.handler.bpByFile[source.Path][20]
@@ -681,7 +686,10 @@ func TestRestartReconcilesBreakpointCache(t *testing.T) {
 	if droppedStillCached {
 		t.Fatal("discarded breakpoint remained in cache")
 	}
+}
 
+func retryDiscardedBreakpoint(t *testing.T, hh *harness, source godap.Source) {
+	t.Helper()
 	hh.sendReq("setBreakpoints", &godap.SetBreakpointsRequest{Arguments: godap.SetBreakpointsArguments{
 		Source:      source,
 		Breakpoints: []godap.SourceBreakpoint{{Line: 10}, {Line: 20}},
@@ -698,10 +706,11 @@ func TestRestartReconcilesBreakpointCache(t *testing.T) {
 		Breakpoint: protocol.Breakpoint{ID: 202, Location: protocol.Location{File: source.Path, Line: 20}},
 	})
 	retried := recvType[*godap.SetBreakpointsResponse](hh)
-	if got := []int{retried.Body.Breakpoints[0].Id, retried.Body.Breakpoints[1].Id}; got[0] != 41 || got[1] != 202 {
-		t.Fatalf("post-restart breakpoint ids = %v, want stable retained id 41 and retried id 202", got)
-	}
+	requireBreakpointIDs(t, retried, 41, 202)
+}
 
+func clearReidentifiedBreakpoint(t *testing.T, hh *harness, source godap.Source) {
+	t.Helper()
 	hh.sendReq("setBreakpoints", &godap.SetBreakpointsRequest{Arguments: godap.SetBreakpointsArguments{
 		Source:      source,
 		Breakpoints: []godap.SourceBreakpoint{{Line: 20}},
@@ -715,6 +724,33 @@ func TestRestartReconcilesBreakpointCache(t *testing.T) {
 		t.Fatalf("clear breakpoint id = %d, want fresh debugger id 101", clear.ID)
 	}
 	_ = recvType[*godap.SetBreakpointsResponse](hh)
+}
+
+func TestRestartReconcilesBreakpointCache(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	hh.inject(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{Goroutine: protocol.Goroutine{ID: 1}})
+	_ = recvType[*godap.StoppedEvent](hh)
+
+	source := godap.Source{Path: "/x/main.go", Name: "main.go"}
+	seedRestartBreakpointCache(t, hh, source)
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{
+		Breakpoints: []protocol.Breakpoint{
+			{ID: 101, Location: protocol.Location{File: source.Path, Line: 10}},
+		},
+		Discarded: []protocol.DiscardedBreakpoint{
+			{Location: protocol.Location{File: source.Path, Line: 20}, Reason: "no such line"},
+		},
+	})
+
+	changed := receiveRestartResult(t, hh, restartSeq)
+	requireDiscardedBreakpointEvent(t, changed)
+	requireRestartBreakpointCache(t, hh, source)
+	retryDiscardedBreakpoint(t, hh, source)
+	clearReidentifiedBreakpoint(t, hh, source)
 }
 
 func TestRestartedPayloadDecodeFailureStillResponds(t *testing.T) {

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -62,6 +62,27 @@ func (r *cmdRecorder) waitForCommand(t *testing.T, kind protocol.CommandKind) pr
 	return protocol.Command{}
 }
 
+func (r *cmdRecorder) waitForCommands(t *testing.T, kind protocol.CommandKind, count int) []protocol.Command {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		r.mu.Lock()
+		var matches []protocol.Command
+		for _, cmd := range r.cmds {
+			if cmd.Kind == kind {
+				matches = append(matches, cmd)
+			}
+		}
+		r.mu.Unlock()
+		if len(matches) >= count {
+			return matches
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d commands of kind %s; saw %v", count, kind, r.kinds())
+	return nil
+}
+
 type fakeSession struct {
 	id      string
 	cmds    *cmdRecorder
@@ -590,6 +611,140 @@ func TestSetBreakpointsDiffAndFIFO(t *testing.T) {
 	}
 	// A ClearBreakpoint for the removed line 10 must have been enqueued.
 	hh.cmds.waitForCommand(t, protocol.CmdClearBreakpoint)
+}
+
+func TestRestartReconcilesBreakpointCache(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	hh.inject(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{Goroutine: protocol.Goroutine{ID: 1}})
+	_ = recvType[*godap.StoppedEvent](hh)
+
+	source := godap.Source{Path: "/x/main.go", Name: "main.go"}
+	hh.sendReq("setBreakpoints", &godap.SetBreakpointsRequest{Arguments: godap.SetBreakpointsArguments{
+		Source:      source,
+		Breakpoints: []godap.SourceBreakpoint{{Line: 10}, {Line: 20}},
+	}})
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 2)
+	hh.inject(protocol.EventBreakpointSet, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{ID: 41, Location: protocol.Location{File: source.Path, Line: 10}},
+	})
+	hh.inject(protocol.EventBreakpointSet, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{ID: 42, Location: protocol.Location{File: source.Path, Line: 20}},
+	})
+	initial := recvType[*godap.SetBreakpointsResponse](hh)
+	if got := []int{initial.Body.Breakpoints[0].Id, initial.Body.Breakpoints[1].Id}; got[0] != 41 || got[1] != 42 {
+		t.Fatalf("initial breakpoint ids = %v, want [41 42]", got)
+	}
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{
+		Breakpoints: []protocol.Breakpoint{
+			{ID: 101, Location: protocol.Location{File: source.Path, Line: 10}},
+		},
+		Discarded: []protocol.DiscardedBreakpoint{
+			{Location: protocol.Location{File: source.Path, Line: 20}, Reason: "no such line"},
+		},
+	})
+
+	var changed *godap.BreakpointEvent
+	var restarted *godap.RestartResponse
+	for range 2 {
+		switch msg := hh.recv().(type) {
+		case *godap.BreakpointEvent:
+			changed = msg
+		case *godap.RestartResponse:
+			restarted = msg
+		}
+	}
+	if restarted == nil || restarted.RequestSeq != restartSeq || !restarted.Success {
+		t.Fatalf("restart response = %+v, want success for request %d", restarted, restartSeq)
+	}
+	if changed == nil {
+		t.Fatal("discarded breakpoint did not emit a breakpoint event")
+	}
+	if changed.Body.Reason != "changed" ||
+		changed.Body.Breakpoint.Id != 42 ||
+		changed.Body.Breakpoint.Verified ||
+		changed.Body.Breakpoint.Line != 20 ||
+		changed.Body.Breakpoint.Message != "no such line" {
+		t.Fatalf("discarded breakpoint event = %+v", changed.Body)
+	}
+
+	hh.handler.mu.Lock()
+	retained := hh.handler.bpByFile[source.Path][10]
+	_, droppedStillCached := hh.handler.bpByFile[source.Path][20]
+	hh.handler.mu.Unlock()
+	if retained.debuggerID != 101 || retained.dapID != 41 {
+		t.Fatalf("retained breakpoint state = %+v, want debuggerID=101 dapID=41", retained)
+	}
+	if droppedStillCached {
+		t.Fatal("discarded breakpoint remained in cache")
+	}
+
+	hh.sendReq("setBreakpoints", &godap.SetBreakpointsRequest{Arguments: godap.SetBreakpointsArguments{
+		Source:      source,
+		Breakpoints: []godap.SourceBreakpoint{{Line: 10}, {Line: 20}},
+	}})
+	setCommands := hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 3)
+	var retry protocol.SetBreakpointPayload
+	if err := protocol.DecodeCommandPayload(setCommands[2], &retry); err != nil {
+		t.Fatal(err)
+	}
+	if retry.File != source.Path || retry.Line != 20 {
+		t.Fatalf("discarded breakpoint retry = %+v, want %s:20", retry, source.Path)
+	}
+	hh.inject(protocol.EventBreakpointSet, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{ID: 202, Location: protocol.Location{File: source.Path, Line: 20}},
+	})
+	retried := recvType[*godap.SetBreakpointsResponse](hh)
+	if got := []int{retried.Body.Breakpoints[0].Id, retried.Body.Breakpoints[1].Id}; got[0] != 41 || got[1] != 202 {
+		t.Fatalf("post-restart breakpoint ids = %v, want stable retained id 41 and retried id 202", got)
+	}
+
+	hh.sendReq("setBreakpoints", &godap.SetBreakpointsRequest{Arguments: godap.SetBreakpointsArguments{
+		Source:      source,
+		Breakpoints: []godap.SourceBreakpoint{{Line: 20}},
+	}})
+	clearCommands := hh.cmds.waitForCommands(t, protocol.CmdClearBreakpoint, 1)
+	var clear protocol.ClearBreakpointPayload
+	if err := protocol.DecodeCommandPayload(clearCommands[0], &clear); err != nil {
+		t.Fatal(err)
+	}
+	if clear.ID != 101 {
+		t.Fatalf("clear breakpoint id = %d, want fresh debugger id 101", clear.ID)
+	}
+	_ = recvType[*godap.SetBreakpointsResponse](hh)
+}
+
+func TestRestartedPayloadDecodeFailureStillResponds(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, map[string]any{"breakpoints": "invalid"})
+
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != restartSeq || !restarted.Success {
+		t.Fatalf("restart response = %+v, want success for request %d", restarted.Response, restartSeq)
+	}
+}
+
+func TestRestartPreservesBreakpointCorrelationQueues(t *testing.T) {
+	h := NewHandler(nil, nil, nil)
+	setSlot := &bpSlot{}
+	h.setQ = []*bpSlot{setSlot}
+	h.clearQ = []int{73}
+
+	h.onRestarted(protocol.MustEvent(protocol.EventRestarted, 1, protocol.RestartedPayload{}))
+
+	if len(h.setQ) != 1 || h.setQ[0] != setSlot {
+		t.Fatalf("setQ changed across restart: %+v", h.setQ)
+	}
+	if len(h.clearQ) != 1 || h.clearQ[0] != 73 {
+		t.Fatalf("clearQ changed across restart: %v", h.clearQ)
+	}
 }
 
 func TestStackTraceAndVariablesCorrelation(t *testing.T) {

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -767,6 +767,50 @@ func TestRestartedPayloadDecodeFailureStillResponds(t *testing.T) {
 	}
 }
 
+func TestRestartRejectsOverlappingRequest(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+
+	firstSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	secondSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	rejected := recvType[*godap.ErrorResponse](hh)
+	if rejected.RequestSeq != secondSeq || rejected.Success || rejected.Message != "restart already in progress" {
+		t.Fatalf("overlapping restart response = %+v, want immediate error for request %d", rejected.Response, secondSeq)
+	}
+	if commands := hh.cmds.waitForCommands(t, protocol.CmdRestart, 1); len(commands) != 1 {
+		t.Fatalf("restart commands = %d, want exactly 1", len(commands))
+	}
+
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != firstSeq || !restarted.Success {
+		t.Fatalf("restart response = %+v, want success for original request %d", restarted.Response, firstSeq)
+	}
+}
+
+func TestRestartErrorAllowsRetry(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+
+	firstSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: protocol.CmdRestart, Message: "relaunch failed"})
+	failed := recvType[*godap.ErrorResponse](hh)
+	if failed.RequestSeq != firstSeq || failed.Success {
+		t.Fatalf("failed restart response = %+v, want error for request %d", failed.Response, firstSeq)
+	}
+
+	secondSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	if commands := hh.cmds.waitForCommands(t, protocol.CmdRestart, 2); len(commands) != 2 {
+		t.Fatalf("restart commands after retry = %d, want 2", len(commands))
+	}
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != secondSeq || !restarted.Success {
+		t.Fatalf("retried restart response = %+v, want success for request %d", restarted.Response, secondSeq)
+	}
+}
+
 func TestRestartPreservesBreakpointCorrelationQueues(t *testing.T) {
 	h := NewHandler(nil, nil, nil)
 	setSlot := &bpSlot{}

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -1254,6 +1254,143 @@ func TestVariablesExpandsNestedStruct(t *testing.T) {
 	}
 }
 
+func cachedChildRef(t *testing.T, hh *harness) int {
+	t.Helper()
+	suspendAtBreakpoint(t, hh)
+	return cacheChildRef(t, hh, "X")
+}
+
+func cacheChildRef(t *testing.T, hh *harness, childName string) int {
+	t.Helper()
+	locals := hh.cmds.count(protocol.CmdLocals)
+	hh.sendReq("variables", &godap.VariablesRequest{Arguments: godap.VariablesArguments{VariablesReference: 1}})
+	hh.cmds.waitForCommands(t, protocol.CmdLocals, locals+1)
+	hh.inject(protocol.EventLocals, protocol.LocalsPayload{Variables: []protocol.Variable{{
+		Name: "p", Value: "main.Point", Type: "main.Point", Kind: "struct",
+		Children: []protocol.Variable{{Name: childName, Value: "1", Type: "int"}},
+	}}})
+	resp := recvType[*godap.VariablesResponse](hh)
+	if len(resp.Body.Variables) != 1 || resp.Body.Variables[0].VariablesReference == 0 {
+		t.Fatalf("variables = %+v, want one expandable child", resp.Body.Variables)
+	}
+	return resp.Body.Variables[0].VariablesReference
+}
+
+func requireStaleChildRefEmpty(t *testing.T, hh *harness, ref int) {
+	t.Helper()
+	locals := hh.cmds.count(protocol.CmdLocals)
+	hh.sendReq("variables", &godap.VariablesRequest{Arguments: godap.VariablesArguments{VariablesReference: ref}})
+	resp := recvType[*godap.VariablesResponse](hh)
+	if len(resp.Body.Variables) != 0 {
+		t.Fatalf("stale child ref expanded to %+v, want empty", resp.Body.Variables)
+	}
+	hh.cmds.requireNoAdditionalCommands(t, protocol.CmdLocals, locals)
+}
+
+func requireChildRefExpands(t *testing.T, hh *harness, ref int, childName string) {
+	t.Helper()
+	locals := hh.cmds.count(protocol.CmdLocals)
+	hh.sendReq("variables", &godap.VariablesRequest{Arguments: godap.VariablesArguments{VariablesReference: ref}})
+	resp := recvType[*godap.VariablesResponse](hh)
+	if len(resp.Body.Variables) != 1 || resp.Body.Variables[0].Name != childName {
+		t.Fatalf("child ref expanded to %+v, want %q", resp.Body.Variables, childName)
+	}
+	hh.cmds.requireNoAdditionalCommands(t, protocol.CmdLocals, locals)
+}
+
+func TestChildVariableRefIsStaleAfterOwnContinue(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	ref := cachedChildRef(t, hh)
+
+	driveContinue(t, hh)
+
+	requireStaleChildRefEmpty(t, hh, ref)
+}
+
+func TestChildVariableRefIsStaleAfterOutOfBandContinue(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	ref := cachedChildRef(t, hh)
+
+	hh.inject(protocol.EventContinued, protocol.ContinuedPayload{})
+	_ = recvType[*godap.ContinuedEvent](hh)
+
+	requireStaleChildRefEmpty(t, hh, ref)
+}
+
+func TestChildVariableRefSurvivesRejectedContinue(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	ref := cachedChildRef(t, hh)
+
+	driveContinue(t, hh)
+	const msg = "continue rejected without moving the process"
+	rejectResume(t, hh, protocol.CmdContinue, "continue", msg)
+	requireResyncStopped(t, hh, msg)
+
+	requireChildRefExpands(t, hh, ref, "X")
+}
+
+func TestChildVariableRefSurvivesRejectedStep(t *testing.T) {
+	tests := []struct {
+		request string
+		kind    protocol.CommandKind
+	}{
+		{request: "next", kind: protocol.CmdStepOver},
+		{request: "stepIn", kind: protocol.CmdStepInto},
+		{request: "stepOut", kind: protocol.CmdStepOut},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.request, func(t *testing.T) {
+			hh := newHarness(t)
+			hh.doHandshake(t)
+			ref := cachedChildRef(t, hh)
+
+			sendStepRequest(t, hh, tt.request)
+			hh.cmds.waitForCommand(t, tt.kind)
+			const msg = "step rejected without moving the process"
+			rejectResume(t, hh, tt.kind, tt.request, msg)
+			requireResyncStopped(t, hh, msg)
+
+			requireChildRefExpands(t, hh, ref, "X")
+		})
+	}
+}
+
+func TestChildVariableRefResetsAtNextStop(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	staleRef := cachedChildRef(t, hh)
+
+	hh.inject(protocol.EventContinued, protocol.ContinuedPayload{})
+	_ = recvType[*godap.ContinuedEvent](hh)
+	suspendAtBreakpoint(t, hh)
+
+	requireStaleChildRefEmpty(t, hh, staleRef)
+	freshRef := cacheChildRef(t, hh, "Y")
+	requireChildRefExpands(t, hh, freshRef, "Y")
+}
+
+func TestChildVariableRefIsStaleDuringOutOfBandStep(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	staleRef := cachedChildRef(t, hh)
+
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{
+		SessionID: "sess-test", State: protocol.StateRunning, Clients: 2,
+	})
+	requireStaleChildRefEmpty(t, hh, staleRef)
+
+	hh.inject(protocol.EventStepped, protocol.SteppedPayload{Goroutine: protocol.Goroutine{ID: 7}})
+	_ = recvType[*godap.StoppedEvent](hh)
+	requireStaleChildRefEmpty(t, hh, staleRef)
+
+	freshRef := cacheChildRef(t, hh, "Y")
+	requireChildRefExpands(t, hh, freshRef, "Y")
+}
+
 // TestEvaluateName drives evaluate(name)→value and evalQ correlation, including
 // a nested result that yields an expandable child ref.
 func TestEvaluateName(t *testing.T) {

--- a/internal/dap/requests.go
+++ b/internal/dap/requests.go
@@ -507,17 +507,20 @@ func (h *Handler) onTerminate(req *godap.TerminateRequest) {
 
 func (h *Handler) onRestart(req *godap.RestartRequest) {
 	h.mu.Lock()
+	if h.restarting {
+		h.mu.Unlock()
+		h.send(h.errorResponse(req.Seq, "restart", "restart already in progress"))
+		return
+	}
 	hasSession := h.session != nil
-	h.restarting = true
-	h.restartReqSeq = req.Seq
-	h.suspended = false
+	if hasSession {
+		h.restarting = true
+		h.restartReqSeq = req.Seq
+		h.suspended = false
+	}
 	h.mu.Unlock()
 
 	if !hasSession {
-		h.mu.Lock()
-		h.restarting = false
-		h.restartReqSeq = 0
-		h.mu.Unlock()
 		h.send(h.errorResponse(req.Seq, "restart", "no session to restart"))
 		return
 	}

--- a/internal/dap/requests.go
+++ b/internal/dap/requests.go
@@ -416,13 +416,22 @@ func (h *Handler) onVariables(req *godap.VariablesRequest) {
 	ref := req.Arguments.VariablesReference
 
 	h.mu.Lock()
+	suspended := h.suspended
 	// A child ref addresses an already-computed subtree (cached eagerly from a
 	// typed EventLocals/EventEvaluate). Serve it synchronously — no round-trip.
-	if children, ok := h.varCache[ref]; ok {
+	if children, ok := h.varCache[ref]; ok && suspended {
 		h.mu.Unlock()
 		h.send(&godap.VariablesResponse{
 			Response: h.response(req.Seq, "variables"),
 			Body:     godap.VariablesResponseBody{Variables: children},
+		})
+		return
+	}
+	if ref >= varRefBase {
+		h.mu.Unlock()
+		h.send(&godap.VariablesResponse{
+			Response: h.response(req.Seq, "variables"),
+			Body:     godap.VariablesResponseBody{Variables: []godap.Variable{}},
 		})
 		return
 	}
@@ -432,7 +441,6 @@ func (h *Handler) onVariables(req *godap.VariablesRequest) {
 	if frameIndex < 0 {
 		frameIndex = 0
 	}
-	suspended := h.suspended
 	if suspended {
 		h.localsQ = append(h.localsQ, &varsReq{seq: req.Seq, frameIndex: frameIndex})
 	}

--- a/internal/dap/requests.go
+++ b/internal/dap/requests.go
@@ -507,7 +507,9 @@ func (h *Handler) onTerminate(req *godap.TerminateRequest) {
 
 func (h *Handler) onRestart(req *godap.RestartRequest) {
 	h.mu.Lock()
-	if h.restarting {
+	// restartReqSeq gates only the unanswered DAP request. restarting stays set
+	// longer so the subsequent entry EventStepped is still recognized.
+	if h.restartReqSeq != 0 {
 		h.mu.Unlock()
 		h.send(h.errorResponse(req.Seq, "restart", "restart already in progress"))
 		return


### PR DESCRIPTION
Fixes #173

## Final current-main replacement

This PR was originally a stacked historical change at head `d4f2c9f0bf5837035fb98f993598ba7534c3277a` on the now-obsolete base `xsachax-fix-dap-resume-rejection`. Its prerequisite semantics have already landed on `main`; none of those old prerequisite commits are replayed here.

The final branch is one surgical current-main commit:

- exact base: `96cda088ce53acbb4c09bae7f45c4e2e018c2bae`
- exact head: `c6ec86c90c48b44f284d4b4299f3a732d3feec10`
- commit: `fix(dap): reject stale child variable refs`

The approved replacement commit `bba4261d7d886f7d2a70a53f5961f10659fbd1da` was transplanted onto the new base without conflict. Stable patch IDs are identical (`97967e19bb68457cafc0cd066a1d5097261eae55`), and `git range-diff` reports `bba4261 = c6ec86c`.

## Problem

DAP child `variablesReference` values point into `Handler.varCache`, an eager variable tree captured at one genuine stop. Previously a cache hit was served before checking `h.suspended`, so stale children could still expand after the adapter knew execution had resumed.

The shared-session cases matter most:

- another client’s `Continue` is observed through `EventContinued`;
- another client’s `StepOver`/`StepInto`/`StepOut` emits no `EventContinued`, but a managed hub broadcasts `EventSessionState(StateRunning)` before the eventual `EventStepped`.

Without handling both signals, this adapter could report a running session while synchronously serving values from the prior stop.

## Final semantics

- A cached child reference expands only while the handler is suspended.
- Accepted own Continue/Step and out-of-band Continue suppress stale cache hits.
- Outside the one-time join welcome, managed `StateRunning` clears the handler’s suspended view, suppressing stale cache during another client’s StepOver/Into/Out without fabricating a DAP `continued` event.
- Child-range cache misses return an empty variables response and never fall through into a bogus `CmdLocals` frame request.
- Resume does not eagerly clear `varCache`: rejected Continue and all rejected Step kinds never moved the process, so `failResume` restores suspension and the same cached subtree remains valid.
- The next genuine stop remains the invalidation boundary (`onStop` → `resetVarsLocked`); old refs are rejected and fresh refs expand.
- Join welcome behavior is unchanged. Non-welcome `StateSuspended` is still represented by actual stop events.

The guarantee begins when this adapter observes the resume state; the unavoidable cross-client event-propagation interval before that observation remains unchanged.

## Deterministic regression coverage

The current loopback DAP harness covers:

- accepted own Continue and out-of-band Continue stale-ref suppression;
- managed out-of-band Step running-state suppression followed by `EventStepped`, old-ref rejection, and fresh-subtree expansion;
- rejected Continue and StepOver/StepInto/StepOut preserving the same cached child synchronously with no extra `CmdLocals`;
- next-stop cache reset and fresh ref expansion;
- child-reference-range cache misses not reaching the hub.

Mutation gates were exercised directly:

- eager cache clearing on resume breaks the rejected-resume preservation tests;
- removing `resetVarsLocked` from `onStop` breaks next-stop invalidation;
- removing the `StateRunning` suspended-state update breaks the out-of-band-step test by expanding the stale child.

## Verification

On exact head `c6ec86c90c48b44f284d4b4299f3a732d3feec10`:

- `go test -tags bingonative -race ./internal/dap -run 'TestChildVariableRef' -count=100`
- `go test -tags bingonative ./internal/dap/...`
- `go vet -tags bingonative ./internal/dap/...`
- `just build linux amd64`
- `go tool goimports` and `git diff --check`

All passed. Two independent reviews of the complete semantic diff reported no branch-introduced issues; each current-main transplant required no conflict resolution and remained patch-identical.

No Darwin verification label is requested: this PR does not touch the Darwin-native verification scope.