### PR TITLE
fix(dap): resync adapter state on rejected resumes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1114,6 +1114,15 @@ context; arrow navigation moves DOM focus with selection.
    (`pendingContinues++`). Restart reuses a `restarting` flag so the post-restart
    entry `EventStepped` is treated as a fresh entry.
 
+`restartReqSeq` separately gates only an unanswered DAP restart. A second
+request before `EventRestarted`/`EventError` is rejected without enqueueing
+another destructive `CmdRestart`; once the response is sent, a new restart is
+allowed even if the prior process's entry stop has not arrived yet. In that
+race, `onStop` suppresses the superseded entry while a newer `restartReqSeq` is
+pending and preserves `restarting` for the replacement process. This relies on
+the hub/client FIFO ordering each restart's `EventRestarted` before its own
+entry `EventStepped`.
+
 ### Joining an existing session (no relaunch)
 
 A DAP `attach` carrying a `session` argument and **no** `pid` means "join an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1156,9 +1156,11 @@ reason=step; `EventBreakpointHit`→`stopped` reason=breakpoint;
 `EventPanic`→reason=exception; `EventPaused`→reason=pause;
 `EventProcessExited`→`exited`(code)+`terminated`; `EventOutput`→`output`;
 `EventRestarted`→delayed `restart` response; `EventEvaluate`→`evaluate` response
-(correlated via `evalQ`, NOT a stop — see below); `EventSessionState`→ignored on
-the launch/attach path, but consumed **once** as the initial state on the join
-path (see *Joining an existing session*); `EventGoroutineSnapshot`→**deliberately
+(correlated via `evalQ`, NOT a stop — see below); `EventSessionState`→sends
+nothing on the launch/attach path (only recorded as the session's lifecycle
+state, which gates resume-rejection resync), but consumed **once** as the initial
+state on the join path (see *Joining an existing session*);
+`EventGoroutineSnapshot`→**deliberately
 ignored** (WebSocket-only concurrency stream with no DAP equivalent; translating
 it would corrupt the `threads`→`EventGoroutines` FIFO — see the goroutine
 snapshot section).
@@ -1189,8 +1191,27 @@ any stop).
 A rejected Continue/Step also emits ONE `stopped` (reason `exception`, the
 rejection text in `Text`, `AllThreadsStopped`, current thread) — the only DAP
 message that can walk a client back after a successful resume response. Restart
