### PR TITLE
fix(dap): make setBreakpoints a per-source transaction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1134,19 +1134,59 @@ documented caveat. Fixing it properly needs correlation ids in the bingo protoco
 need no correlation, so multi-driver continue/step is fine; only the id-less
 confirmation requests are affected.
 
-**setBreakpoints is replace-all** (`breakpoints.go`): diff the requested lines
-for a source against `bpByFile` — clear removed, set new, keep unchanged — and
-respond once every slot in the request resolves, in request order. Clearing the
-breakpoint the process is currently parked on re-arms it through the engine's
-step-off path (see the clearbp spec), so the e2e continue-to-exit uses a
+**setBreakpoints is a replace-all TRANSACTION** (`breakpoints.go`): a request
+records the source's latest-wins intent and is answered only once every operation
+it owns has been confirmed. `bpByFile` is `file → line → *bpLine`, and `bpLine`
+deliberately keeps three things apart, because pipelined requests make them
+legitimately disagree:
+
+- `installedID` — an installed FACT. Written **only** by a confirmed
+  `EventBreakpointSet` and dropped **only** by a confirmed
+  `EventBreakpointCleared`. Never on intent.
+- `desired` — the newest request's intent for that line (latest wins).
+- `pending` — the single in-flight `bpOp` for that line. One op per line at a
+  time is what keeps the id-less `setQ`/`clearQ` FIFOs unambiguous.
+
+`advanceLineLocked` is the convergence loop: it issues the one command the
+installed/desired gap calls for, or settles everyone parked on the line when the
+two already agree. Every confirmation re-enters it, which yields the invariants:
+
+- A **removal is owned by the request that caused it** (`openClears` +
+  `clearOwners`), so a response never precedes its own clears. A remove-all no
+  longer reports success while the `ClearBreakpoint` is still in flight.
+- A **rejected clear retains the mapping** and fails the originating request
+  (`clearFailure` → an error `setBreakpoints` response). Forgetting the id would
+  leave a breakpoint the client can never remove — `breakpointTable.clear` keeps
+  the entry when the memory write fails, so the trap really is still armed. The
+  failure path deliberately does not re-enter the loop; a new request retries.
+- A **pending Set superseded before it confirms** is cancelled on confirm: the id
+  is recorded as a fact (the trap IS armed) but `desired` stays false, so the
+  next advance clears it immediately. It is never committed as desired state.
+- An **overlapping request wanting an already-pending line attaches** to that op
+  (another `setWaiter`) instead of issuing a duplicate `CmdSetBreakpoint`, which
+  the engine would reject with `errBreakpointExists` — and whose failure handling
+  used to delete the entry holding the live id.
+- **Exactly one response per request** (`bpRequest.ready()` claims the right to
+  answer; slots and obligations settle on different goroutines), and requests are
+  answered in `reqSeq` order so a later request's view lands last.
+- Sources are independent; the id-less FIFO limitation is unchanged.
+
+Breakpoint commands are staged in `outbox` and drained by `flushCommands`
+(serialised by `flushMu`) rather than enqueued directly: both the DAP read loop
+and the hub write pump produce them, and the FIFOs only correlate if the wire
+order matches the order slots were reserved under `mu`.
+
+Clearing the breakpoint the process is currently parked on re-arms it through the
+engine's step-off path (see the clearbp spec), so the e2e continue-to-exit uses a
 no-breakpoint target, not a clear-then-continue.
 
-`bpByFile` keeps the stable DAP id separate from the debugger's internal id.
-After `EventRestarted`, reconcile its exact source-path/line keys from
-`RestartedPayload` before replying: retained entries adopt the fresh debugger
-id, while discarded entries are removed and emit a `breakpoint` changed event
-with their prior DAP id and `verified:false`. Do not reset `setQ`/`clearQ`;
-those FIFOs still own any in-flight confirmations.
+`bpLine` keeps the stable DAP id (`dapID`) separate from the debugger's internal
+id (`installedID`). After `EventRestarted`, reconcile its exact source-path/line
+keys from `RestartedPayload` before replying: retained entries adopt the fresh
+debugger id, while discarded entries are removed and emit a `breakpoint` changed
+event with their prior DAP id and `verified:false`. A line with an op in flight
+is skipped — that op still owns the line and its confirmation is still queued.
+Do not reset `setQ`/`clearQ`; those FIFOs still own any in-flight confirmations.
 
 ### Server wiring + multi-client discovery
 
@@ -1274,11 +1314,17 @@ translator keeps DAP entirely outside the hub — a strictly additive package.
 ### Tests
 
 - Unit: [internal/dap/translate_test.go](internal/dap/translate_test.go) (pure
-  translators) and [internal/dap/handler_test.go](internal/dap/handler_test.go)
+  translators), [internal/dap/handler_test.go](internal/dap/handler_test.go)
   (full handshake over loopback TCP + a fake `Session`/`Provider` + a command
   recorder: handshake→breakpoint, own-continue-suppressed, out-of-band-continue-
   surfaced, setBreakpoints diff/FIFO, stackTrace/variables correlation,
-  step→stopped=step, disconnect-terminates). Run with the normal
+  step→stopped=step, disconnect-terminates), and
+  [internal/dap/breakpoints_test.go](internal/dap/breakpoints_test.go) (the
+  breakpoint transaction: a rejected clear retains the id and fails its request,
+  partial clear failure, a superseded pending set clears exactly once, an
+  overlapping pending set issues one command, set→remove→re-add leaves one live
+  breakpoint, cross-source independence, restart around an in-flight op,
+  exactly-once responses). Run with the normal
   `go test -tags bingonative ./internal/dap/...`.
 - E2E: label `dap` in [test/integration](test/integration/) — a real go-dap
   client over TCP through the WHOLE stack (client → TCP →

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1144,8 +1144,18 @@ legitimately disagree:
   `EventBreakpointSet` and dropped **only** by a confirmed
   `EventBreakpointCleared`. Never on intent.
 - `desired` — the newest request's intent for that line (latest wins).
-- `pending` — the single in-flight `bpOp` for that line. One op per line at a
+- `pending` — the single LIVE `bpOp` for that line. One live op per line at a
   time is what keeps the id-less `setQ`/`clearQ` FIFOs unambiguous.
+
+An operation is **abandoned** when a restart discards its line: it stops being
+that line's `pending` op (so the line can converge again immediately instead of
+latching behind a removal that already happened), but it keeps its place in the
+FIFO, because the debugger will still answer it and that answer must pop the head
+it reserved or every later confirmation correlates to the wrong request.
+`liveLineLocked` is the gate — it matches the popped op against the line's
+current `pending`, so an abandoned (or superseded, or forgotten) op's answer does
+exactly one thing: pop. It never settles waiters, fails owners, or writes state
+that now belongs to a re-identified line.
 
 `advanceLineLocked` is the convergence loop: it issues the one command the
 installed/desired gap calls for, or settles everyone parked on the line when the
@@ -1159,6 +1169,9 @@ two already agree. Every confirmation re-enters it, which yields the invariants:
   leave a breakpoint the client can never remove — `breakpointTable.clear` keeps
   the entry when the memory write fails, so the trap really is still armed. The
   failure path deliberately does not re-enter the loop; a new request retries.
+  That no-retry rule is justified **only** while the line is still armed: with
+  nothing armed there is nothing to retry and nothing to report, so the removal
+  completes successfully and the line resumes converging rather than stalling.
 - A **pending Set superseded before it confirms** is cancelled on confirm: the id
   is recorded as a fact (the trap IS armed) but `desired` stays false, so the
   next advance clears it immediately. It is never committed as desired state.
@@ -1191,8 +1204,12 @@ keeping the pre-restart id would strand the line on an identifier the new engine
 never issued (the already-marshalled clear fails, retain-on-failure reissues that
 dead id forever, and the real new breakpoint becomes unremovable). Only a line
 with `installedID == 0` is skipped: it owns no identity yet, so a payload entry
-for it describes another driver's breakpoint. Do not reset `setQ`/`clearQ`; those
-FIFOs still own any in-flight confirmations.
+for it describes another driver's breakpoint. A **discarded** line goes further:
+it abandons its in-flight operation (see above) — the command was addressed to a
+breakpoint the relaunched process no longer has, so its answer can only be stale,
+and leaving it live would latch the line behind a removal that already happened.
+Do not reset `setQ`/`clearQ`; those FIFOs still own any in-flight confirmations,
+abandoned ones included.
 
 **This transaction depends on reliable ordinary-command delivery** (#160 / #162).
 There are deliberately no adapter-side timeouts — inventing one would mask
@@ -1339,8 +1356,9 @@ translator keeps DAP entirely outside the hub — a strictly additive package.
   partial clear failure, a superseded pending set clears exactly once, an
   overlapping pending set issues one command, set→remove→re-add leaves one live
   breakpoint, cross-source independence, restart re-identification with an
-  in-flight operation, no-drop/in-order command delivery, exactly-once
-  responses). Run with the normal
+  in-flight operation, a discarded line abandoning its operation (later set,
+  already-satisfied removal, late stale success), no-drop/in-order command
+  delivery, exactly-once responses). Run with the normal
   `go test -tags bingonative ./internal/dap/...`.
 - E2E: label `dap` in [test/integration](test/integration/) — a real go-dap
   client over TCP through the WHOLE stack (client → TCP →

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1184,9 +1184,24 @@ no-breakpoint target, not a clear-then-continue.
 id (`installedID`). After `EventRestarted`, reconcile its exact source-path/line
 keys from `RestartedPayload` before replying: retained entries adopt the fresh
 debugger id, while discarded entries are removed and emit a `breakpoint` changed
-event with their prior DAP id and `verified:false`. A line with an op in flight
-is skipped — that op still owns the line and its confirmation is still queued.
-Do not reset `setQ`/`clearQ`; those FIFOs still own any in-flight confirmations.
+event with their prior DAP id and `verified:false`. A line with an operation in
+flight is re-identified **too** — correlation rides the queued `*bpOp`, not
+`installedID`, so adopting the fresh id cannot desynchronise the FIFOs, whereas
+keeping the pre-restart id would strand the line on an identifier the new engine
+never issued (the already-marshalled clear fails, retain-on-failure reissues that
+dead id forever, and the real new breakpoint becomes unremovable). Only a line
+with `installedID == 0` is skipped: it owns no identity yet, so a payload entry
+for it describes another driver's breakpoint. Do not reset `setQ`/`clearQ`; those
+FIFOs still own any in-flight confirmations.
+
+**This transaction depends on reliable ordinary-command delivery** (#160 / #162).
+There are deliberately no adapter-side timeouts — inventing one would mask
+command loss and could fire against a merely slow debugger. A silently dropped
+`SetBreakpoint`/`ClearBreakpoint` therefore produces no confirmation, which now
+latches that line's `pending` forever: no further operation can be issued for it
+and the owning request is never answered. The adapter side of the contract is
+covered here (it blocks rather than drops, and wire order matches slot-reservation
+order); the hub side is `injectCommand`'s admission.
 
 ### Server wiring + multi-client discovery
 
@@ -1323,8 +1338,9 @@ translator keeps DAP entirely outside the hub — a strictly additive package.
   breakpoint transaction: a rejected clear retains the id and fails its request,
   partial clear failure, a superseded pending set clears exactly once, an
   overlapping pending set issues one command, set→remove→re-add leaves one live
-  breakpoint, cross-source independence, restart around an in-flight op,
-  exactly-once responses). Run with the normal
+  breakpoint, cross-source independence, restart re-identification with an
+  in-flight operation, no-drop/in-order command delivery, exactly-once
+  responses). Run with the normal
   `go test -tags bingonative ./internal/dap/...`.
 - E2E: label `dap` in [test/integration](test/integration/) — a real go-dap
   client over TCP through the WHOLE stack (client → TCP →

--- a/internal/dap/breakpoints.go
+++ b/internal/dap/breakpoints.go
@@ -173,7 +173,11 @@ func (h *Handler) failClearLocked(file string, line int, msg string) []*bpReques
 		return nil
 	}
 	ready := st.dischargeOwners(msg)
-	return append(ready, st.resolveSlots()...)
+	ready = append(ready, st.resolveSlots()...)
+	// Only reachable when the line is no longer armed (a restart discarded it
+	// under the in-flight clear); a still-armed line is retained by gc.
+	h.gcLineLocked(file, line)
+	return ready
 }
 
 // gcLineLocked forgets a line the adapter has no reason to remember: unwanted,

