### PR TITLE
fix(dapcli): fail requests when the DAP transport dies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1259,6 +1259,24 @@ stays alive for others to join. It buffers `break`s set before launch and flushe
 them on `initialized`. Any mix of `dapcli` and `cli` clients can drive/observe
 one session concurrently.
 
+`dapcli`'s connection death is explicit state, not an implied channel close.
+`markDisconnected` records the cause and closes a `done` channel once
+(`sync.Once`), all under the same `mu` that guards the pending-waiter map, so
+registering a waiter and observing the transport's death is one atomic step —
+a request issued after `readLoop` has already exited fails immediately instead
+of burning the full `replyTimeout`. Waiter channels are **never closed**: a
+receive from a closed channel yields a nil `godap.Message`, whose failed type
+assertion made `request` return `(nil, nil)` and let `restart` print
+"restarted", `initialize` enter the REPL on a dead socket, and
+`threads`/`bt`/`locals` print an empty result — a false success indistinguishable
+from a real one. Blocked waiters instead select on `done` and get a non-nil
+error carrying the underlying read error. That select does a **non-blocking
+re-check of the waiter channel** before reporting death, because a server that
+replies and then closes makes both cases ready at once and `select` picks at
+random; a delivered response must still win or correlation is lost. `close()`
+marks death through the same path, so quitting can't strand an in-flight
+request.
+
 **Option Y (rejected).** The alternative was teaching the hub about DAP directly
 (a second protocol path through `internal/hub`). Rejected: it would fork the most
 fragile fan-out/suspend-gate code for a second protocol. The `hub.WSConn`