-does NOT: its delayed error response already reports the failure while the client
-is still stopped. Invariants: the `pendingContinues` debt of a rejected Continue
+does NOT: its delayed error response already reports the failure, so whatever
+state the client was in remains current. Restart's restore is the **captured
+pre-request view** (`restartWasSuspended`, taken in `onRestart` before the
+optimistic clear), never an unconditional suspend: DAP permits restart while the
+tracee is RUNNING, and the hub rejects a restart on an attach-created session
+(no prior `Launch`) without touching that still-running process — asserting a
+suspension there desynchronizes the adapter the *opposite* way, forwarding
+inspection requests for a process that never stopped. The capture is consumed by
+`failRestart` and cleared on success (`onRestarted`); an overlap rejection
+returns before touching it, so the in-flight request keeps its own.
+
+No resync happens once the session is **idle or exited** (`sessionEndedLocked`,
+fed by `EventSessionState` on every connection plus `EventProcessExited`). The
+hub's relaunch-failure path kills the old process, broadcasts the error, *then*
+transitions the managed session to idle, and answers every later command with
+"no active debugger" — reporting a stop there would leave the client stopped on
+a process that no longer exists. Outside a joiner's welcome, `onSessionState`
+only records that state (and drops a stale `suspended` on idle/exited); it sends
+nothing, since process death is already reported by `EventProcessExited`.
+
+Further invariants: the `pendingContinues` debt of a rejected Continue
 is settled exactly once (its `EventContinued` never arrives); no second `stopped`
 is emitted while the handler is already `suspended` (a real stop won the race) or
 while the handshake still owes an initial state report — `launching` (the entry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1171,6 +1171,35 @@ client on the session arrives with the counter at 0 and IS surfaced as
 `continued`, so the IDE learns the tracee is running again. This is exactly why
 the prerequisite PR made the engine emit `EventContinued` on resume.
 
+**Rejected resumes must resynchronize the adapter (`failResume`/`failRestart`).**
+`onContinue`/`onStep`/`onRestart` clear `suspended` *optimistically* and answer
+their request `success` — DAP has no way to retract a successful `continue`/
+`next` response. But the hub only transitions to `running` on success: a rejected
+`Continue`/`StepOver`/`StepInto`/`StepOut`/`Restart` arrives as `EventError` with
+the engine still `stateSuspended` (see [Suspend/resume
+protocol](#suspendresume-protocol) → Rejected resumes). So `onError` MUST restore
+`suspended = true` for every one of those command kinds — all three step kinds
+handled explicitly, never left to the generic console `default`. Otherwise
+`threads`/`stackTrace`/`variables`/`evaluate` take their not-suspended branch
+forever, answering synthetically without reaching the hub, and the IDE shows a
+running program that can never stop again (the routine trigger is `stepOut` at
+the outermost frame, which `engine.stepOut` rejects without resuming or emitting
+any stop).
+
+A rejected Continue/Step also emits ONE `stopped` (reason `exception`, the
+rejection text in `Text`, `AllThreadsStopped`, current thread) — the only DAP
+message that can walk a client back after a successful resume response. Restart
+does NOT: its delayed error response already reports the failure while the client
+is still stopped. Invariants: the `pendingContinues` debt of a rejected Continue
+is settled exactly once (its `EventContinued` never arrives); no second `stopped`
+is emitted while the handler is already `suspended` (a real stop won the race) or
+while the handshake still owes an initial state report — `launching` (the entry
+stop) or a joiner's `awaitingWelcome` (the hub's welcome `EventSessionState`,
+which another client's rejection can race between `AddClient` and delivery); and
+recovery does NOT route through `onStop` — the process never moved, so the
+current suspension's `varCache` stays valid and the `launching`/`restarting`
+latches are untouched.
+
 ### Request → command + the FIFO-correlation limitation
 
 `continue`→Continue; `next/stepIn/stepOut`→StepOver/Into/Out; `pause`→Pause;

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -49,12 +49,18 @@ func (h *Handler) translateEvent(evt protocol.Event) {
 	}
 }
 
-// onSessionState consumes the hub's welcome EventSessionState for a JOINING
-// connection, reflecting the shared session's current run state as the joiner's
-// initial DAP state: a `stopped` if already suspended, `terminated` if already
-// exited, nothing while idle/running. It fires at most once (gated on
+// onSessionState records the managed session's lifecycle state and, for a
+// JOINING connection, consumes the hub's welcome EventSessionState, reflecting
+// the shared session's current run state as the joiner's initial DAP state: a
+// `stopped` if already suspended, `terminated` if already exited, nothing while
+// idle/running. The welcome translation fires at most once (gated on
 // awaitingWelcome) and is a no-op for the normal launch/attach path, where
 // awaitingWelcome is never set.
+//
+// Outside that welcome, the state is only recorded — with one exception: idle
+// and exited mean the process is gone (a failed relaunch leaves a managed
+// session idle), so a stale suspended view is dropped. Nothing is sent; process
+// death is already reported by EventProcessExited.
 func (h *Handler) onSessionState(evt protocol.Event) {
 	var p protocol.SessionStatePayload
 	if err := protocol.DecodeEventPayload(evt, &p); err != nil {
@@ -62,7 +68,11 @@ func (h *Handler) onSessionState(evt protocol.Event) {
 	}
 
 	h.mu.Lock()
+	h.sessionState = p.State
 	if !h.awaitingWelcome {
+		if h.sessionEndedLocked() {
+			h.suspended = false
+		}
 		h.mu.Unlock()
 		return
 	}
@@ -194,6 +204,7 @@ func (h *Handler) onProcessExited(evt protocol.Event) {
 
 	h.mu.Lock()
 	h.suspended = false
+	h.sessionState = protocol.StateExited
 	h.mu.Unlock()
 
 	h.send(&godap.ExitedEvent{Event: h.event("exited"), Body: godap.ExitedEventBody{ExitCode: p.ExitCode}})
@@ -363,6 +374,9 @@ func (h *Handler) onRestarted(evt protocol.Event) {
 	h.mu.Lock()
 	seq := h.restartReqSeq
 	h.restartReqSeq = 0
+	// The relaunch succeeded, so the captured pre-request view is obsolete: the
+	// new process reports its own state through its entry stop.
+	h.restartWasSuspended = false
 	var discarded []godap.Breakpoint
 	if decoded {
 		discarded = h.reconcileRestartBreakpointsLocked(p)
@@ -524,8 +538,9 @@ func (h *Handler) failResume(kind protocol.CommandKind, msg string) {
 	// this client and the welcome being delivered. Skip while already
 	// suspended: a real stop won the race, or an earlier rejection already
 	// resynced, and the client's current `stopped` already describes this
-	// suspension.
-	resync := !h.suspended && !h.launching && !h.awaitingWelcome
+	// suspension. Skip once the session is idle/exited: there is no process to
+	// be stopped at, so the rejection is just the hub reporting that.
+	resync := !h.suspended && !h.launching && !h.awaitingWelcome && !h.sessionEndedLocked()
 	if resync {
 		h.suspended = true
 	}
@@ -549,17 +564,27 @@ func (h *Handler) failResume(kind protocol.CommandKind, msg string) {
 }
 
 // failRestart resolves a rejected CmdRestart: release the response gate and the
-// entry latch, and restore the suspended view onRestart optimistically cleared.
-// Unlike failResume it emits no `stopped` — the delayed error response tells the
-// client the restart failed while it was already stopped, so the client's
-// existing stopped state is still the current one.
+// entry latch, and restore the view onRestart optimistically cleared. Unlike
+// failResume it emits no `stopped` — the delayed error response tells the client
+// the restart failed, so whatever state the client was in remains the current
+// one.
+//
+// The restore is the CAPTURED pre-request view, not an unconditional suspend:
+// DAP allows restart while the tracee is running, and the hub rejects a restart
+// on an attach-created session (no prior Launch) without touching that still-
+// running process — claiming a suspension there would desynchronize the adapter
+// the opposite way. A relaunch that fails after the old process was killed
+// leaves the session idle, which likewise must not report a suspension.
 func (h *Handler) failRestart(msg string) {
 	h.mu.Lock()
 	seq := h.restartReqSeq
 	h.restartReqSeq = 0
 	h.restarting = false
 	if seq != 0 {
-		h.suspended = true
+		if h.restartWasSuspended && !h.sessionEndedLocked() {
+			h.suspended = true
+		}
+		h.restartWasSuspended = false
 	}
 	h.mu.Unlock()
 

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -138,6 +138,13 @@ func (h *Handler) onStop(evt protocol.Event) {
 
 	// The first Stepped after a Restart is the new process's entry stop.
 	if restarting && evt.Kind == protocol.EventStepped {
+		if h.restartReqSeq != 0 {
+			// EventRestarted precedes its process's entry in the hub/client FIFO.
+			// A pending newer response makes this the superseded process's entry;
+			// preserve the latch for the replacement process.
+			h.mu.Unlock()
+			return
+		}
 		h.restarting = false
 		if stopOnEntry {
 			h.suspended = true

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -471,23 +471,100 @@ func (h *Handler) onError(evt protocol.Event) {
 			h.send(h.errorResponse(seq, "evaluate", p.Message))
 		}
 	case protocol.CmdRestart:
-		h.mu.Lock()
-		seq := h.restartReqSeq
-		h.restartReqSeq = 0
-		h.restarting = false
-		h.mu.Unlock()
-		if seq != 0 {
-			h.send(h.errorResponse(seq, "restart", p.Message))
-		}
-	case protocol.CmdContinue:
-		h.mu.Lock()
-		if h.pendingContinues > 0 {
-			h.pendingContinues--
-		}
-		h.mu.Unlock()
-		h.emitConsole("continue failed: " + p.Message + "\n")
+		h.failRestart(p.Message)
+	case protocol.CmdContinue, protocol.CmdStepOver, protocol.CmdStepInto, protocol.CmdStepOut:
+		h.failResume(p.Command, p.Message)
 	default:
 		h.emitConsole("error: " + p.Message + "\n")
+	}
+}
+
+// resumeCommandName maps a rejected resuming command back to the DAP request
+// that issued it, for the console line reporting the failure.
+func resumeCommandName(kind protocol.CommandKind) string {
+	switch kind {
+	case protocol.CmdStepOver:
+		return "next"
+	case protocol.CmdStepInto:
+		return "stepIn"
+	case protocol.CmdStepOut:
+		return "stepOut"
+	default:
+		return "continue"
+	}
+}
+
+// failResume resynchronizes the adapter after the hub REJECTS a resume it has
+// already acknowledged as successful. onContinue/onStep answer optimistically
+// (DAP has no way to retract a successful continue/next response), but a
+// rejected resume leaves the engine suspended — see AGENTS.md → Suspend/resume
+// (Rejected resumes). Without this the adapter would keep suspended=false
+// forever: every later threads/stackTrace/variables/evaluate takes its
+// not-suspended branch and answers synthetically without reaching the hub, and
+// the IDE shows a running program that can never stop again. A `stopped` event
+// is the only DAP message that can walk the client back, so one is emitted with
+// the rejection text.
+//
+// Recovery deliberately does NOT go through onStop: the process never moved, so
+// the current suspension's varCache stays valid and the launching/restarting
+// latches must not be disturbed.
+func (h *Handler) failResume(kind protocol.CommandKind, msg string) {
+	h.mu.Lock()
+	if kind == protocol.CmdContinue && h.pendingContinues > 0 {
+		// The EventContinued this resume would have produced never arrives, so
+		// its suppression debt has to be settled here or the NEXT out-of-band
+		// continue would be swallowed instead of surfaced.
+		h.pendingContinues--
+	}
+	// Skip while the handshake still owns the initial state report and would
+	// send it after this: `launching` waits for the entry EventStepped (a
+	// `stopped` here would precede the launch response), and a joiner's
+	// `awaitingWelcome` waits for the hub's welcome EventSessionState, which
+	// can be raced by another client's rejection between AddClient registering
+	// this client and the welcome being delivered. Skip while already
+	// suspended: a real stop won the race, or an earlier rejection already
+	// resynced, and the client's current `stopped` already describes this
+	// suspension.
+	resync := !h.suspended && !h.launching && !h.awaitingWelcome
+	if resync {
+		h.suspended = true
+	}
+	tid := threadID(h.curThreadID)
+	h.mu.Unlock()
+
+	h.emitConsole(resumeCommandName(kind) + " failed: " + msg + "\n")
+	if !resync {
+		return
+	}
+	h.send(&godap.StoppedEvent{
+		Event: h.event("stopped"),
+		Body: godap.StoppedEventBody{
+			Reason:            "exception",
+			Description:       "runtime error",
+			Text:              msg,
+			ThreadId:          tid,
+			AllThreadsStopped: true,
+		},
+	})
+}
+
+// failRestart resolves a rejected CmdRestart: release the response gate and the
+// entry latch, and restore the suspended view onRestart optimistically cleared.
+// Unlike failResume it emits no `stopped` — the delayed error response tells the
+// client the restart failed while it was already stopped, so the client's
+// existing stopped state is still the current one.
+func (h *Handler) failRestart(msg string) {
+	h.mu.Lock()
+	seq := h.restartReqSeq
+	h.restartReqSeq = 0
+	h.restarting = false
+	if seq != 0 {
+		h.suspended = true
+	}
+	h.mu.Unlock()
+
+	if seq != 0 {
+		h.send(h.errorResponse(seq, "restart", msg))
 	}
 }
 

--- a/internal/dap/handler.go
+++ b/internal/dap/handler.go
@@ -92,6 +92,23 @@ type Handler struct {
 	restartReqSeq int
 	curThreadID   int
 
+	// restartWasSuspended is the suspended view this connection held when it
+	// issued the in-flight restart, captured before onRestart clears it
+	// optimistically. DAP permits restart while the tracee is RUNNING, and the
+	// hub rejects some restarts (an attach-created session, no prior Launch)
+	// without touching the process at all — so a rejected restart must restore
+	// exactly the prior view rather than unconditionally claiming a suspension
+	// that never existed.
+	restartWasSuspended bool
+
+	// sessionState is the last lifecycle state a managed hub broadcast. It stays
+	// empty for a raw hub (hub.New), which broadcasts none. idle/exited mean no
+	// live process, which is the one case a resume rejection must NOT be
+	// resynchronized into a suspension (see failResume/failRestart): the hub
+	// reports a failed relaunch as an error followed by idle, and answers every
+	// later command with "no active debugger".
+	sessionState protocol.SessionState
+
 	// pendingContinues counts Continue commands THIS adapter issued whose
 	// resulting EventContinued must be suppressed (a DAP adapter must not emit
 	// `continued` for a resume it initiated). Out-of-band continues from other
@@ -395,4 +412,11 @@ func (h *Handler) resetVarsLocked() {
 		h.varCache = make(map[int][]godap.Variable)
 	}
 	h.nextVarRef = 0
+}
+
+// sessionEndedLocked reports whether the hub has told us there is no live
+// process: a failed relaunch leaves a managed session idle, and a terminated one
+// exited. Caller MUST hold h.mu.
+func (h *Handler) sessionEndedLocked() bool {
+	return h.sessionState == protocol.StateIdle || h.sessionState == protocol.StateExited
 }

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -83,6 +83,32 @@ func (r *cmdRecorder) waitForCommands(t *testing.T, kind protocol.CommandKind, c
 	return nil
 }
 
+func (r *cmdRecorder) count(kind protocol.CommandKind) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := 0
+	for _, cmd := range r.cmds {
+		if cmd.Kind == kind {
+			count++
+		}
+	}
+	return count
+}
+
+func (r *cmdRecorder) requireNoAdditionalCommands(t *testing.T, kind protocol.CommandKind, expected int) {
+	t.Helper()
+	deadline := time.Now().Add(50 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if got := r.count(kind); got != expected {
+			t.Fatalf("%s command count = %d, want %d throughout quiet period; saw %v", kind, got, expected, r.kinds())
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if got := r.count(kind); got != expected {
+		t.Fatalf("%s command count = %d, want %d after quiet period; saw %v", kind, got, expected, r.kinds())
+	}
+}
+
 type fakeSession struct {
 	id      string
 	cmds    *cmdRecorder
@@ -777,15 +803,43 @@ func TestRestartRejectsOverlappingRequest(t *testing.T) {
 	if rejected.RequestSeq != secondSeq || rejected.Success || rejected.Message != "restart already in progress" {
 		t.Fatalf("overlapping restart response = %+v, want immediate error for request %d", rejected.Response, secondSeq)
 	}
-	if commands := hh.cmds.waitForCommands(t, protocol.CmdRestart, 1); len(commands) != 1 {
-		t.Fatalf("restart commands = %d, want exactly 1", len(commands))
-	}
+	hh.cmds.waitForCommands(t, protocol.CmdRestart, 1)
+	hh.cmds.requireNoAdditionalCommands(t, protocol.CmdRestart, 1)
 
 	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
 	restarted := recvType[*godap.RestartResponse](hh)
 	if restarted.RequestSeq != firstSeq || !restarted.Success {
 		t.Fatalf("restart response = %+v, want success for original request %d", restarted.Response, firstSeq)
 	}
+}
+
+func TestRestartAfterSuccessSupersedesPendingEntry(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+
+	firstSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	first := recvType[*godap.RestartResponse](hh)
+	if first.RequestSeq != firstSeq || !first.Success {
+		t.Fatalf("first restart response = %+v, want success for request %d", first.Response, firstSeq)
+	}
+
+	secondSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommands(t, protocol.CmdRestart, 2)
+
+	continues := hh.cmds.count(protocol.CmdContinue)
+	hh.inject(protocol.EventStepped, protocol.SteppedPayload{Goroutine: protocol.Goroutine{ID: 1}})
+	hh.cmds.requireNoAdditionalCommands(t, protocol.CmdContinue, continues)
+
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	second := recvType[*godap.RestartResponse](hh)
+	if second.RequestSeq != secondSeq || !second.Success {
+		t.Fatalf("second restart response = %+v, want success for request %d", second.Response, secondSeq)
+	}
+	hh.inject(protocol.EventStepped, protocol.SteppedPayload{Goroutine: protocol.Goroutine{ID: 2}})
+	hh.cmds.waitForCommands(t, protocol.CmdContinue, continues+1)
+	hh.inject(protocol.EventContinued, protocol.ContinuedPayload{})
 }
 
 func TestRestartErrorAllowsRetry(t *testing.T) {

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -1309,10 +1309,37 @@ func TestRejectedResumeWhileSuspendedDoesNotDuplicateStopped(t *testing.T) {
 	}
 }
 
-// TestRejectedRestartRestoresSuspendedWithoutStopped pins the restart variant:
-// the delayed error response already tells the client the restart failed while
-// it was stopped, so no extra stopped event may be sent — but the suspended
-// view onRestart cleared optimistically must still be restored.
+// requireSuspendedFlag asserts the handler's internal suspended view, which is
+// what gates whether inspection requests are forwarded to the hub.
+func requireSuspendedFlag(t *testing.T, hh *harness, want bool) {
+	t.Helper()
+	hh.handler.mu.Lock()
+	got := hh.handler.suspended
+	hh.handler.mu.Unlock()
+	if got != want {
+		t.Fatalf("handler suspended = %v, want %v", got, want)
+	}
+}
+
+// requireInspectionAnsweredSynthetically is the not-suspended counterpart of
+// requireInspectionReachesHub: a stackTrace must be answered locally with an
+// empty stack and must NOT enqueue a Frames command at the hub.
+func requireInspectionAnsweredSynthetically(t *testing.T, hh *harness) {
+	t.Helper()
+	before := hh.cmds.count(protocol.CmdFrames)
+	hh.sendReq("stackTrace", &godap.StackTraceRequest{Arguments: godap.StackTraceArguments{ThreadId: 7}})
+	st := recvType[*godap.StackTraceResponse](hh)
+	if len(st.Body.StackFrames) != 0 {
+		t.Fatalf("stack frames = %+v, want an empty synthetic answer", st.Body.StackFrames)
+	}
+	hh.cmds.requireNoAdditionalCommands(t, protocol.CmdFrames, before)
+}
+
+// TestRejectedRestartRestoresSuspendedWithoutStopped pins the restart variant
+// for a restart issued WHILE SUSPENDED: the delayed error response already tells
+// the client the restart failed while it was stopped, so no extra stopped event
+// may be sent — but the suspended view onRestart cleared optimistically must
+// still be restored.
 func TestRejectedRestartRestoresSuspendedWithoutStopped(t *testing.T) {
 	hh := newHarness(t)
 	hh.doHandshake(t)
@@ -1332,7 +1359,105 @@ func TestRejectedRestartRestoresSuspendedWithoutStopped(t *testing.T) {
 		t.Fatalf("restart response = %+v, want an error for request %d", failed.Response, restartSeq)
 	}
 
+	requireSuspendedFlag(t, hh, true)
 	requireInspectionReachesHub(t, hh)
+	requireNoStoppedEvent(t, hh, 150*time.Millisecond)
+}
+
+// TestRejectedRestartWhileRunningStaysRunning covers the inverse desync: DAP
+// permits restart while the tracee is running, and the hub rejects a restart on
+// an attach-created session without touching that still-running process. The
+// adapter must restore the RUNNING view it cleared, not invent a suspension —
+// otherwise it would forward inspection requests for a process that never
+// stopped.
+func TestRejectedRestartWhileRunningStaysRunning(t *testing.T) {
+	hh := newHarness(t)
+	// doHandshake leaves the session running with no stop delivered.
+	hh.doHandshake(t)
+	requireSuspendedFlag(t, hh, false)
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdRestart,
+		Message: "no launched process to restart — use Launch first",
+	})
+	failed := recvType[*godap.ErrorResponse](hh)
+	if failed.RequestSeq != restartSeq || failed.Success {
+		t.Fatalf("restart response = %+v, want an error for request %d", failed.Response, restartSeq)
+	}
+
+	requireSuspendedFlag(t, hh, false)
+	requireInspectionAnsweredSynthetically(t, hh)
+	requireNoStoppedEvent(t, hh, 150*time.Millisecond)
+}
+
+// TestRejectedRestartAfterFailedRelaunchDropsSuspended covers the hub's
+// relaunch-failure path: it kills the old process, reports the error, then
+// transitions the managed session to idle. There is no process left, so the
+// captured pre-request suspension must not be reasserted — and a retry restart
+// must still correlate to its own request.
+func TestRejectedRestartAfterFailedRelaunchDropsSuspended(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	suspendAtBreakpoint(t, hh)
+
+	firstSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdRestart,
+		Message: "restart: relaunch failed: fork/exec /bin/x: no such file or directory",
+	})
+	failed := recvType[*godap.ErrorResponse](hh)
+	if failed.RequestSeq != firstSeq || failed.Success {
+		t.Fatalf("restart response = %+v, want an error for request %d", failed.Response, firstSeq)
+	}
+	// The hub reports the teardown right after the error.
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{
+		SessionID: "sess-test", State: protocol.StateIdle, Clients: 1,
+	})
+
+	requireSuspendedFlag(t, hh, false)
+	requireInspectionAnsweredSynthetically(t, hh)
+
+	// Retry correlation survives: the gate was released, so a new restart is
+	// accepted and answered against its own request sequence.
+	secondSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommands(t, protocol.CmdRestart, 2)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != secondSeq || !restarted.Success {
+		t.Fatalf("retried restart response = %+v, want success for request %d", restarted.Response, secondSeq)
+	}
+	requireNoStoppedEvent(t, hh, 150*time.Millisecond)
+}
+
+// TestRejectedResumeAfterSessionEndedEmitsNoStopped pins the same lifecycle
+// guard for Continue/Step: once the session is idle or exited the hub answers
+// every command with "no active debugger", and fabricating a stop there would
+// leave the client stopped on a process that no longer exists.
+func TestRejectedResumeAfterSessionEndedEmitsNoStopped(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+
+	hh.inject(protocol.EventProcessExited, protocol.ProcessExitedPayload{ExitCode: 0})
+	_ = recvType[*godap.ExitedEvent](hh)
+	_ = recvType[*godap.TerminatedEvent](hh)
+
+	hh.sendReq("continue", &godap.ContinueRequest{Arguments: godap.ContinueArguments{ThreadId: 7}})
+	_ = recvType[*godap.ContinueResponse](hh)
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdContinue,
+		Message: "no active debugger — send Launch or Attach first",
+	})
+	out := recvType[*godap.OutputEvent](hh)
+	if out.Body.Output != "continue failed: no active debugger — send Launch or Attach first\n" {
+		t.Errorf("console output = %q", out.Body.Output)
+	}
+
+	requireSuspendedFlag(t, hh, false)
 	requireNoStoppedEvent(t, hh, 150*time.Millisecond)
 }
 

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -1082,22 +1082,79 @@ func TestDisconnectTerminatesLaunchedDebuggee(t *testing.T) {
 	hh.cmds.waitForCommand(t, protocol.CmdKill)
 }
 
-// suspendAtBreakpoint runs the handshake and parks the handler at a breakpoint
-// on goroutine 7, leaving it suspended with a delivered stopped event.
+// --- rejected run-control helpers ----------------------------------------------
+//
+// Every rejected-resume scenario shares the same shape: park the adapter in a
+// known run state, issue a run-control request it answers optimistically, then
+// inject the hub's EventError and assert how the adapter resynchronizes. These
+// helpers own the shared mechanics; each test still spells out its own state,
+// command kind and expected recovery so a failure names the exact scenario.
+
+// suspendAtBreakpoint parks the handler at a breakpoint on goroutine 7 and
+// consumes the resulting stopped event.
 func suspendAtBreakpoint(t *testing.T, hh *harness) {
 	t.Helper()
 	hh.inject(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{Goroutine: protocol.Goroutine{ID: 7}})
 	_ = recvType[*godap.StoppedEvent](hh)
 }
 
-// requireResumeFailureStopped reads the console line and the resynchronizing
-// stopped event a rejected resume must produce, in that order.
-func requireResumeFailureStopped(t *testing.T, hh *harness, wantCommand, wantMessage string) {
+// newSuspendedHarness completes the handshake and leaves the adapter suspended
+// at a breakpoint — the starting state for every rejected-resume scenario.
+func newSuspendedHarness(t *testing.T) *harness {
 	t.Helper()
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	suspendAtBreakpoint(t, hh)
+	return hh
+}
+
+// driveContinue issues a DAP continue on goroutine 7, consumes its optimistic
+// success response, and waits for the bingo command to reach the hub.
+func driveContinue(t *testing.T, hh *harness) {
+	t.Helper()
+	before := hh.cmds.count(protocol.CmdContinue)
+	hh.sendReq("continue", &godap.ContinueRequest{Arguments: godap.ContinueArguments{ThreadId: 7}})
+	_ = recvType[*godap.ContinueResponse](hh)
+	hh.cmds.waitForCommands(t, protocol.CmdContinue, before+1)
+}
+
+// sendStepRequest issues one DAP step request on goroutine 7 and consumes its
+// bare acknowledgement. The three kinds are spelled out rather than derived:
+// they share a wire shape but decode to distinct response types, and an explicit
+// case keeps a failure pointing at the exact step that broke.
+func sendStepRequest(t *testing.T, hh *harness, request string) {
+	t.Helper()
+	switch request {
+	case "next":
+		hh.sendReq(request, &godap.NextRequest{Arguments: godap.NextArguments{ThreadId: 7}})
+		_ = recvType[*godap.NextResponse](hh)
+	case "stepIn":
+		hh.sendReq(request, &godap.StepInRequest{Arguments: godap.StepInArguments{ThreadId: 7}})
+		_ = recvType[*godap.StepInResponse](hh)
+	case "stepOut":
+		hh.sendReq(request, &godap.StepOutRequest{Arguments: godap.StepOutArguments{ThreadId: 7}})
+		_ = recvType[*godap.StepOutResponse](hh)
+	default:
+		t.Fatalf("unknown step request %q", request)
+	}
+}
+
+// rejectResume injects the hub's rejection of an in-flight resume and asserts
+// the console line, which must name the DAP request that failed rather than the
+// generic "error:" the pre-fix default branch emitted.
+func rejectResume(t *testing.T, hh *harness, kind protocol.CommandKind, request, msg string) {
+	t.Helper()
+	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: kind, Message: msg})
 	out := recvType[*godap.OutputEvent](hh)
-	if want := wantCommand + " failed: " + wantMessage + "\n"; out.Body.Output != want {
+	if want := request + " failed: " + msg + "\n"; out.Body.Output != want {
 		t.Errorf("console output = %q, want %q", out.Body.Output, want)
 	}
+}
+
+// requireResyncStopped reads the stopped event a rejected Continue/Step must
+// send to walk the client back from the success response it already received.
+func requireResyncStopped(t *testing.T, hh *harness, wantMessage string) {
+	t.Helper()
 	stopped := recvType[*godap.StoppedEvent](hh)
 	if stopped.Body.Reason != "exception" {
 		t.Errorf("stopped reason = %q, want exception", stopped.Body.Reason)
@@ -1110,6 +1167,34 @@ func requireResumeFailureStopped(t *testing.T, hh *harness, wantCommand, wantMes
 	}
 	if stopped.Body.ThreadId != 7 {
 		t.Errorf("stopped threadId = %d, want the current thread 7", stopped.Body.ThreadId)
+	}
+}
+
+// rejectRestart sends a DAP restart, waits for the destructive command, injects
+// the hub's rejection, and asserts the delayed error response correlates back to
+// that request.
+func rejectRestart(t *testing.T, hh *harness, msg string) {
+	t.Helper()
+	before := hh.cmds.count(protocol.CmdRestart)
+	seq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommands(t, protocol.CmdRestart, before+1)
+
+	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: protocol.CmdRestart, Message: msg})
+	failed := recvType[*godap.ErrorResponse](hh)
+	if failed.RequestSeq != seq || failed.Success {
+		t.Fatalf("restart response = %+v, want an error for request %d", failed.Response, seq)
+	}
+}
+
+// requireSuspendedFlag asserts the handler's internal suspended view, which is
+// what gates whether inspection requests are forwarded to the hub.
+func requireSuspendedFlag(t *testing.T, hh *harness, want bool) {
+	t.Helper()
+	hh.handler.mu.Lock()
+	got := hh.handler.suspended
+	hh.handler.mu.Unlock()
+	if got != want {
+		t.Fatalf("handler suspended = %v, want %v", got, want)
 	}
 }
 
@@ -1141,6 +1226,20 @@ func requireInspectionReachesHub(t *testing.T, hh *harness) {
 	t.Fatal("timed out waiting for the hub-answered stackTrace response")
 }
 
+// requireInspectionAnsweredSynthetically is the not-suspended counterpart of
+// requireInspectionReachesHub: a stackTrace must be answered locally with an
+// empty stack and must NOT enqueue a Frames command at the hub.
+func requireInspectionAnsweredSynthetically(t *testing.T, hh *harness) {
+	t.Helper()
+	before := hh.cmds.count(protocol.CmdFrames)
+	hh.sendReq("stackTrace", &godap.StackTraceRequest{Arguments: godap.StackTraceArguments{ThreadId: 7}})
+	st := recvType[*godap.StackTraceResponse](hh)
+	if len(st.Body.StackFrames) != 0 {
+		t.Fatalf("stack frames = %+v, want an empty synthetic answer", st.Body.StackFrames)
+	}
+	hh.cmds.requireNoAdditionalCommands(t, protocol.CmdFrames, before)
+}
+
 // requireNoStoppedEvent fails if any stopped event arrives within the window.
 // It leaves the read deadline expired, so callers must not read afterwards.
 func requireNoStoppedEvent(t *testing.T, hh *harness, within time.Duration) {
@@ -1161,74 +1260,51 @@ func requireNoStoppedEvent(t *testing.T, hh *harness, within time.Duration) {
 	}
 }
 
+// quietWindow bounds the "nothing further arrives" assertions. Translation is
+// synchronous in inject, so an erroneous event is already on the wire long
+// before this elapses.
+const quietWindow = 150 * time.Millisecond
+
+// restartNoLaunchMsg is the hub's rejection for a session it cannot relaunch
+// (attach-created, or no prior Launch). It leaves the process untouched.
+const restartNoLaunchMsg = "no launched process to restart — use Launch first"
+
 // TestRejectedContinueRestoresSuspendedState covers the rejected Continue: the
 // adapter already answered the continue request successfully, so it must
 // resynchronize with the still-suspended engine and report a stop.
 func TestRejectedContinueRestoresSuspendedState(t *testing.T) {
-	hh := newHarness(t)
-	hh.doHandshake(t)
-	suspendAtBreakpoint(t, hh)
-
-	continues := hh.cmds.count(protocol.CmdContinue)
-	hh.sendReq("continue", &godap.ContinueRequest{Arguments: godap.ContinueArguments{ThreadId: 7}})
-	_ = recvType[*godap.ContinueResponse](hh)
-	hh.cmds.waitForCommands(t, protocol.CmdContinue, continues+1)
+	hh := newSuspendedHarness(t)
+	driveContinue(t, hh)
 
 	const msg = "Continue: reinstall breakpoint: write memory: permission denied"
-	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: protocol.CmdContinue, Message: msg})
-	requireResumeFailureStopped(t, hh, "continue", msg)
+	rejectResume(t, hh, protocol.CmdContinue, "continue", msg)
+	requireResyncStopped(t, hh, msg)
 	requireInspectionReachesHub(t, hh)
 }
 
 // TestRejectedStepRestoresSuspendedState covers every step kind: all three DAP
 // step requests share onStep's optimistic resume, so all three must be handled
 // explicitly in onError rather than falling into the generic console default.
+// Each kind is its own named subtest, so a regression names the failing step.
 func TestRejectedStepRestoresSuspendedState(t *testing.T) {
-	cases := []struct {
+	steps := []struct {
 		request string
 		kind    protocol.CommandKind
-		send    func(hh *harness)
-		recv    func(hh *harness)
 	}{
-		{
-			request: "next",
-			kind:    protocol.CmdStepOver,
-			send: func(hh *harness) {
-				hh.sendReq("next", &godap.NextRequest{Arguments: godap.NextArguments{ThreadId: 7}})
-			},
-			recv: func(hh *harness) { _ = recvType[*godap.NextResponse](hh) },
-		},
-		{
-			request: "stepIn",
-			kind:    protocol.CmdStepInto,
-			send: func(hh *harness) {
-				hh.sendReq("stepIn", &godap.StepInRequest{Arguments: godap.StepInArguments{ThreadId: 7}})
-			},
-			recv: func(hh *harness) { _ = recvType[*godap.StepInResponse](hh) },
-		},
-		{
-			request: "stepOut",
-			kind:    protocol.CmdStepOut,
-			send: func(hh *harness) {
-				hh.sendReq("stepOut", &godap.StepOutRequest{Arguments: godap.StepOutArguments{ThreadId: 7}})
-			},
-			recv: func(hh *harness) { _ = recvType[*godap.StepOutResponse](hh) },
-		},
+		{"next", protocol.CmdStepOver},
+		{"stepIn", protocol.CmdStepInto},
+		{"stepOut", protocol.CmdStepOut},
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.request, func(t *testing.T) {
-			hh := newHarness(t)
-			hh.doHandshake(t)
-			suspendAtBreakpoint(t, hh)
+	for _, step := range steps {
+		t.Run(step.request, func(t *testing.T) {
+			hh := newSuspendedHarness(t)
+			sendStepRequest(t, hh, step.request)
+			hh.cmds.waitForCommand(t, step.kind)
 
-			tc.send(hh)
-			tc.recv(hh)
-			hh.cmds.waitForCommand(t, tc.kind)
-
-			msg := string(tc.kind) + " rejected by the engine"
-			hh.inject(protocol.EventError, protocol.ErrorPayload{Command: tc.kind, Message: msg})
-			requireResumeFailureStopped(t, hh, tc.request, msg)
+			msg := string(step.kind) + " rejected by the engine"
+			rejectResume(t, hh, step.kind, step.request, msg)
+			requireResyncStopped(t, hh, msg)
 			requireInspectionReachesHub(t, hh)
 		})
 	}
@@ -1238,17 +1314,13 @@ func TestRejectedStepRestoresSuspendedState(t *testing.T) {
 // trigger: StepOut at the outermost frame fails in the engine before resuming
 // and emits no stop of its own.
 func TestRejectedOutermostStepOutRestoresInspection(t *testing.T) {
-	hh := newHarness(t)
-	hh.doHandshake(t)
-	suspendAtBreakpoint(t, hh)
-
-	hh.sendReq("stepOut", &godap.StepOutRequest{Arguments: godap.StepOutArguments{ThreadId: 7}})
-	_ = recvType[*godap.StepOutResponse](hh)
+	hh := newSuspendedHarness(t)
+	sendStepRequest(t, hh, "stepOut")
 	hh.cmds.waitForCommand(t, protocol.CmdStepOut)
 
 	const msg = "StepOut: null frame pointer — at outermost frame?"
-	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: protocol.CmdStepOut, Message: msg})
-	requireResumeFailureStopped(t, hh, "stepOut", msg)
+	rejectResume(t, hh, protocol.CmdStepOut, "stepOut", msg)
+	requireResyncStopped(t, hh, msg)
 	requireInspectionReachesHub(t, hh)
 }
 
@@ -1256,18 +1328,12 @@ func TestRejectedOutermostStepOutRestoresInspection(t *testing.T) {
 // of a rejected Continue is settled exactly once: the EventContinued it would
 // have produced never arrives, so the NEXT out-of-band continue must surface.
 func TestRejectedResumeSettlesContinueSuppression(t *testing.T) {
-	hh := newHarness(t)
-	hh.doHandshake(t)
-	suspendAtBreakpoint(t, hh)
-
-	continues := hh.cmds.count(protocol.CmdContinue)
-	hh.sendReq("continue", &godap.ContinueRequest{Arguments: godap.ContinueArguments{ThreadId: 7}})
-	_ = recvType[*godap.ContinueResponse](hh)
-	hh.cmds.waitForCommands(t, protocol.CmdContinue, continues+1)
+	hh := newSuspendedHarness(t)
+	driveContinue(t, hh)
 
 	const msg = "Continue: not suspended"
-	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: protocol.CmdContinue, Message: msg})
-	requireResumeFailureStopped(t, hh, "continue", msg)
+	rejectResume(t, hh, protocol.CmdContinue, "continue", msg)
+	requireResyncStopped(t, hh, msg)
 
 	// Another client drives the resume: with the debt settled this must be
 	// surfaced rather than suppressed as our own.
@@ -1282,57 +1348,15 @@ func TestRejectedResumeSettlesContinueSuppression(t *testing.T) {
 // that loses the race with a real stop: the client's existing stopped already
 // describes this suspension, so a second one must not be fabricated.
 func TestRejectedResumeWhileSuspendedDoesNotDuplicateStopped(t *testing.T) {
-	hh := newHarness(t)
-	hh.doHandshake(t)
-	suspendAtBreakpoint(t, hh)
-
-	hh.sendReq("continue", &godap.ContinueRequest{Arguments: godap.ContinueArguments{ThreadId: 7}})
-	_ = recvType[*godap.ContinueResponse](hh)
-	hh.cmds.waitForCommand(t, protocol.CmdContinue)
+	hh := newSuspendedHarness(t)
+	driveContinue(t, hh)
 
 	// A genuine stop lands first, putting the client back in a stopped state.
-	hh.inject(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{Goroutine: protocol.Goroutine{ID: 7}})
-	_ = recvType[*godap.StoppedEvent](hh)
+	suspendAtBreakpoint(t, hh)
 
-	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: protocol.CmdContinue, Message: "stale rejection"})
-	out := recvType[*godap.OutputEvent](hh)
-	if out.Body.Output != "continue failed: stale rejection\n" {
-		t.Errorf("console output = %q", out.Body.Output)
-	}
-	requireNoStoppedEvent(t, hh, 150*time.Millisecond)
-
-	hh.handler.mu.Lock()
-	suspended := hh.handler.suspended
-	hh.handler.mu.Unlock()
-	if !suspended {
-		t.Fatal("handler left the suspended state after a stale rejection")
-	}
-}
-
-// requireSuspendedFlag asserts the handler's internal suspended view, which is
-// what gates whether inspection requests are forwarded to the hub.
-func requireSuspendedFlag(t *testing.T, hh *harness, want bool) {
-	t.Helper()
-	hh.handler.mu.Lock()
-	got := hh.handler.suspended
-	hh.handler.mu.Unlock()
-	if got != want {
-		t.Fatalf("handler suspended = %v, want %v", got, want)
-	}
-}
-
-// requireInspectionAnsweredSynthetically is the not-suspended counterpart of
-// requireInspectionReachesHub: a stackTrace must be answered locally with an
-// empty stack and must NOT enqueue a Frames command at the hub.
-func requireInspectionAnsweredSynthetically(t *testing.T, hh *harness) {
-	t.Helper()
-	before := hh.cmds.count(protocol.CmdFrames)
-	hh.sendReq("stackTrace", &godap.StackTraceRequest{Arguments: godap.StackTraceArguments{ThreadId: 7}})
-	st := recvType[*godap.StackTraceResponse](hh)
-	if len(st.Body.StackFrames) != 0 {
-		t.Fatalf("stack frames = %+v, want an empty synthetic answer", st.Body.StackFrames)
-	}
-	hh.cmds.requireNoAdditionalCommands(t, protocol.CmdFrames, before)
+	rejectResume(t, hh, protocol.CmdContinue, "continue", "stale rejection")
+	requireNoStoppedEvent(t, hh, quietWindow)
+	requireSuspendedFlag(t, hh, true)
 }
 
 // TestRejectedRestartRestoresSuspendedWithoutStopped pins the restart variant
@@ -1341,27 +1365,12 @@ func requireInspectionAnsweredSynthetically(t *testing.T, hh *harness) {
 // may be sent — but the suspended view onRestart cleared optimistically must
 // still be restored.
 func TestRejectedRestartRestoresSuspendedWithoutStopped(t *testing.T) {
-	hh := newHarness(t)
-	hh.doHandshake(t)
-	suspendAtBreakpoint(t, hh)
-
-	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
-	hh.cmds.waitForCommand(t, protocol.CmdRestart)
-
-	// An attach-created session has no launch to relaunch, so the hub rejects
-	// the restart without touching the still-suspended process.
-	hh.inject(protocol.EventError, protocol.ErrorPayload{
-		Command: protocol.CmdRestart,
-		Message: "no launched process to restart — use Launch first",
-	})
-	failed := recvType[*godap.ErrorResponse](hh)
-	if failed.RequestSeq != restartSeq || failed.Success {
-		t.Fatalf("restart response = %+v, want an error for request %d", failed.Response, restartSeq)
-	}
+	hh := newSuspendedHarness(t)
+	rejectRestart(t, hh, restartNoLaunchMsg)
 
 	requireSuspendedFlag(t, hh, true)
 	requireInspectionReachesHub(t, hh)
-	requireNoStoppedEvent(t, hh, 150*time.Millisecond)
+	requireNoStoppedEvent(t, hh, quietWindow)
 }
 
 // TestRejectedRestartWhileRunningStaysRunning covers the inverse desync: DAP
@@ -1376,21 +1385,11 @@ func TestRejectedRestartWhileRunningStaysRunning(t *testing.T) {
 	hh.doHandshake(t)
 	requireSuspendedFlag(t, hh, false)
 
-	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
-	hh.cmds.waitForCommand(t, protocol.CmdRestart)
-
-	hh.inject(protocol.EventError, protocol.ErrorPayload{
-		Command: protocol.CmdRestart,
-		Message: "no launched process to restart — use Launch first",
-	})
-	failed := recvType[*godap.ErrorResponse](hh)
-	if failed.RequestSeq != restartSeq || failed.Success {
-		t.Fatalf("restart response = %+v, want an error for request %d", failed.Response, restartSeq)
-	}
+	rejectRestart(t, hh, restartNoLaunchMsg)
 
 	requireSuspendedFlag(t, hh, false)
 	requireInspectionAnsweredSynthetically(t, hh)
-	requireNoStoppedEvent(t, hh, 150*time.Millisecond)
+	requireNoStoppedEvent(t, hh, quietWindow)
 }
 
 // TestRejectedRestartAfterFailedRelaunchDropsSuspended covers the hub's
@@ -1399,39 +1398,26 @@ func TestRejectedRestartWhileRunningStaysRunning(t *testing.T) {
 // captured pre-request suspension must not be reasserted — and a retry restart
 // must still correlate to its own request.
 func TestRejectedRestartAfterFailedRelaunchDropsSuspended(t *testing.T) {
-	hh := newHarness(t)
-	hh.doHandshake(t)
-	suspendAtBreakpoint(t, hh)
+	hh := newSuspendedHarness(t)
+	rejectRestart(t, hh, "restart: relaunch failed: fork/exec /bin/x: no such file or directory")
 
-	firstSeq := hh.sendReq("restart", &godap.RestartRequest{})
-	hh.cmds.waitForCommand(t, protocol.CmdRestart)
-
-	hh.inject(protocol.EventError, protocol.ErrorPayload{
-		Command: protocol.CmdRestart,
-		Message: "restart: relaunch failed: fork/exec /bin/x: no such file or directory",
-	})
-	failed := recvType[*godap.ErrorResponse](hh)
-	if failed.RequestSeq != firstSeq || failed.Success {
-		t.Fatalf("restart response = %+v, want an error for request %d", failed.Response, firstSeq)
-	}
 	// The hub reports the teardown right after the error.
 	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{
 		SessionID: "sess-test", State: protocol.StateIdle, Clients: 1,
 	})
-
 	requireSuspendedFlag(t, hh, false)
 	requireInspectionAnsweredSynthetically(t, hh)
 
 	// Retry correlation survives: the gate was released, so a new restart is
 	// accepted and answered against its own request sequence.
-	secondSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	retrySeq := hh.sendReq("restart", &godap.RestartRequest{})
 	hh.cmds.waitForCommands(t, protocol.CmdRestart, 2)
 	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
 	restarted := recvType[*godap.RestartResponse](hh)
-	if restarted.RequestSeq != secondSeq || !restarted.Success {
-		t.Fatalf("retried restart response = %+v, want success for request %d", restarted.Response, secondSeq)
+	if restarted.RequestSeq != retrySeq || !restarted.Success {
+		t.Fatalf("retried restart response = %+v, want success for request %d", restarted.Response, retrySeq)
 	}
-	requireNoStoppedEvent(t, hh, 150*time.Millisecond)
+	requireNoStoppedEvent(t, hh, quietWindow)
 }
 
 // TestRejectedResumeAfterSessionEndedEmitsNoStopped pins the same lifecycle
@@ -1446,19 +1432,11 @@ func TestRejectedResumeAfterSessionEndedEmitsNoStopped(t *testing.T) {
 	_ = recvType[*godap.ExitedEvent](hh)
 	_ = recvType[*godap.TerminatedEvent](hh)
 
-	hh.sendReq("continue", &godap.ContinueRequest{Arguments: godap.ContinueArguments{ThreadId: 7}})
-	_ = recvType[*godap.ContinueResponse](hh)
-	hh.inject(protocol.EventError, protocol.ErrorPayload{
-		Command: protocol.CmdContinue,
-		Message: "no active debugger — send Launch or Attach first",
-	})
-	out := recvType[*godap.OutputEvent](hh)
-	if out.Body.Output != "continue failed: no active debugger — send Launch or Attach first\n" {
-		t.Errorf("console output = %q", out.Body.Output)
-	}
+	driveContinue(t, hh)
+	rejectResume(t, hh, protocol.CmdContinue, "continue", "no active debugger — send Launch or Attach first")
 
 	requireSuspendedFlag(t, hh, false)
-	requireNoStoppedEvent(t, hh, 150*time.Millisecond)
+	requireNoStoppedEvent(t, hh, quietWindow)
 }
 
 // TestRejectedResumeDuringJoinDefersToWelcome covers a joiner that receives
@@ -1475,15 +1453,8 @@ func TestRejectedResumeDuringJoinDefersToWelcome(t *testing.T) {
 	hh.sendReq("attach", &godap.AttachRequest{Arguments: json.RawMessage(`{"session":"sess-test"}`)})
 	_ = recvType[*godap.InitializedEvent](hh)
 
-	hh.inject(protocol.EventError, protocol.ErrorPayload{
-		Command: protocol.CmdContinue,
-		Message: "another client's continue failed",
-	})
-	out := recvType[*godap.OutputEvent](hh)
-	if out.Body.Output != "continue failed: another client's continue failed\n" {
-		t.Errorf("console output = %q", out.Body.Output)
-	}
-	requireNoStoppedEvent(t, hh, 150*time.Millisecond)
+	rejectResume(t, hh, protocol.CmdContinue, "continue", "another client's continue failed")
+	requireNoStoppedEvent(t, hh, quietWindow)
 
 	// The welcome still owns the initial state and reports the suspension.
 	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{
@@ -1517,8 +1488,8 @@ func TestRejectedAutoContinueRestoresSuspendedState(t *testing.T) {
 	hh.cmds.waitForCommand(t, protocol.CmdContinue)
 
 	const msg = "Continue: resume from breakpoint: single-step: no such process"
-	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: protocol.CmdContinue, Message: msg})
-	requireResumeFailureStopped(t, hh, "continue", msg)
+	rejectResume(t, hh, protocol.CmdContinue, "continue", msg)
+	requireResyncStopped(t, hh, msg)
 	requireInspectionReachesHub(t, hh)
 }
 

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -1082,6 +1082,321 @@ func TestDisconnectTerminatesLaunchedDebuggee(t *testing.T) {
 	hh.cmds.waitForCommand(t, protocol.CmdKill)
 }
 
+// suspendAtBreakpoint runs the handshake and parks the handler at a breakpoint
+// on goroutine 7, leaving it suspended with a delivered stopped event.
+func suspendAtBreakpoint(t *testing.T, hh *harness) {
+	t.Helper()
+	hh.inject(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{Goroutine: protocol.Goroutine{ID: 7}})
+	_ = recvType[*godap.StoppedEvent](hh)
+}
+
+// requireResumeFailureStopped reads the console line and the resynchronizing
+// stopped event a rejected resume must produce, in that order.
+func requireResumeFailureStopped(t *testing.T, hh *harness, wantCommand, wantMessage string) {
+	t.Helper()
+	out := recvType[*godap.OutputEvent](hh)
+	if want := wantCommand + " failed: " + wantMessage + "\n"; out.Body.Output != want {
+		t.Errorf("console output = %q, want %q", out.Body.Output, want)
+	}
+	stopped := recvType[*godap.StoppedEvent](hh)
+	if stopped.Body.Reason != "exception" {
+		t.Errorf("stopped reason = %q, want exception", stopped.Body.Reason)
+	}
+	if stopped.Body.Text != wantMessage {
+		t.Errorf("stopped text = %q, want %q", stopped.Body.Text, wantMessage)
+	}
+	if !stopped.Body.AllThreadsStopped {
+		t.Error("stopped allThreadsStopped = false, want true")
+	}
+	if stopped.Body.ThreadId != 7 {
+		t.Errorf("stopped threadId = %d, want the current thread 7", stopped.Body.ThreadId)
+	}
+}
+
+// requireInspectionReachesHub proves the handler considers itself suspended
+// again: a stackTrace must enqueue a Frames command instead of being answered
+// synthetically, and the correlated response must carry the injected frames. Any
+// stopped event arriving while it waits is a duplicate and fails the test.
+func requireInspectionReachesHub(t *testing.T, hh *harness) {
+	t.Helper()
+	before := hh.cmds.count(protocol.CmdFrames)
+	hh.sendReq("stackTrace", &godap.StackTraceRequest{Arguments: godap.StackTraceArguments{ThreadId: 7}})
+	hh.cmds.waitForCommands(t, protocol.CmdFrames, before+1)
+	hh.inject(protocol.EventFrames, protocol.FramesPayload{Frames: []protocol.Frame{
+		{Index: 0, Location: protocol.Location{Function: "main.f", File: "/x/main.go", Line: 12}},
+	}})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		switch m := hh.recv().(type) {
+		case *godap.StoppedEvent:
+			t.Fatalf("unexpected stopped event while inspecting: %+v", m.Body)
+		case *godap.StackTraceResponse:
+			if len(m.Body.StackFrames) != 1 {
+				t.Fatalf("stack frames = %+v, want the frame answered by the hub", m.Body.StackFrames)
+			}
+			return
+		}
+	}
+	t.Fatal("timed out waiting for the hub-answered stackTrace response")
+}
+
+// requireNoStoppedEvent fails if any stopped event arrives within the window.
+// It leaves the read deadline expired, so callers must not read afterwards.
+func requireNoStoppedEvent(t *testing.T, hh *harness, within time.Duration) {
+	t.Helper()
+	_ = hh.client.SetReadDeadline(time.Now().Add(within))
+	for {
+		data, err := godap.ReadBaseMessage(hh.reader)
+		if err != nil {
+			return
+		}
+		m, decodeErr := hh.codec.DecodeMessage(data)
+		if decodeErr != nil {
+			continue
+		}
+		if stopped, ok := m.(*godap.StoppedEvent); ok {
+			t.Fatalf("unexpected stopped event: %+v", stopped.Body)
+		}
+	}
+}
+
+// TestRejectedContinueRestoresSuspendedState covers the rejected Continue: the
+// adapter already answered the continue request successfully, so it must
+// resynchronize with the still-suspended engine and report a stop.
+func TestRejectedContinueRestoresSuspendedState(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	suspendAtBreakpoint(t, hh)
+
+	continues := hh.cmds.count(protocol.CmdContinue)
+	hh.sendReq("continue", &godap.ContinueRequest{Arguments: godap.ContinueArguments{ThreadId: 7}})
+	_ = recvType[*godap.ContinueResponse](hh)
+	hh.cmds.waitForCommands(t, protocol.CmdContinue, continues+1)
+
+	const msg = "Continue: reinstall breakpoint: write memory: permission denied"
+	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: protocol.CmdContinue, Message: msg})
+	requireResumeFailureStopped(t, hh, "continue", msg)
+	requireInspectionReachesHub(t, hh)
+}
+
+// TestRejectedStepRestoresSuspendedState covers every step kind: all three DAP
+// step requests share onStep's optimistic resume, so all three must be handled
+// explicitly in onError rather than falling into the generic console default.
+func TestRejectedStepRestoresSuspendedState(t *testing.T) {
+	cases := []struct {
+		request string
+		kind    protocol.CommandKind
+		send    func(hh *harness)
+		recv    func(hh *harness)
+	}{
+		{
+			request: "next",
+			kind:    protocol.CmdStepOver,
+			send: func(hh *harness) {
+				hh.sendReq("next", &godap.NextRequest{Arguments: godap.NextArguments{ThreadId: 7}})
+			},
+			recv: func(hh *harness) { _ = recvType[*godap.NextResponse](hh) },
+		},
+		{
+			request: "stepIn",
+			kind:    protocol.CmdStepInto,
+			send: func(hh *harness) {
+				hh.sendReq("stepIn", &godap.StepInRequest{Arguments: godap.StepInArguments{ThreadId: 7}})
+			},
+			recv: func(hh *harness) { _ = recvType[*godap.StepInResponse](hh) },
+		},
+		{
+			request: "stepOut",
+			kind:    protocol.CmdStepOut,
+			send: func(hh *harness) {
+				hh.sendReq("stepOut", &godap.StepOutRequest{Arguments: godap.StepOutArguments{ThreadId: 7}})
+			},
+			recv: func(hh *harness) { _ = recvType[*godap.StepOutResponse](hh) },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.request, func(t *testing.T) {
+			hh := newHarness(t)
+			hh.doHandshake(t)
+			suspendAtBreakpoint(t, hh)
+
+			tc.send(hh)
+			tc.recv(hh)
+			hh.cmds.waitForCommand(t, tc.kind)
+
+			msg := string(tc.kind) + " rejected by the engine"
+			hh.inject(protocol.EventError, protocol.ErrorPayload{Command: tc.kind, Message: msg})
+			requireResumeFailureStopped(t, hh, tc.request, msg)
+			requireInspectionReachesHub(t, hh)
+		})
+	}
+}
+
+// TestRejectedOutermostStepOutRestoresInspection pins the routine deterministic
+// trigger: StepOut at the outermost frame fails in the engine before resuming
+// and emits no stop of its own.
+func TestRejectedOutermostStepOutRestoresInspection(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	suspendAtBreakpoint(t, hh)
+
+	hh.sendReq("stepOut", &godap.StepOutRequest{Arguments: godap.StepOutArguments{ThreadId: 7}})
+	_ = recvType[*godap.StepOutResponse](hh)
+	hh.cmds.waitForCommand(t, protocol.CmdStepOut)
+
+	const msg = "StepOut: null frame pointer — at outermost frame?"
+	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: protocol.CmdStepOut, Message: msg})
+	requireResumeFailureStopped(t, hh, "stepOut", msg)
+	requireInspectionReachesHub(t, hh)
+}
+
+// TestRejectedResumeSettlesContinueSuppression proves the pendingContinues debt
+// of a rejected Continue is settled exactly once: the EventContinued it would
+// have produced never arrives, so the NEXT out-of-band continue must surface.
+func TestRejectedResumeSettlesContinueSuppression(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	suspendAtBreakpoint(t, hh)
+
+	continues := hh.cmds.count(protocol.CmdContinue)
+	hh.sendReq("continue", &godap.ContinueRequest{Arguments: godap.ContinueArguments{ThreadId: 7}})
+	_ = recvType[*godap.ContinueResponse](hh)
+	hh.cmds.waitForCommands(t, protocol.CmdContinue, continues+1)
+
+	const msg = "Continue: not suspended"
+	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: protocol.CmdContinue, Message: msg})
+	requireResumeFailureStopped(t, hh, "continue", msg)
+
+	// Another client drives the resume: with the debt settled this must be
+	// surfaced rather than suppressed as our own.
+	hh.inject(protocol.EventContinued, protocol.ContinuedPayload{})
+	cont := recvType[*godap.ContinuedEvent](hh)
+	if cont.Body.ThreadId != 7 || !cont.Body.AllThreadsContinued {
+		t.Fatalf("continued body = %+v, want the current thread and allThreadsContinued", cont.Body)
+	}
+}
+
+// TestRejectedResumeWhileSuspendedDoesNotDuplicateStopped covers a rejection
+// that loses the race with a real stop: the client's existing stopped already
+// describes this suspension, so a second one must not be fabricated.
+func TestRejectedResumeWhileSuspendedDoesNotDuplicateStopped(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	suspendAtBreakpoint(t, hh)
+
+	hh.sendReq("continue", &godap.ContinueRequest{Arguments: godap.ContinueArguments{ThreadId: 7}})
+	_ = recvType[*godap.ContinueResponse](hh)
+	hh.cmds.waitForCommand(t, protocol.CmdContinue)
+
+	// A genuine stop lands first, putting the client back in a stopped state.
+	hh.inject(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{Goroutine: protocol.Goroutine{ID: 7}})
+	_ = recvType[*godap.StoppedEvent](hh)
+
+	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: protocol.CmdContinue, Message: "stale rejection"})
+	out := recvType[*godap.OutputEvent](hh)
+	if out.Body.Output != "continue failed: stale rejection\n" {
+		t.Errorf("console output = %q", out.Body.Output)
+	}
+	requireNoStoppedEvent(t, hh, 150*time.Millisecond)
+
+	hh.handler.mu.Lock()
+	suspended := hh.handler.suspended
+	hh.handler.mu.Unlock()
+	if !suspended {
+		t.Fatal("handler left the suspended state after a stale rejection")
+	}
+}
+
+// TestRejectedRestartRestoresSuspendedWithoutStopped pins the restart variant:
+// the delayed error response already tells the client the restart failed while
+// it was stopped, so no extra stopped event may be sent — but the suspended
+// view onRestart cleared optimistically must still be restored.
+func TestRejectedRestartRestoresSuspendedWithoutStopped(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	suspendAtBreakpoint(t, hh)
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+
+	// An attach-created session has no launch to relaunch, so the hub rejects
+	// the restart without touching the still-suspended process.
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdRestart,
+		Message: "no launched process to restart — use Launch first",
+	})
+	failed := recvType[*godap.ErrorResponse](hh)
+	if failed.RequestSeq != restartSeq || failed.Success {
+		t.Fatalf("restart response = %+v, want an error for request %d", failed.Response, restartSeq)
+	}
+
+	requireInspectionReachesHub(t, hh)
+	requireNoStoppedEvent(t, hh, 150*time.Millisecond)
+}
+
+// TestRejectedResumeDuringJoinDefersToWelcome covers a joiner that receives
+// another client's resume rejection in the window between AddClient registering
+// it and the hub's welcome arriving: the welcome owns the joiner's initial state,
+// so the rejection must not fabricate a `stopped` carrying a foreign error.
+func TestRejectedResumeDuringJoinDefersToWelcome(t *testing.T) {
+	// An empty welcome keeps the fake session from sending one, holding the
+	// handler in the awaitingWelcome window for the whole test.
+	hh := newHarnessWelcome(t, "")
+
+	hh.sendReq("initialize", initArgs())
+	_ = recvType[*godap.InitializeResponse](hh)
+	hh.sendReq("attach", &godap.AttachRequest{Arguments: json.RawMessage(`{"session":"sess-test"}`)})
+	_ = recvType[*godap.InitializedEvent](hh)
+
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdContinue,
+		Message: "another client's continue failed",
+	})
+	out := recvType[*godap.OutputEvent](hh)
+	if out.Body.Output != "continue failed: another client's continue failed\n" {
+		t.Errorf("console output = %q", out.Body.Output)
+	}
+	requireNoStoppedEvent(t, hh, 150*time.Millisecond)
+
+	// The welcome still owns the initial state and reports the suspension.
+	hh.inject(protocol.EventSessionState, protocol.SessionStatePayload{
+		SessionID: "sess-test", State: protocol.StateSuspended, Clients: 2,
+	})
+	_ = hh.client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	stopped := recvType[*godap.StoppedEvent](hh)
+	if stopped.Body.Reason != "pause" {
+		t.Fatalf("welcome stopped reason = %q, want pause", stopped.Body.Reason)
+	}
+}
+
+// TestRejectedAutoContinueRestoresSuspendedState covers the auto-continue the
+// handshake itself issues at configurationDone: it takes the same optimistic
+// resume path, so its rejection must resynchronize identically.
+func TestRejectedAutoContinueRestoresSuspendedState(t *testing.T) {
+	hh := newHarness(t)
+
+	hh.sendReq("initialize", initArgs())
+	_ = recvType[*godap.InitializeResponse](hh)
+
+	lr := &godap.LaunchRequest{Arguments: json.RawMessage(`{"program":"/bin/x","stopOnEntry":false}`)}
+	hh.sendReq("launch", lr)
+	hh.cmds.waitForCommand(t, protocol.CmdLaunch)
+	hh.inject(protocol.EventStepped, protocol.SteppedPayload{Goroutine: protocol.Goroutine{ID: 7}})
+	_ = recvType[*godap.InitializedEvent](hh)
+
+	hh.sendReq("configurationDone", &godap.ConfigurationDoneRequest{})
+	_ = recvType[*godap.ConfigurationDoneResponse](hh)
+	_ = recvType[*godap.LaunchResponse](hh)
+	hh.cmds.waitForCommand(t, protocol.CmdContinue)
+
+	const msg = "Continue: resume from breakpoint: single-step: no such process"
+	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: protocol.CmdContinue, Message: msg})
+	requireResumeFailureStopped(t, hh, "continue", msg)
+	requireInspectionReachesHub(t, hh)
+}
+
 // TestJoinExistingSuspendedSession drives the JOIN path: attach with a session
 // id and no pid registers as an additional client on an already-suspended
 // session WITHOUT relaunching it, reflects the welcome as an initial

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -767,6 +767,50 @@ func TestRestartedPayloadDecodeFailureStillResponds(t *testing.T) {
 	}
 }
 