--- a/internal/dap/breakpoints.go
+++ b/internal/dap/breakpoints.go
@@ -1,17 +1,24 @@
 package dap
 
 import (
+	"sort"
+
 	godap "github.com/google/go-dap"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
 
-// onSetBreakpoints reconciles the debugger's breakpoints for one source with
-// the complete set the client requested (DAP replace-all semantics). It diffs
-// against bpByFile: lines no longer wanted are cleared, new lines are set, and
-// unchanged lines keep their existing id. The response lists one breakpoint per
-// requested line, in request order — pending ones are filled in as their
-// EventBreakpointSet confirmations arrive (see events.go onBreakpointSet).
+// onSetBreakpoints applies DAP replace-all semantics for one source as a
+// transaction over the lines of that source.
+//
+// The request records its intent (latest wins) and then parks on the lines it
+// touches: a slot per requested line, and a removal obligation per line it drops
+// that is still armed or still has an operation in flight. Nothing is answered
+// until every one of those has settled, so a request can never report success
+// while a clear it caused is unconfirmed — which is what makes a rejected clear
+// reportable at all. Convergence itself is driven by advanceLineLocked, one
+// in-flight operation per line, so a line whose Set is already pending attaches
+// the new slot instead of issuing a duplicate.
 //
 // The FIFO correlation assumes the DAP client is the sole breakpoint driver for
 // this session; a WebSocket client concurrently setting breakpoints on the same
@@ -24,66 +31,256 @@ func (h *Handler) onSetBreakpoints(req *godap.SetBreakpointsRequest) {
 		file = src.Name
 	}
 
-	desired := make(map[int]bool, len(req.Arguments.Breakpoints))
-	for _, b := range req.Arguments.Breakpoints {
-		desired[b.Line] = true
-	}
-
-	reqObj := &bpRequest{reqSeq: req.Seq}
-	var clears, sets [][]byte
+	r := &bpRequest{reqSeq: req.Seq}
 
 	h.mu.Lock()
-	current := h.bpByFile[file]
-	if current == nil {
-		current = make(map[int]breakpointState)
-		h.bpByFile[file] = current
+	lines := h.bpByFile[file]
+	if lines == nil {
+		lines = make(map[int]*bpLine)
+		h.bpByFile[file] = lines
 	}
 
-	// Clear breakpoints no longer requested.
-	for line, state := range current {
-		if desired[line] {
-			continue
-		}
-		delete(current, line)
-		if state.debuggerID == 0 {
-			continue // never confirmed; nothing to clear on the debugger
-		}
-		h.clearQ = append(h.clearQ, state.debuggerID)
-		if cmd, err := marshalCommand(protocol.CmdClearBreakpoint, protocol.ClearBreakpointPayload{ID: state.debuggerID}); err == nil {
-			clears = append(clears, cmd)
-		}
-	}
-
-	// Set new lines; keep unchanged ones as already-verified.
+	wanted := make(map[int]bool, len(req.Arguments.Breakpoints))
 	for _, b := range req.Arguments.Breakpoints {
-		slot := &bpSlot{req: reqObj, file: file, line: b.Line}
-		reqObj.slots = append(reqObj.slots, slot)
-
-		if state, ok := current[b.Line]; ok && state.debuggerID != 0 {
-			slot.resolved = true
-			slot.bp = godap.Breakpoint{Id: state.dapID, Verified: true, Line: b.Line, Source: &src}
-			continue
-		}
-
-		current[b.Line] = breakpointState{} // pending sentinel, replaced on confirmation
-		h.setQ = append(h.setQ, slot)
-		if cmd, err := marshalCommand(protocol.CmdSetBreakpoint, protocol.SetBreakpointPayload{File: file, Line: b.Line}); err == nil {
-			sets = append(sets, cmd)
+		wanted[b.Line] = true
+		if lines[b.Line] == nil {
+			lines[b.Line] = &bpLine{}
 		}
 	}
-	allResolved := reqObj.done()
+	for line, st := range lines {
+		st.desired = wanted[line]
+	}
+
+	// One slot per requested line, in request order. A repeated line, or a line
+	// whose Set is already in flight, simply parks another waiter on it.
+	for _, b := range req.Arguments.Breakpoints {
+		slot := &bpSlot{req: r, line: b.Line, source: src}
+		r.slots = append(r.slots, slot)
+		st := lines[b.Line]
+		st.failure = ""
+		st.setWaiters = append(st.setWaiters, slot)
+	}
+
+	// Every dropped line that is still armed — or whose in-flight Set is about
+	// to arm it — is this request's obligation to remove.
+	touched := sortedLines(lines)
+	for _, line := range touched {
+		st := lines[line]
+		if st.desired || (st.installedID == 0 && st.pending == nil) {
+			continue
+		}
+		st.clearOwners = append(st.clearOwners, r)
+		r.openClears++
+	}
+
+	var ready []*bpRequest
+	for _, line := range touched {
+		ready = append(ready, h.advanceLineLocked(file, line)...)
+	}
+	// A request that neither installs nor removes anything (an empty request
+	// for a source with nothing armed) settles on nobody's behalf.
+	if r.ready() {
+		ready = append(ready, r)
+	}
 	h.mu.Unlock()
 
-	for _, c := range clears {
-		h.enqueue(c)
+	h.flushCommands()
+	h.respond(ready)
+}
+
+// sortedLines orders a source's lines so command issue and response assembly are
+// deterministic regardless of map iteration order.
+func sortedLines(lines map[int]*bpLine) []int {
+	out := make([]int, 0, len(lines))
+	for line := range lines {
+		out = append(out, line)
 	}
-	for _, c := range sets {
-		h.enqueue(c)
+	sort.Ints(out)
+	return out
+}
+
+// advanceLineLocked drives one line toward its desired state, issuing the single
+// command the gap calls for; when installed and desired already agree it settles
+// everyone parked on the line instead. A line with an operation in flight is
+// left alone — that operation owns it, and its completion re-enters here, which
+// is how a Set superseded before it confirmed gets cleared the moment its id
+// arrives. Caller MUST hold h.mu.
+func (h *Handler) advanceLineLocked(file string, line int) []*bpRequest {
+	st := h.bpByFile[file][line]
+	if st == nil || st.pending != nil {
+		return nil
 	}
 
-	// A request with only unchanged (or empty) breakpoints has no pending
-	// confirmations, so respond immediately.
-	if allResolved {
-		h.sendSetBreakpointsResponse(reqObj)
+	switch {
+	case st.desired && st.installedID == 0:
+		cmd, err := marshalCommand(protocol.CmdSetBreakpoint, protocol.SetBreakpointPayload{File: file, Line: line})
+		if err != nil {
+			st.desired = false
+			st.failure = err.Error()
+			return h.settleLineLocked(file, line)
+		}
+		st.pending = &bpOp{file: file, line: line}
+		h.setQ = append(h.setQ, st.pending)
+		h.queueCommandLocked(cmd)
+
+	case !st.desired && st.installedID != 0:
+		cmd, err := marshalCommand(protocol.CmdClearBreakpoint, protocol.ClearBreakpointPayload{ID: st.installedID})
+		if err != nil {
+			return h.failClearLocked(file, line, err.Error())
+		}
+		st.pending = &bpOp{file: file, line: line}
+		h.clearQ = append(h.clearQ, st.pending)
+		h.queueCommandLocked(cmd)
+
+	default:
+		return h.settleLineLocked(file, line)
 	}
+	return nil
+}
+
+// settleLineLocked answers everyone parked on a converged line. Removal
+// obligations are discharged once the line is actually gone — or once a later
+// request re-desired it, which supersedes the removal under latest-wins.
+// Caller MUST hold h.mu.
+func (h *Handler) settleLineLocked(file string, line int) []*bpRequest {
+	st := h.bpByFile[file][line]
+	if st == nil {
+		return nil
+	}
+	ready := st.resolveSlots()
+	if st.installedID == 0 || st.desired {
+		ready = append(ready, st.dischargeOwners("")...)
+	}
+	h.gcLineLocked(file, line)
+	return ready
+}
+
+// failClearLocked completes the removal obligations on a line whose clear could
+// not be issued or was rejected, failing their requests. It deliberately does
+// NOT re-enter the convergence loop: the line is still armed and still unwanted,
+// so advancing it again would retry a failing clear forever. The retained
+// mapping means the next setBreakpoints for the source can retry it.
+//
+// Slots parked on the line are answered here too, unconditionally. A failed
+// clear ends the line's only in-flight operation, so this is the last thing that
+// will happen to it until a new request arrives — anything still waiting would
+// otherwise wait forever. That includes an earlier pipelined request whose Set
+// this clear was cancelling: its breakpoint really is armed, so the line's
+// current identity is a truthful answer for it. Caller MUST hold h.mu.
+func (h *Handler) failClearLocked(file string, line int, msg string) []*bpRequest {
+	st := h.bpByFile[file][line]
+	if st == nil {
+		return nil
+	}
+	ready := st.dischargeOwners(msg)
+	return append(ready, st.resolveSlots()...)
+}
+
+// gcLineLocked forgets a line the adapter has no reason to remember: unwanted,
+// nothing armed, nothing in flight, nobody waiting. A line that is still armed
+// is ALWAYS retained even when unwanted — dropping its debugger id would leave a
+// breakpoint no later request could ever remove. Caller MUST hold h.mu.
+func (h *Handler) gcLineLocked(file string, line int) {
+	lines := h.bpByFile[file]
+	st := lines[line]
+	if st == nil {
+		return
+	}
+	if st.desired || st.installedID != 0 || st.pending != nil {
+		return
+	}
+	if len(st.setWaiters) > 0 || len(st.clearOwners) > 0 {
+		return
+	}
+	delete(lines, line)
+}
+
+// resolveSlots answers every requested slot parked on the line from its current
+// installed identity. Caller MUST hold h.mu.
+func (st *bpLine) resolveSlots() []*bpRequest {
+	if len(st.setWaiters) == 0 {
+		return nil
+	}
+	var ready []*bpRequest
+	for _, slot := range st.setWaiters {
+		slot.resolved = true
+		slot.bp = st.breakpoint(slot)
+		if slot.req.ready() {
+			ready = append(ready, slot.req)
+		}
+	}
+	st.setWaiters = nil
+	return ready
+}
+
+// dischargeOwners completes the removal obligations parked on the line. A
+// non-empty failure marks each owning request failed. Caller MUST hold h.mu.
+func (st *bpLine) dischargeOwners(failure string) []*bpRequest {
+	if len(st.clearOwners) == 0 {
+		return nil
+	}
+	var ready []*bpRequest
+	for _, r := range st.clearOwners {
+		if failure != "" && r.clearFailure == "" {
+			r.clearFailure = failure
+		}
+		r.openClears--
+		if r.ready() {
+			ready = append(ready, r)
+		}
+	}
+	st.clearOwners = nil
+	return ready
+}
+
+// breakpoint renders the line's installed identity as the DAP breakpoint
+// reported for one requested slot. The debugger may resolve a request to a
+// different line than asked, so a confirmed location wins over the requested one.
+func (st *bpLine) breakpoint(slot *bpSlot) godap.Breakpoint {
+	source := slot.source
+	if st.installedID == 0 {
+		return godap.Breakpoint{Verified: false, Line: slot.line, Source: &source, Message: st.failure}
+	}
+	line := slot.line
+	resolved := &source
+	if st.loc.Line != 0 {
+		line = st.loc.Line
+	}
+	if s := dapSource(st.loc); s != nil {
+		resolved = s
+	}
+	return godap.Breakpoint{Id: st.dapID, Verified: true, Line: line, Source: resolved}
+}
+
+// respond answers completed requests in request order. Two pipelined requests
+// can complete on the same confirmation, and a DAP client applies responses as
+// they arrive, so the later request must be answered last or an older view of
+// the source would land on top of the authoritative one.
+func (h *Handler) respond(ready []*bpRequest) {
+	if len(ready) == 0 {
+		return
+	}
+	sort.SliceStable(ready, func(i, j int) bool { return ready[i].reqSeq < ready[j].reqSeq })
+	for _, r := range ready {
+		h.sendSetBreakpointsResponse(r)
+	}
+}
+
+// sendSetBreakpointsResponse answers one setBreakpoints request. A request whose
+// removal was rejected by the debugger is failed rather than answered success:
+// its breakpoints are still armed, so reporting the requested state would be a
+// lie the client has no other way to detect.
+func (h *Handler) sendSetBreakpointsResponse(r *bpRequest) {
+	if r.clearFailure != "" {
+		h.send(h.errorResponse(r.reqSeq, "setBreakpoints", "clear breakpoint failed: "+r.clearFailure))
+		return
+	}
+	bps := make([]godap.Breakpoint, len(r.slots))
+	for i, s := range r.slots {
+		bps[i] = s.bp
+	}
+	h.send(&godap.SetBreakpointsResponse{
+		Response: h.response(r.reqSeq, "setBreakpoints"),
+		Body:     godap.SetBreakpointsResponseBody{Breakpoints: bps},
+	})
 }

--- a/internal/dap/breakpoints.go
+++ b/internal/dap/breakpoints.go
@@ -156,28 +156,32 @@ func (h *Handler) settleLineLocked(file string, line int) []*bpRequest {
 }
 
 // failClearLocked completes the removal obligations on a line whose clear could
-// not be issued or was rejected, failing their requests. It deliberately does
-// NOT re-enter the convergence loop: the line is still armed and still unwanted,
-// so advancing it again would retry a failing clear forever. The retained
-// mapping means the next setBreakpoints for the source can retry it.
+// not be issued or was rejected.
 //
-// Slots parked on the line are answered here too, unconditionally. A failed
-// clear ends the line's only in-flight operation, so this is the last thing that
-// will happen to it until a new request arrives — anything still waiting would
-// otherwise wait forever. That includes an earlier pipelined request whose Set
-// this clear was cancelling: its breakpoint really is armed, so the line's
-// current identity is a truthful answer for it. Caller MUST hold h.mu.
+// While the line is still armed this is the end of the road for it: re-entering
+// the convergence loop would retry a failing clear forever, so the rejection is
+// reported to the requests that asked for the removal and the mapping is
+// retained (the next setBreakpoints for the source can retry it). Slots parked
+// on the line are answered from that armed identity — including an earlier
+// pipelined request whose Set this clear was cancelling, whose breakpoint really
+// is armed. Nothing else will touch the line until a new request arrives, so
+// anything left waiting here would wait forever.
+//
+// If nothing is armed there is neither anything to retry nor anything to report:
+// the removal these requests asked for did happen, so they are completed rather
+// than failed, and the line is free to converge on whatever the newest request
+// wants. Caller MUST hold h.mu.
 func (h *Handler) failClearLocked(file string, line int, msg string) []*bpRequest {
 	st := h.bpByFile[file][line]
 	if st == nil {
 		return nil
 	}
-	ready := st.dischargeOwners(msg)
-	ready = append(ready, st.resolveSlots()...)
-	// Only reachable when the line is no longer armed (a restart discarded it
-	// under the in-flight clear); a still-armed line is retained by gc.
-	h.gcLineLocked(file, line)
-	return ready
+	if st.installedID != 0 {
+		ready := st.dischargeOwners(msg)
+		return append(ready, st.resolveSlots()...)
+	}
+	ready := st.dischargeOwners("")
+	return append(ready, h.advanceLineLocked(file, line)...)
 }
 
 // gcLineLocked forgets a line the adapter has no reason to remember: unwanted,

--- a/internal/dap/breakpoints_test.go
+++ b/internal/dap/breakpoints_test.go
@@ -1,0 +1,473 @@
+package dap
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	godap "github.com/google/go-dap"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+// These specs pin the setBreakpoints transaction: installed facts versus
+// latest-wins intent, request-owned removals, and exactly one response per
+// request under pipelining. See AGENTS.md → DAP (breakpoint transaction).
+
+var bpSource = godap.Source{Path: "/x/main.go", Name: "main.go"}
+var otherSource = godap.Source{Path: "/x/other.go", Name: "other.go"}
+
+// suspendedHarness runs the handshake and parks the adapter at a breakpoint,
+// the state a client sets breakpoints from.
+func suspendedHarness(t *testing.T) *harness {
+	t.Helper()
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	hh.inject(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{Goroutine: protocol.Goroutine{ID: 1}})
+	_ = recvType[*godap.StoppedEvent](hh)
+	return hh
+}
+
+func setBreakpointsFor(source godap.Source, lines ...int) *godap.SetBreakpointsRequest {
+	bps := make([]godap.SourceBreakpoint, len(lines))
+	for i, line := range lines {
+		bps[i] = godap.SourceBreakpoint{Line: line}
+	}
+	return &godap.SetBreakpointsRequest{Arguments: godap.SetBreakpointsArguments{
+		Source:      source,
+		Breakpoints: bps,
+	}}
+}
+
+func (hh *harness) confirmSet(source godap.Source, line, id int) {
+	hh.t.Helper()
+	hh.inject(protocol.EventBreakpointSet, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{ID: id, Location: protocol.Location{File: source.Path, Line: line}},
+	})
+}
+
+// installBreakpoint drives one line to a confirmed install and consumes its
+// response, leaving the source with exactly that breakpoint armed.
+func (hh *harness) installBreakpoint(source godap.Source, lines []int, ids []int) {
+	hh.t.Helper()
+	hh.sendReq("setBreakpoints", setBreakpointsFor(source, lines...))
+	hh.cmds.waitForCommands(hh.t, protocol.CmdSetBreakpoint, len(lines))
+	for i, line := range lines {
+		hh.confirmSet(source, line, ids[i])
+	}
+	_ = recvType[*godap.SetBreakpointsResponse](hh)
+}
+
+// clearIDs decodes the ClearBreakpoint commands the handler has issued so far.
+func (hh *harness) clearIDs(count int) []int {
+	hh.t.Helper()
+	cmds := hh.cmds.waitForCommands(hh.t, protocol.CmdClearBreakpoint, count)
+	out := make([]int, len(cmds))
+	for i, cmd := range cmds {
+		var p protocol.ClearBreakpointPayload
+		if err := protocol.DecodeCommandPayload(cmd, &p); err != nil {
+			hh.t.Fatal(err)
+		}
+		out[i] = p.ID
+	}
+	return out
+}
+
+func (hh *harness) countCommands(kind protocol.CommandKind) int {
+	hh.t.Helper()
+	n := 0
+	for _, k := range hh.cmds.kinds() {
+		if k == kind {
+			n++
+		}
+	}
+	return n
+}
+
+// lineState copies one line's transaction state for assertions.
+func (hh *harness) lineState(file string, line int) (bpLine, bool) {
+	hh.t.Helper()
+	hh.handler.mu.Lock()
+	defer hh.handler.mu.Unlock()
+	st := hh.handler.bpByFile[file][line]
+	if st == nil {
+		return bpLine{}, false
+	}
+	return *st, true
+}
+
+// waitForLine polls until pred holds, so a test can synchronise on a request
+// that issues no command of its own — a removal parked behind an in-flight set.
+func (hh *harness) waitForLine(file string, line int, pred func(bpLine) bool) {
+	hh.t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if st, ok := hh.lineState(file, line); ok && pred(st) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	hh.t.Fatalf("timed out waiting for %s:%d state", file, line)
+}
+
+func requireErrorResponse(t *testing.T, resp *godap.ErrorResponse, reqSeq int, contains string) {
+	t.Helper()
+	if resp.RequestSeq != reqSeq || resp.Success {
+		t.Fatalf("error response = %+v, want failure for request %d", resp.Response, reqSeq)
+	}
+	if !strings.Contains(resp.Message, contains) {
+		t.Fatalf("error message = %q, want it to mention %q", resp.Message, contains)
+	}
+}
+
+// A remove-all must not report success before its clear is confirmed, and a
+// rejected clear must fail the request while keeping the still-armed id.
+func TestRemoveAllFailedClearRetainsIDAndFailsRequest(t *testing.T) {
+	hh := suspendedHarness(t)
+	hh.installBreakpoint(bpSource, []int{10}, []int{101})
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	if ids := hh.clearIDs(1); ids[0] != 101 {
+		t.Fatalf("clear id = %d, want 101", ids[0])
+	}
+	hh.expectNoResponse()
+
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdClearBreakpoint,
+		Message: "breakpoint clear: restore bytes at 0x1000: boom",
+	})
+	requireErrorResponse(t, recvType[*godap.ErrorResponse](hh), removeSeq, "boom")
+
+	st, ok := hh.lineState(bpSource.Path, 10)
+	if !ok || st.installedID != 101 {
+		t.Fatalf("line state after failed clear = %+v (present=%v), want installedID 101 retained", st, ok)
+	}
+
+	// The retained mapping is what makes the removal retryable at all.
+	hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	if ids := hh.clearIDs(2); ids[1] != 101 {
+		t.Fatalf("retry clear id = %d, want 101", ids[1])
+	}
+}
+
+// One rejected clear among several fails the whole request, exactly once.
+func TestPartialClearFailureFailsRequestExactlyOnce(t *testing.T) {
+	hh := suspendedHarness(t)
+	hh.installBreakpoint(bpSource, []int{10, 20}, []int{101, 102})
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	if ids := hh.clearIDs(2); ids[0] != 101 || ids[1] != 102 {
+		t.Fatalf("clear ids = %v, want [101 102]", ids)
+	}
+
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
+	hh.expectNoResponse()
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdClearBreakpoint,
+		Message: "breakpoint 102 not found",
+	})
+
+	requireErrorResponse(t, recvType[*godap.ErrorResponse](hh), removeSeq, "breakpoint 102 not found")
+	hh.expectNoResponse()
+
+	if _, ok := hh.lineState(bpSource.Path, 10); ok {
+		t.Fatal("confirmed clear left line 10 in the cache")
+	}
+	st, ok := hh.lineState(bpSource.Path, 20)
+	if !ok || st.installedID != 102 {
+		t.Fatalf("line 20 state = %+v (present=%v), want installedID 102 retained", st, ok)
+	}
+}
+
+// A pending set superseded by a later empty request is cleared the moment its id
+// arrives, and neither request is answered before that removal completes.
+func TestSupersededPendingSetIsClearedOnConfirmation(t *testing.T) {
+	hh := suspendedHarness(t)
+
+	setSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 1)
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	hh.waitForLine(bpSource.Path, 10, func(st bpLine) bool { return !st.desired && len(st.clearOwners) == 1 })
+	hh.expectNoResponse()
+
+	hh.confirmSet(bpSource, 10, 101)
+	if ids := hh.clearIDs(1); ids[0] != 101 {
+		t.Fatalf("clear id = %d, want the id that just arrived (101)", ids[0])
+	}
+	hh.expectNoResponse()
+
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
+
+	// Request order: the superseded set answers first, the authoritative empty
+	// request last.
+	first := recvType[*godap.SetBreakpointsResponse](hh)
+	if first.RequestSeq != setSeq || len(first.Body.Breakpoints) != 1 || first.Body.Breakpoints[0].Verified {
+		t.Fatalf("superseded response = %+v (seq %d), want one unverified breakpoint for %d", first.Body, first.RequestSeq, setSeq)
+	}
+	second := recvType[*godap.SetBreakpointsResponse](hh)
+	if second.RequestSeq != removeSeq || len(second.Body.Breakpoints) != 0 {
+		t.Fatalf("remove response = %+v (seq %d), want empty for %d", second.Body, second.RequestSeq, removeSeq)
+	}
+
+	if _, ok := hh.lineState(bpSource.Path, 10); ok {
+		t.Fatal("superseded breakpoint survived in the cache")
+	}
+	if n := hh.countCommands(protocol.CmdSetBreakpoint); n != 1 {
+		t.Fatalf("SetBreakpoint commands = %d, want 1", n)
+	}
+	if n := hh.countCommands(protocol.CmdClearBreakpoint); n != 1 {
+		t.Fatalf("ClearBreakpoint commands = %d, want exactly 1", n)
+	}
+}
+
+// An overlapping request wanting an already-pending line attaches to that
+// operation instead of issuing a second SetBreakpoint for the same location.
+func TestOverlappingPendingSetIssuesOneCommand(t *testing.T) {
+	hh := suspendedHarness(t)
+
+	firstSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 1)
+
+	secondSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10, 20))
+	sets := hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 2)
+	var retried protocol.SetBreakpointPayload
+	if err := protocol.DecodeCommandPayload(sets[1], &retried); err != nil {
+		t.Fatal(err)
+	}
+	if retried.Line != 20 {
+		t.Fatalf("second SetBreakpoint = %+v, want the new line 20 only", retried)
+	}
+
+	hh.confirmSet(bpSource, 10, 101)
+	first := recvType[*godap.SetBreakpointsResponse](hh)
+	if first.RequestSeq != firstSeq {
+		t.Fatalf("first response seq = %d, want %d", first.RequestSeq, firstSeq)
+	}
+	requireBreakpointIDs(t, first, 101)
+
+	hh.confirmSet(bpSource, 20, 102)
+	second := recvType[*godap.SetBreakpointsResponse](hh)
+	if second.RequestSeq != secondSeq {
+		t.Fatalf("second response seq = %d, want %d", second.RequestSeq, secondSeq)
+	}
+	requireBreakpointIDs(t, second, 101, 102)
+
+	if n := hh.countCommands(protocol.CmdSetBreakpoint); n != 2 {
+		t.Fatalf("SetBreakpoint commands = %d, want 2 (no duplicate for line 10)", n)
+	}
+	if n := hh.countCommands(protocol.CmdClearBreakpoint); n != 0 {
+		t.Fatalf("ClearBreakpoint commands = %d, want 0", n)
+	}
+}
+
+// set → remove → re-add while the first set is still in flight: the latest
+// intent wins and leaves exactly one live breakpoint, with no wasted round trip.
+func TestSetRemoveReaddLeavesOneLiveBreakpoint(t *testing.T) {
+	hh := suspendedHarness(t)
+
+	setSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 1)
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	hh.waitForLine(bpSource.Path, 10, func(st bpLine) bool { return !st.desired })
+
+	readdSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.waitForLine(bpSource.Path, 10, func(st bpLine) bool { return st.desired })
+	hh.expectNoResponse()
+
+	hh.confirmSet(bpSource, 10, 101)
+
+	for _, want := range []int{setSeq, removeSeq, readdSeq} {
+		resp := recvType[*godap.SetBreakpointsResponse](hh)
+		if resp.RequestSeq != want {
+			t.Fatalf("response seq = %d, want %d (requests answer in order)", resp.RequestSeq, want)
+		}
+		switch want {
+		case removeSeq:
+			if len(resp.Body.Breakpoints) != 0 {
+				t.Fatalf("superseded removal response = %+v, want empty", resp.Body)
+			}
+		default:
+			requireBreakpointIDs(t, resp, 101)
+		}
+	}
+
+	st, ok := hh.lineState(bpSource.Path, 10)
+	if !ok || st.installedID != 101 || !st.desired {
+		t.Fatalf("final line state = %+v (present=%v), want one live breakpoint", st, ok)
+	}
+	if n := hh.countCommands(protocol.CmdSetBreakpoint); n != 1 {
+		t.Fatalf("SetBreakpoint commands = %d, want 1", n)
+	}
+	if n := hh.countCommands(protocol.CmdClearBreakpoint); n != 0 {
+		t.Fatalf("ClearBreakpoint commands = %d, want 0", n)
+	}
+}
+
+// A source blocked on its own removal must not hold up another source.
+func TestBreakpointSourcesSettleIndependently(t *testing.T) {
+	hh := suspendedHarness(t)
+	hh.installBreakpoint(bpSource, []int{10}, []int{101})
+
+	blockedSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	hh.clearIDs(1)
+
+	otherSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(otherSource, 20))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 2)
+	hh.confirmSet(otherSource, 20, 102)
+
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	if resp.RequestSeq != otherSeq {
+		t.Fatalf("response seq = %d, want the independent source %d", resp.RequestSeq, otherSeq)
+	}
+	requireBreakpointIDs(t, resp, 102)
+	hh.expectNoResponse()
+
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
+	blocked := recvType[*godap.SetBreakpointsResponse](hh)
+	if blocked.RequestSeq != blockedSeq || len(blocked.Body.Breakpoints) != 0 {
+		t.Fatalf("blocked response = %+v (seq %d), want empty for %d", blocked.Body, blocked.RequestSeq, blockedSeq)
+	}
+}
+
+// A restart re-identifies settled lines but must leave an in-flight operation —
+// and the FIFO slot correlating it — untouched.
+func TestRestartReconcilesAroundPendingOperation(t *testing.T) {
+	hh := suspendedHarness(t)
+	hh.installBreakpoint(bpSource, []int{10}, []int{41})
+
+	pendingSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10, 20))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 2)
+	hh.expectNoResponse()
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{
+		Breakpoints: []protocol.Breakpoint{
+			{ID: 101, Location: protocol.Location{File: bpSource.Path, Line: 10}},
+		},
+	})
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != restartSeq || !restarted.Success {
+		t.Fatalf("restart response = %+v, want success for %d", restarted.Response, restartSeq)
+	}
+
+	settled, ok := hh.lineState(bpSource.Path, 10)
+	if !ok || settled.installedID != 101 || settled.dapID != 41 {
+		t.Fatalf("settled line = %+v (present=%v), want installedID 101 with stable dapID 41", settled, ok)
+	}
+	pending, ok := hh.lineState(bpSource.Path, 20)
+	if !ok || pending.pending == nil || pending.installedID != 0 {
+		t.Fatalf("in-flight line = %+v (present=%v), want its operation preserved", pending, ok)
+	}
+
+	// The preserved FIFO slot still correlates the confirmation that arrives
+	// after the relaunch.
+	hh.confirmSet(bpSource, 20, 55)
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	if resp.RequestSeq != pendingSeq {
+		t.Fatalf("response seq = %d, want %d", resp.RequestSeq, pendingSeq)
+	}
+	requireBreakpointIDs(t, resp, 41, 55)
+}
+
+// A removal is complete as soon as its trap is gone: a re-add pipelined behind
+// it must not hold the removing request open until the new install lands.
+func TestRemovalCompletesBeforeReaddIsInstalled(t *testing.T) {
+	hh := suspendedHarness(t)
+	hh.installBreakpoint(bpSource, []int{10}, []int{101})
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	hh.clearIDs(1)
+
+	readdSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.waitForLine(bpSource.Path, 10, func(st bpLine) bool { return st.desired })
+	hh.expectNoResponse()
+
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
+
+	removed := recvType[*godap.SetBreakpointsResponse](hh)
+	if removed.RequestSeq != removeSeq || len(removed.Body.Breakpoints) != 0 {
+		t.Fatalf("remove response = %+v (seq %d), want empty for %d", removed.Body, removed.RequestSeq, removeSeq)
+	}
+
+	// Only now is the re-add issued, against a line the debugger has released.
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 2)
+	hh.confirmSet(bpSource, 10, 102)
+	readded := recvType[*godap.SetBreakpointsResponse](hh)
+	if readded.RequestSeq != readdSeq {
+		t.Fatalf("re-add response seq = %d, want %d", readded.RequestSeq, readdSeq)
+	}
+	requireBreakpointIDs(t, readded, 102)
+}
+
+// A rejected clear ends the line's only in-flight operation, so it must also
+// answer the earlier pipelined request whose Set it was cancelling — that
+// breakpoint really is armed, and nothing else will ever settle it.
+func TestFailedClearStillAnswersSupersededSet(t *testing.T) {
+	hh := suspendedHarness(t)
+
+	setSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 1)
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	hh.waitForLine(bpSource.Path, 10, func(st bpLine) bool { return !st.desired && len(st.clearOwners) == 1 })
+
+	hh.confirmSet(bpSource, 10, 101)
+	hh.clearIDs(1)
+	hh.expectNoResponse()
+
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdClearBreakpoint,
+		Message: "breakpoint clear: restore bytes at 0x1000: boom",
+	})
+
+	installed, ok := hh.recv().(*godap.SetBreakpointsResponse)
+	if !ok {
+		t.Fatal("superseded set was not answered before the failed removal")
+	}
+	if installed.RequestSeq != setSeq {
+		t.Fatalf("response seq = %d, want %d", installed.RequestSeq, setSeq)
+	}
+	// The clear failed, so the breakpoint this request asked for is genuinely
+	// armed — reporting it unverified would be a lie.
+	requireBreakpointIDs(t, installed, 101)
+	if !installed.Body.Breakpoints[0].Verified {
+		t.Fatalf("superseded breakpoint = %+v, want verified (its removal failed)", installed.Body.Breakpoints[0])
+	}
+
+	failed, ok := hh.recv().(*godap.ErrorResponse)
+	if !ok {
+		t.Fatal("failed removal was not reported as an error response")
+	}
+	requireErrorResponse(t, failed, removeSeq, "boom")
+	hh.expectNoResponse()
+
+	st, ok := hh.lineState(bpSource.Path, 10)
+	if !ok || st.installedID != 101 {
+		t.Fatalf("line state = %+v (present=%v), want the armed id retained", st, ok)
+	}
+}
+
+// Confirmations the adapter did not ask for must never produce a second
+// response for an already-answered request.
+func TestSetBreakpointsRespondsExactlyOnce(t *testing.T) {
+	hh := suspendedHarness(t)
+	hh.installBreakpoint(bpSource, []int{10}, []int{101})
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	hh.clearIDs(1)
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
+
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	if resp.RequestSeq != removeSeq || len(resp.Body.Breakpoints) != 0 {
+		t.Fatalf("remove response = %+v (seq %d), want empty for %d", resp.Body, resp.RequestSeq, removeSeq)
+	}
+
+	// Duplicate and out-of-band confirmations for the same work.
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
+	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: protocol.CmdClearBreakpoint, Message: "already gone"})
+	hh.confirmSet(bpSource, 10, 102)
+	hh.expectNoResponse()
+}