--- a/cmd/dapcli/main.go
+++ b/cmd/dapcli/main.go
@@ -54,10 +54,23 @@ type dapCLI struct {
 	conn   net.Conn
 	reader *bufio.Reader
 
-	// mu guards seq and pending (the response-waiter registry).
-	mu      sync.Mutex
-	seq     int
-	pending map[int]chan godap.Message
+	// mu guards seq, pending (the response-waiter registry), and the
+	// connection-death fields. Registering a waiter and observing the
+	// connection's death must be one atomic step, or a request racing the read
+	// loop's exit would register with nobody left to answer it and block for
+	// the whole replyTimeout.
+	mu           sync.Mutex
+	seq          int
+	pending      map[int]chan godap.Message
+	disconnected bool
+	connErr      error
+
+	// done is closed exactly once (closeOnce) when the transport dies, so
+	// waiters already blocked in request unblock. Waiter channels themselves
+	// are never closed: onResponse can be mid-send on one, and a receive from a
+	// closed channel yields a nil message that reads as a successful response.
+	done      chan struct{}
+	closeOnce sync.Once
 
 	// writeMu serialises WriteProtocolMessage across the REPL goroutine, the
 	// initialized-handler goroutine, and any command handler — concurrent writes
@@ -75,6 +88,20 @@ type dapCLI struct {
 	printMu sync.Mutex
 }
 
+// newDAPCLI builds a client over conn. Always construct through this so done is
+// non-nil: a nil channel blocks forever, which would silently defeat every
+// connection-death select.
+func newDAPCLI(conn net.Conn) *dapCLI {
+	return &dapCLI{
+		conn:      conn,
+		reader:    bufio.NewReader(conn),
+		pending:   make(map[int]chan godap.Message),
+		bpsByFile: make(map[string][]breakpoint),
+		curThread: 1,
+		done:      make(chan struct{}),
+	}
+}
+
 func main() {
 	addr := flag.String("addr", "localhost:4711", "DAP server address (host:port)")
 	sessionID := flag.String("session", "", "existing bingo session ID to join (omit to create on launch)")
@@ -86,13 +113,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	h := &dapCLI{
-		conn:      conn,
-		reader:    bufio.NewReader(conn),
-		pending:   make(map[int]chan godap.Message),
-		bpsByFile: make(map[string][]breakpoint),
-		curThread: 1,
-	}
+	h := newDAPCLI(conn)
 	go h.readLoop()
 
 	if *sessionID != "" {
@@ -283,7 +304,7 @@ func (h *dapCLI) readLoop() {
 	for {
 		msg, err := readDAPMessage(h.reader)
 		if err != nil {
-			h.failPending()
+			h.markDisconnected(err)
 			if !isClosed(err) {
 				h.printAsync("connection closed: " + err.Error())
 			} else {
@@ -324,43 +345,73 @@ func (h *dapCLI) onResponse(rm godap.ResponseMessage, msg godap.Message) {
 // ack we don't surface). Errors still surface via onResponse.
 func (h *dapCLI) fire(command string, m godap.RequestMessage) {
 	h.mu.Lock()
+	if h.disconnected {
+		cause := h.connErr
+		h.mu.Unlock()
+		h.printAsync("[error] " + connClosedError(command, cause).Error())
+		return
+	}
 	h.seq++
 	seq := h.seq
 	h.mu.Unlock()
-	h.write(command, seq, m)
+	if err := h.write(command, seq, m); err != nil {
+		h.printAsync(fmt.Sprintf("[error] write %s: %v", command, err))
+	}
 }
 
-// request sends a request and blocks for its response (or a timeout).
+// request sends a request and blocks for its response (or a timeout, or the
+// death of the connection).
 func (h *dapCLI) request(command string, m godap.RequestMessage) (godap.Message, error) {
 	h.mu.Lock()
+	if h.disconnected {
+		cause := h.connErr
+		h.mu.Unlock()
+		return nil, connClosedError(command, cause)
+	}
 	h.seq++
 	seq := h.seq
 	ch := make(chan godap.Message, 1)
 	h.pending[seq] = ch
 	h.mu.Unlock()
 
-	h.write(command, seq, m)
+	defer func() {
+		h.mu.Lock()
+		delete(h.pending, seq)
+		h.mu.Unlock()
+	}()
+
+	if err := h.write(command, seq, m); err != nil {
+		return nil, fmt.Errorf("write %s: %w", command, err)
+	}
 
 	select {
 	case msg := <-ch:
-		h.mu.Lock()
-		delete(h.pending, seq)
-		h.mu.Unlock()
-		if rm, ok := msg.(godap.ResponseMessage); ok {
-			if rs := rm.GetResponse(); !rs.Success {
-				return msg, fmt.Errorf("%s", rs.Message)
-			}
+		return decodeResponse(msg)
+	case <-h.done:
+		// The response and the transport's death can become ready together
+		// (a server that replies then closes), and select picks at random. A
+		// delivered response still wins so correlation is never lost.
+		select {
+		case msg := <-ch:
+			return decodeResponse(msg)
+		default:
 		}
-		return msg, nil
+		return nil, h.connClosed(command)
 	case <-time.After(replyTimeout):
-		h.mu.Lock()
-		delete(h.pending, seq)
-		h.mu.Unlock()
 		return nil, fmt.Errorf("timeout awaiting %s response", command)
 	}
 }
 
-func (h *dapCLI) write(command string, seq int, m godap.RequestMessage) {
+func decodeResponse(msg godap.Message) (godap.Message, error) {
+	if rm, ok := msg.(godap.ResponseMessage); ok {
+		if rs := rm.GetResponse(); !rs.Success {
+			return msg, fmt.Errorf("%s", rs.Message)
+		}
+	}
+	return msg, nil
+}
+
+func (h *dapCLI) write(command string, seq int, m godap.RequestMessage) error {
 	req := m.GetRequest()
 	req.Seq = seq
 	req.Type = "request"
@@ -368,22 +419,47 @@ func (h *dapCLI) write(command string, seq int, m godap.RequestMessage) {
 	h.writeMu.Lock()
 	err := godap.WriteProtocolMessage(h.conn, m)
 	h.writeMu.Unlock()
-	if err != nil {
-		h.printAsync(fmt.Sprintf("[error] write %s: %v", command, err))
-	}
+	return err
 }
 
-// failPending unblocks every outstanding waiter when the connection drops.
-func (h *dapCLI) failPending() {
+// markDisconnected records the transport failure once and releases every
+// waiter. Waiter channels are deliberately left unclosed — onResponse may be
+// mid-send on one, and a closed channel hands the waiter a nil message that is
+// indistinguishable from a successful empty response.
+func (h *dapCLI) markDisconnected(cause error) {
 	h.mu.Lock()
-	for seq, ch := range h.pending {
-		close(ch)
+	h.disconnected = true
+	if h.connErr == nil {
+		h.connErr = cause
+	}
+	for seq := range h.pending {
 		delete(h.pending, seq)
 	}
 	h.mu.Unlock()
+	h.closeOnce.Do(func() { close(h.done) })
 }
 
-func (h *dapCLI) close() { _ = h.conn.Close() }
+func (h *dapCLI) connClosed(command string) error {
+	h.mu.Lock()
+	cause := h.connErr
+	h.mu.Unlock()
+	return connClosedError(command, cause)
+}
+
+// connClosedError always prefixes the cause. A bare io.EOF from the read loop
+// reads as an ordinary end-of-stream success rather than a lost debug session,
+// so it must never reach the operator unqualified.
+func connClosedError(command string, cause error) error {
+	if cause == nil {
+		return fmt.Errorf("%s failed: connection to DAP server closed", command)
+	}
+	return fmt.Errorf("%s failed: connection to DAP server closed: %w", command, cause)
+}
+
+func (h *dapCLI) close() {
+	h.markDisconnected(nil)
+	_ = h.conn.Close()
+}
 
 // --- event handling ------------------------------------------------------------
 

--- a/cmd/dapcli/main_test.go
+++ b/cmd/dapcli/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"net"
 	"testing"
 	"time"
@@ -48,12 +49,8 @@ func TestReadLoopContinuesAfterSessionAnnouncement(t *testing.T) {
 	})
 
 	response := make(chan godap.Message, 1)
-	h := &dapCLI{
-		conn:      client,
-		reader:    bufio.NewReader(client),
-		pending:   map[int]chan godap.Message{7: response},
-		bpsByFile: make(map[string][]breakpoint),
-	}
+	h := newDAPCLI(client)
+	h.pending[7] = response
 	go h.readLoop()
 
 	go func() {
@@ -92,4 +89,191 @@ func writeDAPFrame(buffer *bytes.Buffer, content string) {
 
 func writeDAPFrameTo(writer net.Conn, content string) {
 	_, _ = fmt.Fprintf(writer, "Content-Length: %d\r\n\r\n%s", len(content), content)
+}
+
+// --- connection-death regressions ----------------------------------------------
+
+// An in-flight request must not read a dead transport as a successful response.
+// The read loop used to close each waiter channel, and request received without
+// comma-ok, so the waiter got a nil message and returned (nil, nil).
+func TestRequestInFlightFailsWhenConnectionDies(t *testing.T) {
+	g := NewWithT(t)
+	h, server := newPipedCLI(t)
+	go h.readLoop()
+
+	go func() {
+		_, _ = readDAPMessage(bufio.NewReader(server))
+		_ = server.Close()
+	}()
+
+	type result struct {
+		message godap.Message
+		err     error
+	}
+	done := make(chan result, 1)
+	go func() {
+		message, err := h.request("restart", &godap.RestartRequest{})
+		done <- result{message, err}
+	}()
+
+	select {
+	case got := <-done:
+		g.Expect(got.err).To(HaveOccurred())
+		g.Expect(got.err.Error()).To(ContainSubstring("restart failed"))
+		g.Expect(got.err.Error()).To(ContainSubstring("connection to DAP server closed"))
+		g.Expect(got.message).To(BeNil())
+	case <-time.After(5 * time.Second):
+		t.Fatal("in-flight request never unblocked after the connection died")
+	}
+}
+
+// The `restart` command prints success purely from a nil error, so a dead
+// transport must not let it announce a relaunch that never happened.
+func TestRestartRequestDoesNotSucceedOnDeadConnection(t *testing.T) {
+	g := NewWithT(t)
+	h, server := newPipedCLI(t)
+	go h.readLoop()
+	_ = server.Close()
+
+	g.Eventually(h.isDisconnected).WithTimeout(2 * time.Second).Should(BeTrue())
+
+	start := time.Now()
+	message, err := h.request("restart", &godap.RestartRequest{})
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("restart failed"))
+	g.Expect(err.Error()).To(ContainSubstring("connection to DAP server closed"))
+	g.Expect(message).To(BeNil())
+	g.Expect(time.Since(start)).To(BeNumerically("<", time.Second))
+}
+
+// The startup handshake exits on a non-nil error; a false success would drop
+// the operator into a REPL bound to a dead socket.
+func TestInitializeRequestDoesNotSucceedOnDeadConnection(t *testing.T) {
+	g := NewWithT(t)
+	h, server := newPipedCLI(t)
+	go h.readLoop()
+	_ = server.Close()
+
+	g.Eventually(h.isDisconnected).WithTimeout(2 * time.Second).Should(BeTrue())
+
+	start := time.Now()
+	message, err := h.request("initialize", &godap.InitializeRequest{})
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("initialize failed"))
+	g.Expect(err.Error()).To(ContainSubstring("connection to DAP server closed"))
+	g.Expect(message).To(BeNil())
+	g.Expect(time.Since(start)).To(BeNumerically("<", time.Second))
+}
+
+// A request registered after the read loop has died has nobody left to answer
+// it, so it must fail immediately rather than burn the full replyTimeout.
+func TestRequestAfterReadLoopDeathFailsImmediately(t *testing.T) {
+	g := NewWithT(t)
+	h, server := newPipedCLI(t)
+	go h.readLoop()
+	_ = server.Close()
+
+	g.Eventually(h.isDisconnected).WithTimeout(2 * time.Second).Should(BeTrue())
+
+	start := time.Now()
+	message, err := h.request("threads", &godap.ThreadsRequest{})
+	elapsed := time.Since(start)
+
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(message).To(BeNil())
+	g.Expect(elapsed).To(BeNumerically("<", time.Second))
+	g.Expect(elapsed).To(BeNumerically("<", replyTimeout))
+	g.Expect(err.Error()).NotTo(ContainSubstring("timeout"))
+}
+
+// A response already delivered must still win when it becomes ready at the same
+// moment as the transport's death, or correlation is lost on a server that
+// replies and immediately closes.
+func TestRequestPrefersDeliveredResponseOverConnectionDeath(t *testing.T) {
+	g := NewWithT(t)
+	h, server := newPipedCLI(t)
+
+	go func() {
+		request, err := readDAPMessage(bufio.NewReader(server))
+		if err != nil {
+			return
+		}
+		seq := request.(godap.RequestMessage).GetRequest().Seq
+		_ = godap.WriteProtocolMessage(server, &godap.ThreadsResponse{
+			Response: godap.Response{
+				ProtocolMessage: godap.ProtocolMessage{Seq: 1, Type: "response"},
+				RequestSeq:      seq,
+				Success:         true,
+				Command:         "threads",
+			},
+			Body: godap.ThreadsResponseBody{Threads: []godap.Thread{{Id: 1, Name: "main"}}},
+		})
+		_ = server.Close()
+	}()
+	go h.readLoop()
+
+	message, err := h.request("threads", &godap.ThreadsRequest{})
+	g.Expect(err).NotTo(HaveOccurred())
+	response, ok := message.(*godap.ThreadsResponse)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(response.Body.Threads).To(HaveLen(1))
+}
+
+// Concurrent requests racing a disconnect must all unblock with an error and
+// must not trip the race detector on the pending map, done, or a waiter channel.
+func TestConcurrentRequestsSurviveDisconnect(t *testing.T) {
+	g := NewWithT(t)
+	h, server := newPipedCLI(t)
+	go h.readLoop()
+	go func() {
+		reader := bufio.NewReader(server)
+		for i := 0; i < 4; i++ {
+			if _, err := readDAPMessage(reader); err != nil {
+				break
+			}
+		}
+		_ = server.Close()
+	}()
+
+	const callers = 16
+	errs := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			_, err := h.request("threads", &godap.ThreadsRequest{})
+			errs <- err
+		}()
+	}
+	go h.close()
+
+	deadline := time.After(10 * time.Second)
+	for i := 0; i < callers; i++ {
+		select {
+		case err := <-errs:
+			g.Expect(err).To(HaveOccurred())
+		case <-deadline:
+			t.Fatalf("only %d of %d concurrent requests unblocked", i, callers)
+		}
+	}
+
+	// close and the read loop both mark death; neither may double-close done.
+	h.close()
+	h.markDisconnected(io.EOF)
+}
+
+func (h *dapCLI) isDisconnected() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.disconnected
+}
+
+func newPipedCLI(t *testing.T) (*dapCLI, net.Conn) {
+	t.Helper()
+	server, client := net.Pipe()
+	t.Cleanup(func() {
+		_ = server.Close()
+		_ = client.Close()
+	})
+	return newDAPCLI(client), server
 }


### PR DESCRIPTION
## Summary

`cmd/dapcli` had no connection-death state, so a lost DAP transport surfaced as success.

`failPending` unblocked waiters by **closing** each pending channel, but `request` received without comma-ok:

```go
case msg := <-ch:
	if rm, ok := msg.(godap.ResponseMessage); ok { ... }
	return msg, nil   // msg is nil, err is nil
```

A receive from a closed channel yields a nil `godap.Message`; the type assertion fails, the `!rs.Success` branch is skipped, and `request` returns `(nil, nil)`. Callers then reported success on a dead socket:

- `restart` printed `restarted (breakpoints reinstalled)`
- the startup `initialize` succeeded, dropping the operator into a REPL bound to a dead socket
- `threads` / `bt` / `locals` printed `(no threads)` / `(no frames)` / `(no locals)`, indistinguishable from a genuinely empty result

Separately, a request registered **after** `readLoop` had already exited still registered a waiter nobody could answer and blocked the full 15s `replyTimeout` before returning a misleading `timeout awaiting X response`.

## What changed

Explicit connection-death state modelled on the `pkg/client/ws.go` precedent (`done` + `sync.Once` + `signalDone`), scoped to `cmd/dapcli`:

- `markDisconnected(cause)` records the cause and closes a `done` channel exactly once (`sync.Once`), **under the same `mu` that guards the pending-waiter map** — registering a waiter and observing death is one atomic step, so a post-death request fails immediately instead of burning `replyTimeout`.
- **Waiter channels are never closed.** `onResponse` can be mid-send on one, and a closed channel is precisely what produced the nil-message false success. Blocked waiters select on `done` and get a non-nil error carrying the underlying read error.
- That `done` case does a **non-blocking re-check of the waiter channel first**: a server that replies and then closes makes both cases ready at once and `select` picks at random, so a delivered response must still win or correlation is lost.
- `write` now returns its error, so `request` fails fast on a dead send instead of stalling; `fire` keeps its existing async error print.
- `close()` marks death through the same path, so quitting can't strand an in-flight request.
- `newDAPCLI` constructor guarantees `done` is non-nil — a nil channel blocks forever and would silently defeat every death select.

Error text is explicit (`restart failed: connection to DAP server closed: EOF`), never a bare EOF that reads as end-of-stream success. Normal response correlation and the ordinary reply timeout on a live connection are unchanged. No unrelated CLI refactor.

## Tests

Six `net.Pipe` regressions in `cmd/dapcli/main_test.go`:

| Test | Gate |
| --- | --- |
| `TestRequestInFlightFailsWhenConnectionDies` | server reads the request then closes → in-flight request returns a non-nil error, nil message |
| `TestRestartRequestDoesNotSucceedOnDeadConnection` | `restart` at request level cannot succeed; fails in <1s |
| `TestInitializeRequestDoesNotSucceedOnDeadConnection` | handshake cannot enter the REPL on a dead socket |
| `TestRequestAfterReadLoopDeathFailsImmediately` | post-death request completes in <1s, not 15s, and is not a timeout error |
| `TestRequestPrefersDeliveredResponseOverConnectionDeath` | reply-then-close still resolves the response (correlation preserved) |
| `TestConcurrentRequestsSurviveDisconnect` | 16 concurrent requests + `close()` + read-loop death, clean under `-race`; no send-on-closed / double-close |

Verified these actually gate the bug: with the old semantics temporarily restored, 4 of them fail (`TestRequestInFlightFailsWhenConnectionDies` in 0.00s with `err=<nil>`, `TestInitializeRequestDoesNotSucceedOnDeadConnection` and `TestRequestAfterReadLoopDeathFailsImmediately` each after 15.01s). With the fix all 8 tests in the package pass, none exceeding 0.01s.

```
go tool goimports -l cmd/dapcli/   # clean
gofmt -l cmd/dapcli/               # clean
go vet -tags bingonative ./...     # clean
go test -tags bingonative -race -count=1 ./cmd/dapcli   # 8 run / 8 pass / 0 fail
go test -tags bingonative -race -count=25 ./cmd/dapcli  # ok (flake check)
go test -tags bingonative ./cmd/... ./pkg/... ./internal/dap/... ./internal/dapclient/...  # all ok
```

`AGENTS.md` records the new invariant in the same commit, per the repo's doc-sync rule.

## Scope

Independent of PR #148 (`pkg/client` timeout reply debt — no shared code) and distinct from #128/#135, which is only `clear 0` breakpoint-ID validation.

Fixes #172