### PR TITLE
fix(hub): keep suspended loop on rejected Restart or Kill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,10 +192,8 @@ reported asynchronously via the `Paused` event once the interrupt surfaces (see
 [Pause — async interrupt](#pause--async-interrupt)). `Kill` was previously
 misrouted through `resumeCh`, which is only drained while suspended — so a `Kill`
 against a runaway target (tight loop, no breakpoints) could never terminate it
-through the protocol. Routing `Kill` via `cmdCh` fixes that; the suspended wait
-loop `return`s after executing a `Kill` (like `Restart`), since the process it
-was waiting to resume no longer exists. `Kill` with no active debugger is a
-benign no-op success (nothing to terminate).
+through the protocol. Routing `Kill` via `cmdCh` fixes that. `Kill` with no active
+debugger is a benign no-op success (nothing to terminate).
 
 Stale resumes: a resuming command sent **while the process is still running**
 (an erroneous or racing client) lands in `resumeCh` but is not drained by Run's
@@ -222,6 +220,30 @@ loop** (it checks that the session left `suspended` before returning). Bailing
 out on a failed resume would strand the client: the process is still suspended,
 but a retry resume lands in `resumeCh`, which only the wait loop drains, so the
 session could never be resumed again.
+
+**Leaving the wait loop is decided by observed state, never by command kind.**
+Both branches that execute a command while suspended — `resumeCh` and `cmdCh` —
+return only `if h.State() != protocol.StateSuspended`. The `cmdCh` branch used to
+return unconditionally for `CmdRestart`/`CmdKill` on the premise that the process
+it was waiting on no longer existed. That premise only holds when the command
+*succeeded*: a `Restart` rejected before it touches the debugger (raw hub with no
+factory, no prior `Launch` — an Attach-based session, malformed `RestartPayload`)
+and a `Kill` the debugger refuses both broadcast an `EventError` and leave the
+original process suspended. Returning there stranded the session exactly like a
+rejected resume — every later `Continue`/`Step*` landed in `resumeCh`, which
+Run's outer loop never drains — leaving a live, frozen tracee that only a
+successful `Kill`/`Restart` or a full session teardown could recover (and on a
+raw hub `Restart` can never succeed, so only teardown could). The state check is
+exhaustive: successful Restart → `running` (returns), failed relaunch → `idle`
+(returns, old debugger discarded), rejected Restart / failed `Kill` → still
+`suspended` (stays, retryable). A **successful** `Kill` also leaves the state
+`suspended` — `executeCommand` has no state case for it — so the loop stays
+parked until the debugger reports its own teardown as `EventProcessExited` or a
+closed `Events` channel, which the wait loop's events branch already handles
+(engine shutdown always produces one; see
+[Engine concurrency model](#engine-concurrency-model--non-obvious-invariants)).
+Waiting for that signal is strictly more accurate than inferring death from a
+command kind.
 
 ### Session state machine
 
@@ -823,12 +845,16 @@ a resuming command); it is now routed via `cmdCh` for exactly this reason — se
 routed through the ordinary `cmdCh` (like `SetBreakpoint`), which both Run's
 outer loop and the suspend-wait loop's `case cc := <-h.cmdCh:` branch drain.
 The one special case: that branch normally loops back to keep waiting for a
-resume after executing a non-resuming command, but for `CmdRestart` **and**
-`CmdKill` it `return`s instead — the suspended process it was waiting on no
-longer exists (replaced or terminated), so there's nothing left to resume, and
-returning lets Run's outer loop naturally pick up the new/closed debugger's
-events channel (`h.dbg` is reassigned inside `handleRestart` before the
-confirmation event is broadcast).
+resume after executing a non-resuming command, and it leaves only when the
+command moved the session out of `suspended` — `h.State() != StateSuspended`,
+the same guard the `resumeCh` branch uses. A **successful** `CmdRestart` hits
+that (it transitions to `running`, or to `idle` if the relaunch failed), so
+Run's outer loop naturally picks up the new debugger's events channel (`h.dbg`
+is reassigned inside `handleRestart` before the confirmation event is
+broadcast). A `CmdRestart` **rejected** before it touches the debugger, or a
+failed `CmdKill`, leaves the original process suspended and the loop keeps
+waiting — keying the exit off the command kind instead wedged those sessions,
+see [Suspend/resume protocol](#suspendresume-protocol).
 
 `EventRestarted` is a confirmation event (like `BreakpointSet`), not a
 suspending one — the new process's suspended state (if any, e.g. break-on-

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -382,14 +382,24 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 
 		case cc := <-h.cmdCh:
 			// Non-resuming command (SetBreakpoint, Locals, …) while suspended.
-			// Execute immediately — process is paused — and keep waiting.
-			// Restart and Kill are the exceptions: Restart tears down and
-			// replaces the suspended process, and Kill terminates it, so in
-			// both cases the process we were waiting to resume no longer
-			// exists — return and let Run's outer loop pick up the new or
-			// closed debugger's events channel.
+			// Execute immediately — the process is paused — and decide whether
+			// to keep waiting from the OBSERVED state, never from the command
+			// kind. Restart and Kill only dissolve the suspend when they
+			// actually take effect: a Restart rejected before it touches the
+			// debugger (raw hub, no prior Launch, malformed payload) or a
+			// failed Kill broadcasts an EventError and leaves the original
+			// process suspended. Returning on kind alone stranded those cases —
+			// a later resume lands in resumeCh, which only this wait loop
+			// drains (Run's outer loop never selects on it), wedging the
+			// session forever. Same guard as the resumeCh branch above.
+			//
+			// A SUCCESSFUL Kill also leaves the state suspended (Kill has no
+			// state transition of its own), so the loop stays parked until the
+			// debugger reports its own teardown — ProcessExited or a closed
+			// Events channel — which the eventsCh branch above already handles.
+			// That is strictly more accurate than inferring death from a kind.
 			h.executeCommand(cc.cmd)
-			if cc.cmd.Kind == protocol.CmdRestart || cc.cmd.Kind == protocol.CmdKill {
+			if h.State() != protocol.StateSuspended {
 				return
 			}
 

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -735,60 +735,32 @@ var _ = Describe("Hub", func() {
 		It("stays resumable after a raw hub rejects Restart", func() {
 			conn := newFakeWSConn()
 			mustAddClient(h, conn)
-
-			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
-				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
-			waitForEventKind(conn, protocol.EventBreakpointHit, nil)
+			suspendAtBreakpoint(conn, fd)
 
 			// hub.New has no session ID and no debugger factory, so Restart is
 			// refused without touching h.dbg or the state.
-			conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
-			waitForEventKind(conn, protocol.EventError, nil)
-			Expect(h.State()).To(Equal(protocol.StateSuspended))
-
-			conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
-			Eventually(fd.recordedCalls, "500ms", "10ms").
-				Should(ContainElement("Continue"))
+			expectRejectedWhileSuspended(h, conn,
+				mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+			expectResumable(conn, fd)
 		})
 
 		It("stays resumable after a failed Kill", func() {
 			conn := newFakeWSConn()
 			mustAddClient(h, conn)
-			fd.killErr = errors.New("kill failed")
+			refuseKillWhileSuspended(h, conn, fd)
 
-			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
-				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
-			waitForEventKind(conn, protocol.EventBreakpointHit, nil)
-
-			conn.inject(mustCommand(protocol.CmdKill, struct{}{}))
-			waitForEventKind(conn, protocol.EventError, nil)
-			Expect(h.State()).To(Equal(protocol.StateSuspended))
-
-			conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
-			Eventually(fd.recordedCalls, "500ms", "10ms").
-				Should(ContainElement("Continue"))
+			expectResumable(conn, fd)
 		})
 
 		It("lets a retry Kill reach the debugger after the first fails", func() {
 			conn := newFakeWSConn()
 			mustAddClient(h, conn)
-			fd.killErr = errors.New("kill failed")
-
-			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
-				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
-			waitForEventKind(conn, protocol.EventBreakpointHit, nil)
-
-			conn.inject(mustCommand(protocol.CmdKill, struct{}{}))
-			// The rejection surfaces as an EventError, which also serves as a
-			// happens-before barrier before the transient failure is cleared.
-			waitForEventKind(conn, protocol.EventError, nil)
-			Expect(countCalls(fd.recordedCalls(), "Kill")).To(Equal(1))
+			refuseKillWhileSuspended(h, conn, fd)
+			expectCallCount(fd, "Kill", 1, "the rejected Kill ran exactly once")
 
 			fd.killErr = nil
 			conn.inject(mustCommand(protocol.CmdKill, struct{}{}))
-			Eventually(func() int {
-				return countCalls(fd.recordedCalls(), "Kill")
-			}, "500ms", "10ms").Should(Equal(2),
+			expectCallCount(fd, "Kill", 2,
 				"retry Kill must reach the debugger after a failed Kill")
 		})
 	})
@@ -894,23 +866,15 @@ var _ = Describe("Hub", func() {
 			conn := newFakeWSConn()
 			mustAddClient(h, conn)
 			fd.continueErr = errors.New("reinstall failed")
+			suspendAtBreakpoint(conn, fd)
 
-			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
-				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
-			waitForEventKind(conn, protocol.EventBreakpointHit, nil)
-
-			conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
 			// The rejected resume surfaces as an EventError; it also serves as a
 			// happens-before barrier before we clear the transient error below.
-			waitForEventKind(conn, protocol.EventError, nil)
-			Expect(countCalls(fd.recordedCalls(), "Continue")).To(Equal(1))
+			expectRejectedWhileSuspended(h, conn, mustCommand(protocol.CmdContinue, struct{}{}))
+			expectCallCount(fd, "Continue", 1, "the rejected resume ran exactly once")
 
 			fd.continueErr = nil
-			conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
-			Eventually(func() int {
-				return countCalls(fd.recordedCalls(), "Continue")
-			}, "500ms", "10ms").Should(Equal(2),
-				"retry resume must reach the debugger after a failed resume")
+			expectResumable(conn, fd)
 		})
 
 		It("still resumes via Continue after a failed StepOver", func() {
@@ -1168,6 +1132,15 @@ func launchManaged(conn *fakeWSConn, fd *fakeDebugger, program string) {
 	_, _ = recvEvent(conn) // state -> running
 }
 
+// attachManaged is launchManaged's counterpart for an Attach-based session.
+// Attach clears lastLaunch, so the session has no binary Restart could
+// relaunch — the setup for every "Restart is refused" scenario.
+func attachManaged(conn *fakeWSConn, fd *fakeDebugger, pid int) {
+	conn.inject(mustCommand(protocol.CmdAttach, protocol.AttachPayload{PID: pid}))
+	EventuallyWithOffset(1, fd.recordedCalls, "500ms", "10ms").Should(ContainElement("Attach"))
+	_, _ = recvEvent(conn) // state -> running
+}
+
 // waitForEventKind polls conn until an event of the given kind arrives,
 // decoding it into out (if non-nil) before returning.
 func waitForEventKind(conn *fakeWSConn, kind protocol.EventKind, out any) {
@@ -1300,6 +1273,55 @@ var _ = Describe("Suspend safety timeout", func() {
 	})
 })
 
+// expectCallCount waits until name has been dispatched to fd exactly want
+// times, then holds — catching both a missing dispatch and a duplicate one.
+func expectCallCount(fd *fakeDebugger, name string, want int, msg string) {
+	EventuallyWithOffset(1, func() int {
+		return countCalls(fd.recordedCalls(), name)
+	}, "500ms", "10ms").Should(Equal(want), msg)
+}
+
+// suspendAtBreakpoint pushes a BreakpointHit from fd and waits for conn to
+// observe it, leaving the hub parked in the suspend-wait loop. The pushed seq
+// is cosmetic — the hub re-stamps every outbound event with its own counter.
+func suspendAtBreakpoint(conn *fakeWSConn, fd *fakeDebugger) {
+	fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+		protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+	waitForEventKind(conn, protocol.EventBreakpointHit, nil)
+}
+
+// expectRejectedWhileSuspended injects cmd and waits for the resulting
+// EventError, then asserts the session is untouched — still suspended, with
+// the original process alive. The error also serves as a happens-before
+// barrier for anything the caller mutates afterwards.
+func expectRejectedWhileSuspended(h *hub.Hub, conn *fakeWSConn, cmd protocol.Command) {
+	conn.inject(cmd)
+	waitForEventKind(conn, protocol.EventError, nil)
+	ExpectWithOffset(1, h.State()).To(Equal(protocol.StateSuspended))
+}
+
+// expectResumable proves the hub is still parked in the suspend-wait loop by
+// driving one more Continue through to the debugger. That loop is the only
+// drainer of resumeCh (Run's outer select never reads it), so a Continue that
+// lands is proof the suspend was not abandoned.
+func expectResumable(conn *fakeWSConn, fd *fakeDebugger) {
+	want := countCalls(fd.recordedCalls(), "Continue") + 1
+	conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
+	EventuallyWithOffset(1, func() int {
+		return countCalls(fd.recordedCalls(), "Continue")
+	}, "500ms", "10ms").Should(Equal(want),
+		"resume must still reach the debugger while suspended")
+}
+
+// refuseKillWhileSuspended parks the hub at a breakpoint behind a debugger
+// that refuses Kill, then drives that rejected Kill — the shared starting
+// state for every "a failed Kill must not dissolve the suspend" scenario.
+func refuseKillWhileSuspended(h *hub.Hub, conn *fakeWSConn, fd *fakeDebugger) {
+	fd.killErr = errors.New("kill failed")
+	suspendAtBreakpoint(conn, fd)
+	expectRejectedWhileSuspended(h, conn, mustCommand(protocol.CmdKill, struct{}{}))
+}
+
 var _ = Describe("Restart", func() {
 	var fd *fakeDebugger
 
@@ -1331,8 +1353,7 @@ var _ = Describe("Restart", func() {
 		_, conn, cancel := newManagedRestartHub(fd)
 		defer cancel()
 
-		conn.inject(mustCommand(protocol.CmdAttach, protocol.AttachPayload{PID: 123}))
-		Eventually(fd.recordedCalls, "500ms", "10ms").Should(ContainElement("Attach"))
+		attachManaged(conn, fd, 123)
 
 		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
 		waitForEventKind(conn, protocol.EventError, nil)
@@ -1386,10 +1407,7 @@ var _ = Describe("Restart", func() {
 		managed, conn, cancel := newManagedRestartHub(fd)
 		defer cancel()
 		launchManaged(conn, fd, "myapp")
-
-		fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
-			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
-		waitForEventKind(conn, protocol.EventBreakpointHit, nil)
+		suspendAtBreakpoint(conn, fd)
 
 		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
 		waitForEventKind(conn, protocol.EventRestarted, nil)
@@ -1397,13 +1415,8 @@ var _ = Describe("Restart", func() {
 
 		// Run's outer loop owns the relaunched debugger's events again: a
 		// fresh stop suspends the hub and a Continue resumes it.
-		fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 2,
-			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
-		waitForEventKind(conn, protocol.EventBreakpointHit, nil)
-
-		conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
-		Eventually(fd.recordedCalls, "500ms", "10ms").
-			Should(ContainElement("Continue"))
+		suspendAtBreakpoint(conn, fd)
+		expectResumable(conn, fd)
 	})
 
 	// Restart is refused before it touches the debugger or the session state
@@ -1413,32 +1426,19 @@ var _ = Describe("Restart", func() {
 	It("stays resumable when Restart is rejected while suspended", func() {
 		managed, conn, cancel := newManagedRestartHub(fd)
 		defer cancel()
+		attachManaged(conn, fd, 123)
+		suspendAtBreakpoint(conn, fd)
 
-		// Attach leaves lastLaunch nil, so Restart has no binary to relaunch.
-		conn.inject(mustCommand(protocol.CmdAttach, protocol.AttachPayload{PID: 123}))
-		Eventually(fd.recordedCalls, "500ms", "10ms").Should(ContainElement("Attach"))
-
-		fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
-			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
-		waitForEventKind(conn, protocol.EventBreakpointHit, nil)
-
-		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
-		waitForEventKind(conn, protocol.EventError, nil)
-		Expect(managed.State()).To(Equal(protocol.StateSuspended))
-
-		conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
-		Eventually(fd.recordedCalls, "500ms", "10ms").
-			Should(ContainElement("Continue"))
+		expectRejectedWhileSuspended(managed, conn,
+			mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		expectResumable(conn, fd)
 	})
 
 	It("goes idle and leaves the suspend loop when the relaunch fails", func() {
 		managed, conn, cancel := newManagedRestartHub(fd)
 		defer cancel()
 		launchManaged(conn, fd, "myapp")
-
-		fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
-			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
-		waitForEventKind(conn, protocol.EventBreakpointHit, nil)
+		suspendAtBreakpoint(conn, fd)
 
 		fd.launchErr = errors.New("relaunch failed")
 		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -29,6 +29,7 @@ type fakeDebugger struct {
 
 	launchErr        error
 	attachErr        error
+	killErr          error
 	setBPResult      protocol.Breakpoint
 	setBPErr         error
 	setBPGate        chan struct{}
@@ -79,7 +80,7 @@ func (f *fakeDebugger) Attach(pid int, binaryPath string) error {
 	f.record("Attach")
 	return f.attachErr
 }
-func (f *fakeDebugger) Kill() error { f.record("Kill"); return nil }
+func (f *fakeDebugger) Kill() error { f.record("Kill"); return f.killErr }
 func (f *fakeDebugger) Continue() error {
 	f.record("Continue")
 	if f.continueErr == nil && f.emitContinued {
@@ -714,6 +715,81 @@ var _ = Describe("Hub", func() {
 			conn.inject(mustCommand(protocol.CmdKill, struct{}{}))
 			Eventually(fd.recordedCalls, "500ms", "10ms").
 				Should(ContainElement("Kill"))
+
+			// A successful Kill performs no state transition of its own, so
+			// the hub stays parked in the suspend-wait loop until the debugger
+			// reports its own teardown. A real engine closes Events (AGENTS.md
+			// → engine shutdown sequence); the loop must end the session on
+			// that signal rather than inferring death from the command kind.
+			fd.closeEvents()
+			Eventually(h.Done(), "1s", "10ms").Should(BeClosed())
+		})
+	})
+
+	// A Restart rejected before it touches the debugger, or a Kill the
+	// debugger refuses, leaves the original process suspended. The hub must
+	// stay in the suspend-wait loop — the only loop that drains resumeCh
+	// (Run's outer select never selects on it) — or every later resume is
+	// stranded and the session is wedged with a live, frozen tracee.
+	Describe("rejected Restart or failed Kill keeps the hub suspended", func() {
+		It("stays resumable after a raw hub rejects Restart", func() {
+			conn := newFakeWSConn()
+			mustAddClient(h, conn)
+
+			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+			waitForEventKind(conn, protocol.EventBreakpointHit, nil)
+
+			// hub.New has no session ID and no debugger factory, so Restart is
+			// refused without touching h.dbg or the state.
+			conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+			waitForEventKind(conn, protocol.EventError, nil)
+			Expect(h.State()).To(Equal(protocol.StateSuspended))
+
+			conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
+			Eventually(fd.recordedCalls, "500ms", "10ms").
+				Should(ContainElement("Continue"))
+		})
+
+		It("stays resumable after a failed Kill", func() {
+			conn := newFakeWSConn()
+			mustAddClient(h, conn)
+			fd.killErr = errors.New("kill failed")
+
+			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+			waitForEventKind(conn, protocol.EventBreakpointHit, nil)
+
+			conn.inject(mustCommand(protocol.CmdKill, struct{}{}))
+			waitForEventKind(conn, protocol.EventError, nil)
+			Expect(h.State()).To(Equal(protocol.StateSuspended))
+
+			conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
+			Eventually(fd.recordedCalls, "500ms", "10ms").
+				Should(ContainElement("Continue"))
+		})
+
+		It("lets a retry Kill reach the debugger after the first fails", func() {
+			conn := newFakeWSConn()
+			mustAddClient(h, conn)
+			fd.killErr = errors.New("kill failed")
+
+			fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+				protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+			waitForEventKind(conn, protocol.EventBreakpointHit, nil)
+
+			conn.inject(mustCommand(protocol.CmdKill, struct{}{}))
+			// The rejection surfaces as an EventError, which also serves as a
+			// happens-before barrier before the transient failure is cleared.
+			waitForEventKind(conn, protocol.EventError, nil)
+			Expect(countCalls(fd.recordedCalls(), "Kill")).To(Equal(1))
+
+			fd.killErr = nil
+			conn.inject(mustCommand(protocol.CmdKill, struct{}{}))
+			Eventually(func() int {
+				return countCalls(fd.recordedCalls(), "Kill")
+			}, "500ms", "10ms").Should(Equal(2),
+				"retry Kill must reach the debugger after a failed Kill")
 		})
 	})
 
@@ -1306,17 +1382,71 @@ var _ = Describe("Restart", func() {
 		Expect(restarted.Discarded[0].Reason).To(Equal("no such line"))
 	})
 
-	It("unblocks a suspended hub, same as Kill", func() {
-		_, conn, cancel := newManagedRestartHub(fd)
+	It("leaves the suspend loop once the relaunch succeeds", func() {
+		managed, conn, cancel := newManagedRestartHub(fd)
 		defer cancel()
 		launchManaged(conn, fd, "myapp")
 
 		fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
 			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
-		_, _ = recvEvent(conn)
+		waitForEventKind(conn, protocol.EventBreakpointHit, nil)
 
 		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
 		waitForEventKind(conn, protocol.EventRestarted, nil)
+		Expect(managed.State()).To(Equal(protocol.StateRunning))
+
+		// Run's outer loop owns the relaunched debugger's events again: a
+		// fresh stop suspends the hub and a Continue resumes it.
+		fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 2,
+			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+		waitForEventKind(conn, protocol.EventBreakpointHit, nil)
+
+		conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
+		Eventually(fd.recordedCalls, "500ms", "10ms").
+			Should(ContainElement("Continue"))
+	})
+
+	// Restart is refused before it touches the debugger or the session state
+	// when there is no relaunchable binary. The suspended process is untouched,
+	// so the hub must stay in the suspend-wait loop — the only loop that
+	// drains resumeCh — instead of stranding every later resume.
+	It("stays resumable when Restart is rejected while suspended", func() {
+		managed, conn, cancel := newManagedRestartHub(fd)
+		defer cancel()
+
+		// Attach leaves lastLaunch nil, so Restart has no binary to relaunch.
+		conn.inject(mustCommand(protocol.CmdAttach, protocol.AttachPayload{PID: 123}))
+		Eventually(fd.recordedCalls, "500ms", "10ms").Should(ContainElement("Attach"))
+
+		fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+		waitForEventKind(conn, protocol.EventBreakpointHit, nil)
+
+		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		waitForEventKind(conn, protocol.EventError, nil)
+		Expect(managed.State()).To(Equal(protocol.StateSuspended))
+
+		conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
+		Eventually(fd.recordedCalls, "500ms", "10ms").
+			Should(ContainElement("Continue"))
+	})
+
+	It("goes idle and leaves the suspend loop when the relaunch fails", func() {
+		managed, conn, cancel := newManagedRestartHub(fd)
+		defer cancel()
+		launchManaged(conn, fd, "myapp")
+
+		fd.push(protocol.MustEvent(protocol.EventBreakpointHit, 1,
+			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{ID: 1}}))
+		waitForEventKind(conn, protocol.EventBreakpointHit, nil)
+
+		fd.launchErr = errors.New("relaunch failed")
+		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		waitForEventKind(conn, protocol.EventError, nil)
+
+		// A failed relaunch discards the old debugger, so the suspended
+		// process is genuinely gone and the loop must not keep waiting.
+		Eventually(managed.State, "500ms", "10ms").Should(Equal(protocol.StateIdle))
 	})
 })
 


### PR DESCRIPTION
Fixes #174

## Problem

`Hub.handleEvent`'s suspend-wait loop decided whether to abandon the suspend from the **command kind alone**:

```go
h.executeCommand(cc.cmd)
if cc.cmd.Kind == protocol.CmdRestart || cc.cmd.Kind == protocol.CmdKill {
    return
}
```

The comment's premise — "the process we were waiting to resume no longer exists" — only holds when the command *succeeded*. Several paths reach that `return` with the tracee still alive and the hub still `StateSuspended`:

- **Restart rejected before it touches anything** — `handleRestart` returns early for a raw hub (`sessionID == ""` / no `newDebugger`), for `lastLaunch == nil` (an Attach-based session or no prior Launch), and for a malformed `RestartPayload`. Each broadcasts an `EventError` and changes nothing.
- **Failed `Kill`** — `executeCommand`'s dispatch-error branch broadcasts an `EventError` with no state transition.

The return is unrecoverable: `Run`'s outer `select` reads `ctx.Done()`, `shutdownCh`, `eventsCh()` and `cmdCh`, but **never `resumeCh`**, and `injectCommand` routes every `Continue`/`Step*` to the capacity-1 `resumeCh`. So the first resume fills the buffer, every later one is dropped, and the session is permanently wedged in `suspended` with a live, frozen tracee. On a raw hub `Restart` can never succeed, so only tearing down every client recovers it.

This is the same invariant #95 established for the `resumeCh` branch, which was never extended to `cmdCh`.

## Fix

Key the exit off the observed state, exactly like the `resumeCh` branch:

```go
h.executeCommand(cc.cmd)
if h.State() != protocol.StateSuspended {
    return
}
```

Exhaustive over the outcomes:

| Outcome | State | Loop |
| --- | --- | --- |
| Successful Restart | `running` | returns (unchanged) |
| Restart whose relaunch fails | `idle`, old debugger discarded | returns (unchanged) |
| Restart rejected before touching state | `suspended` | **stays — fixed** |
| Failed `Kill` | `suspended` | **stays — fixed, retry works** |
| Successful `Kill` | `suspended` (Kill has no state case) | stays until the debugger's own teardown |
| Non-resuming command | `suspended` | stays (unchanged) |

The successful-`Kill` row is safe and strictly more accurate than inferring death from a kind: a real engine tears itself down on `Kill` (AGENTS.md → engine shutdown sequence: `StopExited` → `stateExited` → `drainCmds` → close `done`, then close `events`), and the wait loop's `case nextEvt, ok := <-h.eventsCh():` already handles both `EventProcessExited` and the channel close.

No refactor, no protocol change, no backend change — one branch condition plus tests and docs.

## Reproduction

Both cases reproduce deterministically with the existing `internal/hub` fakes. Against `0509b53` (pre-fix):

```
Continue never reached the debugger after rejected Restart: calls=[Attach]
Continue never reached the debugger after failed Kill:      calls=[Kill]
```

Runtime equivalent: attach a managed session to a PID, hit a breakpoint, send `Restart` (rejected: no relaunchable binary), then send `Continue` — nothing happens, forever.

## Tests

New specs in `internal/hub/hub_test.go`, all using the existing `fakeDebugger`/`fakeWSConn` (added a `killErr` seam to the fake so `Kill` can fail):

- *stays resumable after a raw hub rejects Restart* — **fails without the fix**
- *stays resumable after a failed Kill* — **fails without the fix**
- *stays resumable when Restart is rejected while suspended* (managed, Attach-based) — **fails without the fix**
- *lets a retry Kill reach the debugger after the first fails*
- *goes idle and leaves the suspend loop when the relaunch fails*
- *leaves the suspend loop once the relaunch succeeds* (was "unblocks a suspended hub, same as Kill") — now also asserts `StateRunning` and that Run's outer loop resumed ownership: a fresh `BreakpointHit` re-suspends and a `Continue` resumes
- *still terminates the process while suspended* — extended to assert that after a successful `Kill` the session ends when the debugger closes its `Events` channel

Verified the three regression gates fail on the unpatched `hub.go` (`42 Passed | 3 Failed`) and pass with it.

## Verification

```
gofmt -l internal/hub/ && go tool goimports -l internal/hub/     # clean
go vet -tags bingonative ./internal/hub/... ./internal/server/... ./internal/dap/... ./pkg/client/...   # clean
go test -tags bingonative -race ./internal/hub ./internal/server ./internal/dap ./pkg/client   # all ok
go test -tags bingonative ./...                                   # all ok
internal/hub race suite repeated 5x                               # stable, no flakes
```

## Docs

`AGENTS.md` updated in the same commit — the "Suspend/resume protocol" and "Restart — hub-level, not engine-level" sections documented the kind-based return as intentional. They now state the invariant: **leaving the wait loop is decided by observed state, never by command kind**, with the exhaustive outcome table and the successful-`Kill` reasoning.