--- a/internal/dap/breakpoints_test.go
+++ b/internal/dap/breakpoints_test.go
@@ -450,6 +450,138 @@ func TestFailedClearStillAnswersSupersededSet(t *testing.T) {
 	}
 }
 
+// A restart re-identifies EVERY line it retains, including one with an
+// operation still in flight: the in-flight clear was marshalled with the
+// pre-restart id and will fail against the relaunched process, and retain-on-
+// failure would otherwise reissue that dead id forever while the real new
+// breakpoint stayed armed.
+func TestRestartReidentifiesLineUnderPendingClear(t *testing.T) {
+	hh := suspendedHarness(t)
+	hh.installBreakpoint(bpSource, []int{10}, []int{101})
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	if ids := hh.clearIDs(1); ids[0] != 101 {
+		t.Fatalf("clear id = %d, want 101", ids[0])
+	}
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{
+		Breakpoints: []protocol.Breakpoint{
+			{ID: 1, Location: protocol.Location{File: bpSource.Path, Line: 10}},
+		},
+	})
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != restartSeq || !restarted.Success {
+		t.Fatalf("restart response = %+v, want success for %d", restarted.Response, restartSeq)
+	}
+
+	st, ok := hh.lineState(bpSource.Path, 10)
+	if !ok || st.installedID != 1 {
+		t.Fatalf("line state = %+v (present=%v), want the fresh debugger id 1", st, ok)
+	}
+	if st.dapID != 101 {
+		t.Fatalf("dapID = %d, want the stable client identity 101", st.dapID)
+	}
+	if st.pending == nil {
+		t.Fatal("restart cancelled the in-flight operation")
+	}
+	hh.handler.mu.Lock()
+	inFlight := len(hh.handler.clearQ)
+	hh.handler.mu.Unlock()
+	if inFlight != 1 {
+		t.Fatalf("clearQ length = %d, want the in-flight operation preserved", inFlight)
+	}
+
+	// The stale clear, carrying the pre-restart id, is rejected by the new
+	// engine — but the mapping has already self-healed.
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdClearBreakpoint,
+		Message: "breakpoint 101 not found",
+	})
+	requireErrorResponse(t, recvType[*godap.ErrorResponse](hh), removeSeq, "breakpoint 101 not found")
+
+	hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	ids := hh.clearIDs(2)
+	if ids[1] != 1 {
+		t.Fatalf("retry clear id = %d, want the fresh id 1 (not the dead %d)", ids[1], ids[0])
+	}
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 1})
+	_ = recvType[*godap.SetBreakpointsResponse](hh)
+
+	if _, ok := hh.lineState(bpSource.Path, 10); ok {
+		t.Fatal("confirmed clear left the line in the cache")
+	}
+}
+
+// A line whose Set is still in flight owns no identity yet, so a restart
+// payload naming it describes another driver's breakpoint and must not be
+// adopted — neither as a retained id nor as a discard.
+func TestRestartIgnoresLineWithNoInstalledIdentity(t *testing.T) {
+	hh := suspendedHarness(t)
+
+	hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 1)
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{
+		Breakpoints: []protocol.Breakpoint{
+			{ID: 7, Location: protocol.Location{File: bpSource.Path, Line: 10}},
+		},
+		Discarded: []protocol.DiscardedBreakpoint{
+			{Location: protocol.Location{File: bpSource.Path, Line: 10}, Reason: "no such line"},
+		},
+	})
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != restartSeq {
+		t.Fatalf("restart response seq = %d, want %d", restarted.RequestSeq, restartSeq)
+	}
+
+	st, ok := hh.lineState(bpSource.Path, 10)
+	if !ok || st.installedID != 0 || st.pending == nil || !st.desired {
+		t.Fatalf("line state = %+v (present=%v), want the in-flight set untouched", st, ok)
+	}
+
+	// Our own confirmation still lands on it and settles the request normally.
+	hh.confirmSet(bpSource, 10, 55)
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	requireBreakpointIDs(t, resp, 55)
+}
+
+// The adapter must hand every breakpoint command to the hub, in the order their
+// FIFO slots were reserved, however large the burst — it blocks rather than
+// drops. This is one half of the delivery contract the transaction depends on:
+// a command that never reaches the debugger produces no confirmation, so its
+// line stays `pending` forever and its request is never answered. Hub-side
+// admission is the other half (#160 / #162).
+func TestLargeSetBreakpointsDeliversEveryCommandInOrder(t *testing.T) {
+	hh := suspendedHarness(t)
+
+	// Comfortably past the handler's own command buffer, so the staged outbox
+	// has to block on the hub read pump rather than discard.
+	count := 3 * cmdBufferSize
+	lines := make([]int, count)
+	for i := range lines {
+		lines[i] = 10 + i
+	}
+	hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, lines...))
+
+	cmds := hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, count)
+	if len(cmds) != count {
+		t.Fatalf("SetBreakpoint commands = %d, want %d", len(cmds), count)
+	}
+	for i, cmd := range cmds {
+		var p protocol.SetBreakpointPayload
+		if err := protocol.DecodeCommandPayload(cmd, &p); err != nil {
+			t.Fatal(err)
+		}
+		if p.Line != lines[i] {
+			t.Fatalf("command %d = line %d, want %d (wire order must match reservation order)", i, p.Line, lines[i])
+		}
+	}
+}
+
 // Confirmations the adapter did not ask for must never produce a second
 // response for an already-answered request.
 func TestSetBreakpointsRespondsExactlyOnce(t *testing.T) {

--- a/internal/dap/breakpoints_test.go
+++ b/internal/dap/breakpoints_test.go
@@ -632,6 +632,20 @@ func (hh *harness) staleClearIsStillQueued() bool {
 	return len(hh.handler.clearQ) == 1
 }
 
+// setQIsOnlyPendingFor reports whether the set FIFO holds exactly one operation
+// and it is the one the line is currently waiting on — the shape that proves an
+// abandoned operation's answer neither reissued a command nor left a phantom
+// slot the next confirmation would correlate to.
+func (hh *harness) setQIsOnlyPendingFor(file string, line int) bool {
+	hh.handler.mu.Lock()
+	defer hh.handler.mu.Unlock()
+	st := hh.handler.bpByFile[file][line]
+	if st == nil || st.pending == nil || len(hh.handler.setQ) != 1 {
+		return false
+	}
+	return hh.handler.setQ[0] == st.pending
+}
+
 // After a discard abandons its clear, a later request that wants the line back
 // must converge immediately, and the stale clear's rejection must not touch it.
 func TestDiscardedLineAcceptsLaterSetAndIgnoresStaleClearError(t *testing.T) {
@@ -652,6 +666,15 @@ func TestDiscardedLineAcceptsLaterSetAndIgnoresStaleClearError(t *testing.T) {
 	// The stale rejection belongs to nobody: it must not fail or resolve the
 	// request now waiting on this line.
 	hh.expectNoResponse()
+	// Nor may it act on the line it no longer speaks for. Reissuing here would
+	// arm a second trap for one requested breakpoint and put a second operation
+	// in the FIFO, so every later confirmation would correlate to the wrong one.
+	if n := hh.countCommands(protocol.CmdSetBreakpoint); n != 2 {
+		t.Fatalf("SetBreakpoint commands = %d, want 2 — the stale rejection must not reissue the line", n)
+	}
+	if !hh.setQIsOnlyPendingFor(bpSource.Path, 10) {
+		t.Fatal("set FIFO must hold exactly the live re-add operation")
+	}
 
 	hh.confirmSet(bpSource, 10, 7)
 	resp := recvType[*godap.SetBreakpointsResponse](hh)
@@ -761,19 +784,35 @@ func TestFailedClearWithNothingArmedCompletesAndResumes(t *testing.T) {
 	}
 }
 
-// Confirmations the adapter did not ask for must never produce a second
-// response for an already-answered request.
+// A request must be answered exactly once even when its own settlement is
+// re-offered. A line that is already installed and still wanted converges inside
+// onSetBreakpoints itself, so the request is settled by the line AND then
+// re-tested by the final readiness check that exists for requests which settle
+// on nobody's behalf: only the claim in ready() keeps that from being two
+// responses to one request. Confirmations the adapter did not ask for must not
+// produce a second response either.
 func TestSetBreakpointsRespondsExactlyOnce(t *testing.T) {
 	hh := suspendedHarness(t)
 	hh.installBreakpoint(bpSource, []int{10}, []int{101})
+
+	resetSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	if resp.RequestSeq != resetSeq {
+		t.Fatalf("re-set response seq = %d, want %d", resp.RequestSeq, resetSeq)
+	}
+	requireBreakpointIDs(t, resp, 101)
+	hh.expectNoResponse()
+	if n := hh.countCommands(protocol.CmdSetBreakpoint); n != 1 {
+		t.Fatalf("SetBreakpoint commands = %d, want the already-converged line left alone", n)
+	}
 
 	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
 	hh.clearIDs(1)
 	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
 
-	resp := recvType[*godap.SetBreakpointsResponse](hh)
-	if resp.RequestSeq != removeSeq || len(resp.Body.Breakpoints) != 0 {
-		t.Fatalf("remove response = %+v (seq %d), want empty for %d", resp.Body, resp.RequestSeq, removeSeq)
+	removed := recvType[*godap.SetBreakpointsResponse](hh)
+	if removed.RequestSeq != removeSeq || len(removed.Body.Breakpoints) != 0 {
+		t.Fatalf("remove response = %+v (seq %d), want empty for %d", removed.Body, removed.RequestSeq, removeSeq)
 	}
 
 	// Duplicate and out-of-band confirmations for the same work.

--- a/internal/dap/breakpoints_test.go
+++ b/internal/dap/breakpoints_test.go
@@ -582,6 +582,185 @@ func TestLargeSetBreakpointsDeliversEveryCommandInOrder(t *testing.T) {
 	}
 }
 
+// discardUnderPendingClear installs a breakpoint, starts removing it, then has a
+// restart discard the line while that clear is still in flight. The removal is
+// satisfied by the discard itself, so its request completes successfully and the
+// line is forgotten — leaving the clear abandoned, still queued, still owed an
+// answer by the debugger.
+func discardUnderPendingClear(t *testing.T, hh *harness) int {
+	t.Helper()
+	hh.installBreakpoint(bpSource, []int{10}, []int{101})
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	hh.clearIDs(1)
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{
+		Discarded: []protocol.DiscardedBreakpoint{
+			{Location: protocol.Location{File: bpSource.Path, Line: 10}, Reason: "no such line"},
+		},
+	})
+
+	var removed *godap.SetBreakpointsResponse
+	var restarted *godap.RestartResponse
+	for range 3 {
+		switch msg := hh.recv().(type) {
+		case *godap.SetBreakpointsResponse:
+			removed = msg
+		case *godap.RestartResponse:
+			restarted = msg
+		case *godap.ErrorResponse:
+			t.Fatalf("removal failed although the discard already satisfied it: %+v", msg.Response)
+		}
+	}
+	if removed == nil || removed.RequestSeq != removeSeq || len(removed.Body.Breakpoints) != 0 {
+		t.Fatalf("removal response = %+v, want empty success for %d", removed, removeSeq)
+	}
+	if restarted == nil || restarted.RequestSeq != restartSeq {
+		t.Fatalf("restart response = %+v, want %d", restarted, restartSeq)
+	}
+	if st, ok := hh.lineState(bpSource.Path, 10); ok {
+		t.Fatalf("discarded line survived as %+v, want it forgotten", st)
+	}
+	return restartSeq
+}
+
+func (hh *harness) staleClearIsStillQueued() bool {
+	hh.handler.mu.Lock()
+	defer hh.handler.mu.Unlock()
+	return len(hh.handler.clearQ) == 1
+}
+
+// After a discard abandons its clear, a later request that wants the line back
+// must converge immediately, and the stale clear's rejection must not touch it.
+func TestDiscardedLineAcceptsLaterSetAndIgnoresStaleClearError(t *testing.T) {
+	hh := suspendedHarness(t)
+	discardUnderPendingClear(t, hh)
+	if !hh.staleClearIsStillQueued() {
+		t.Fatal("abandoned clear lost its FIFO slot")
+	}
+
+	// The abandoned operation must not latch the line: this has to issue a Set.
+	readdSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 2)
+
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdClearBreakpoint,
+		Message: "breakpoint 101 not found",
+	})
+	// The stale rejection belongs to nobody: it must not fail or resolve the
+	// request now waiting on this line.
+	hh.expectNoResponse()
+
+	hh.confirmSet(bpSource, 10, 7)
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	if resp.RequestSeq != readdSeq {
+		t.Fatalf("response seq = %d, want %d", resp.RequestSeq, readdSeq)
+	}
+	requireBreakpointIDs(t, resp, 7)
+	if !resp.Body.Breakpoints[0].Verified {
+		t.Fatalf("re-added breakpoint = %+v, want verified", resp.Body.Breakpoints[0])
+	}
+}
+
+// A removal the discard already satisfied must not be failed by the stale
+// rejection that arrives afterwards.
+func TestDiscardedLineDoesNotFailAlreadySatisfiedRemoval(t *testing.T) {
+	hh := suspendedHarness(t)
+	discardUnderPendingClear(t, hh)
+
+	// Nothing is armed, so this replace-all owns no removal and answers at once.
+	emptySeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	if resp.RequestSeq != emptySeq || len(resp.Body.Breakpoints) != 0 {
+		t.Fatalf("empty response = %+v (seq %d), want empty success for %d", resp.Body, resp.RequestSeq, emptySeq)
+	}
+
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdClearBreakpoint,
+		Message: "breakpoint 101 not found",
+	})
+	hh.expectNoResponse()
+
+	if n := hh.countCommands(protocol.CmdClearBreakpoint); n != 1 {
+		t.Fatalf("ClearBreakpoint commands = %d, want no retry of the discarded line", n)
+	}
+}
+
+// A stale clear that succeeds late must also be a pure FIFO pop: it must not
+// disarm the line's new identity, and the next real removal must still
+// correlate to its own confirmation.
+func TestStaleClearSuccessDoesNotDisturbReidentifiedLine(t *testing.T) {
+	hh := suspendedHarness(t)
+	discardUnderPendingClear(t, hh)
+
+	hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 2)
+	hh.confirmSet(bpSource, 10, 7)
+	_ = recvType[*godap.SetBreakpointsResponse](hh)
+
+	// The abandoned clear finally succeeds against the old process.
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
+	hh.expectNoResponse()
+	st, ok := hh.lineState(bpSource.Path, 10)
+	if !ok || st.installedID != 7 {
+		t.Fatalf("line state = %+v (present=%v), want the new identity 7 intact", st, ok)
+	}
+
+	// The FIFO is still aligned: a real removal targets the new id and is
+	// answered by its own confirmation.
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	ids := hh.clearIDs(2)
+	if ids[1] != 7 {
+		t.Fatalf("clear id = %d, want the current identity 7", ids[1])
+	}
+	hh.expectNoResponse()
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 7})
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	if resp.RequestSeq != removeSeq || len(resp.Body.Breakpoints) != 0 {
+		t.Fatalf("removal response = %+v (seq %d), want empty success for %d", resp.Body, resp.RequestSeq, removeSeq)
+	}
+	if _, ok := hh.lineState(bpSource.Path, 10); ok {
+		t.Fatal("confirmed clear left the line in the cache")
+	}
+}
+
+// A rejected clear is only un-retryable while its breakpoint is still armed.
+// With nothing armed there is nothing to retry and nothing to report: the
+// removal did happen, so its requests complete rather than fail, and the line
+// resumes converging on the newest intent instead of stalling.
+func TestFailedClearWithNothingArmedCompletesAndResumes(t *testing.T) {
+	h := NewHandler(nil, nil, nil)
+
+	removal := &bpRequest{reqSeq: 1, openClears: 1}
+	readd := &bpRequest{reqSeq: 2}
+	slot := &bpSlot{req: readd, line: 10, source: bpSource}
+	readd.slots = []*bpSlot{slot}
+	h.bpByFile[bpSource.Path] = map[int]*bpLine{10: {
+		desired:     true,
+		setWaiters:  []*bpSlot{slot},
+		clearOwners: []*bpRequest{removal},
+	}}
+
+	h.mu.Lock()
+	ready := h.failClearLocked(bpSource.Path, 10, "breakpoint 101 not found")
+	h.mu.Unlock()
+
+	if len(ready) != 1 || ready[0] != removal {
+		t.Fatalf("ready = %+v, want only the removal request", ready)
+	}
+	if removal.clearFailure != "" {
+		t.Fatalf("removal reported %q, want success — nothing was armed to fail on", removal.clearFailure)
+	}
+	if len(h.setQ) != 1 || len(h.outbox) != 1 {
+		t.Fatalf("setQ=%d outbox=%d, want the desired line to resume converging", len(h.setQ), len(h.outbox))
+	}
+	if slot.resolved {
+		t.Fatal("waiting slot was resolved before its breakpoint was installed")
+	}
+}
+
 // Confirmations the adapter did not ask for must never produce a second
 // response for an already-answered request.
 func TestSetBreakpointsRespondsExactlyOnce(t *testing.T) {

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -203,6 +203,11 @@ func (h *Handler) onOutput(evt protocol.Event) {
 	h.send(&godap.OutputEvent{Event: h.event("output"), Body: godap.OutputEventBody{Category: category, Output: p.Content}})
 }
 
+// onBreakpointSet records a confirmed install against the operation at the head
+// of setQ. The id is an installed FACT and is recorded even when a later request
+// already dropped the line — the trap IS armed, and forgetting it is how it
+// becomes unremovable. Advancing the line then immediately clears it, so a
+// superseded Set is never committed as the line's desired state.
 func (h *Handler) onBreakpointSet(evt protocol.Event) {
 	var p protocol.BreakpointSetPayload
 	if err := protocol.DecodeEventPayload(evt, &p); err != nil {
@@ -210,40 +215,70 @@ func (h *Handler) onBreakpointSet(evt protocol.Event) {
 	}
 
 	h.mu.Lock()
-	var ready *bpRequest
-	if len(h.setQ) > 0 {
-		slot := h.setQ[0]
-		h.setQ = h.setQ[1:]
-		if lines := h.bpByFile[slot.file]; lines != nil {
-			lines[slot.line] = breakpointState{
-				dapID:      p.Breakpoint.ID,
-				debuggerID: p.Breakpoint.ID,
+	var ready []*bpRequest
+	if op := h.popSetLocked(); op != nil {
+		if st := h.bpByFile[op.file][op.line]; st != nil {
+			st.pending = nil
+			st.installedID = p.Breakpoint.ID
+			st.loc = p.Breakpoint.Location
+			st.failure = ""
+			if st.dapID == 0 {
+				st.dapID = p.Breakpoint.ID
 			}
-		}
-		slot.resolved = true
-		slot.bp = godap.Breakpoint{
-			Id:       p.Breakpoint.ID,
-			Verified: true,
-			Line:     p.Breakpoint.Location.Line,
-			Source:   dapSource(p.Breakpoint.Location),
-		}
-		if slot.req.done() {
-			ready = slot.req
+			ready = h.advanceLineLocked(op.file, op.line)
 		}
 	}
 	h.mu.Unlock()
 
-	if ready != nil {
-		h.sendSetBreakpointsResponse(ready)
-	}
+	h.flushCommands()
+	h.respond(ready)
 }
 
+// onBreakpointCleared retires the operation at the head of clearQ. A line's
+// debugger id is dropped ONLY here: a confirmed removal is the only proof the
+// trap is actually gone.
 func (h *Handler) onBreakpointCleared() {
 	h.mu.Lock()
-	if len(h.clearQ) > 0 {
-		h.clearQ = h.clearQ[1:]
+	var ready []*bpRequest
+	if op := h.popClearLocked(); op != nil {
+		if st := h.bpByFile[op.file][op.line]; st != nil {
+			st.pending = nil
+			st.installedID = 0
+			st.dapID = 0
+			st.loc = protocol.Location{}
+			// The removal is complete the moment the trap is gone — even if a
+			// later request has already re-desired the line and the next Set is
+			// about to be issued for it.
+			ready = st.dischargeOwners("")
+			ready = append(ready, h.advanceLineLocked(op.file, op.line)...)
+		}
 	}
 	h.mu.Unlock()
+
+	h.flushCommands()
+	h.respond(ready)
+}
+
+// popSetLocked takes the operation the next EventBreakpointSet belongs to. A nil
+// result means the confirmation was driven by another client — there is nothing
+// of ours to correlate it to. Caller MUST hold h.mu.
+func (h *Handler) popSetLocked() *bpOp {
+	if len(h.setQ) == 0 {
+		return nil
+	}
+	op := h.setQ[0]
+	h.setQ = h.setQ[1:]
+	return op
+}
+
+// popClearLocked is popSetLocked for EventBreakpointCleared. Caller MUST hold h.mu.
+func (h *Handler) popClearLocked() *bpOp {
+	if len(h.clearQ) == 0 {
+		return nil
+	}
+	op := h.clearQ[0]
+	h.clearQ = h.clearQ[1:]
+	return op
 }
 
 func (h *Handler) onFrames(evt protocol.Event) {
@@ -357,8 +392,9 @@ func (h *Handler) onRestarted(evt protocol.Event) {
 	seq := h.restartReqSeq
 	h.restartReqSeq = 0
 	var discarded []godap.Breakpoint
+	var ready []*bpRequest
 	if decoded {
-		discarded = h.reconcileRestartBreakpointsLocked(p)
+		discarded, ready = h.reconcileRestartBreakpointsLocked(p)
 	}
 	h.mu.Unlock()
 
@@ -371,39 +407,53 @@ func (h *Handler) onRestarted(evt protocol.Event) {
 			},
 		})
 	}
+	h.respond(ready)
 	if seq != 0 {
 		h.send(&godap.RestartResponse{Response: h.response(seq, "restart")})
 	}
 }
 
-func (h *Handler) reconcileRestartBreakpointsLocked(p protocol.RestartedPayload) []godap.Breakpoint {
+// reconcileRestartBreakpointsLocked adopts the relaunched process's breakpoint
+// identities: retained lines keep their stable DAP id but take the fresh
+// debugger id, and discarded lines are dropped and reported unverified. A line
+// with an operation in flight is left alone — that operation still owns the
+// line's convergence and its confirmation is still queued in setQ/clearQ, so
+// rewriting its state here would desynchronise both. Caller MUST hold h.mu.
+func (h *Handler) reconcileRestartBreakpointsLocked(p protocol.RestartedPayload) ([]godap.Breakpoint, []*bpRequest) {
 	for _, bp := range p.Breakpoints {
-		lines := h.bpByFile[bp.Location.File]
-		state, ok := lines[bp.Location.Line]
-		if !ok || state.debuggerID == 0 {
+		st := h.bpByFile[bp.Location.File][bp.Location.Line]
+		if st == nil || st.installedID == 0 || st.pending != nil {
 			continue
 		}
-		state.debuggerID = bp.ID
-		lines[bp.Location.Line] = state
+		st.installedID = bp.ID
+		st.loc = bp.Location
 	}
 
 	discarded := make([]godap.Breakpoint, 0, len(p.Discarded))
+	var ready []*bpRequest
 	for _, dropped := range p.Discarded {
-		lines := h.bpByFile[dropped.Location.File]
-		state, ok := lines[dropped.Location.Line]
-		if !ok || state.debuggerID == 0 {
+		st := h.bpByFile[dropped.Location.File][dropped.Location.Line]
+		if st == nil || st.installedID == 0 || st.pending != nil {
 			continue
 		}
-		delete(lines, dropped.Location.Line)
+		dapID := st.dapID
+		st.installedID = 0
+		st.dapID = 0
+		st.desired = false
+		st.loc = protocol.Location{}
+		st.failure = dropped.Reason
+		// The breakpoint is gone, so anyone parked on the line — including a
+		// request still waiting for it to be removed — can be answered now.
+		ready = append(ready, h.settleLineLocked(dropped.Location.File, dropped.Location.Line)...)
 		discarded = append(discarded, godap.Breakpoint{
-			Id:       state.dapID,
+			Id:       dapID,
 			Verified: false,
 			Message:  dropped.Reason,
 			Source:   dapSource(dropped.Location),
 			Line:     dropped.Location.Line,
 		})
 	}
-	return discarded
+	return discarded, ready
 }
 
 // onError routes a bingo EventError to the DAP request it corresponds to,
@@ -418,7 +468,7 @@ func (h *Handler) onError(evt protocol.Event) {
 	case protocol.CmdSetBreakpoint:
 		h.failBreakpointSet(p.Message)
 	case protocol.CmdClearBreakpoint:
-		h.onBreakpointCleared()
+		h.failBreakpointClear(p.Message)
 	case protocol.CmdGoroutines:
 		h.mu.Lock()
 		seq, ok := 0, false
@@ -504,37 +554,40 @@ func (h *Handler) failStart(msg string) {
 	h.send(&godap.TerminatedEvent{Event: h.event("terminated")})
 }
 
-// failBreakpointSet resolves the head pending set slot as unverified, then
-// completes its request if that was the last outstanding slot.
+// failBreakpointSet reports a rejected SetBreakpoint against the operation at the
+// head of setQ: every slot parked on the line is answered unverified. The line's
+// intent is dropped so the convergence loop does not spin re-issuing a request
+// the debugger just refused — the client's next setBreakpoints drives any retry.
 func (h *Handler) failBreakpointSet(msg string) {
 	h.mu.Lock()
-	var ready *bpRequest
-	if len(h.setQ) > 0 {
-		slot := h.setQ[0]
-		h.setQ = h.setQ[1:]
-		if lines := h.bpByFile[slot.file]; lines != nil {
-			delete(lines, slot.line)
-		}
-		slot.resolved = true
-		slot.bp = godap.Breakpoint{Verified: false, Line: slot.line, Message: msg}
-		if slot.req.done() {
-			ready = slot.req
+	var ready []*bpRequest
+	if op := h.popSetLocked(); op != nil {
+		if st := h.bpByFile[op.file][op.line]; st != nil {
+			st.pending = nil
+			st.failure = msg
+			st.desired = false
+			ready = h.settleLineLocked(op.file, op.line)
 		}
 	}
 	h.mu.Unlock()
 
-	if ready != nil {
-		h.sendSetBreakpointsResponse(ready)
-	}
+	h.respond(ready)
 }
 
-func (h *Handler) sendSetBreakpointsResponse(r *bpRequest) {
-	bps := make([]godap.Breakpoint, len(r.slots))
-	for i, s := range r.slots {
-		bps[i] = s.bp
+// failBreakpointClear reports a rejected ClearBreakpoint. The line's mapping is
+// deliberately RETAINED: the trap is still armed in the debugger, so dropping
+// its id would leave a breakpoint the client could never remove. The requests
+// that asked for the removal are failed rather than answered success.
+func (h *Handler) failBreakpointClear(msg string) {
+	h.mu.Lock()
+	var ready []*bpRequest
+	if op := h.popClearLocked(); op != nil {
+		if st := h.bpByFile[op.file][op.line]; st != nil {
+			st.pending = nil
+			ready = h.failClearLocked(op.file, op.line, msg)
+		}
 	}
-	h.send(&godap.SetBreakpointsResponse{
-		Response: h.response(r.reqSeq, "setBreakpoints"),
-		Body:     godap.SetBreakpointsResponseBody{Breakpoints: bps},
-	})
+	h.mu.Unlock()
+
+	h.respond(ready)
 }

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -415,14 +415,25 @@ func (h *Handler) onRestarted(evt protocol.Event) {
 
 // reconcileRestartBreakpointsLocked adopts the relaunched process's breakpoint
 // identities: retained lines keep their stable DAP id but take the fresh
-// debugger id, and discarded lines are dropped and reported unverified. A line
-// with an operation in flight is left alone — that operation still owns the
-// line's convergence and its confirmation is still queued in setQ/clearQ, so
-// rewriting its state here would desynchronise both. Caller MUST hold h.mu.
+// debugger id, and discarded lines are dropped and reported unverified.
+//
+// A line whose operation is still in flight is re-identified too. FIFO
+// correlation rides the queued *bpOp, not installedID, so adopting the fresh id
+// cannot desynchronise setQ/clearQ — whereas keeping the pre-restart id would
+// strand the line on an identifier the new engine never issued: the in-flight
+// clear (already marshalled with the dead id) fails against the relaunched
+// process, and failClearLocked's deliberate retain-on-failure would then reissue
+// that dead id for every later attempt, leaving the real new breakpoint
+// unremovable. Re-identifying here is what lets the mapping self-heal.
+//
+// A line with nothing installed (installedID == 0) is still skipped: its
+// convergence has not produced an identity of ours yet, so a payload entry for
+// that line describes some other driver's breakpoint, not one we own.
+// Caller MUST hold h.mu.
 func (h *Handler) reconcileRestartBreakpointsLocked(p protocol.RestartedPayload) ([]godap.Breakpoint, []*bpRequest) {
 	for _, bp := range p.Breakpoints {
 		st := h.bpByFile[bp.Location.File][bp.Location.Line]
-		if st == nil || st.installedID == 0 || st.pending != nil {
+		if st == nil || st.installedID == 0 {
 			continue
 		}
 		st.installedID = bp.ID
@@ -433,7 +444,7 @@ func (h *Handler) reconcileRestartBreakpointsLocked(p protocol.RestartedPayload)
 	var ready []*bpRequest
 	for _, dropped := range p.Discarded {
 		st := h.bpByFile[dropped.Location.File][dropped.Location.Line]
-		if st == nil || st.installedID == 0 || st.pending != nil {
+		if st == nil || st.installedID == 0 {
 			continue
 		}
 		dapID := st.dapID
@@ -443,7 +454,9 @@ func (h *Handler) reconcileRestartBreakpointsLocked(p protocol.RestartedPayload)
 		st.loc = protocol.Location{}
 		st.failure = dropped.Reason
 		// The breakpoint is gone, so anyone parked on the line — including a
-		// request still waiting for it to be removed — can be answered now.
+		// request still waiting for it to be removed — can be answered now. Any
+		// in-flight operation is left to run its course; its confirmation finds
+		// a line that no longer has anything to converge.
 		ready = append(ready, h.settleLineLocked(dropped.Location.File, dropped.Location.Line)...)
 		discarded = append(discarded, godap.Breakpoint{
 			Id:       dapID,

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -217,7 +217,7 @@ func (h *Handler) onBreakpointSet(evt protocol.Event) {
 	h.mu.Lock()
 	var ready []*bpRequest
 	if op := h.popSetLocked(); op != nil {
-		if st := h.bpByFile[op.file][op.line]; st != nil {
+		if st := h.liveLineLocked(op); st != nil {
 			st.pending = nil
 			st.installedID = p.Breakpoint.ID
 			st.loc = p.Breakpoint.Location
@@ -241,7 +241,7 @@ func (h *Handler) onBreakpointCleared() {
 	h.mu.Lock()
 	var ready []*bpRequest
 	if op := h.popClearLocked(); op != nil {
-		if st := h.bpByFile[op.file][op.line]; st != nil {
+		if st := h.liveLineLocked(op); st != nil {
 			st.pending = nil
 			st.installedID = 0
 			st.dapID = 0
@@ -279,6 +279,25 @@ func (h *Handler) popClearLocked() *bpOp {
 	op := h.clearQ[0]
 	h.clearQ = h.clearQ[1:]
 	return op
+}
+
+// liveLineLocked returns the line an operation still speaks for, or nil if the
+// operation has been abandoned — its line was discarded by a restart, forgotten,
+// or has since moved on to a different operation.
+//
+// An abandoned operation keeps its place in setQ/clearQ, because the debugger
+// will still answer it and that answer has to pop the queue head it reserved or
+// every later confirmation correlates to the wrong request. But it must not
+// settle waiters, fail owners, or write state: the removal it was performing was
+// already accounted for when it was abandoned, and the line's identity now
+// belongs to whatever replaced it. So its answer does exactly one thing — pop.
+// Caller MUST hold h.mu.
+func (h *Handler) liveLineLocked(op *bpOp) *bpLine {
+	st := h.bpByFile[op.file][op.line]
+	if st == nil || st.pending != op {
+		return nil
+	}
+	return st
 }
 
 func (h *Handler) onFrames(evt protocol.Event) {
@@ -453,10 +472,16 @@ func (h *Handler) reconcileRestartBreakpointsLocked(p protocol.RestartedPayload)
 		st.desired = false
 		st.loc = protocol.Location{}
 		st.failure = dropped.Reason
+		// Abandon any operation still in flight against the dropped line. Its
+		// command was addressed to a breakpoint the relaunched process no longer
+		// has, so its answer can only be stale — leaving it as the line's live
+		// operation would latch the line, blocking every later request behind a
+		// removal that has already happened. The op stays queued in
+		// setQ/clearQ purely so its answer pops the right head (see
+		// liveLineLocked).
+		st.pending = nil
 		// The breakpoint is gone, so anyone parked on the line — including a
-		// request still waiting for it to be removed — can be answered now. Any
-		// in-flight operation is left to run its course; its confirmation finds
-		// a line that no longer has anything to converge.
+		// request still waiting for it to be removed — can be answered now.
 		ready = append(ready, h.settleLineLocked(dropped.Location.File, dropped.Location.Line)...)
 		discarded = append(discarded, godap.Breakpoint{
 			Id:       dapID,
@@ -575,7 +600,7 @@ func (h *Handler) failBreakpointSet(msg string) {
 	h.mu.Lock()
 	var ready []*bpRequest
 	if op := h.popSetLocked(); op != nil {
-		if st := h.bpByFile[op.file][op.line]; st != nil {
+		if st := h.liveLineLocked(op); st != nil {
 			st.pending = nil
 			st.failure = msg
 			st.desired = false
@@ -595,12 +620,13 @@ func (h *Handler) failBreakpointClear(msg string) {
 	h.mu.Lock()
 	var ready []*bpRequest
 	if op := h.popClearLocked(); op != nil {
-		if st := h.bpByFile[op.file][op.line]; st != nil {
+		if st := h.liveLineLocked(op); st != nil {
 			st.pending = nil
 			ready = h.failClearLocked(op.file, op.line, msg)
 		}
 	}
 	h.mu.Unlock()
 
+	h.flushCommands()
 	h.respond(ready)
 }

--- a/internal/dap/handler.go
+++ b/internal/dap/handler.go
@@ -152,10 +152,13 @@ type bpSlot struct {
 	bp       godap.Breakpoint
 }
 
-// bpOp is one in-flight debugger command for a single file:line. At most one
-// exists per line at a time, which is what keeps the id-less FIFO correlation
-// unambiguous: the head of setQ/clearQ is the operation the next confirmation
-// belongs to — and which queue it sits in is what makes it a set or a clear.
+// bpOp is one in-flight debugger command for a single file:line. A line has at
+// most one LIVE operation at a time, which is what keeps the id-less FIFO
+// correlation unambiguous: the head of setQ/clearQ is the operation the next
+// confirmation belongs to — and which queue it sits in is what makes it a set or
+// a clear. An operation whose line was discarded by a restart is abandoned and
+// no longer speaks for that line, but stays queued so its answer still pops the
+// head it reserved (see liveLineLocked).
 type bpOp struct {
 	file string
 	line int
@@ -166,7 +169,7 @@ type bpOp struct {
 // legitimately disagree. installedID is a fact — set only by a confirmed
 // SetBreakpoint, dropped only by a confirmed ClearBreakpoint — while desired is
 // the latest-wins intent of the most recent request for the source. A line with
-// the two in agreement is converged; otherwise exactly one op is in flight and
+// the two in agreement is converged; otherwise exactly one operation is live and
 // every waiter parks here until it completes. dapID is the stable client-facing
 // identity, which deliberately outlives a debugger id change across restart.
 type bpLine struct {

--- a/internal/dap/handler.go
+++ b/internal/dap/handler.go
@@ -60,6 +60,10 @@ type Handler struct {
 	writeMu sync.Mutex
 	seq     int
 
+	// flushMu serialises outbox drains so staged commands are handed to the hub
+	// in staging order. Never taken while holding mu.
+	flushMu sync.Mutex
+
 	// mu guards all coordination state below. Never held across a socket
 	// write (release mu, then take writeMu) or a cmdOut enqueue.
 	mu sync.Mutex
@@ -99,15 +103,20 @@ type Handler struct {
 	// Suspend/resume (EventContinued).
 	pendingContinues int
 
-	// Breakpoint bookkeeping. bpByFile maps file -> requested line -> DAP and
-	// debugger identities. The two diverge after Restart: DAP identity remains
-	// stable while the fresh debugger assigns a new internal id.
-	// setQ/clearQ are FIFOs of in-flight confirmations, correlated to the hub's
-	// ordered event stream (valid while the DAP client is the sole breakpoint
-	// driver).
-	bpByFile map[string]map[int]breakpointState
-	setQ     []*bpSlot
-	clearQ   []int
+	// Breakpoint bookkeeping. bpByFile maps file -> line -> that line's
+	// transaction state (see bpLine). setQ/clearQ are FIFOs of in-flight
+	// operations, correlated to the hub's ordered event stream (valid while the
+	// DAP client is the sole breakpoint driver).
+	bpByFile map[string]map[int]*bpLine
+	setQ     []*bpOp
+	clearQ   []*bpOp
+
+	// outbox stages breakpoint commands so they reach the hub in the exact
+	// order their setQ/clearQ slot was reserved. Two goroutines produce them —
+	// the DAP read loop (a new setBreakpoints) and the hub write pump (a
+	// confirmation that advances a line) — and the FIFOs are only meaningful
+	// if the wire order matches the reservation order. See flushCommands.
+	outbox [][]byte
 
 	// Data-request correlation FIFOs, one per bingo confirmation event kind.
 	threadsQ []int
@@ -137,30 +146,67 @@ const varRefBase = 1 << 16
 // (or already holding) its resolved DAP breakpoint.
 type bpSlot struct {
 	req      *bpRequest
-	file     string
 	line     int
+	source   godap.Source
 	resolved bool
 	bp       godap.Breakpoint
 }
 
-type breakpointState struct {
-	dapID      int
-	debuggerID int
+// bpOp is one in-flight debugger command for a single file:line. At most one
+// exists per line at a time, which is what keeps the id-less FIFO correlation
+// unambiguous: the head of setQ/clearQ is the operation the next confirmation
+// belongs to — and which queue it sits in is what makes it a set or a clear.
+type bpOp struct {
+	file string
+	line int
 }
 
-// bpRequest collects the slots of a single setBreakpoints request; its response
-// is sent once every slot is resolved (in request order — see AGENTS.md).
+// bpLine keeps what is INSTALLED in the debugger separate from what the client
+// last asked for, because pipelined setBreakpoints requests make the two
+// legitimately disagree. installedID is a fact — set only by a confirmed
+// SetBreakpoint, dropped only by a confirmed ClearBreakpoint — while desired is
+// the latest-wins intent of the most recent request for the source. A line with
+// the two in agreement is converged; otherwise exactly one op is in flight and
+// every waiter parks here until it completes. dapID is the stable client-facing
+// identity, which deliberately outlives a debugger id change across restart.
+type bpLine struct {
+	dapID       int
+	installedID int
+	loc         protocol.Location
+	desired     bool
+	failure     string
+
+	pending     *bpOp
+	setWaiters  []*bpSlot
+	clearOwners []*bpRequest
+}
+
+// bpRequest collects one setBreakpoints request's outstanding work: a slot per
+// requested line plus openClears, the removals it owns. Its response is sent
+// once BOTH are settled, so a request can never report success while a clear it
+// caused is still in flight (or has failed).
 type bpRequest struct {
-	reqSeq int
-	slots  []*bpSlot
+	reqSeq       int
+	slots        []*bpSlot
+	openClears   int
+	clearFailure string
+	responded    bool
 }
 
-func (r *bpRequest) done() bool {
+// ready reports whether the request may be answered now, claiming the right to
+// answer it. Slots and clear obligations settle on different goroutines and can
+// complete in either order, so the claim is what guarantees exactly one
+// response per request. Caller MUST hold h.mu.
+func (r *bpRequest) ready() bool {
+	if r.responded || r.openClears > 0 {
+		return false
+	}
 	for _, s := range r.slots {
 		if !s.resolved {
 			return false
 		}
 	}
+	r.responded = true
 	return true
 }
 
@@ -201,7 +247,7 @@ func NewHandler(conn net.Conn, provider Provider, log *slog.Logger) *Handler {
 		log:      log,
 		cmdOut:   make(chan []byte, cmdBufferSize),
 		done:     make(chan struct{}),
-		bpByFile: make(map[string]map[int]breakpointState),
+		bpByFile: make(map[string]map[int]*bpLine),
 		varCache: make(map[int][]godap.Variable),
 	}
 }
@@ -374,6 +420,37 @@ func (h *Handler) enqueue(cmd []byte) {
 	select {
 	case h.cmdOut <- cmd:
 	case <-h.done:
+	}
+}
+
+// queueCommandLocked stages a breakpoint command for the hub. Staging (rather
+// than enqueuing directly) is what keeps the wire order equal to the setQ/clearQ
+// reservation order: the reservation happens under mu, but the enqueue cannot
+// (it may block), so two producers could otherwise interleave and correlate a
+// confirmation to the wrong operation. Caller MUST hold h.mu.
+func (h *Handler) queueCommandLocked(cmd []byte) {
+	if cmd == nil {
+		return
+	}
+	h.outbox = append(h.outbox, cmd)
+}
+
+// flushCommands drains staged commands to the hub in staging order. flushMu
+// serialises concurrent drains; mu is released around each enqueue so the rule
+// against holding mu across a cmdOut send still holds.
+func (h *Handler) flushCommands() {
+	h.flushMu.Lock()
+	defer h.flushMu.Unlock()
+	for {
+		h.mu.Lock()
+		if len(h.outbox) == 0 {
+			h.mu.Unlock()
+			return
+		}
+		cmd := h.outbox[0]
+		h.outbox = h.outbox[1:]
+		h.mu.Unlock()
+		h.enqueue(cmd)
 	}
 }
 

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -302,6 +302,19 @@ func (hh *harness) inject(kind protocol.EventKind, payload any) {
 	}
 }
 
+// expectNoResponse asserts the handler is not answering anything right now — a
+// setBreakpoints request must stay open while an operation it owns is in flight.
+func (hh *harness) expectNoResponse() {
+	hh.t.Helper()
+	_ = hh.client.SetReadDeadline(time.Now().Add(80 * time.Millisecond))
+	defer func() { _ = hh.client.SetReadDeadline(time.Time{}) }()
+	if _, err := hh.reader.Peek(1); err == nil {
+		hh.t.Fatal("handler responded while an owned breakpoint operation was still pending")
+	} else if nerr, ok := err.(net.Error); !ok || !nerr.Timeout() {
+		hh.t.Fatalf("peek while pending: %v", err)
+	}
+}
+
 func initArgs() *godap.InitializeRequest {
 	return &godap.InitializeRequest{Arguments: godap.InitializeRequestArguments{AdapterID: "bingo"}}
 }
@@ -604,13 +617,16 @@ func TestSetBreakpointsDiffAndFIFO(t *testing.T) {
 		Breakpoints: []godap.SourceBreakpoint{{Line: 20}},
 	}}
 	hh.sendReq("setBreakpoints", sb2)
-	// Line 20 unchanged → resolves immediately without a new SetBreakpoint.
+	// A ClearBreakpoint for the removed line 10 must have been enqueued, and the
+	// response must wait for it: the request owns that removal.
+	hh.cmds.waitForCommand(t, protocol.CmdClearBreakpoint)
+	hh.expectNoResponse()
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
+
 	resp2 := recvType[*godap.SetBreakpointsResponse](hh)
 	if len(resp2.Body.Breakpoints) != 1 || resp2.Body.Breakpoints[0].Line != 20 {
 		t.Fatalf("diff response = %+v", resp2.Body.Breakpoints)
 	}
-	// A ClearBreakpoint for the removed line 10 must have been enqueued.
-	hh.cmds.waitForCommand(t, protocol.CmdClearBreakpoint)
 }
 
 func seedRestartBreakpointCache(t *testing.T, hh *harness, source godap.Source) {
@@ -680,8 +696,8 @@ func requireRestartBreakpointCache(t *testing.T, hh *harness, source godap.Sourc
 	retained := hh.handler.bpByFile[source.Path][10]
 	_, droppedStillCached := hh.handler.bpByFile[source.Path][20]
 	hh.handler.mu.Unlock()
-	if retained.debuggerID != 101 || retained.dapID != 41 {
-		t.Fatalf("retained breakpoint state = %+v, want debuggerID=101 dapID=41", retained)
+	if retained == nil || retained.installedID != 101 || retained.dapID != 41 {
+		t.Fatalf("retained breakpoint state = %+v, want installedID=101 dapID=41", retained)
 	}
 	if droppedStillCached {
 		t.Fatal("discarded breakpoint remained in cache")
@@ -723,6 +739,7 @@ func clearReidentifiedBreakpoint(t *testing.T, hh *harness, source godap.Source)
 	if clear.ID != 101 {
 		t.Fatalf("clear breakpoint id = %d, want fresh debugger id 101", clear.ID)
 	}
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
 	_ = recvType[*godap.SetBreakpointsResponse](hh)
 }
 
@@ -769,17 +786,18 @@ func TestRestartedPayloadDecodeFailureStillResponds(t *testing.T) {
 
 func TestRestartPreservesBreakpointCorrelationQueues(t *testing.T) {
 	h := NewHandler(nil, nil, nil)
-	setSlot := &bpSlot{}
-	h.setQ = []*bpSlot{setSlot}
-	h.clearQ = []int{73}
+	setOp := &bpOp{file: "/x/main.go", line: 10}
+	clearOp := &bpOp{file: "/x/main.go", line: 20}
+	h.setQ = []*bpOp{setOp}
+	h.clearQ = []*bpOp{clearOp}
 
 	h.onRestarted(protocol.MustEvent(protocol.EventRestarted, 1, protocol.RestartedPayload{}))
 
-	if len(h.setQ) != 1 || h.setQ[0] != setSlot {
+	if len(h.setQ) != 1 || h.setQ[0] != setOp {
 		t.Fatalf("setQ changed across restart: %+v", h.setQ)
 	}
-	if len(h.clearQ) != 1 || h.clearQ[0] != 73 {
-		t.Fatalf("clearQ changed across restart: %v", h.clearQ)
+	if len(h.clearQ) != 1 || h.clearQ[0] != clearOp {
+		t.Fatalf("clearQ changed across restart: %+v", h.clearQ)
 	}
 }
 


### PR DESCRIPTION
Stacked on #138 (base `xsachax-fix-dap-restart-breakpoints`) — its dapID/debuggerID split is a prerequisite.

> **Depends on #162** (`fix(hub): prevent ordinary command loss`, fixing #160). See *Dependency and merge order* below — this PR is **not** standalone-merge-safe to `main` before #162.

## Summary

`setBreakpoints` was a fire-and-forget diff over a single fused per-line record, so "installed in the debugger" and "what the client last asked for" could never disagree — but under pipelining they legitimately do. Two independently reproduced symptoms shared that one root:

- **Replace-all forgot live IDs.** The removed line was deleted from `bpByFile` before its `ClearBreakpoint` was confirmed, and a request's completion check only looked at its Set slots. A remove-all responded success immediately; a rejected clear only popped `clearQ`, leaving the trap armed (`breakpointTable.clear` keeps the entry when the memory write fails), its debugger id forgotten, and the user told it worked.
- **Pipelined requests resurrected removed breakpoints.** `A:[10]` then `B:[]` dropped line 10 without sending a Clear (its id wasn't known yet) and answered B success; A's late confirmation then wrote the line back as live. An overlapping request wanting an already-pending line also issued a duplicate `CmdSetBreakpoint`, whose `errBreakpointExists` failure deleted the entry holding the first, live id.

## What changed

`bpLine` now keeps three things apart per file:line — `installedID` (a fact: written only by a confirmed set, dropped only by a confirmed clear), `desired` (latest-wins intent), and `pending` (the single **live** `bpOp`). `advanceLineLocked` is a convergence loop: issue the one command the gap calls for, or settle everyone parked on the line when the two agree. Every confirmation re-enters it.

That yields the invariants:

- removals are owned by the request that caused them, so a response never precedes its own clears;
- a rejected clear **retains** the mapping and fails the originating request with a DAP error response — and, because it ends the line's only in-flight operation, it also answers anything else parked there rather than stranding it;
- a superseded pending set is cleared the instant its id arrives, never committed as desired state;
- an overlapping request attaches to the in-flight operation instead of duplicating it;
- exactly one response per request (`bpRequest.ready()` claims the right to answer), answered in `reqSeq` order;
- sources stay independent.

Commands are staged in an `outbox` drained in reservation order (`flushCommands`/`flushMu`), because both the DAP read loop and the hub write pump now produce them and the id-less FIFO correlation only works if wire order matches slot-reservation order.

No wire-protocol change, no rejection of overlapping requests, and the documented id-less FIFO limitation is unchanged.

### Restart: re-identification and abandoned operations (commits 2–3)

Restart reconciliation from #138 is preserved, with two corrections the transaction made reachable:

**Re-identify, don't skip.** A line with an operation in flight is re-identified too. Keeping the pre-restart id was a real defect: that id is dead after the relaunch, the already-marshalled clear is rejected by the new engine, and retain-on-failure would then reissue the same dead id forever — leaving the breakpoint the restart actually installed permanently unremovable. Correlation rides the queued `*bpOp`, not `installedID`, so adopting the fresh id cannot desynchronise `setQ`/`clearQ`, and the mapping self-heals before the stale clear fails. A line with `installedID == 0` is still skipped — it owns no identity yet, so a payload entry for it describes another driver's breakpoint.

**Abandon the operation on a discard.** A discarded line previously kept its in-flight clear as `pending` while zeroing everything else — a zombie operation that latched the line. A later request wanting the breakpoint back could issue nothing; another empty replace-all took on a removal obligation for a line already removed; and the eventual stale rejection then discharged both against the wrong state — spuriously failing a removal that had happened, and answering the waiting request unverified without ever attempting its Set, leaving the line `desired` but unarmed with nothing left to drive it. Such an operation is now **abandoned**: it stops being the line's `pending` op (so the line converges again immediately) but keeps its FIFO slot, because the debugger will still answer it and that answer must pop the head it reserved. `liveLineLocked` matches a popped op against the line's current `pending`, so an abandoned or superseded answer does exactly one thing — pop. It never settles waiters, fails owners, or disarms an identity that now belongs to a re-identified line.

`failClearLocked`'s refusal to re-enter the convergence loop is narrowed to the case that justifies it — a still-armed line, where retrying would reissue a failing clear forever. With nothing armed there is nothing to retry and nothing to report, so the removal completes successfully and the line converges on the newest intent.

## Dependency and merge order

This transaction assumes every ordinary command it enqueues eventually produces a confirmation or an error. There are deliberately **no adapter-side timeouts**: one would mask command loss and could fire against a merely slow debugger, so the fix does not invent one.

Under #160 the hub silently drops ordinary commands once `cmdCh` fills. With this change, such a drop no longer merely strands a request — it latches that line's `pending` forever, so no later operation can be issued for it either. #162 is therefore a genuine dependency, not a nice-to-have.

**Merge order: #162 → (#138) → this PR.** #138 and #162 are independent of each other (different packages) and may land in either order, but #182 must not reach `main` before #162. This branch deliberately does **not** duplicate or vendor any part of the hub fix. The adapter's half of the delivery contract is covered here — `TestLargeSetBreakpointsDeliversEveryCommandInOrder` proves the handler blocks rather than drops on a `3 × cmdBufferSize` burst and preserves reservation order; the hub's half is `injectCommand`'s admission in #162. A cross-cutting regression that only passes with #162 present would fail CI on this branch, so it belongs with the hub fix.

## Tests

New `internal/dap/breakpoints_test.go` over the existing loopback-TCP handler harness — 21 specs covering: failed clear after remove-all retains the id and fails the request; partial clear failure; a failed clear still answers the superseded set; a failed clear with nothing armed completes rather than fails and resumes converging; A-set-then-B-empty issues exactly one Clear and ends empty; duplicate pending set emits one Set; set→remove→re-add leaves exactly one live breakpoint; removal completes before a re-add is installed; cross-source independence; restart re-identifying a line under a pending clear (self-healing id) and ignoring a line with no installed identity; a discarded line accepting a later set and ignoring the stale rejection; a discarded line not failing an already-satisfied removal; a late stale clear *success* not disturbing the re-identified line while keeping the FIFO aligned; no-drop/in-order command delivery; exactly-once responses. `TestSetBreakpointsDiffAndFIFO` and the restart specs were updated for the new (correct) "wait for the clear" semantics.

Every new spec was mutation-checked against the behaviour it pins. Two are hardened specifically so the mechanism cannot be removed silently: the stale-rejection spec asserts the abandoned operation's answer is a pure FIFO pop (SetBreakpoint count stays at two, the set queue holds exactly the one live re-add op), which fails if `liveLineLocked` loses its pending-op guard; and the exactly-once spec drives a request that is genuinely re-offered — an already-converged line settles it inside `onSetBreakpoints` and the trailing readiness check then tests it again — which produces a duplicate response if `ready()` stops claiming.

```
gofmt/goimports: clean
golangci-lint run --build-tags bingonative ./internal/dap/...   # 0 issues
go vet -tags bingonative ./...
go vet -tags "e2e bingonative" ./test/integration/
go test -tags bingonative -race -count=1 ./internal/dap/... ./internal/hub/...
go test -tags bingonative -race -count=5 ./internal/dap/
```

AGENTS.md records the transaction invariant, live-vs-abandoned operation semantics, the restart rules, and the ordinary-command delivery dependency.

Fixes #178
