### PR TITLE
fix(debugger): respect lexical variable scopes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -558,6 +558,20 @@ are detected by a `mach_msg` receive loop.
   raw bytes and are unit-tested without DWARF or a backend; the global ceiling is
   pinned by `TestFormatTypedBudget` (a pathological nested aggregate truncates to
   ~`maxTotalNodes`).
+- `subprogramVars` is a depth-aware walk of the full containing subprogram,
+  not a flat scan to the first null DIE. Both `DW_TAG_lexical_block` and
+  `DW_TAG_inlined_subroutine` define variable scope. The containing subprogram
+  must have a concrete matching range (Go's no-range subprograms are abstract
+  inline definitions); nested-scope containment compares the **unslid** stopped
+  PC against every range from `dwarf.Data.Ranges`
+  (linux lexical blocks use range lists and ranges can be discontiguous);
+  missing or unreadable ranges are conservatively active rather than making
+  variables disappear. Definitely inactive subtrees are pruned with
+  `Reader.SkipChildren`, and same-name variables are deduplicated so the
+  deepest active declaration wins for both Locals and EvaluateName. Concrete
+  inline DIEs whose names only exist through `DW_AT_abstract_origin` remain
+  unsupported and are skipped — do not resolve abstract origins or location
+  lists without extending the documented expression model deliberately.
 - `EvaluateName` resolves a **single variable name only** (no dotted paths /
   indexing / arithmetic): a local or parameter in the subprogram containing the
   frame PC first, then a package-level global via `globalVar` (matches the exact

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -596,9 +596,14 @@ are detected by a `mach_msg` receive loop.
   calls `dwarfReader.cfa(pc, sp, fp)` per frame, **chaining outward by
   `SP_{i+1} = CFA_i`** (a callee's CFA is its caller's SP; Go passes args in
   registers so arm64 leaves SP unmoved and amd64's retaddr push is already in the
-  FP rule) and walking the saved-FP chain (`fp = *fp`). Missing/uncovered CFI
-  degrades gracefully to the old `FP + 16` heuristic (`cfaFallbackFromFP`) rather
-  than erroring the stop. The reader is arch-generic (maps SP/FP DWARF register
+  FP rule) and walking the saved-FP chain (`fp = *fp`). `walkStack` preserves
+  saved return PCs, but every non-top frame uses `returnPC-1` for function/line/
+  scope and CFI lookup (underflow guarded): the saved PC is after CALL/BL and can
+  equal an exclusive lexical/FDE boundary, while one byte back lies within the
+  call instruction on both supported architectures. The top frame's live PC is
+  never adjusted. Missing/uncovered CFI degrades gracefully to the old `FP + 16`
+  heuristic (`cfaFallbackFromFP`) rather than erroring the stop. The reader is
+  arch-generic (maps SP/FP DWARF register
   numbers by `runtime.GOARCH` — arm64 SP=31/FP=29, amd64 RSP=7/RBP=6) and
   wrapped in `recover()` so malformed CFI can never crash the engine. Go's DWARF
   sections are zlib-compressed (`__zdebug_frame`/`.zdebug_frame` with a 12-byte

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -571,7 +571,10 @@ are detected by a `mach_msg` receive loop.
   deepest active declaration wins for both Locals and EvaluateName. Concrete
   inline DIEs whose names only exist through `DW_AT_abstract_origin` remain
   unsupported and are skipped — do not resolve abstract origins or location
-  lists without extending the documented expression model deliberately.
+  lists without extending the documented expression model deliberately. A
+  concrete ranged subprogram with `Children=false` has no locals; never seed a
+  child walk for it, or the next sibling DIE leaks into the frame. Malformed
+  child-DIE read errors propagate instead of becoming a truncated success.
 - `EvaluateName` resolves a **single variable name only** (no dotted paths /
   indexing / arithmetic): a local or parameter in the subprogram containing the
   frame PC first, then a package-level global via `globalVar` (matches the exact

--- a/internal/debugger/caller_frame_test.go
+++ b/internal/debugger/caller_frame_test.go
@@ -1,0 +1,278 @@
+package debugger
+
+import (
+	"debug/dwarf"
+	"encoding/binary"
+	"strings"
+	"testing"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+const callerScopeFixtureSrc = `package main
+
+var observed int
+
+//go:noinline
+func perturb(v int) int {
+	return v + 1
+}
+
+//go:noinline
+func callerWithBlock(n int) int {
+	if n > 0 {
+		result := n + 7
+		if n&1 == 0 {
+			result += perturb(n)
+		}
+		callee(result) // caller-call-marker
+	}
+	return n
+}
+
+//go:noinline
+func callee(v int) {
+	observed = v // callee-marker
+}
+
+func main() {
+	callerWithBlock(2)
+}
+`
+
+func TestFrameLookupPC(t *testing.T) {
+	if got := frameLookupPC(0x1000, 0); got != 0x1000 {
+		t.Fatalf("top frame lookup PC = %#x, want live PC %#x", got, uint64(0x1000))
+	}
+	if got := frameLookupPC(0x2000, 1); got != 0x1fff {
+		t.Fatalf("caller lookup PC = %#x, want call PC %#x", got, uint64(0x1fff))
+	}
+	if got := frameLookupPC(0, 1); got != 0 {
+		t.Fatalf("zero caller PC underflowed to %#x", got)
+	}
+
+	discontiguous := [][2]uint64{{0x1000, 0x1010}, {0x2000, 0x2010}}
+	if classifyScopePC(0x2010, discontiguous, nil) != scopePCOutside {
+		t.Fatal("saved return PC should be outside the exclusive second range")
+	}
+	if classifyScopePC(frameLookupPC(0x2010, 1), discontiguous, nil) != scopePCInside {
+		t.Fatal("adjusted caller PC should be inside the second discontiguous range")
+	}
+}
+
+func TestCallerFrameUsesCallPCForScopesAndCFI(t *testing.T) {
+	r := buildDWARFScopeFixture(t, callerScopeFixtureSrc, false)
+	ranges := variableScopeRanges(t, r, "callerWithBlock", "result")
+	if len(ranges) == 0 {
+		t.Fatal("caller fixture result scope has no ranges")
+	}
+	returnPC := scopeEndAtMarker(t, r, ranges, callerScopeFixtureSrc, "caller-call-marker")
+	calleePC := pcAtMarker(t, r, callerScopeFixtureSrc, "callee-marker")
+	r.frame = &frameTable{fdes: []fde{{
+		loc: returnPC - 0x10,
+		end: returnPC,
+		c: &cie{
+			codeAlign: 1,
+			initInstr: []byte{0x0c, byte(dwarfFPReg()), 0x40}, // DW_CFA_def_cfa fp, 64
+		},
+	}}}
+
+	if names := entryNameCounts(requiredSubprogramVars(t, r, returnPC)); names["result"] != 0 {
+		t.Fatalf("raw return PC unexpectedly includes result: %v", names)
+	}
+	if names := entryNameCounts(requiredSubprogramVars(t, r, returnPC-1)); names["result"] != 1 {
+		t.Fatalf("call PC does not include result: %v", names)
+	}
+
+	const (
+		calleeSP = uint64(0x700000)
+		calleeBP = uint64(0x700100)
+		callerBP = uint64(0x700200)
+	)
+	backend := &callerFrameBackend{
+		regs: Registers{PC: calleePC, SP: calleeSP, BP: calleeBP},
+		mem:  make(map[uint64]byte),
+	}
+	backend.seedUint64(calleeBP, callerBP)
+	backend.seedUint64(calleeBP+8, returnPC)
+	backend.seedUint64(callerBP, 0)
+	backend.seedUint64(callerBP+8, 0)
+
+	e := newEngine(backend, nil)
+	if err := e.dispatch(func() error {
+		e.dw = r
+		e.proc.live = true
+		e.curTID = 1
+		e.setState(stateSuspended)
+		return nil
+	}); err != nil {
+		t.Fatalf("prepare engine: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = e.Kill()
+		<-e.done
+	})
+
+	var callerPC, callerCFA uint64
+	if err := e.dispatch(func() error {
+		var frameErr error
+		callerPC, callerCFA, frameErr = e.frameLocation(1)
+		return frameErr
+	}); err != nil {
+		t.Fatalf("frameLocation(caller): %v", err)
+	}
+	if callerPC != returnPC-1 {
+		t.Fatalf("caller frame PC = %#x, want call PC %#x", callerPC, returnPC-1)
+	}
+	if callerCFA != callerBP+0x40 {
+		t.Fatalf("caller CFA = %#x, want adjusted-PC CFI result %#x", callerCFA, callerBP+0x40)
+	}
+
+	frames, err := e.StackFrames()
+	if err != nil {
+		t.Fatalf("StackFrames: %v", err)
+	}
+	if len(frames) < 2 {
+		t.Fatalf("StackFrames returned %d frames, want caller frame", len(frames))
+	}
+	callLine := markerLine(t, callerScopeFixtureSrc, "caller-call-marker")
+	if got := frames[1].Location; !strings.HasSuffix(got.Function, ".callerWithBlock") || got.Line != callLine {
+		t.Fatalf("caller frame location = %+v, want callerWithBlock line %d", got, callLine)
+	}
+
+	vars, err := e.Locals(1)
+	if err != nil {
+		t.Fatalf("Locals(caller): %v", err)
+	}
+	if names := variableNameCounts(vars); names["result"] != 1 {
+		t.Fatalf("caller locals omit block result: %v", names)
+	}
+	result, err := e.Evaluate(1, "result")
+	if err != nil {
+		t.Fatalf("Evaluate(caller result): %v", err)
+	}
+	if result.Name != "result" {
+		t.Fatalf("Evaluate result = %+v", result)
+	}
+}
+
+func variableScopeRanges(t *testing.T, r *dwarfReader, function, variable string) [][2]uint64 {
+	t.Helper()
+	rd := r.data.Reader()
+	for {
+		entry, err := rd.Next()
+		if err != nil {
+			t.Fatalf("read fixture DWARF: %v", err)
+		}
+		if entry == nil {
+			break
+		}
+		name, _ := entry.Val(dwarf.AttrName).(string)
+		if entry.Tag != dwarf.TagSubprogram || !strings.HasSuffix(name, "."+function) {
+			continue
+		}
+		return variableRangesInSubprogram(t, r, rd, variable)
+	}
+	t.Fatalf("subprogram %q not found", function)
+	return nil
+}
+
+func variableRangesInSubprogram(t *testing.T, r *dwarfReader, rd *dwarf.Reader, variable string) [][2]uint64 {
+	t.Helper()
+	depth := 1
+	scopeAtDepth := []*dwarf.Entry{nil, nil}
+	for depth > 0 {
+		entry := requiredDIE(t, rd, "subprogram variables")
+		if entry.Tag == 0 {
+			depth--
+			continue
+		}
+		name, _ := entry.Val(dwarf.AttrName).(string)
+		if entry.Tag == dwarf.TagVariable && name == variable {
+			scope := scopeAtDepth[depth]
+			if scope == nil {
+				t.Fatalf("variable %q has no lexical scope", variable)
+			}
+			return requiredRanges(t, r, scope, "variable scope")
+		}
+		if !entry.Children {
+			continue
+		}
+		parentScope := scopeAtDepth[depth]
+		depth++
+		if depth >= len(scopeAtDepth) {
+			scopeAtDepth = append(scopeAtDepth, nil)
+		}
+		scopeAtDepth[depth] = parentScope
+		if isVariableScope(entry.Tag) {
+			scopeAtDepth[depth] = entry
+		}
+	}
+	t.Fatalf("variable %q not found", variable)
+	return nil
+}
+
+func scopeEndAtMarker(t *testing.T, r *dwarfReader, ranges [][2]uint64, source, marker string) uint64 {
+	t.Helper()
+	line := markerLine(t, source, marker)
+	for _, pcs := range ranges {
+		if pcs[1] == 0 || pcs[1] <= pcs[0] {
+			continue
+		}
+		runtimeEnd := uint64(int64(pcs[1]) + r.slide)
+		if r.locationForPC(runtimeEnd-1).Line == line {
+			return runtimeEnd
+		}
+	}
+	t.Fatalf("no scope range ends at marker %q: %v", marker, ranges)
+	return 0
+}
+
+func requiredSubprogramVars(t *testing.T, r *dwarfReader, pc uint64) []*dwarf.Entry {
+	t.Helper()
+	entries, err := r.subprogramVars(pc)
+	if err != nil {
+		t.Fatalf("subprogramVars(%#x): %v", pc, err)
+	}
+	return entries
+}
+
+func variableNameCounts(vars []protocol.Variable) map[string]int {
+	names := make(map[string]int)
+	for _, variable := range vars {
+		names[variable.Name]++
+	}
+	return names
+}
+
+type callerFrameBackend struct {
+	regs Registers
+	mem  map[uint64]byte
+}
+
+func (b *callerFrameBackend) seedUint64(addr, value uint64) {
+	var data [8]byte
+	binary.LittleEndian.PutUint64(data[:], value)
+	for i, byt := range data {
+		b.mem[addr+uint64(i)] = byt
+	}
+}
+
+func (*callerFrameBackend) ContinueProcess() error           { return nil }
+func (*callerFrameBackend) SingleStep(int) error             { return nil }
+func (*callerFrameBackend) StopProcess() error               { return nil }
+func (*callerFrameBackend) PauseSignal() int                 { return 0 }
+func (*callerFrameBackend) WriteMemory(uint64, []byte) error { return nil }
+func (b *callerFrameBackend) GetRegisters(int) (Registers, error) {
+	return b.regs, nil
+}
+func (*callerFrameBackend) SetRegisters(int, Registers) error { return nil }
+func (*callerFrameBackend) Threads() ([]int, error)           { return []int{1}, nil }
+func (*callerFrameBackend) Wait() (StopEvent, error)          { return StopEvent{}, ErrProcessExited }
+
+func (b *callerFrameBackend) ReadMemory(addr uint64, dst []byte) error {
+	for i := range dst {
+		dst[i] = b.mem[addr+uint64(i)]
+	}
+	return nil
+}

--- a/internal/debugger/dwarf.go
+++ b/internal/debugger/dwarf.go
@@ -384,16 +384,27 @@ func highPCValue(entry *dwarf.Entry, lowpc uint64) (uint64, bool) {
 	return 0, false
 }
 
-// FramesForStack resolves PCs (from the frame-pointer walk) to source frames.
+// FramesForStack resolves raw PCs from the frame-pointer walk to source frames.
 func (r *dwarfReader) FramesForStack(pcs []uint64) []protocol.Frame {
 	frames := make([]protocol.Frame, len(pcs))
 	for i, pc := range pcs {
 		frames[i] = protocol.Frame{
 			Index:    i,
-			Location: r.locationForPC(pc),
+			Location: r.locationForPC(frameLookupPC(pc, i)),
 		}
 	}
 	return frames
+}
+
+// frameLookupPC converts a saved return PC to the call instruction it belongs
+// to. DWARF ranges are byte intervals, so subtracting one works for both amd64's
+// variable-width CALL and arm64's fixed-width BL. The top frame carries a live
+// PC rather than a return address and must remain unchanged.
+func frameLookupPC(pc uint64, frameIndex int) uint64 {
+	if frameIndex > 0 && pc > 0 {
+		return pc - 1
+	}
+	return pc
 }
 
 // LocalsForFrame returns type-aware, bounded variable trees for every local and

--- a/internal/debugger/dwarf.go
+++ b/internal/debugger/dwarf.go
@@ -467,37 +467,117 @@ func (r *dwarfReader) subprogramVars(pc uint64) ([]*dwarf.Entry, error) {
 			continue
 		}
 
-		lowpc, hasLow := entry.Val(dwarf.AttrLowpc).(uint64)
-		if !hasLow {
+		switch r.scopePCState(entry, dwarfPC) {
+		case scopePCOutside:
 			rd.SkipChildren()
 			continue
-		}
-		highpc, ok := highPCValue(entry, lowpc)
-		if !ok || dwarfPC < lowpc || dwarfPC >= highpc {
+		case scopePCUnknown:
+			// Go uses no-range subprograms as abstract inline definitions; they
+			// cannot identify the concrete frame whose variables are requested.
 			rd.SkipChildren()
 			continue
 		}
 
-		var out []*dwarf.Entry
-		for {
-			child, err := rd.Next()
-			if err == io.EOF || child == nil {
-				break
-			}
-			if err != nil {
-				return nil, fmt.Errorf("DWARF child read: %w", err)
-			}
-			if child.Tag == 0 {
-				break
-			}
-			if child.Tag != dwarf.TagVariable && child.Tag != dwarf.TagFormalParameter {
-				continue
-			}
-			out = append(out, child)
-		}
-		return out, nil
+		return r.collectSubprogramVars(rd, dwarfPC)
 	}
 	return nil, nil
+}
+
+type scopePCMatch uint8
+
+const (
+	scopePCUnknown scopePCMatch = iota
+	scopePCOutside
+	scopePCInside
+)
+
+func (r *dwarfReader) scopePCState(entry *dwarf.Entry, dwarfPC uint64) scopePCMatch {
+	ranges, err := r.data.Ranges(entry)
+	return classifyScopePC(dwarfPC, ranges, err)
+}
+
+func classifyScopePC(dwarfPC uint64, ranges [][2]uint64, err error) scopePCMatch {
+	// Missing or unreadable ranges cannot safely exclude a scope from inspection.
+	if err != nil || len(ranges) == 0 {
+		return scopePCUnknown
+	}
+	for _, pcs := range ranges {
+		if dwarfPC >= pcs[0] && dwarfPC < pcs[1] {
+			return scopePCInside
+		}
+	}
+	return scopePCOutside
+}
+
+func isVariableScope(tag dwarf.Tag) bool {
+	return tag == dwarf.TagLexDwarfBlock || tag == dwarf.TagInlinedSubroutine
+}
+
+type scopedVariable struct {
+	entry *dwarf.Entry
+	depth int
+}
+
+func (r *dwarfReader) collectSubprogramVars(rd *dwarf.Reader, dwarfPC uint64) ([]*dwarf.Entry, error) {
+	depth := 1
+	scopeDepth := 0
+	// SkipChildren consumes the skipped subtree's terminator, so only traversed
+	// children get a depth slot.
+	scopeAtDepth := []bool{false, false}
+	vars := make([]scopedVariable, 0)
+	byName := make(map[string]int)
+
+	for depth > 0 {
+		entry, err := rd.Next()
+		if err == io.EOF || entry == nil {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("DWARF child read: %w", err)
+		}
+		if entry.Tag == 0 {
+			if scopeAtDepth[depth] {
+				scopeDepth--
+			}
+			depth--
+			continue
+		}
+
+		isScope := isVariableScope(entry.Tag)
+		if isScope && r.scopePCState(entry, dwarfPC) == scopePCOutside {
+			rd.SkipChildren()
+			continue
+		}
+
+		if entry.Tag == dwarf.TagVariable || entry.Tag == dwarf.TagFormalParameter {
+			name, _ := entry.Val(dwarf.AttrName).(string)
+			if name != "" {
+				if index, ok := byName[name]; !ok {
+					byName[name] = len(vars)
+					vars = append(vars, scopedVariable{entry: entry, depth: scopeDepth})
+				} else if scopeDepth > vars[index].depth {
+					vars[index] = scopedVariable{entry: entry, depth: scopeDepth}
+				}
+			}
+		}
+
+		if entry.Children {
+			depth++
+			if depth >= len(scopeAtDepth) {
+				scopeAtDepth = append(scopeAtDepth, false)
+			}
+			scopeAtDepth[depth] = isScope
+			if isScope {
+				scopeDepth++
+			}
+		}
+	}
+
+	out := make([]*dwarf.Entry, len(vars))
+	for i := range vars {
+		out[i] = vars[i].entry
+	}
+	return out, nil
 }
 
 // varType resolves a DIE's DW_AT_type to a concrete dwarf.Type (nil on absence

--- a/internal/debugger/dwarf.go
+++ b/internal/debugger/dwarf.go
@@ -478,6 +478,9 @@ func (r *dwarfReader) subprogramVars(pc uint64) ([]*dwarf.Entry, error) {
 			continue
 		}
 
+		if !entry.Children {
+			return nil, nil
+		}
 		return r.collectSubprogramVars(rd, dwarfPC)
 	}
 	return nil, nil
@@ -518,28 +521,30 @@ type scopedVariable struct {
 	depth int
 }
 
-func (r *dwarfReader) collectSubprogramVars(rd *dwarf.Reader, dwarfPC uint64) ([]*dwarf.Entry, error) {
-	depth := 1
-	scopeDepth := 0
-	// SkipChildren consumes the skipped subtree's terminator, so only traversed
-	// children get a depth slot.
-	scopeAtDepth := []bool{false, false}
-	vars := make([]scopedVariable, 0)
-	byName := make(map[string]int)
+type subprogramVarCollector struct {
+	depth        int
+	scopeDepth   int
+	scopeAtDepth []bool
+	vars         []scopedVariable
+	byName       map[string]int
+}
 
-	for depth > 0 {
-		entry, err := rd.Next()
-		if err == io.EOF || entry == nil {
+func (r *dwarfReader) collectSubprogramVars(rd *dwarf.Reader, dwarfPC uint64) ([]*dwarf.Entry, error) {
+	collector := subprogramVarCollector{
+		depth:        1,
+		scopeAtDepth: []bool{false, false},
+		byName:       make(map[string]int),
+	}
+	for collector.depth > 0 {
+		entry, done, err := nextSubprogramDIE(rd)
+		if err != nil {
+			return nil, err
+		}
+		if done {
 			break
 		}
-		if err != nil {
-			return nil, fmt.Errorf("DWARF child read: %w", err)
-		}
 		if entry.Tag == 0 {
-			if scopeAtDepth[depth] {
-				scopeDepth--
-			}
-			depth--
+			collector.leaveScope()
 			continue
 		}
 
@@ -548,36 +553,72 @@ func (r *dwarfReader) collectSubprogramVars(rd *dwarf.Reader, dwarfPC uint64) ([
 			rd.SkipChildren()
 			continue
 		}
-
-		if entry.Tag == dwarf.TagVariable || entry.Tag == dwarf.TagFormalParameter {
-			name, _ := entry.Val(dwarf.AttrName).(string)
-			if name != "" {
-				if index, ok := byName[name]; !ok {
-					byName[name] = len(vars)
-					vars = append(vars, scopedVariable{entry: entry, depth: scopeDepth})
-				} else if scopeDepth > vars[index].depth {
-					vars[index] = scopedVariable{entry: entry, depth: scopeDepth}
-				}
-			}
-		}
-
-		if entry.Children {
-			depth++
-			if depth >= len(scopeAtDepth) {
-				scopeAtDepth = append(scopeAtDepth, false)
-			}
-			scopeAtDepth[depth] = isScope
-			if isScope {
-				scopeDepth++
-			}
-		}
+		collector.addVariable(entry)
+		collector.enterScope(entry, isScope)
 	}
 
-	out := make([]*dwarf.Entry, len(vars))
-	for i := range vars {
-		out[i] = vars[i].entry
+	return collector.entries(), nil
+}
+
+func nextSubprogramDIE(rd *dwarf.Reader) (*dwarf.Entry, bool, error) {
+	entry, err := rd.Next()
+	if err != nil && err != io.EOF {
+		return nil, false, fmt.Errorf("DWARF child read: %w", err)
 	}
-	return out, nil
+	if err == io.EOF || entry == nil {
+		return nil, true, nil
+	}
+	return entry, false, nil
+}
+
+func (c *subprogramVarCollector) leaveScope() {
+	if c.scopeAtDepth[c.depth] {
+		c.scopeDepth--
+	}
+	c.depth--
+}
+
+func (c *subprogramVarCollector) addVariable(entry *dwarf.Entry) {
+	if entry.Tag != dwarf.TagVariable && entry.Tag != dwarf.TagFormalParameter {
+		return
+	}
+	name, _ := entry.Val(dwarf.AttrName).(string)
+	if name == "" {
+		return
+	}
+	index, ok := c.byName[name]
+	if !ok {
+		c.byName[name] = len(c.vars)
+		c.vars = append(c.vars, scopedVariable{entry: entry, depth: c.scopeDepth})
+		return
+	}
+	if c.scopeDepth > c.vars[index].depth {
+		c.vars[index] = scopedVariable{entry: entry, depth: c.scopeDepth}
+	}
+}
+
+func (c *subprogramVarCollector) enterScope(entry *dwarf.Entry, isScope bool) {
+	if !entry.Children {
+		return
+	}
+	c.depth++
+	// SkipChildren consumes the skipped subtree's terminator, so only traversed
+	// children get a depth slot.
+	if c.depth >= len(c.scopeAtDepth) {
+		c.scopeAtDepth = append(c.scopeAtDepth, false)
+	}
+	c.scopeAtDepth[c.depth] = isScope
+	if isScope {
+		c.scopeDepth++
+	}
+}
+
+func (c *subprogramVarCollector) entries() []*dwarf.Entry {
+	out := make([]*dwarf.Entry, len(c.vars))
+	for i := range c.vars {
+		out[i] = c.vars[i].entry
+	}
+	return out
 }
 
 // varType resolves a DIE's DW_AT_type to a concrete dwarf.Type (nil on absence

--- a/internal/debugger/dwarf_scopes_test.go
+++ b/internal/debugger/dwarf_scopes_test.go
@@ -1,0 +1,340 @@
+package debugger
+
+import (
+	"debug/dwarf"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestClassifyScopePC(t *testing.T) {
+	tests := []struct {
+		name   string
+		pc     uint64
+		ranges [][2]uint64
+		err    error
+		want   scopePCMatch
+	}{
+		{name: "second discontiguous range", pc: 0x205, ranges: [][2]uint64{{0x100, 0x110}, {0x200, 0x210}}, want: scopePCInside},
+		{name: "outside all ranges", pc: 0x180, ranges: [][2]uint64{{0x100, 0x110}, {0x200, 0x210}}, want: scopePCOutside},
+		{name: "empty ranges are unknown", pc: 0x100, want: scopePCUnknown},
+		{name: "range error is unknown", pc: 0x100, err: errors.New("bad ranges"), want: scopePCUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyScopePC(tt.pc, tt.ranges, tt.err); got != tt.want {
+				t.Fatalf("classifyScopePC() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVariableScopeTags(t *testing.T) {
+	if !isVariableScope(dwarf.TagLexDwarfBlock) {
+		t.Error("DW_TAG_lexical_block must define variable scope")
+	}
+	if !isVariableScope(dwarf.TagInlinedSubroutine) {
+		t.Error("DW_TAG_inlined_subroutine must define variable scope")
+	}
+	if isVariableScope(dwarf.TagSubprogram) {
+		t.Error("the containing subprogram is selected before nested scope traversal")
+	}
+}
+
+const lexicalScopeFixtureSrc = `package main
+
+//go:noinline
+func lexicalScopes(n int) int {
+	sink := n
+	shadow := n + 10
+	if n > 0 {
+		shadow := n + 20
+		if shadow > 0 {
+			shadow := n + 30
+			sink += shadow // inner-shadow-marker
+		}
+		sink += shadow // middle-shadow-marker
+	}
+	sink += shadow // outer-shadow-marker
+	if n%2 == 0 {
+		left := n + 40
+		sink += left // left-marker
+	} else {
+		right := n + 50
+		sink += right // right-marker
+	}
+	for i := 0; i < 1; i++ {
+		loop := n + i
+		sink += loop // loop-marker
+	}
+	sink++ // after-marker
+	return sink
+}
+
+func main() {
+	println(lexicalScopes(1))
+}
+`
+
+const inlineScopeFixtureSrc = `package main
+
+func inlineAdd(v int) int {
+	inlineLocal := v + 1
+	if inlineLocal > 2 {
+		inlineLocal *= 2
+	}
+	return inlineLocal
+}
+
+//go:noinline
+func optimizedScopes(n int) int {
+	result := inlineAdd(n) // inline-marker
+	result++ // after-inline-marker
+	return result
+}
+
+func main() {
+	println(optimizedScopes(1))
+}
+`
+
+func TestSubprogramVarsRespectLexicalScopes(t *testing.T) {
+	r := buildDWARFScopeFixture(t, lexicalScopeFixtureSrc, false)
+	r.slide = 0x12345000
+
+	assertNames := func(marker string, present, absent []string) {
+		t.Helper()
+		entries := varsAtMarker(t, r, lexicalScopeFixtureSrc, marker)
+		names := entryNameCounts(entries)
+		for _, name := range present {
+			if names[name] != 1 {
+				t.Errorf("%s: expected exactly one %q, got names %v", marker, name, names)
+			}
+		}
+		for _, name := range absent {
+			if names[name] != 0 {
+				t.Errorf("%s: expected %q to be out of scope, got names %v", marker, name, names)
+			}
+		}
+	}
+
+	assertNames("left-marker", []string{"n", "sink", "shadow", "left"}, []string{"right", "i", "loop"})
+	assertNames("right-marker", []string{"n", "sink", "shadow", "right"}, []string{"left", "i", "loop"})
+	assertNames("loop-marker", []string{"n", "sink", "shadow", "i", "loop"}, []string{"left", "right"})
+	assertNames("after-marker", []string{"n", "sink", "shadow"}, []string{"left", "right", "i", "loop"})
+
+	outer := variableAddressAtMarker(t, r, lexicalScopeFixtureSrc, "outer-shadow-marker", "shadow")
+	middle := variableAddressAtMarker(t, r, lexicalScopeFixtureSrc, "middle-shadow-marker", "shadow")
+	inner := variableAddressAtMarker(t, r, lexicalScopeFixtureSrc, "inner-shadow-marker", "shadow")
+	if outer == middle || middle == inner || outer == inner {
+		t.Fatalf("shadowed variables must resolve to distinct deepest-active stack slots: outer=%#x middle=%#x inner=%#x", outer, middle, inner)
+	}
+
+	if runtime.GOOS == "linux" && runtime.GOARCH == "amd64" {
+		assertLinuxLexicalRangeForm(t, r)
+	}
+}
+
+func TestSubprogramVarsPruneInactiveInlineScopes(t *testing.T) {
+	r := buildDWARFScopeFixture(t, inlineScopeFixtureSrc, true)
+	r.slide = 0x12345000
+	pc := pcAtMarker(t, r, inlineScopeFixtureSrc, "after-inline-marker")
+	inlineScopes, inactive := inlineScopesAtPC(t, r, pc)
+	if inlineScopes == 0 {
+		t.Fatal("optimized fixture did not emit a DW_TAG_inlined_subroutine")
+	}
+	if inactive == 0 {
+		t.Fatal("optimized fixture did not emit an inactive inline scope at the post-inline PC")
+	}
+
+	entries, err := r.subprogramVars(pc)
+	if err != nil {
+		t.Fatalf("subprogramVars: %v", err)
+	}
+	names := entryNameCounts(entries)
+	if names[""] != 0 {
+		t.Fatalf("inactive abstract-origin variables leaked as nameless locals: %v", names)
+	}
+	for name, count := range names {
+		if count != 1 {
+			t.Fatalf("local %q appeared %d times: %v", name, count, names)
+		}
+	}
+
+	outside, err := r.subprogramVars(0)
+	if err != nil {
+		t.Fatalf("subprogramVars outside executable ranges: %v", err)
+	}
+	if len(outside) != 0 {
+		t.Fatalf("abstract no-range subprogram used as a frame fallback: %v", entryNameCounts(outside))
+	}
+}
+
+func buildDWARFScopeFixture(t *testing.T, source string, optimized bool) *dwarfReader {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "scope_fixture.go")
+	if err := os.WriteFile(src, []byte(source), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	bin := filepath.Join(dir, "scope_fixture")
+	args := []string{"build", "-o", bin}
+	if !optimized {
+		args = append(args, "-gcflags=all=-N -l")
+	}
+	args = append(args, src)
+	cmd := exec.Command("go", args...)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build fixture: %v\n%s", err, out)
+	}
+	r, err := openDWARF(bin)
+	if err != nil {
+		t.Fatalf("open fixture DWARF: %v", err)
+	}
+	return r
+}
+
+func varsAtMarker(t *testing.T, r *dwarfReader, source, marker string) []*dwarf.Entry {
+	t.Helper()
+	pc := pcAtMarker(t, r, source, marker)
+	entries, err := r.subprogramVars(pc)
+	if err != nil {
+		t.Fatalf("%s: subprogramVars: %v", marker, err)
+	}
+	return entries
+}
+
+func pcAtMarker(t *testing.T, r *dwarfReader, source, marker string) uint64 {
+	t.Helper()
+	line := markerLine(t, source, marker)
+	pc, err := r.PCForFileLine("scope_fixture.go", line)
+	if err != nil {
+		t.Fatalf("%s: PCForFileLine: %v", marker, err)
+	}
+	return pc
+}
+
+func markerLine(t *testing.T, source, marker string) int {
+	t.Helper()
+	for i, line := range strings.Split(source, "\n") {
+		if strings.Contains(line, marker) {
+			return i + 1
+		}
+	}
+	t.Fatalf("marker %q not found", marker)
+	return 0
+}
+
+func entryNameCounts(entries []*dwarf.Entry) map[string]int {
+	names := make(map[string]int)
+	for _, entry := range entries {
+		name, _ := entry.Val(dwarf.AttrName).(string)
+		names[name]++
+	}
+	return names
+}
+
+func variableAddressAtMarker(t *testing.T, r *dwarfReader, source, marker, name string) uint64 {
+	t.Helper()
+	entries := varsAtMarker(t, r, source, marker)
+	for _, entry := range entries {
+		if entryName, _ := entry.Val(dwarf.AttrName).(string); entryName == name {
+			addr, ok := r.varAddress(entry, 0x100000)
+			if !ok {
+				t.Fatalf("%s: %q has no supported location", marker, name)
+			}
+			return addr
+		}
+	}
+	t.Fatalf("%s: no variable named %q in %v", marker, name, entryNameCounts(entries))
+	return 0
+}
+
+func assertLinuxLexicalRangeForm(t *testing.T, r *dwarfReader) {
+	t.Helper()
+	rd := r.data.Reader()
+	for {
+		entry, err := rd.Next()
+		if err != nil {
+			t.Fatalf("read fixture DWARF: %v", err)
+		}
+		if entry == nil {
+			break
+		}
+		if entry.Tag == dwarf.TagLexDwarfBlock && entry.Val(dwarf.AttrRanges) != nil {
+			return
+		}
+	}
+	t.Fatal("linux fixture emitted no range-list lexical block")
+}
+
+func inlineScopesAtPC(t *testing.T, r *dwarfReader, runtimePC uint64) (total, inactive int) {
+	t.Helper()
+	dwarfPC := uint64(int64(runtimePC) - r.slide)
+	rd := r.data.Reader()
+	for {
+		entry, err := rd.Next()
+		if err != nil {
+			t.Fatalf("read fixture DWARF: %v", err)
+		}
+		if entry == nil {
+			return 0, 0
+		}
+		if entry.Tag != dwarf.TagSubprogram {
+			continue
+		}
+		ranges, err := r.data.Ranges(entry)
+		if err != nil {
+			t.Fatalf("read subprogram ranges: %v", err)
+		}
+		if !pcInRanges(dwarfPC, ranges) {
+			rd.SkipChildren()
+			continue
+		}
+		if !entry.Children {
+			t.Fatal("containing subprogram has no children")
+		}
+		depth := 1
+		for depth > 0 {
+			child, err := rd.Next()
+			if err != nil {
+				t.Fatalf("read subprogram children: %v", err)
+			}
+			if child == nil {
+				t.Fatal("unexpected end of subprogram children")
+			}
+			if child.Tag == 0 {
+				depth--
+				continue
+			}
+			if child.Tag == dwarf.TagInlinedSubroutine {
+				total++
+				ranges, err := r.data.Ranges(child)
+				if err != nil {
+					t.Fatalf("read inline ranges: %v", err)
+				}
+				if len(ranges) > 0 && !pcInRanges(dwarfPC, ranges) {
+					inactive++
+				}
+			}
+			if child.Children {
+				depth++
+			}
+		}
+		return total, inactive
+	}
+}
+
+func pcInRanges(pc uint64, ranges [][2]uint64) bool {
+	for _, pcs := range ranges {
+		if pc >= pcs[0] && pc < pcs[1] {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/debugger/dwarf_scopes_test.go
+++ b/internal/debugger/dwarf_scopes_test.go
@@ -2,6 +2,7 @@ package debugger
 
 import (
 	"debug/dwarf"
+	"encoding/binary"
 	"errors"
 	"os"
 	"os/exec"
@@ -43,6 +44,84 @@ func TestVariableScopeTags(t *testing.T) {
 	if isVariableScope(dwarf.TagSubprogram) {
 		t.Error("the containing subprogram is selected before nested scope traversal")
 	}
+}
+
+func TestSubprogramVarsRejectChildlessSubprogramSiblings(t *testing.T) {
+	dies := []byte{1}
+	dies = appendSyntheticSubprogram(dies, 2, "childless", 0x1000)
+	dies = appendSyntheticSubprogram(dies, 3, "sibling", 0x2000)
+	dies = append(dies, 4)
+	dies = append(dies, "siblingOnly"...)
+	dies = append(dies, 0, 0, 0)
+	r := syntheticScopeReader(t, dies)
+
+	entries, err := r.subprogramVars(0x1001)
+	if err != nil {
+		t.Fatalf("subprogramVars: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("childless subprogram leaked sibling locals: %v", entryNameCounts(entries))
+	}
+	if _, err := r.EvaluateName(readableBackend{}, 0x1001, 0, "siblingOnly"); err == nil {
+		t.Fatal("EvaluateName matched a sibling parameter for a childless subprogram")
+	}
+}
+
+func TestSubprogramVarsReturnsMalformedChildError(t *testing.T) {
+	dies := []byte{1}
+	dies = appendSyntheticSubprogram(dies, 3, "malformed", 0x3000)
+	dies = append(dies, 0x7f, 0, 0)
+	r := syntheticScopeReader(t, dies)
+
+	_, err := r.subprogramVars(0x3001)
+	if err == nil || !strings.Contains(err.Error(), "DWARF child read") {
+		t.Fatalf("subprogramVars error = %v, want malformed child read error", err)
+	}
+}
+
+func syntheticScopeReader(t *testing.T, dies []byte) *dwarfReader {
+	t.Helper()
+	const (
+		dwarfFormAddr   = 0x01
+		dwarfFormData4  = 0x06
+		dwarfFormString = 0x08
+	)
+	abbrev := []byte{
+		1, byte(dwarf.TagCompileUnit), 1, 0, 0,
+		2, byte(dwarf.TagSubprogram), 0,
+		byte(dwarf.AttrName), dwarfFormString,
+		byte(dwarf.AttrLowpc), dwarfFormAddr,
+		byte(dwarf.AttrHighpc), dwarfFormData4,
+		0, 0,
+		3, byte(dwarf.TagSubprogram), 1,
+		byte(dwarf.AttrName), dwarfFormString,
+		byte(dwarf.AttrLowpc), dwarfFormAddr,
+		byte(dwarf.AttrHighpc), dwarfFormData4,
+		0, 0,
+		4, byte(dwarf.TagFormalParameter), 0,
+		byte(dwarf.AttrName), dwarfFormString,
+		0, 0,
+		0,
+	}
+	unit := []byte{4, 0, 0, 0, 0, 0, 8}
+	unit = append(unit, dies...)
+	info := make([]byte, 4, 4+len(unit))
+	binary.LittleEndian.PutUint32(info, uint32(len(unit)))
+	info = append(info, unit...)
+
+	data, err := dwarf.New(abbrev, nil, nil, info, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("create synthetic DWARF: %v", err)
+	}
+	return &dwarfReader{data: data}
+}
+
+func appendSyntheticSubprogram(dst []byte, abbreviation byte, name string, lowPC uint64) []byte {
+	dst = append(dst, abbreviation)
+	dst = append(dst, name...)
+	dst = append(dst, 0)
+	dst = binary.LittleEndian.AppendUint64(dst, lowPC)
+	return binary.LittleEndian.AppendUint32(dst, 0x10)
 }
 
 const lexicalScopeFixtureSrc = `package main
@@ -276,22 +355,40 @@ func assertLinuxLexicalRangeForm(t *testing.T, r *dwarfReader) {
 func inlineScopesAtPC(t *testing.T, r *dwarfReader, runtimePC uint64) (total, inactive int) {
 	t.Helper()
 	dwarfPC := uint64(int64(runtimePC) - r.slide)
+	rd := containingSubprogramReader(t, r, dwarfPC)
+	depth := 1
+	for depth > 0 {
+		child := requiredDIE(t, rd, "subprogram children")
+		if child.Tag == 0 {
+			depth--
+			continue
+		}
+		if child.Tag == dwarf.TagInlinedSubroutine {
+			total++
+			ranges := requiredRanges(t, r, child, "inline")
+			if len(ranges) > 0 && !pcInRanges(dwarfPC, ranges) {
+				inactive++
+			}
+		}
+		if child.Children {
+			depth++
+		}
+	}
+	return total, inactive
+}
+
+func containingSubprogramReader(t *testing.T, r *dwarfReader, dwarfPC uint64) *dwarf.Reader {
+	t.Helper()
 	rd := r.data.Reader()
 	for {
-		entry, err := rd.Next()
-		if err != nil {
-			t.Fatalf("read fixture DWARF: %v", err)
-		}
+		entry := requiredDIE(t, rd, "fixture DWARF")
 		if entry == nil {
-			return 0, 0
+			t.Fatal("no subprogram contains fixture PC")
 		}
 		if entry.Tag != dwarf.TagSubprogram {
 			continue
 		}
-		ranges, err := r.data.Ranges(entry)
-		if err != nil {
-			t.Fatalf("read subprogram ranges: %v", err)
-		}
+		ranges := requiredRanges(t, r, entry, "subprogram")
 		if !pcInRanges(dwarfPC, ranges) {
 			rd.SkipChildren()
 			continue
@@ -299,35 +396,29 @@ func inlineScopesAtPC(t *testing.T, r *dwarfReader, runtimePC uint64) (total, in
 		if !entry.Children {
 			t.Fatal("containing subprogram has no children")
 		}
-		depth := 1
-		for depth > 0 {
-			child, err := rd.Next()
-			if err != nil {
-				t.Fatalf("read subprogram children: %v", err)
-			}
-			if child == nil {
-				t.Fatal("unexpected end of subprogram children")
-			}
-			if child.Tag == 0 {
-				depth--
-				continue
-			}
-			if child.Tag == dwarf.TagInlinedSubroutine {
-				total++
-				ranges, err := r.data.Ranges(child)
-				if err != nil {
-					t.Fatalf("read inline ranges: %v", err)
-				}
-				if len(ranges) > 0 && !pcInRanges(dwarfPC, ranges) {
-					inactive++
-				}
-			}
-			if child.Children {
-				depth++
-			}
-		}
-		return total, inactive
+		return rd
 	}
+}
+
+func requiredDIE(t *testing.T, rd *dwarf.Reader, context string) *dwarf.Entry {
+	t.Helper()
+	entry, err := rd.Next()
+	if err != nil {
+		t.Fatalf("read %s: %v", context, err)
+	}
+	if entry == nil {
+		t.Fatalf("unexpected end of %s", context)
+	}
+	return entry
+}
+
+func requiredRanges(t *testing.T, r *dwarfReader, entry *dwarf.Entry, context string) [][2]uint64 {
+	t.Helper()
+	ranges, err := r.data.Ranges(entry)
+	if err != nil {
+		t.Fatalf("read %s ranges: %v", context, err)
+	}
+	return ranges
 }
 
 func pcInRanges(pc uint64, ranges [][2]uint64) bool {

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -404,9 +404,9 @@ func (e *engine) Evaluate(frameIndex int, name string) (protocol.Variable, error
 	return result, err
 }
 
-// frameLocation computes the PC and frame-base address for the given stack frame
-// of the currently-stopped thread. Callers must already be on the engine loop
-// (inside dispatch) and have verified suspension.
+// frameLocation computes the DWARF lookup PC and frame-base address for the
+// given stack frame of the currently-stopped thread. Callers must already be on
+// the engine loop (inside dispatch) and have verified suspension.
 //
 // It inspects the thread the user is stopped on (curTID via activeTID), not
 // threads[0]: on Darwin threads[0] is frequently an idle runtime M, so a
@@ -441,7 +441,7 @@ func (e *engine) frameLocation(frameIndex int) (framePC, frameBase uint64, err e
 	const cfaFallbackFromFP = 16
 	sp, fp := regs.SP, regs.BP
 	for i := 0; i < frameIndex; i++ {
-		cfa, ok := e.dw.cfa(framePCs[i], sp, fp)
+		cfa, ok := e.dw.cfa(frameLookupPC(framePCs[i], i), sp, fp)
 		if !ok {
 			cfa = fp + cfaFallbackFromFP
 		}
@@ -452,11 +452,12 @@ func (e *engine) frameLocation(frameIndex int) (framePC, frameBase uint64, err e
 		sp = cfa
 		fp = binary.LittleEndian.Uint64(buf[:])
 	}
-	frameBase, ok := e.dw.cfa(framePCs[frameIndex], sp, fp)
+	framePC = frameLookupPC(framePCs[frameIndex], frameIndex)
+	frameBase, ok := e.dw.cfa(framePC, sp, fp)
 	if !ok {
 		frameBase = fp + cfaFallbackFromFP
 	}
-	return framePCs[frameIndex], frameBase, nil
+	return framePC, frameBase, nil
 }
 
 func (e *engine) StackFrames() ([]protocol.Frame, error) {


### PR DESCRIPTION
## Summary

Fix shared DWARF variable inspection so `Locals` and `EvaluateName` only expose declarations active at the selected frame PC and choose the innermost active shadow.

The old flat child scan descended into nested lexical blocks, stopped at the first nested null DIE, and never filtered by PC. That leaked leftmost-block locals, omitted later sibling/loop locals, and made `EvaluateName` read the outer stack slot for shadowed names. Caller frames also used saved return PCs directly; because those point after CALL/BL, they could equal an exclusive lexical/CFI boundary and hide an otherwise in-scope caller local.

## Changes

- walk the full containing subprogram subtree with explicit DIE depth;
- treat both `DW_TAG_lexical_block` and `DW_TAG_inlined_subroutine` as scope-bearing;
- compare the unslid PC against every range from `dwarf.Data.Ranges`;
- conservatively traverse nested scopes with missing/unreadable ranges;
- prune definitely inactive children with `Reader.SkipChildren` without disturbing depth;
- skip nameless abstract-origin concrete inline variables without expanding the supported expression model;
- deduplicate locals by name with deepest-active scope winning;
- reject no-range abstract subprograms as concrete frame fallbacks and return no locals for concrete childless subprograms;
- propagate malformed child-DIE decoder errors;
- use underflow-safe `returnPC-1` for every non-top frame's function/line/scope and CFI lookup while preserving raw saved PCs and the top live PC;
- document the range/depth/shadow/caller-PC invariants in `AGENTS.md`.

## Regression coverage

Compiler-built fixtures cover sibling `if` blocks, a `for` local, a post-block PC, three nested same-name declarations with distinct stack addresses, non-zero ASLR slide, linux range-list lexical blocks, optimized inactive inline scopes, and abstract-subprogram rejection.

A caller/callee fixture stops in the callee and selects a caller block whose final statement is the call. It proves the raw return PC is outside the exclusive scope, then verifies adjusted function/line, CFI, `Locals`, and `Evaluate`. Pure/synthetic coverage pins discontiguous ranges, zero-underflow, childless-subprogram sibling isolation, false `EvaluateName` rejection, and malformed-DWARF error propagation.

## Validation

- `GOTOOLCHAIN=go1.25.5 go test -tags bingonative -race ./internal/debugger ./internal/dap -count=1`
- `GOTOOLCHAIN=go1.25.5 go vet -tags bingonative ./...`
- `GOTOOLCHAIN=go1.25.5 golangci-lint run --build-tags bingonative ./...`
- codesigned darwin/arm64 native `inspect || dap` E2E: 7 passed, 0 failed

No OS backend or debugger control-path code changes.

Fixes #168