+func TestRestartRejectsOverlappingRequest(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+
+	firstSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	secondSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	rejected := recvType[*godap.ErrorResponse](hh)
+	if rejected.RequestSeq != secondSeq || rejected.Success || rejected.Message != "restart already in progress" {
+		t.Fatalf("overlapping restart response = %+v, want immediate error for request %d", rejected.Response, secondSeq)
+	}
+	if commands := hh.cmds.waitForCommands(t, protocol.CmdRestart, 1); len(commands) != 1 {
+		t.Fatalf("restart commands = %d, want exactly 1", len(commands))
+	}
+
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != firstSeq || !restarted.Success {
+		t.Fatalf("restart response = %+v, want success for original request %d", restarted.Response, firstSeq)
+	}
+}
+
+func TestRestartErrorAllowsRetry(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+
+	firstSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: protocol.CmdRestart, Message: "relaunch failed"})
+	failed := recvType[*godap.ErrorResponse](hh)
+	if failed.RequestSeq != firstSeq || failed.Success {
+		t.Fatalf("failed restart response = %+v, want error for request %d", failed.Response, firstSeq)
+	}
+
+	secondSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	if commands := hh.cmds.waitForCommands(t, protocol.CmdRestart, 2); len(commands) != 2 {
+		t.Fatalf("restart commands after retry = %d, want 2", len(commands))
+	}
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != secondSeq || !restarted.Success {
+		t.Fatalf("retried restart response = %+v, want success for request %d", restarted.Response, secondSeq)
+	}
+}
+
 func TestRestartPreservesBreakpointCorrelationQueues(t *testing.T) {
 	h := NewHandler(nil, nil, nil)
 	setSlot := &bpSlot{}

--- a/internal/dap/requests.go
+++ b/internal/dap/requests.go
@@ -507,17 +507,20 @@ func (h *Handler) onTerminate(req *godap.TerminateRequest) {
 
 func (h *Handler) onRestart(req *godap.RestartRequest) {
 	h.mu.Lock()
+	if h.restarting {
+		h.mu.Unlock()
+		h.send(h.errorResponse(req.Seq, "restart", "restart already in progress"))
+		return
+	}
 	hasSession := h.session != nil
-	h.restarting = true
-	h.restartReqSeq = req.Seq
-	h.suspended = false
+	if hasSession {
+		h.restarting = true
+		h.restartReqSeq = req.Seq
+		h.suspended = false
+	}
 	h.mu.Unlock()
 
 	if !hasSession {
-		h.mu.Lock()
-		h.restarting = false
-		h.restartReqSeq = 0
-		h.mu.Unlock()
 		h.send(h.errorResponse(req.Seq, "restart", "no session to restart"))
 		return
 	}

--- a/internal/dap/requests.go
+++ b/internal/dap/requests.go
@@ -518,6 +518,9 @@ func (h *Handler) onRestart(req *godap.RestartRequest) {
 	if hasSession {
 		h.restarting = true
 		h.restartReqSeq = req.Seq
+		// Remember the view being cleared: DAP allows restart while running, so
+		// a rejected restart must restore this exact state, not a suspension.
+		h.restartWasSuspended = h.suspended
 		h.suspended = false
 	}
 	h.mu.Unlock()

--- a/internal/dap/requests.go
+++ b/internal/dap/requests.go
@@ -507,7 +507,9 @@ func (h *Handler) onTerminate(req *godap.TerminateRequest) {
 
 func (h *Handler) onRestart(req *godap.RestartRequest) {
 	h.mu.Lock()
-	if h.restarting {
+	// restartReqSeq gates only the unanswered DAP request. restarting stays set
+	// longer so the subsequent entry EventStepped is still recognized.
+	if h.restartReqSeq != 0 {
 		h.mu.Unlock()
 		h.send(h.errorResponse(req.Seq, "restart", "restart already in progress"))
 		return


### PR DESCRIPTION
> **Prerequisite — #174 / draft PR #180 (hub suspend wait loop).** This PR repairs the **DAP adapter's view, i.e. inspection only**. It does **not** by itself make a rejected `Restart` on a *suspended* session resumable: the hub's suspend wait loop returns on `CmdRestart` from the command kind alone — even when `handleRestart` rejected the request without touching the process — and after that return nothing drains `resumeCh` again, so a later `Continue`/`Step` is stranded forever. **#180 repairs that hub command drain, i.e. resumability**, by keeping the loop draining `resumeCh` after the rejection. Both are required for that path. This is a **logical** prerequisite, not a branch one: #180 is an orthogonal branch off `main` touching only `internal/hub`, so this PR's git base stays `xsachax-reject-concurrent-dap-restarts` (#143) and the two merge independently in either order. Rejected `Continue`/`Step*` are unaffected and are fully fixed here.

## Summary
- **scope split:** this PR fixes the **DAP adapter's view and inspection path**; the hub's command drain and resumability after a rejected `Restart` are #174 / draft PR #180's fix (see the prerequisite note above)
- restore the adapter's `suspended` view whenever the hub rejects a resume it already acknowledged, so inspection requests reach the hub again instead of being answered synthetically
- handle `CmdStepOver`/`CmdStepInto`/`CmdStepOut` explicitly in `onError` rather than letting them fall into the generic console `default`
- report a rejected `Continue`/`Step*` as exactly one DAP `stopped` (reason `exception`, rejection text, `allThreadsStopped`, current thread) — the only message that can walk a client back after a successful resume response
- restore the **captured pre-request view** for a rejected `Restart`, with no extra `stopped`; DAP permits restart while the tracee is running, so an unconditional suspend would desynchronize the adapter the opposite way
- never resync into a suspension once the session is idle or exited — the hub's relaunch-failure path kills the process, errors, then goes idle
- settle the `pendingContinues` suppression debt exactly once, and suppress a duplicate `stopped` while already suspended or while the handshake still owes an initial state report (`launching`, or a joiner's `awaitingWelcome`)

## Why
`onContinue`/`onStep`/`onRestart` clear `suspended` optimistically and answer `success`, because DAP cannot retract a successful `continue`/`next` response. The hub only transitions to `running` on success, so a rejected `Continue`/`StepOver`/`StepInto`/`StepOut`/`Restart` arrives as `EventError` with the engine still `stateSuspended`. `onError` never repaired the flag, so `threads`/`stackTrace`/`variables`/`evaluate` took their not-suspended branch forever — empty bodies, no command reaching the hub — while the IDE showed a running program that could never stop again. `stepOut` at the outermost frame triggers this routinely: `engine.stepOut` rejects it without resuming and without emitting any stop.

Restart needs the symmetric care. It is legal while the tracee is *running*, and the hub rejects a restart on an attach-created session (`lastLaunch == nil`) without touching that still-running process — so `onRestart` captures the view it clears (`restartWasSuspended`) and `failRestart` restores exactly that. The capture is cleared on success and left untouched by the overlap rejection, which returns before reading the in-flight request's state.

A third case is a relaunch that fails *after* the old process was killed: the hub broadcasts the error, transitions the managed session to idle, and answers every later command with "no active debugger". The handler therefore tracks the session lifecycle (`EventSessionState` recorded on every connection, plus `EventProcessExited`) and suppresses the resync for both `Restart` and `Continue`/`Step` once the session is idle or exited — reporting a stop there would leave the client stopped on a process that no longer exists.

Recovery does not route through `onStop`: the process never moved, so the current suspension's `varCache` stays valid and the `launching`/`restarting` latches are untouched. Lock discipline is preserved — state is settled under `h.mu`, which is released before any socket write.

## Prerequisite: #174 / draft PR #180 — this PR fixes the DAP view, #180 fixes hub resumability

| Concern | Owner |
| --- | --- |
| DAP adapter's `suspended` view; inspection (`threads`/`stackTrace`/`variables`/`evaluate`) reaching the hub | **this PR (#181)** |
| Hub suspend wait loop continuing to drain `resumeCh` after a rejection; resumability (`Continue`/`Step*` delivered) | **#174 / draft PR #180** |

Recoverability differs by command class, and only the resuming half is self-contained:

- **Rejected `Continue`/`StepOver`/`StepInto`/`StepOut` (resuming commands, routed to `resumeCh`).** The hub's `resumeCh` branch already keys its exit off the observed state, so on a rejection it stays in the suspend wait loop — that specific behavior is intentional and documented (AGENTS.md → *Suspend/resume protocol* → *Rejected resumes*). This PR is sufficient on its own here: after the resync the client can inspect **and** resume, because a retry `Continue` still lands in a `resumeCh` the wait loop is draining.

- **Rejected `Restart` (a NON-resuming command, routed to `cmdCh`).** That invariant does not cover it. The suspend wait loop currently abandons the suspend from the command *kind* alone, returning on `CmdRestart` even when `handleRestart` rejected the request before touching anything — exactly the `lastLaunch == nil` attach-created-session case this PR's `TestRejectedRestartRestoresSuspendedWithoutStopped` models, where the tracee is still alive and the hub is still `StateSuspended`. Nothing drains `resumeCh` after that return. So **this PR alone leaves such a session inspectable but not resumable**: `threads`/`stackTrace`/`variables` ride `cmdCh`, which `Run`'s outer loop does drain, and are answered by the still-suspended engine — while a later `Continue`/`Step` lands in the capacity-1 `resumeCh` and is never read.

  #174 / draft PR #180 is therefore a **prerequisite** for that path, not an optional companion: it keys the wait loop's exit off `h.State() != protocol.StateSuspended` instead of the command kind, so the loop keeps draining `resumeCh` after the rejection and a retry `Continue` is delivered. Neither change suffices alone — #180 without this PR leaves the hub correct while the adapter still believes the tracee is running, so inspection never reaches the hub at all; this PR without #180 restores inspection but strands resume.

No hub change is made here — that is #180's fix, in a different package. Genuinely out of scope and unrelated to both: the `EventError`-with-`CmdNone` breakpoint reinstall path.

## Stack
This is stack layer 3. Its base must remain `xsachax-reject-concurrent-dap-restarts` (draft PR #143), which itself stacks on draft PR #138. Layer 1 owns breakpoint reconciliation and layer 2 owns restart response correlation; both are unchanged here. `failRestart` preserves layer 2's `restartReqSeq`/`restarting` semantics verbatim and only adds the captured-view restore, gated on this handler actually having a pending restart.

The #174/#180 relationship above is a **logical prerequisite, not a git dependency**: #180 targets `main` and touches only `internal/hub`, so it is an orthogonal branch, the base of this PR stays #143, and the two merge independently in either order.

## Tests
Real-DAP loopback specs in `internal/dap/handler_test.go`, each verified load-bearing by ablation — reverting a guard fails exactly the specs that cover it:
- `TestRejectedContinueRestoresSuspendedState`
- `TestRejectedStepRestoresSuspendedState` — one named subtest per step kind (`next`, `stepIn`, `stepOut`)
- `TestRejectedOutermostStepOutRestoresInspection` (the routine deterministic trigger)
- `TestRejectedResumeSettlesContinueSuppression` (exact `pendingContinues` accounting)
- `TestRejectedResumeWhileSuspendedDoesNotDuplicateStopped`
- `TestRejectedRestartRestoresSuspendedWithoutStopped` (restart issued while suspended)
- `TestRejectedRestartWhileRunningStaysRunning` (restart issued while running stays running)
- `TestRejectedRestartAfterFailedRelaunchDropsSuspended` (idle teardown, plus retry correlation)
- `TestRejectedResumeAfterSessionEndedEmitsNoStopped`
- `TestRejectedResumeDuringJoinDefersToWelcome`
- `TestRejectedAutoContinueRestoresSuspendedState` (the `configurationDone` auto-continue)

These assert the DAP-side contract only — that inspection reaches the hub again, and that no bogus `stopped` is fabricated. Resumability after a rejected `Restart` is covered by #180's own hub tests.

Their shared scaffolding lives in named helpers (`newSuspendedHarness`, `driveContinue`, `sendStepRequest`, `rejectResume`, `requireResyncStopped`, `rejectRestart`, `requireSuspendedFlag`, `requireInspectionReachesHub`, `requireInspectionAnsweredSynthetically`) so the duplicated-lines gate stays clear. Every helper is a `t.Helper()` reporting at the caller, each step kind keeps its own explicit request/response types, and each test still states its own run state, command kind, rejection message and expected recovery inline.

Commands run:
- `go test -tags bingonative -race ./...`
- `go test -tags bingonative -race ./internal/dap -count=40`
- native darwin/arm64 Mach-backend E2E (codesigned, real stack): `-ginkgo.label-filter=dap` (5 passed) and `-ginkgo.label-filter='restart || fullstack'` (2 passed)
- `go vet -tags bingonative ./...`
- `go tool goimports -l internal/dap/`, `gofmt -l internal/dap/`
- lefthook pre-commit goimports and commit-message checks

## Docs
`AGENTS.md` gains the rejected-resume resynchronization invariant in the DAP event-mapping section, including the captured-view rule for Restart and the idle/exited lifecycle guard, and corrects the `EventSessionState` mapping line.

Fixes #175