### PR TITLE
fix(debugger): suspend the hub on asynchronous engine halts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,12 +342,24 @@ that can never fire.
 
 What a halt promises is **control**, not a pristine tracee: the operator regains
 the ability to inspect, retry, or kill. It does not guarantee the tracee's byte
-state is consistent — a write that failed partway can leave an untracked trap,
-and at the `populateBreakpointStop` site the PC was never rewound — so a
-subsequent resume is best-effort and the error text says the breakpoint may no
-longer be armed or tracked. Reconciling tracee state after a partially-applied
-breakpoint write is a separate problem; do not add disabled-breakpoint
+state is consistent, and at the `populateBreakpointStop` site it specifically is
+not — with no located stop the PC was never rewound off the trap, so on amd64
+RIP sits one byte past the `INT3` and a plain `Continue` would execute from
+mid-instruction. **`Kill`/`Restart` is the safe recovery there, not `Continue`**;
+that site's `EventError` says so explicitly. Elsewhere a failed or partially
+applied breakpoint write can leave an untracked trap behind. Reconciling tracee
+state after such a write is a separate problem — do not add disabled-breakpoint
 protocol/state here.
+
+Note also that this rule covers the *reporting* of halts, not every internal
+resume: five `handleStop` paths still ignore `ContinueProcess`'s error (the
+spurious-trap advance, `bpResumeContinue`, the successful `StepOut`
+continuation, the leftover-pause-signal suppression, and the ordinary-signal
+auto-resume). If one of those ever fails, the engine records `stateRunning` for
+a tracee that never resumed and no event is emitted at all — the same class of
+liveness loss from the other direction. None has a confirmed backend
+reachability, so none is fixed or filed yet; **do not treat this class as
+globally closed.**
 
 The sites are `populateBreakpointStop` failure (`StopBreakpoint`),
 `populateStopPC` failure and `bps.reinstall` failure (`StopSingleStep`), the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,13 +187,20 @@ When multiple clients race resume commands: **first writer wins**, the rest
 are dropped (`resumeCh` has capacity 1; see [hub.go injectCommand](internal/hub/hub.go)).
 
 Rejected resumes: a resuming command only ends the suspend if the debugger
-actually resumes the process. If the resume is **rejected** — e.g. a transient
-backend error while reinstalling a software breakpoint leaves the engine
-`stateSuspended` — the hub broadcasts the `EventError` but **stays in the wait
-loop** (it checks that the session left `suspended` before returning). Bailing
-out on a failed resume would strand the client: the process is still suspended,
-but a retry resume lands in `resumeCh`, which only the wait loop drains, so the
-session could never be resumed again.
+actually resumes the process. If the resume is **rejected synchronously** —
+e.g. the dispatch returns an error and leaves the engine `stateSuspended` — the
+hub broadcasts the `EventError` but **stays in the wait loop** (it checks that
+the session left `suspended` before returning). Bailing out on a failed resume
+would strand the client: the process is still suspended, but a retry resume
+lands in `resumeCh`, which only the wait loop drains, so the session could never
+be resumed again.
+
+Resumes that are **accepted and only fail later** are a different problem, and
+the wait loop cannot catch them: `Continue`/`Step*` off a software breakpoint
+return `nil` as soon as the step-over single-step is armed, so the hub has
+already transitioned to `running` and left the wait loop by the time the
+failure happens on the engine loop. Those asynchronous halts are reported with a
+suspending `EventPaused` — see [step-over flow](#software-breakpoint-step-over-flow).
 
 ### Session state machine
 
@@ -296,6 +303,59 @@ Internal sentinel BP files: `<stepover-next>`, `<stepout-return>`,
 If `bps.reinstall` ever fails after a single-step, **suspend instead of
 resuming**. Running without the trap is a runaway process; reporting the
 error lets the operator intervene.
+
+**Every asynchronous halt in `handleStop` must be reported with a *suspending*
+event, not a bare `EventError`.** These failures happen after the resume that
+led to them already returned `nil` and emitted `EventContinued`, so the hub has
+transitioned to `running` and left its suspend wait loop. `EventError` is not
+suspending, so on its own it leaves the hub believing the tracee runs while it
+is halted — and since `resumeCh` is drained *only* inside that wait loop, every
+later `Continue`/`Step*` sits unread and the session is stranded for good
+(issue #183). The rule at each such site is:
+
+1. emit the detailed `EventError` (it carries the real cause),
+2. ensure `setState(stateSuspended)`,
+3. emit the suspending `EventPaused`.
+
+`haltOnError(cmd, cause, stop)` does all three in the right order — use it
+rather than open-coding the pair. Order matters: `Continued → Error → Paused`.
+`Paused` must be last because the hub drains `resumeCh` *before* broadcasting a
+suspending event, so a legitimate retry sent in response to `Paused`
+necessarily lands after that drain.
+
+`emitHaltedOnError` emits `EventPaused` with a **synthetic** goroutine and a
+pure-DWARF location, and issues **no backend calls at all** — not
+`emitPaused`/`goroutineSnapshot`, and not even a stack walk. The backend on this
+path is by definition already failing, so any read could delay or prevent the
+one event that restores liveness; clients can ask for frames or a snapshot once
+the session is responsive again. `haltOnError` wraps the pair and, because
+`emit` drops events when the buffer is full, gives the last free slot to the
+`Paused` rather than the `Error` — losing the suspend is what strands the
+session, losing the cause merely loses detail.
+
+`EventPaused` is the right kind: `EventStepped` is treated as the entry stop by
+the DAP restart path and can auto-continue, `EventBreakpointHit` would claim a
+trap that may not be installed, and an unsolicited `EventBreakpointCleared`
+would corrupt DAP's id-less FIFO correlation. A failed-reinstall breakpoint
+stays **out** of the table: re-adding it would advertise an armed breakpoint
+that can never fire.
+
+What a halt promises is **control**, not a pristine tracee: the operator regains
+the ability to inspect, retry, or kill. It does not guarantee the tracee's byte
+state is consistent — a write that failed partway can leave an untracked trap,
+and at the `populateBreakpointStop` site the PC was never rewound — so a
+subsequent resume is best-effort and the error text says the breakpoint may no
+longer be armed or tracked. Reconciling tracee state after a partially-applied
+breakpoint write is a separate problem; do not add disabled-breakpoint
+protocol/state here.
+
+The sites are `populateBreakpointStop` failure (`StopBreakpoint`),
+`populateStopPC` failure and `bps.reinstall` failure (`StopSingleStep`), the
+`bpResumeStepOut` return-breakpoint `set` failure (which is also the one site
+that must add the otherwise-missing `setState(stateSuspended)` — it is reached
+with the engine still `stateRunning`), and the in-flight reinstall and manual
+`populateStopPC` failures (`StopSignal`). The `bpResumeSourceStep` fallback is
+already safe: it emits a suspending `EventStepped`.
 
 ## Architecture-specific traps
 
@@ -624,7 +684,12 @@ auto-emitted on exactly the suspends that can change the concurrency picture —
 single-step/step-over path from extra per-step memory reads. `emitBreakpointHit`
 / `emitPaused` build the snapshot **once**, embed its current goroutine in the
 stop event, then stream the same snapshot — one build, no double scan, no double
-delta pass.
+delta pass. The one `EventPaused` that carries **no** snapshot is the internal
+async halt (`emitHaltedOnError`, see [step-over flow](#software-breakpoint-step-over-flow)):
+it is emitted on a backend error path, where a snapshot would push dozens of
+further reads through the backend that just failed. Observers keep their last
+good model; the halt is still reported, and `CmdGoroutineSnapshot` can refresh
+on demand.
 
 **Not a suspending event.** It follows a suspending event (or answers a query)
 and never gates the hub. DAP `translateEvent` **deliberately ignores** it:
@@ -1325,10 +1390,20 @@ side `chan error` — every debugger outcome, failures included, rides the singl
 - `pkg/protocol`: pure wire round-trip tests, no fakes needed.
 - `internal/debugger`: `fakeBackend` in [engine_test.go](internal/debugger/engine_test.go)
   replaces the OS. Tests seed mem/regs, push `StopEvent`s onto `stopCh`, and
-  inspect recorded calls. `export_test.go` exposes a few internals
+  inspect recorded calls. It also supports **fault injection**
+  (`failWriteAt` / `failReadAt` / `failRegisters` / `failThreads`, guarded by
+  `faultMu`) so the asynchronous `handleStop` error paths can be driven
+  deterministically; arm the fault *before* pushing the stop that reaches it.
+  [engine_halt_test.go](internal/debugger/engine_halt_test.go) uses this to pin
+  the suspending-halt invariant at every site, and pairs a **real `Hub` with a
+  real engine** over the fake backend — the hub's own `fakeDebugger` cannot
+  exercise asynchronous stop handling, so that spec lives here rather than in
+  `internal/hub`. `export_test.go` exposes a few internals
   (`ExportedForceSuspended`, `ExportedSetBreakpointAt`, …) so tests can
-  bypass DWARF and the OS process model. Engine tests are tagged-agnostic —
-  they avoid native code paths.
+  bypass DWARF and the OS process model. Note `ExportedForceRunning` only flips
+  the state field — it starts no `waitLoop`, so a stop pushed after it is never
+  consumed; reach `running` through a real `Continue` when a stop must be
+  delivered. Engine tests are tagged-agnostic — they avoid native code paths.
 - `internal/hub`: `fakeDebugger` + `fakeWSConn` in [hub_test.go](internal/hub/hub_test.go).
   The fake conn uses a 256-deep `incoming` buffer so `WriteMessage` never
   blocks the hub event loop.
@@ -1519,6 +1594,11 @@ through the justfile.
 - **Suspend/resume sets**: update both `suspendingEvents` and
   `resumingCommands` in [hub.go](internal/hub/hub.go), and the matching
   hub_test cases.
+- **New `handleStop` error path**: any new place where `handleStop` gives up on
+  a resume must report it with `haltOnError` (detailed `EventError` + suspending
+  `EventPaused`) with the engine in `stateSuspended`. A bare `EventError` is
+  non-suspending and strands the session permanently — see
+  [step-over flow](#software-breakpoint-step-over-flow).
 - **New `EventKind`/`CommandKind`**: if it should reach an IDE, add its
   translation to [internal/dap](internal/dap/) (`translateEvent`/event handlers
   for events, `dispatchRequest` for the reverse). Events with no DAP equivalent

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,10 +328,25 @@ pure-DWARF location, and issues **no backend calls at all** — not
 `emitPaused`/`goroutineSnapshot`, and not even a stack walk. The backend on this
 path is by definition already failing, so any read could delay or prevent the
 one event that restores liveness; clients can ask for frames or a snapshot once
-the session is responsive again. `haltOnError` wraps the pair and, because
-`emit` drops events when the buffer is full, gives the last free slot to the
-`Paused` rather than the `Error` — losing the suspend is what strands the
-session, losing the cause merely loses detail.
+the session is responsive again.
+
+Delivery of that `Paused` is guaranteed by a **reserved buffer slot**. The
+events channel is `eventBufSize + eventBufReserve` deep; ordinary `emit` refuses
+to use the last slot, and only `emitReserved` — used solely by the halt path —
+may. Without it a saturated buffer silently dropped the halt and recreated the
+strand. `haltOnError` therefore emits the cause as an ordinary event (logging it
+instead when no ordinary slot is free, since losing detail is far cheaper than
+losing the suspend) and the `Paused` through `emitReserved`.
+
+**One reserved slot suffices**, because a second halt can never be queued behind
+the first: emitting a halt leaves the engine `stateSuspended` with the tracee
+stopped, a stopped tracee cannot produce the next stop, and the only route back
+to running is a resume — which the hub sends exclusively from inside the suspend
+wait loop it enters *after receiving* that event. The same argument covers the
+ordinary suspending events (`BreakpointHit`/`Stepped`/`Paused`/`Panic`): none can
+still be sitting in the buffer when a halt is handled. The length check needs no
+lock: the loop thread is the only writer, so `len` can only fall as the hub
+drains, and observing room guarantees the send succeeds.
 
 `EventPaused` is the right kind: `EventStepped` is treated as the entry stop by
 the DAP restart path and can auto-continue, `EventBreakpointHit` would claim a

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -858,3 +858,81 @@ func TestJoinExistingSuspendedSession(t *testing.T) {
 	_ = recvType[*godap.ContinueResponse](hh)
 	hh.cmds.waitForCommand(t, protocol.CmdContinue)
 }
+
+// TestAsyncHaltSurfacesAsStoppedPause pins the adapter side of the engine's
+// asynchronous-halt reporting (issue #183). handleStop failures emit a detailed
+// EventError followed by a suspending EventPaused; the error alone carries no
+// correlation for CmdNone, so it is the Paused that must restore the adapter's
+// suspended view and tell the IDE the tracee is halted.
+func TestAsyncHaltSurfacesAsStoppedPause(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	hh.inject(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{Goroutine: protocol.Goroutine{ID: 1}})
+	_ = recvType[*godap.StoppedEvent](hh)
+
+	hh.sendReq("continue", &godap.ContinueRequest{})
+	_ = recvType[*godap.ContinueResponse](hh)
+	hh.cmds.waitForCommand(t, protocol.CmdContinue)
+	hh.inject(protocol.EventContinued, protocol.ContinuedPayload{})
+
+	// The step-over fails asynchronously: no DAP request is outstanding, so the
+	// CmdNone error produces no response of its own.
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdNone,
+		Message: "reinstall breakpoint 0x1000: injected",
+	})
+	hh.inject(protocol.EventPaused, protocol.PausedPayload{Goroutine: protocol.Goroutine{ID: 1}})
+
+	stopped := recvType[*godap.StoppedEvent](hh)
+	if stopped.Body.Reason != "pause" {
+		t.Errorf("reason = %q, want pause", stopped.Body.Reason)
+	}
+
+	// Being suspended again is what makes the session usable: a data request
+	// must now reach the hub instead of being answered with an empty stub.
+	hh.sendReq("stackTrace", &godap.StackTraceRequest{Arguments: godap.StackTraceArguments{ThreadId: 1}})
+	hh.cmds.waitForCommand(t, protocol.CmdFrames)
+}
+
+// TestAsyncHaltDuringRestartIsNotTreatedAsEntry is why the halt is reported as
+// EventPaused rather than EventStepped: onStop's restart branch treats the
+// first Stepped as the relaunched process's entry stop and, without
+// stopOnEntry, auto-continues past it. A halt must never do that — the tracee
+// is stopped precisely because it is not safe to resume.
+func TestAsyncHaltDuringRestartIsNotTreatedAsEntry(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	hh.inject(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{Goroutine: protocol.Goroutine{ID: 1}})
+	_ = recvType[*godap.StoppedEvent](hh)
+
+	hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{})
+	_ = recvType[*godap.RestartResponse](hh)
+
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdNone,
+		Message: "get stop PC for tid 1: injected",
+	})
+	continuesBefore := countKind(hh.cmds.kinds(), protocol.CmdContinue)
+	hh.inject(protocol.EventPaused, protocol.PausedPayload{Goroutine: protocol.Goroutine{ID: 1}})
+
+	stopped := recvType[*godap.StoppedEvent](hh)
+	if stopped.Body.Reason != "pause" {
+		t.Errorf("reason = %q, want pause", stopped.Body.Reason)
+	}
+	if got := countKind(hh.cmds.kinds(), protocol.CmdContinue); got != continuesBefore {
+		t.Fatalf("halt during restart auto-continued the tracee: continues %d -> %d",
+			continuesBefore, got)
+	}
+}
+
+func countKind(kinds []protocol.CommandKind, want protocol.CommandKind) int {
+	n := 0
+	for _, k := range kinds {
+		if k == want {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -591,7 +591,7 @@ func (e *engine) handleStop(stop StopEvent) {
 		var err error
 		stop, err = e.populateBreakpointStop(stop)
 		if err != nil {
-			e.emitError(protocol.CmdNone, err)
+			e.haltOnError(protocol.CmdNone, err, stop)
 			return
 		}
 		bp := e.bps.atAddr(stop.PC)
@@ -647,7 +647,7 @@ func (e *engine) handleStop(stop StopEvent) {
 			}
 			e.endThreadStep()
 			e.setState(stateSuspended)
-			e.emitError(protocol.CmdNone, err)
+			e.haltOnError(protocol.CmdNone, err, stop)
 			return
 		}
 		e.log.Debug("StopSingleStep", "pc", fmt.Sprintf("0x%x", stop.PC),
@@ -656,12 +656,16 @@ func (e *engine) handleStop(stop StopEvent) {
 			e.steppingOverBP = nil
 			if rerr := e.bps.reinstall(e.backend, sob); rerr != nil {
 				// Reinstall failed. Suspend instead of resuming — running
-				// without the trap would let the process loose.
+				// without the trap would let the process loose. The breakpoint
+				// stays out of the table: its trap is not guaranteed to be
+				// installed, so re-adding the entry would advertise an armed
+				// breakpoint that can never fire.
 				e.endThreadStep()
 				e.log.Error("breakpoint reinstall failed — suspending to prevent runaway process",
 					"addr", fmt.Sprintf("0x%x", sob.addr), "err", rerr)
 				e.setState(stateSuspended)
-				e.emitError(protocol.CmdNone, fmt.Errorf("reinstall breakpoint 0x%x: %w", sob.addr, rerr))
+				e.haltOnError(protocol.CmdNone, fmt.Errorf(
+					"reinstall breakpoint 0x%x (it may no longer be armed or tracked): %w", sob.addr, rerr), stop)
 				return
 			}
 			// The trap byte is back in place; only now is it safe to release
@@ -713,7 +717,15 @@ func (e *engine) handleStop(stop StopEvent) {
 			case bpResumeStepOut:
 				_, setErr := e.bps.set(e.backend, stepOutReturnFile, 0, e.bpRetAddr)
 				if setErr != nil && !errors.Is(setErr, errBreakpointExists) {
-					e.emitError(protocol.CmdStepOut, fmt.Errorf("StepOut: set return breakpoint: %w", setErr))
+					// The tracee is halted here — the trap was reinstalled and
+					// the held threads released, but ContinueProcess is never
+					// reached. resumeFromBreakpoint left the engine running, so
+					// unlike the other failure paths this one must correct the
+					// state itself or every later command is rejected with
+					// ErrNotSuspended against a process that cannot move.
+					e.setState(stateSuspended)
+					e.haltOnError(protocol.CmdStepOut,
+						fmt.Errorf("StepOut: set return breakpoint: %w", setErr), stop)
 					return
 				}
 				_ = e.backend.ContinueProcess()
@@ -733,7 +745,9 @@ func (e *engine) handleStop(stop StopEvent) {
 			if rerr := e.bps.reinstall(e.backend, sob); rerr != nil {
 				e.endThreadStep()
 				e.setState(stateSuspended)
-				e.emitError(protocol.CmdNone, fmt.Errorf("reinstall breakpoint 0x%x after signal: %w", sob.addr, rerr))
+				e.haltOnError(protocol.CmdNone, fmt.Errorf(
+					"reinstall breakpoint 0x%x after signal (it may no longer be armed or tracked): %w",
+					sob.addr, rerr), stop)
 				return
 			}
 			e.endThreadStep()
@@ -747,7 +761,7 @@ func (e *engine) handleStop(stop StopEvent) {
 				var err error
 				if stop, err = e.populateStopPC(stop, false); err != nil {
 					e.setState(stateSuspended)
-					e.emitError(protocol.CmdNone, err)
+					e.haltOnError(protocol.CmdNone, err, stop)
 					return
 				}
 				e.setState(stateSuspended)
@@ -1244,6 +1258,60 @@ func (e *engine) emitPaused(stop StopEvent) {
 		Frames:    frames,
 	})
 	e.emit(protocol.EventGoroutineSnapshot, snap)
+}
+
+// haltOnError reports a FAILED asynchronous stop-handling operation: the
+// detailed cause first, then the suspending EventPaused that puts the hub back
+// into its suspend wait loop. Callers must already have ensured stateSuspended.
+//
+// The Paused is the load-bearing half. emit drops events when the buffer is
+// full, and losing the Paused while the Error got through would recreate
+// exactly the strand this exists to prevent (issue #183) — so when the buffer
+// cannot hold both, the cause is logged rather than emitted and the suspend is
+// kept. Only the loop thread writes e.events, so free capacity observed here
+// cannot be consumed by anyone else; a hub draining concurrently only frees
+// more.
+func (e *engine) haltOnError(cmd protocol.CommandKind, cause error, stop StopEvent) {
+	if cap(e.events)-len(e.events) >= 2 {
+		e.emitError(cmd, cause)
+	} else {
+		e.log.Error("halting: event buffer full — dropping the cause to preserve the suspend",
+			"command", cmd, "err", cause)
+	}
+	e.emitHaltedOnError(stop)
+}
+
+// emitHaltedOnError emits the suspending event for an internal halt. It exists
+// because these failures are not attributable to any command in flight: the
+// resume that led here already returned nil and already emitted EventContinued,
+// so the hub has transitioned to running and left its suspend wait loop.
+// EventError is not a suspending event, so reporting the failure alone leaves
+// the hub believing the tracee runs while it is in fact halted — and since
+// resumeCh is drained only inside that wait loop, every later resume sits
+// unread and the session is stranded for good.
+//
+// It issues NO backend calls. The caller is on a backend error path, so the
+// backend is by definition already failing or gone: a goroutineSnapshot (as
+// emitPaused does) or even a stack walk would push dozens of further reads
+// through it and could delay or prevent the one event that restores liveness.
+// A synthetic goroutine and a pure-DWARF location are all the hub needs to gate
+// on and all DAP needs to map to `stopped` reason=pause; clients that want more
+// can request frames or a snapshot now that the session is responsive again.
+func (e *engine) emitHaltedOnError(stop StopEvent) {
+	if stop.TID != 0 {
+		e.curTID = stop.TID
+	}
+	// This is a suspend like any other self-stop, so it cancels a racing Pause
+	// whose interrupt is still queued in the tracee (see emitBreakpointHit).
+	e.manualStopPending = false
+	loc := protocol.Location{}
+	if e.dw != nil {
+		loc = e.dw.locationForPC(stop.PC)
+	}
+	e.emit(protocol.EventPaused, protocol.PausedPayload{
+		Goroutine: e.syntheticGoroutine(stop.PC),
+		Location:  loc,
+	})
 }
 
 // emitContinued reports that the tracee has resumed free execution in response

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -591,7 +591,13 @@ func (e *engine) handleStop(stop StopEvent) {
 		var err error
 		stop, err = e.populateBreakpointStop(stop)
 		if err != nil {
-			e.haltOnError(protocol.CmdNone, err, stop)
+			// Without a located stop the PC was never rewound off the trap.
+			// On amd64 RIP is left one byte past the INT3, so a plain resume
+			// would execute from mid-instruction; say so, because the client
+			// has no other way to know that continuing is the unsafe option.
+			e.haltOnError(protocol.CmdNone, fmt.Errorf(
+				"%w — the breakpoint PC was not rewound, so resuming may execute "+
+					"from mid-instruction; kill or restart to recover safely", err), stop)
 			return
 		}
 		bp := e.bps.atAddr(stop.PC)
@@ -792,7 +798,15 @@ func (e *engine) populateStopPC(stop StopEvent, rewind bool) (StopEvent, error) 
 	if stop.PC != 0 {
 		return stop, nil
 	}
-	if stop.TID == 0 {
+	// Keep the guessed thread local until it is confirmed by a successful
+	// register read. On darwin task_threads returns creation order, so
+	// threads[0] is frequently an idle runtime M rather than the thread that
+	// stopped; committing it to stop.TID on the error path would hand that
+	// wrong thread to curTID via the halt event, and curTID is what every
+	// later step primitive targets (see the curTID field comment). A real TID
+	// supplied by the backend is preserved untouched either way.
+	tid := stop.TID
+	if tid == 0 {
 		threads, err := e.backend.Threads()
 		if err != nil {
 			return stop, fmt.Errorf("get stop thread: %w", err)
@@ -800,12 +814,13 @@ func (e *engine) populateStopPC(stop StopEvent, rewind bool) (StopEvent, error) 
 		if len(threads) == 0 {
 			return stop, fmt.Errorf("get stop thread: no threads")
 		}
-		stop.TID = threads[0]
+		tid = threads[0]
 	}
-	regs, err := e.backend.GetRegisters(stop.TID)
+	regs, err := e.backend.GetRegisters(tid)
 	if err != nil {
-		return stop, fmt.Errorf("get stop PC for tid %d: %w", stop.TID, err)
+		return stop, fmt.Errorf("get stop PC for tid %d: %w", tid, err)
 	}
+	stop.TID = tid
 	if rewind {
 		stop.PC = archRewindPC(regs.PC)
 	} else {
@@ -1300,6 +1315,8 @@ func (e *engine) haltOnError(cmd protocol.CommandKind, cause error, stop StopEve
 // A synthetic goroutine and a pure-DWARF location are all the hub needs to gate
 // on and all DAP needs to map to `stopped` reason=pause; clients that want more
 // can request frames or a snapshot now that the session is responsive again.
+// Both go through locForPC so a PC of 0 short-circuits instead of scanning
+// every compilation unit, and so the location agrees with the goroutine's.
 func (e *engine) emitHaltedOnError(stop StopEvent) {
 	if stop.TID != 0 {
 		e.curTID = stop.TID
@@ -1307,13 +1324,9 @@ func (e *engine) emitHaltedOnError(stop StopEvent) {
 	// This is a suspend like any other self-stop, so it cancels a racing Pause
 	// whose interrupt is still queued in the tracee (see emitBreakpointHit).
 	e.manualStopPending = false
-	loc := protocol.Location{}
-	if e.dw != nil {
-		loc = e.dw.locationForPC(stop.PC)
-	}
 	e.emit(protocol.EventPaused, protocol.PausedPayload{
 		Goroutine: e.syntheticGoroutine(stop.PC),
-		Location:  loc,
+		Location:  e.locForPC(stop.PC),
 	})
 }
 

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -717,12 +717,15 @@ func (e *engine) handleStop(stop StopEvent) {
 			case bpResumeStepOut:
 				_, setErr := e.bps.set(e.backend, stepOutReturnFile, 0, e.bpRetAddr)
 				if setErr != nil && !errors.Is(setErr, errBreakpointExists) {
-					// The tracee is halted here — the trap was reinstalled and
-					// the held threads released, but ContinueProcess is never
-					// reached. resumeFromBreakpoint left the engine running, so
-					// unlike the other failure paths this one must correct the
-					// state itself or every later command is rejected with
-					// ErrNotSuspended against a process that cannot move.
+					// The tracee is halted here — the step-over trap was
+					// reinstalled and the stepping bookkeeping ended (which
+					// disarms the hardware single-step but deliberately does
+					// NOT resume the world; only ContinueProcess does, and it
+					// is never reached on this path). resumeFromBreakpoint left
+					// the engine running, so unlike the other failure paths
+					// this one must correct the state itself or every later
+					// command is rejected with ErrNotSuspended against a
+					// process that cannot move.
 					e.setState(stateSuspended)
 					e.haltOnError(protocol.CmdStepOut,
 						fmt.Errorf("StepOut: set return breakpoint: %w", setErr), stop)

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -15,6 +15,13 @@ const (
 	eventBufSize  = 64
 	maxStackDepth = 64
 
+	// eventBufReserve is extra channel capacity on top of eventBufSize that
+	// ORDINARY events may never occupy. It is held back so a suspending halt
+	// event always has somewhere to go: emit is non-blocking and drops on a
+	// full buffer, and dropping the halt's EventPaused is what strands a
+	// session for good (issue #183). See haltOnError and emitReserved.
+	eventBufReserve = 1
+
 	stepOverNextFile  = "<stepover-next>"
 	stepOutReturnFile = "<stepout-return>"
 )
@@ -174,7 +181,7 @@ func newEngine(b Backend, log *slog.Logger) *engine {
 	e := &engine{
 		backend: b,
 		bps:     newBreakpointTable(),
-		events:  make(chan protocol.Event, eventBufSize),
+		events:  make(chan protocol.Event, eventBufSize+eventBufReserve),
 		cmdCh:   make(chan engineCmd, 8),
 		stopCh:  make(chan stopResult, 1),
 		done:    make(chan struct{}),
@@ -1167,7 +1174,31 @@ func (e *engine) nextSeq() uint64 {
 	return s
 }
 
+// emit queues an ordinary event. It refuses to touch the reserved tail slot,
+// which exists solely so a suspending halt event can always be delivered — see
+// emitReserved.
 func (e *engine) emit(kind protocol.EventKind, payload any) {
+	e.emitWithin(kind, payload, eventBufSize)
+}
+
+// emitReserved queues an event that may use the reserved slot on top of
+// eventBufSize. Only suspending halt events use it: they are the one kind whose
+// loss is unrecoverable, because the hub gates on them and drains resumeCh only
+// while gated.
+//
+// One reserved slot is enough because a second halt cannot be queued behind the
+// first. Emitting a halt leaves the engine stateSuspended with the tracee
+// stopped, and a stopped tracee cannot produce the next stop; the only way back
+// to running is a resume, which the hub sends exclusively from inside the
+// suspend wait loop it enters after RECEIVING the suspending event. So the
+// reserved slot is always free again before another halt can be reported. The
+// same argument covers the ordinary suspending events (BreakpointHit/Stepped/
+// Paused/Panic): none can still be queued when a halt is handled.
+func (e *engine) emitReserved(kind protocol.EventKind, payload any) {
+	e.emitWithin(kind, payload, eventBufSize+eventBufReserve)
+}
+
+func (e *engine) emitWithin(kind protocol.EventKind, payload any, limit int) {
 	evt, err := protocol.NewEvent(kind, e.nextSeq(), payload)
 	if err != nil {
 		slog.Error("engine.emit: marshal event failed", "kind", kind, "err", err)
@@ -1177,6 +1208,14 @@ func (e *engine) emit(kind protocol.EventKind, payload any) {
 	// while a reader is gone would deadlock the loop against its own teardown.
 	// The buffer is sized so the continuously-draining hub never fills it, and
 	// the exit path is backstopped by the events channel closing on loop return.
+	//
+	// The length check is race-safe without a lock: the loop thread is the only
+	// writer, so len can only FALL between the check and the send as the hub
+	// drains. Observing room therefore guarantees the send succeeds.
+	if len(e.events) >= limit {
+		slog.Warn("engine.emit: events buffer full — dropping", "kind", kind, "limit", limit)
+		return
+	}
 	select {
 	case e.events <- evt:
 	default:
@@ -1282,18 +1321,18 @@ func (e *engine) emitPaused(stop StopEvent) {
 // detailed cause first, then the suspending EventPaused that puts the hub back
 // into its suspend wait loop. Callers must already have ensured stateSuspended.
 //
-// The Paused is the load-bearing half. emit drops events when the buffer is
-// full, and losing the Paused while the Error got through would recreate
-// exactly the strand this exists to prevent (issue #183) — so when the buffer
-// cannot hold both, the cause is logged rather than emitted and the suspend is
-// kept. Only the loop thread writes e.events, so free capacity observed here
-// cannot be consumed by anyone else; a hub draining concurrently only frees
-// more.
+// The Paused is the load-bearing half, so the two are emitted with different
+// guarantees. The cause is an ordinary event and takes an ordinary slot; when
+// none is free it is logged instead of emitted, since losing detail is far
+// cheaper than losing the suspend. The Paused then goes out through
+// emitReserved, which can always fall back on the slot ordinary events are
+// forbidden to use. That is what stops a saturated buffer from delivering a
+// lone non-suspending EventError and recreating issue #183.
 func (e *engine) haltOnError(cmd protocol.CommandKind, cause error, stop StopEvent) {
-	if cap(e.events)-len(e.events) >= 2 {
+	if len(e.events) < eventBufSize {
 		e.emitError(cmd, cause)
 	} else {
-		e.log.Error("halting: event buffer full — dropping the cause to preserve the suspend",
+		e.log.Error("halting: event buffer full — logging the cause instead of emitting it",
 			"command", cmd, "err", cause)
 	}
 	e.emitHaltedOnError(stop)
@@ -1324,7 +1363,7 @@ func (e *engine) emitHaltedOnError(stop StopEvent) {
 	// This is a suspend like any other self-stop, so it cancels a racing Pause
 	// whose interrupt is still queued in the tracee (see emitBreakpointHit).
 	e.manualStopPending = false
-	e.emit(protocol.EventPaused, protocol.PausedPayload{
+	e.emitReserved(protocol.EventPaused, protocol.PausedPayload{
 		Goroutine: e.syntheticGoroutine(stop.PC),
 		Location:  e.locForPC(stop.PC),
 	})

--- a/internal/debugger/engine_halt_test.go
+++ b/internal/debugger/engine_halt_test.go
@@ -1,0 +1,366 @@
+package debugger_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/bingosuite/bingo/internal/debugger"
+	"github.com/bingosuite/bingo/internal/hub"
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+// These specs pin the invariant that every asynchronous halt in handleStop is
+// reported with a SUSPENDING event, not a bare EventError. handleStop runs long
+// after the resume command was answered — the client has already been told the
+// process resumed (EventContinued) and the hub has already left its suspend
+// wait loop. A non-suspending EventError therefore leaves the hub believing the
+// tracee runs while it is in fact halted forever, and since resumeCh is drained
+// only inside that wait loop, every later resume is stranded unread.
+
+// haltEvents is the Error-then-Paused pair every asynchronous stop-handling
+// failure must produce, in that order.
+func expectHaltReported(d debugger.Debugger, msgSubstring string) {
+	errEvt := mustNextEvent(d)
+	ExpectWithOffset(1, errEvt.Kind).To(Equal(protocol.EventError),
+		"the detailed error must be reported first")
+	var ep protocol.ErrorPayload
+	ExpectWithOffset(1, protocol.DecodeEventPayload(errEvt, &ep)).To(Succeed())
+	if msgSubstring != "" {
+		ExpectWithOffset(1, ep.Message).To(ContainSubstring(msgSubstring))
+	}
+
+	pausedEvt := mustNextEvent(d)
+	ExpectWithOffset(1, pausedEvt.Kind).To(Equal(protocol.EventPaused),
+		"a suspending event must follow so the hub re-enters its suspend wait loop")
+}
+
+// runWithWaitLoop moves a suspended engine to running through the real Continue
+// path, which is what starts the waitLoop goroutine that consumes backend
+// stops. ExportedForceRunning only flips the state field, so a stop pushed
+// after it would never be read.
+func runWithWaitLoop(d debugger.Debugger) {
+	debugger.ExportedForceSuspended(d)
+	ExpectWithOffset(1, d.Continue()).To(Succeed())
+	ExpectWithOffset(1, mustNextEvent(d).Kind).To(Equal(protocol.EventContinued))
+}
+
+// arriveAtBreakpoint drives the engine to a real user-breakpoint suspend at
+// addr, leaving lastBP set so the next resume takes the step-over path.
+func arriveAtBreakpoint(fb *fakeBackend, d debugger.Debugger, addr uint64) {
+	fb.seedMem(addr, []byte{0x90, 0x90, 0x90, 0x90, 0x90})
+	debugger.ExportedForceSuspended(d)
+	debugger.ExportedSetBreakpointAt(d, addr)
+
+	runWithWaitLoop(d)
+	fb.pushStop(debugger.StopEvent{Reason: debugger.StopBreakpoint, TID: 1, PC: addr})
+	ExpectWithOffset(1, mustNextEvent(d).Kind).To(Equal(protocol.EventBreakpointHit))
+}
+
+var _ = Describe("asynchronous halts in handleStop", func() {
+	var (
+		fb *fakeBackend
+		d  debugger.Debugger
+	)
+
+	BeforeEach(func() {
+		fb = newFakeBackend()
+		d = debugger.NewWithBackend(fb, nil)
+	})
+
+	AfterEach(func() {
+		fb.clearFaults()
+		_ = d.Kill()
+		if !fb.stopped {
+			close(fb.stopCh)
+			fb.stopped = true
+		}
+	})
+
+	// Site A — StopBreakpoint: populateBreakpointStop failure.
+	It("reports a halt when the breakpoint stop cannot be located", func() {
+		runWithWaitLoop(d)
+
+		fb.failThreads(errInjected)
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopBreakpoint})
+
+		expectHaltReported(d, "find breakpoint thread")
+
+		fb.clearFaults()
+		Expect(d.Continue()).To(Succeed(), "the session must remain resumable")
+	})
+
+	// Site B — StopSingleStep: populateStopPC failure.
+	It("reports a halt when the single-step PC cannot be read", func() {
+		debugger.ExportedForceSuspended(d)
+		Expect(d.StepInto()).To(Succeed())
+
+		fb.failRegisters(errInjected)
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSingleStep})
+
+		expectHaltReported(d, "get stop PC")
+
+		fb.clearFaults()
+		Expect(d.Continue()).To(Succeed(), "the session must remain resumable")
+	})
+
+	// Site C — StopSingleStep: breakpoint reinstall failure. This is the
+	// canonical stranding case: the resume was accepted and EventContinued
+	// already told every client the process runs again.
+	It("reports a halt when the step-over breakpoint cannot be reinstalled", func() {
+		const bpAddr = uint64(0x4100)
+		arriveAtBreakpoint(fb, d, bpAddr)
+
+		continueAndConsumeContinued(d)
+
+		fb.failWriteAt(bpAddr, errInjected)
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSingleStep, TID: 1, PC: bpAddr + 4})
+
+		expectHaltReported(d, "reinstall breakpoint")
+
+		fb.clearFaults()
+		before := fb.continueCount()
+		Expect(d.Continue()).To(Succeed(), "the session must remain resumable")
+		Expect(fb.continueCount()).To(BeNumerically(">", before),
+			"the retry must actually reach the backend")
+	})
+
+	// Site D — StopSingleStep/bpResumeStepOut: the temporary return breakpoint
+	// cannot be set. Uniquely, this site left the engine in stateRunning while
+	// the tracee was halted, so it also has to correct the state.
+	It("reports a halt when the StepOut return breakpoint cannot be set", func() {
+		const bpAddr = uint64(0x4200)
+		const retAddr = uint64(0x9900)
+		arriveAtBreakpoint(fb, d, bpAddr)
+
+		// Frame chain so stepOut can resolve the return address.
+		seedFrameChain(fb, bpAddr, 0x7000, 0x7100, retAddr)
+		fb.seedMem(retAddr, []byte{0x90, 0x90, 0x90, 0x90, 0x90})
+
+		Expect(d.StepOut()).To(Succeed())
+
+		fb.failReadAt(retAddr, errInjected)
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSingleStep, TID: 1, PC: bpAddr + 4})
+
+		expectHaltReported(d, "return breakpoint")
+
+		fb.clearFaults()
+		before := fb.continueCount()
+		Expect(d.Continue()).To(Succeed(),
+			"the engine must be suspended, not left believing it is running")
+		Expect(fb.continueCount()).To(BeNumerically(">", before))
+	})
+
+	// Site E — StopSignal: in-flight step-over reinstall failure.
+	It("reports a halt when a signal interrupts an unreinstallable step-over", func() {
+		const bpAddr = uint64(0x4300)
+		arriveAtBreakpoint(fb, d, bpAddr)
+
+		continueAndConsumeContinued(d)
+
+		fb.failWriteAt(bpAddr, errInjected)
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSignal, TID: 1, Signal: 11})
+
+		expectHaltReported(d, "after signal")
+
+		fb.clearFaults()
+		before := fb.continueCount()
+		Expect(d.Continue()).To(Succeed(), "the session must remain resumable")
+		Expect(fb.continueCount()).To(BeNumerically(">", before))
+	})
+
+	// The suspending event is the load-bearing half: emit() drops events when
+	// the buffer is full, and losing the Paused while the Error got through
+	// would recreate the strand this whole change prevents.
+	It("keeps the suspend when only one event slot is left", func() {
+		debugger.ExportedFillEventBuffer(d, 1)
+		debugger.ExportedHaltOnError(d, "injected")
+
+		var kinds []protocol.EventKind
+		for {
+			select {
+			case evt := <-d.Events():
+				kinds = append(kinds, evt.Kind)
+				continue
+			default:
+			}
+			break
+		}
+		Expect(kinds).To(ContainElement(protocol.EventPaused),
+			"the last free slot must carry the suspend, not the cause")
+	})
+
+	// Site F — StopSignal/manual Pause: populateStopPC failure.
+	It("reports a halt when a Pause stop's PC cannot be read", func() {
+		runWithWaitLoop(d)
+		Expect(d.Pause()).To(Succeed())
+
+		fb.failRegisters(errInjected)
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSignal, Signal: fb.PauseSignal()})
+
+		expectHaltReported(d, "get stop PC")
+
+		fb.clearFaults()
+		Expect(d.Continue()).To(Succeed(), "the session must remain resumable")
+	})
+})
+
+// haltConn is a minimal hub.WSConn for the integration spec below. The hub's
+// own fakeWSConn lives in package hub_test and cannot be reused from here.
+type haltConn struct {
+	mu       sync.Mutex
+	incoming chan []byte
+	outgoing chan []byte
+	closed   bool
+}
+
+func newHaltConn() *haltConn {
+	return &haltConn{
+		incoming: make(chan []byte, 256),
+		outgoing: make(chan []byte, 32),
+	}
+}
+
+func (c *haltConn) send(cmd protocol.Command) {
+	data, err := json.Marshal(cmd)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	c.mu.Lock()
+	closed := c.closed
+	c.mu.Unlock()
+	if !closed {
+		c.outgoing <- data
+	}
+}
+
+// awaitEvent drains broadcasts until kind arrives, so auxiliary events
+// (snapshots, session state) don't make the assertion order-sensitive.
+func (c *haltConn) awaitEvent(kind protocol.EventKind) bool {
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case msg := <-c.incoming:
+			var evt protocol.Event
+			if err := json.Unmarshal(msg, &evt); err != nil {
+				continue
+			}
+			if evt.Kind == kind {
+				return true
+			}
+		case <-deadline:
+			return false
+		}
+	}
+}
+
+func (c *haltConn) ReadMessage() (int, []byte, error) {
+	data, ok := <-c.outgoing
+	if !ok {
+		return 0, nil, errInjected
+	}
+	return hub.TextMessage, data, nil
+}
+
+func (c *haltConn) WriteMessage(_ int, data []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return errInjected
+	}
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	c.incoming <- cp
+	return nil
+}
+
+func (c *haltConn) SetReadLimit(int64)                {}
+func (c *haltConn) SetReadDeadline(time.Time) error   { return nil }
+func (c *haltConn) SetWriteDeadline(time.Time) error  { return nil }
+func (c *haltConn) SetPongHandler(func(string) error) {}
+
+func (c *haltConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.closed {
+		c.closed = true
+		close(c.outgoing)
+	}
+	return nil
+}
+
+// This is the end-to-end proof: a REAL hub driving a REAL engine over a
+// fault-injected backend. It is deliberately not in internal/hub, whose
+// fakeDebugger cannot exercise the engine's asynchronous stop handling.
+var _ = Describe("hub recovery from an asynchronous engine halt", func() {
+	It("keeps a session resumable after a failed breakpoint reinstall", func() {
+		const bpAddr = uint64(0x4400)
+
+		fb := newFakeBackend()
+		d := debugger.NewWithBackend(fb, nil)
+		h := hub.New(d, nil)
+
+		conn := newHaltConn()
+		_, err := h.AddClient(conn, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go h.Run(ctx)
+		defer func() {
+			cancel()
+			fb.clearFaults()
+			_ = d.Kill()
+			if !fb.stopped {
+				close(fb.stopCh)
+				fb.stopped = true
+			}
+		}()
+
+		arriveAtBreakpoint := func() {
+			// Deliberately inlined rather than sharing the engine-only helper:
+			// the hub's Run loop is the sole consumer of d.Events(), so the
+			// setup must never read that channel itself.
+			fb.seedMem(bpAddr, []byte{0x90, 0x90, 0x90, 0x90, 0x90})
+			debugger.ExportedForceSuspended(d)
+			debugger.ExportedSetBreakpointAt(d, bpAddr)
+
+			// Drive the first resume straight at the engine: it is what starts
+			// the waitLoop, and a CmdContinue sent while the hub is running
+			// would sit unread in resumeCh (that is the very bug under test).
+			Expect(d.Continue()).To(Succeed())
+			fb.pushStop(debugger.StopEvent{Reason: debugger.StopBreakpoint, TID: 1, PC: bpAddr})
+		}
+
+		arriveAtBreakpoint()
+		Expect(conn.awaitEvent(protocol.EventBreakpointHit)).To(BeTrue())
+		Eventually(h.State).Should(Equal(protocol.StateSuspended))
+
+		// A resume the hub accepts: the engine arms the step-over single-step,
+		// answers nil, and the hub leaves its suspend wait loop.
+		conn.send(protocol.Command{Version: protocol.Version, Kind: protocol.CmdContinue})
+		Expect(conn.awaitEvent(protocol.EventContinued)).To(BeTrue())
+		Eventually(h.State).Should(Equal(protocol.StateRunning))
+
+		// The step-over now fails asynchronously, far from the resume that the
+		// hub already reported as successful.
+		fb.failWriteAt(bpAddr, errInjected)
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSingleStep, TID: 1, PC: bpAddr + 4})
+
+		Expect(conn.awaitEvent(protocol.EventError)).To(BeTrue())
+		Eventually(h.State).Should(Equal(protocol.StateSuspended),
+			"the halted tracee must be reported as suspended, not running")
+
+		fb.clearFaults()
+		before := fb.continueCount()
+
+		// The decisive assertion: resumeCh is drained only inside the hub's
+		// suspend wait loop, so this second Continue reaches the engine only if
+		// the halt was reported as a suspending event.
+		conn.send(protocol.Command{Version: protocol.Version, Kind: protocol.CmdContinue})
+		Eventually(fb.continueCount, 2*time.Second).
+			Should(BeNumerically(">", before),
+				"the retried Continue never reached the backend — the session is stranded")
+	})
+})

--- a/internal/debugger/engine_halt_test.go
+++ b/internal/debugger/engine_halt_test.go
@@ -173,12 +173,32 @@ var _ = Describe("asynchronous halts in handleStop", func() {
 		Expect(fb.continueCount()).To(BeNumerically(">", before))
 	})
 
-	// The suspending event is the load-bearing half: emit() drops events when
-	// the buffer is full, and losing the Paused while the Error got through
-	// would recreate the strand this whole change prevents.
-	It("keeps the suspend when only one event slot is left", func() {
-		debugger.ExportedFillEventBuffer(d, 1)
-		debugger.ExportedHaltOnError(d, "injected")
+	// The suspending event is the load-bearing half: emit drops events when the
+	// buffer is full, so a saturated buffer used to lose the Paused (and, once
+	// the cause was also dropped, report nothing at all) and recreate the exact
+	// strand this change prevents. The reserved slot must make the suspend
+	// survive even with zero ordinary slots left.
+	It("keeps the suspend and stays resumable with zero free ordinary slots", func() {
+		const bpAddr = uint64(0x4700)
+		arriveAtBreakpoint(fb, d, bpAddr)
+		continueAndConsumeContinued(d)
+
+		debugger.ExportedFillEventBuffer(d, 0)
+
+		fb.failWriteAt(bpAddr, errInjected)
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSingleStep, TID: 1, PC: bpAddr + 4})
+
+		// Continue is dispatched and requires stateSuspended, so it starts
+		// succeeding only once the halt has been fully handled. Retrying it
+		// synchronises on that without draining the buffer, and its success
+		// proves the session re-entered the suspended gate. The write fault
+		// stays armed: after the halt lastBP is nil, so the retry is a plain
+		// ContinueProcess that touches no memory.
+		before := fb.continueCount()
+		Eventually(d.Continue).Should(Succeed(),
+			"the halt never suspended the engine")
+		Expect(fb.continueCount()).To(BeNumerically(">", before),
+			"the retried Continue never reached the backend")
 
 		var kinds []protocol.EventKind
 		for {
@@ -191,7 +211,7 @@ var _ = Describe("asynchronous halts in handleStop", func() {
 			break
 		}
 		Expect(kinds).To(ContainElement(protocol.EventPaused),
-			"the last free slot must carry the suspend, not the cause")
+			"the reserved slot must carry the suspend even when the buffer is full")
 	})
 
 	// A halt whose stop never resolved a thread must not overwrite curTID with

--- a/internal/debugger/engine_halt_test.go
+++ b/internal/debugger/engine_halt_test.go
@@ -194,6 +194,37 @@ var _ = Describe("asynchronous halts in handleStop", func() {
 			"the last free slot must carry the suspend, not the cause")
 	})
 
+	// A halt whose stop never resolved a thread must not overwrite curTID with
+	// the Threads()[0] guess. curTID is what every later step primitive
+	// targets, and on darwin threads[0] is frequently an idle runtime M.
+	It("keeps the previous current thread when the stop's TID is unresolved", func() {
+		const bpAddr = uint64(0x4600)
+		const stoppedTID = 7
+
+		Expect(fb.tids).To(Equal([]int{1}), "threads[0] must differ from the stopped thread")
+
+		fb.seedMem(bpAddr, []byte{0x90, 0x90, 0x90, 0x90, 0x90})
+		debugger.ExportedForceSuspended(d)
+		debugger.ExportedSetBreakpointAt(d, bpAddr)
+		runWithWaitLoop(d)
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopBreakpoint, TID: stoppedTID, PC: bpAddr})
+		Expect(mustNextEvent(d).Kind).To(Equal(protocol.EventBreakpointHit))
+
+		Expect(d.StepInto()).To(Succeed())
+
+		// The step's stop carries no TID, and resolving one fails.
+		fb.failRegisters(errInjected)
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSingleStep})
+		expectHaltReported(d, "get stop PC")
+
+		fb.clearFaults()
+		before := len(fb.singleStepCalls)
+		Expect(d.StepInto()).To(Succeed())
+		Expect(fb.singleStepCalls).To(HaveLen(before+1), "a step must have been issued")
+		Expect(fb.singleStepCalls[before]).To(Equal(stoppedTID),
+			"the guessed thread leaked into curTID")
+	})
+
 	// Site F — StopSignal/manual Pause: populateStopPC failure.
 	It("reports a halt when a Pause stop's PC cannot be read", func() {
 		runWithWaitLoop(d)

--- a/internal/debugger/engine_test.go
+++ b/internal/debugger/engine_test.go
@@ -3,6 +3,7 @@ package debugger_test
 import (
 	"encoding/binary"
 	"errors"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -33,16 +34,80 @@ type fakeBackend struct {
 	singleStepCalls  []int
 	stopProcessCalls int
 	writtenAt        map[uint64][]byte
+
+	// Fault injection for the asynchronous stop-handling error paths. A test
+	// arms a fault and only then pushes the stop event that reaches the
+	// faulting code, so the arming is already ordered before the engine's
+	// read; faultMu makes that explicit rather than leaning on the channel's
+	// happens-before edge, and keeps -race quiet if a waitLoop is in flight.
+	faultMu    sync.Mutex
+	threadsErr error
+	regsErr    error
+	writeErrAt map[uint64]error
+	readErrAt  map[uint64]error
 }
 
 func newFakeBackend() *fakeBackend {
 	return &fakeBackend{
-		mem:       make(map[uint64]byte),
-		regs:      map[int]debugger.Registers{1: {}},
-		tids:      []int{1},
-		stopCh:    make(chan debugger.StopEvent, 8),
-		writtenAt: make(map[uint64][]byte),
+		mem:        make(map[uint64]byte),
+		regs:       map[int]debugger.Registers{1: {}},
+		tids:       []int{1},
+		stopCh:     make(chan debugger.StopEvent, 8),
+		writtenAt:  make(map[uint64][]byte),
+		writeErrAt: make(map[uint64]error),
+		readErrAt:  make(map[uint64]error),
 	}
+}
+
+var errInjected = errors.New("injected backend fault")
+
+func (f *fakeBackend) failThreads(err error) {
+	f.faultMu.Lock()
+	defer f.faultMu.Unlock()
+	f.threadsErr = err
+}
+
+func (f *fakeBackend) failRegisters(err error) {
+	f.faultMu.Lock()
+	defer f.faultMu.Unlock()
+	f.regsErr = err
+}
+
+func (f *fakeBackend) failWriteAt(addr uint64, err error) {
+	f.faultMu.Lock()
+	defer f.faultMu.Unlock()
+	f.writeErrAt[addr] = err
+}
+
+func (f *fakeBackend) failReadAt(addr uint64, err error) {
+	f.faultMu.Lock()
+	defer f.faultMu.Unlock()
+	f.readErrAt[addr] = err
+}
+
+func (f *fakeBackend) clearFaults() {
+	f.faultMu.Lock()
+	defer f.faultMu.Unlock()
+	f.threadsErr = nil
+	f.regsErr = nil
+	f.writeErrAt = make(map[uint64]error)
+	f.readErrAt = make(map[uint64]error)
+}
+
+func (f *fakeBackend) faultFor(kind string, addr uint64) error {
+	f.faultMu.Lock()
+	defer f.faultMu.Unlock()
+	switch kind {
+	case "threads":
+		return f.threadsErr
+	case "regs":
+		return f.regsErr
+	case "write":
+		return f.writeErrAt[addr]
+	case "read":
+		return f.readErrAt[addr]
+	}
+	return nil
 }
 
 func (f *fakeBackend) seedMem(addr uint64, data []byte) {
@@ -72,10 +137,31 @@ func (f *fakeBackend) peekMem(addr uint64, n int) []byte {
 	return out
 }
 
-func (f *fakeBackend) ContinueProcess() error  { f.continueCalls++; return nil }
-func (f *fakeBackend) StopProcess() error      { f.stopProcessCalls++; return nil }
-func (f *fakeBackend) PauseSignal() int        { return int(syscall.SIGSTOP) }
-func (f *fakeBackend) Threads() ([]int, error) { return f.tids, nil }
+func (f *fakeBackend) ContinueProcess() error {
+	f.faultMu.Lock()
+	f.continueCalls++
+	f.faultMu.Unlock()
+	return nil
+}
+
+// continueCount reads the resume counter under the lock. Assertions that poll
+// (Eventually) must use it: unlike the synchronously-dispatched cases, a
+// polling read genuinely races the engine loop's ContinueProcess.
+func (f *fakeBackend) continueCount() int {
+	f.faultMu.Lock()
+	defer f.faultMu.Unlock()
+	return f.continueCalls
+}
+
+func (f *fakeBackend) StopProcess() error { f.stopProcessCalls++; return nil }
+func (f *fakeBackend) PauseSignal() int   { return int(syscall.SIGSTOP) }
+
+func (f *fakeBackend) Threads() ([]int, error) {
+	if err := f.faultFor("threads", 0); err != nil {
+		return nil, err
+	}
+	return f.tids, nil
+}
 
 func (f *fakeBackend) SingleStep(tid int) error {
 	f.singleStepCalls = append(f.singleStepCalls, tid)
@@ -83,6 +169,9 @@ func (f *fakeBackend) SingleStep(tid int) error {
 }
 
 func (f *fakeBackend) ReadMemory(addr uint64, dst []byte) error {
+	if err := f.faultFor("read", addr); err != nil {
+		return err
+	}
 	for i := range dst {
 		dst[i] = f.mem[addr+uint64(i)]
 	}
@@ -90,6 +179,9 @@ func (f *fakeBackend) ReadMemory(addr uint64, dst []byte) error {
 }
 
 func (f *fakeBackend) WriteMemory(addr uint64, src []byte) error {
+	if err := f.faultFor("write", addr); err != nil {
+		return err
+	}
 	cp := make([]byte, len(src))
 	copy(cp, src)
 	f.writtenAt[addr] = cp
@@ -100,6 +192,9 @@ func (f *fakeBackend) WriteMemory(addr uint64, src []byte) error {
 }
 
 func (f *fakeBackend) GetRegisters(tid int) (debugger.Registers, error) {
+	if err := f.faultFor("regs", 0); err != nil {
+		return debugger.Registers{}, err
+	}
 	return f.regs[tid], nil
 }
 
@@ -575,9 +670,9 @@ var _ = Describe("Engine", func() {
 		})
 
 		It("calls ContinueProcess on the backend", func() {
-			before := fb.continueCalls
+			before := fb.continueCount()
 			Expect(d.Continue()).To(Succeed())
-			Expect(fb.continueCalls).To(Equal(before + 1))
+			Expect(fb.continueCount()).To(Equal(before + 1))
 		})
 
 		It("rejects a second Continue without an intervening stop", func() {

--- a/internal/debugger/export_test.go
+++ b/internal/debugger/export_test.go
@@ -1,12 +1,7 @@
 // Exposes internal symbols to debugger_test. Compiled only during `go test`.
 package debugger
 
-import (
-	"errors"
-	"fmt"
-
-	"github.com/bingosuite/bingo/pkg/protocol"
-)
+import "fmt"
 
 func ExportedTrapInstruction() []byte {
 	return archTrapInstruction()
@@ -102,30 +97,19 @@ func ExportedSetBreakpointAtErr(d Debugger, addr uint64) error {
 	})
 }
 
-// ExportedFillEventBuffer emits filler events on the loop until exactly free
-// slots remain in the engine's event buffer, so tests can drive emit() to
-// saturation. Deterministic only while nothing is draining Events().
+// ExportedFillEventBuffer emits filler events until exactly free ORDINARY slots
+// remain in the engine's event buffer. Ordinary emits can never occupy the
+// reserved halt slot, so free=0 means the buffer is full for every normal event
+// while the reserved slot is still open. Deterministic only while nothing is
+// draining Events().
 func ExportedFillEventBuffer(d Debugger, free int) {
 	e := d.(*engine)
 	if err := e.dispatch(func() error {
-		for cap(e.events)-len(e.events) > free {
+		for eventBufSize-len(e.events) > free {
 			e.emitOutput("stdout", "filler")
 		}
 		return nil
 	}); err != nil {
 		panic("ExportedFillEventBuffer: " + err.Error())
-	}
-}
-
-// ExportedHaltOnError runs the halt-reporting path on the loop. dispatch only
-// returns once the closure has run, so a test can observe the resulting events
-// without racing the loop.
-func ExportedHaltOnError(d Debugger, msg string) {
-	e := d.(*engine)
-	if err := e.dispatch(func() error {
-		e.haltOnError(protocol.CmdNone, errors.New(msg), StopEvent{TID: 1, PC: 0x1000})
-		return nil
-	}); err != nil {
-		panic("ExportedHaltOnError: " + err.Error())
 	}
 }

--- a/internal/debugger/export_test.go
+++ b/internal/debugger/export_test.go
@@ -1,7 +1,12 @@
 // Exposes internal symbols to debugger_test. Compiled only during `go test`.
 package debugger
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
 
 func ExportedTrapInstruction() []byte {
 	return archTrapInstruction()
@@ -95,4 +100,32 @@ func ExportedSetBreakpointAtErr(d Debugger, addr uint64) error {
 		_, err := e.bps.set(e.backend, "<direct-addr>", 0, addr)
 		return err
 	})
+}
+
+// ExportedFillEventBuffer emits filler events on the loop until exactly free
+// slots remain in the engine's event buffer, so tests can drive emit() to
+// saturation. Deterministic only while nothing is draining Events().
+func ExportedFillEventBuffer(d Debugger, free int) {
+	e := d.(*engine)
+	if err := e.dispatch(func() error {
+		for cap(e.events)-len(e.events) > free {
+			e.emitOutput("stdout", "filler")
+		}
+		return nil
+	}); err != nil {
+		panic("ExportedFillEventBuffer: " + err.Error())
+	}
+}
+
+// ExportedHaltOnError runs the halt-reporting path on the loop. dispatch only
+// returns once the closure has run, so a test can observe the resulting events
+// without racing the loop.
+func ExportedHaltOnError(d Debugger, msg string) {
+	e := d.(*engine)
+	if err := e.dispatch(func() error {
+		e.haltOnError(protocol.CmdNone, errors.New(msg), StopEvent{TID: 1, PC: 0x1000})
+		return nil
+	}); err != nil {
+		panic("ExportedHaltOnError: " + err.Error())
+	}
 }

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -316,15 +316,22 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 		case cmd := <-h.resumeCh:
 			h.log.Info("resuming", "command", cmd.Kind)
 			// A resume ends the suspend only if it actually took effect. When
-			// the debugger rejects it — e.g. a transient backend error while
-			// reinstalling a software breakpoint (AGENTS.md → step-over flow),
-			// leaving the engine stateSuspended — executeCommand broadcasts an
-			// EventError but performs no → running transition. Returning here
-			// would strand the client: a retry resume lands in resumeCh, which
-			// only this wait loop drains (Run's outer loop never selects on it),
-			// so the process could never be resumed again. Keep waiting unless
-			// the resume advanced the session out of suspended (running on
-			// success, or exited if the process died mid-resume).
+			// the debugger rejects it SYNCHRONOUSLY — the dispatch returns an
+			// error while the engine stays stateSuspended — executeCommand
+			// broadcasts an EventError but performs no → running transition.
+			// Returning here would strand the client: a retry resume lands in
+			// resumeCh, which only this wait loop drains (Run's outer loop
+			// never selects on it), so the process could never be resumed
+			// again. Keep waiting unless the resume advanced the session out of
+			// suspended (running on success, or exited if the process died
+			// mid-resume).
+			//
+			// A resume that is accepted and only fails LATER — e.g. the
+			// software-breakpoint reinstall after the step-over single-step —
+			// cannot be caught here: the dispatch already returned nil and this
+			// loop has already exited. The engine reports those asynchronous
+			// halts with a suspending EventPaused so Run's outer loop re-enters
+			// this wait; see AGENTS.md → step-over flow.
 			h.executeCommand(cmd)
 			if h.State() != protocol.StateSuspended {
 				return

--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -30,10 +30,19 @@ const (
 	EventPanic         EventKind = "Panic"
 	EventStepped       EventKind = "Stepped"
 
-	// EventPaused reports that a Pause request forcibly halted the running
-	// tracee. Like BreakpointHit it is a suspending event — the process is
-	// stopped and the hub waits for a resuming command — but it is delivered
-	// asynchronously in response to CmdPause rather than a self-stop.
+	// EventPaused reports that the tracee was forcibly halted rather than
+	// reaching a self-stop. Like BreakpointHit it is a suspending event — the
+	// process is stopped and the hub waits for a resuming command — but it is
+	// delivered asynchronously, at whatever instruction execution reached.
+	//
+	// Two things produce it: a client's CmdPause, and an INTERNAL halt where
+	// the engine aborts an in-flight resume it can no longer complete safely
+	// (e.g. a software breakpoint that cannot be reinstalled after the
+	// step-over single-step). The internal case is always preceded by an
+	// EventError carrying the cause; this event exists so the halt is still
+	// reported as a suspend, because EventError is not suspending and on its
+	// own would leave the hub believing the tracee is running — permanently
+	// stranding every later resume. See AGENTS.md → step-over flow.
 	EventPaused EventKind = "Paused"
 )
 


### PR DESCRIPTION
Fixes #183

## The bug

Six error paths in `engine.handleStop` halted the tracee and set `stateSuspended`, but reported the halt with only a **non-suspending** `EventError`.

These failures are *asynchronous*. The resume that led to them — `Continue`/`Step*` off a software breakpoint — already returned `nil` as soon as the step-over single-step was armed, and already emitted `EventContinued`. By the time the failure happens on the engine loop, the hub has transitioned to `running` and **left its suspend wait loop**. Since `resumeCh` is drained *only* inside that loop (`Run`'s outer select never reads it), every later `Continue`/`Step*` sits unread in a capacity-1 channel.

Result: the tracee is halted forever, while `Hub.State()`, `/api/sessions` and DAP all report `running`. The 30-minute safety timeout doesn't help — it lives in the loop that was never re-entered.

Trace (site C, canonical):

```
suspended at breakpoint → hub in wait loop
  CmdContinue → resumeFromBreakpoint arms single-step → returns nil
  EventContinued → hub transitions running → wait loop RETURNS
  single-step completes → bps.reinstall fails
  setState(stateSuspended) + EventError        ← non-suspending
  hub stays running, never waits, never drains resumeCh
  CmdContinue → resumeCh → unread → stranded forever
```

| Site | Trigger | State on exit (before) |
| --- | --- | --- |
| A | `StopBreakpoint` `populateBreakpointStop` fails | suspended |
| B | `StopSingleStep` `populateStopPC` fails | suspended |
| C | `StopSingleStep` `bps.reinstall` fails | suspended |
| D | `bpResumeStepOut` return-BP `set` fails | **running** (wrong) |
| E | `StopSignal` in-flight reinstall fails | suspended |
| F | `StopSignal` manual-Pause `populateStopPC` fails | suspended |

Site D was strictly worse: it never called `setState(stateSuspended)`, so the engine believed the process was running while it sat halted with the step-over trap reinstalled and the world still held — every later command rejected with `ErrNotSuspended` against a process that could not move. (`endThreadStep` ends the stepping bookkeeping and disarms the hardware single-step; it deliberately does *not* resume the other threads — only `ContinueProcess` does, and it is never reached on that path.)

## The fix

`haltOnError(cmd, cause, stop)` reports these halts like any other suspend: the detailed `EventError` first, then a suspending `EventPaused`. The hub re-enters its wait loop and the retry is delivered. Site D also gains the missing `setState(stateSuspended)`.

Order is `Continued → Error → Paused`, and `Paused` must be last: the hub drains `resumeCh` *before* broadcasting a suspending event, so a retry sent in response to `Paused` necessarily lands after that drain and cannot be eaten as a stale resume.

`emitHaltedOnError` issues **no backend calls at all** — no `goroutineSnapshot` (as `emitPaused` does) and not even a stack walk. The backend on this path is by definition already failing, so any read could delay or prevent the one event that restores liveness. Both the location and the synthetic goroutine go through `locForPC`, so a PC of 0 short-circuits instead of scanning every CU and the two always agree.

### Delivering the suspend is guaranteed by a reserved slot

`emit` is non-blocking and drops on a full buffer, so a saturated buffer could lose the `Paused` and recreate #183 — deterministically at zero free slots, where the cause was skipped *and* the suspend dropped, leaving the hub with nothing at all.

The events channel is now `eventBufSize + eventBufReserve` deep. Ordinary `emit` refuses to use the last slot; only `emitReserved`, used solely by the halt path, may. `haltOnError` emits the cause as an ordinary event — logging it instead when no ordinary slot is free, since losing detail is far cheaper than losing the suspend — and the `Paused` through `emitReserved`.

**One reserved slot suffices**: a second halt can never be queued behind the first. Emitting a halt leaves the engine `stateSuspended` with the tracee stopped; a stopped tracee cannot produce the next stop; and the only route back to running is a resume, which the hub sends exclusively from inside the suspend wait loop it enters *after receiving* that event. The same argument covers the ordinary suspending events — none can still be buffered when a halt is handled.

Eviction was considered and rejected: removing a queued event requires receiving it, and putting a suspending one back would reorder the entire buffer behind it. The length check needs no lock — the loop thread is the sole writer, so `len` can only fall as the hub drains, and observing room guarantees the send succeeds. The engine loop stays non-blocking throughout.

### `curTID` must not inherit a guessed thread

`populateStopPC` committed `Threads()[0]` into `stop.TID` *before* confirming it with a register read, so a TID-less stop whose `GetRegisters` then failed handed that guess back — and the halt event adopted it into `curTID`, the thread every later step primitive targets. On darwin `task_threads` returns creation order, so `threads[0]` is frequently an idle runtime M. The guess is now kept local until `GetRegisters` succeeds; a real nonzero backend TID is preserved on either path, and an unresolved stop leaves `curTID` alone.

### Why `EventPaused`, and not something else

- **`EventStepped`** — DAP's restart path treats the first Stepped as the relaunched process's entry stop and, without `stopOnEntry`, auto-continues past it. A halt must never auto-resume. Pinned by a test.
- **`EventBreakpointHit`** — would claim a trap that may not be installed (sites C/E are precisely a failed reinstall).
- **unsolicited `EventBreakpointCleared`** — would corrupt DAP's id-less FIFO correlation.
- **making all `EventError`s suspending** — wrong; most errors do not halt anything.

No wire-protocol bump, no new event kind. A failed-reinstall breakpoint stays **out** of the table — re-adding it would advertise an armed breakpoint that can never fire — and the error text says so.

## Scope

- **No OS backend changes.** `backend_darwin_arm64.go`, `backend_linux_amd64.go`, `trap_*.go` untouched, so the Darwin verification gate is not triggered.
- **No hub or DAP production changes.** Those diffs are comments only, including correcting one in `hub.go` that described the reinstall failure as a *synchronous* rejected resume — it is not, and that is exactly why the wait loop could not catch it.
- Synchronous rejection behaviour is unchanged (#174/#175/#180 cover that; #158 covers the timeout).

## Tests

`fakeBackend` gains mutex-guarded fault injection (`failWriteAt`/`failReadAt`/`failRegisters`/`failThreads`); faults are armed before the triggering stop is pushed, so the arming is ordered ahead of the engine's read.

- `internal/debugger/engine_halt_test.go` — one spec per site A–F, each asserting `Error` then `Paused` **and** that a subsequent `Continue` reaches the backend; a spec pinning that an unresolved stop TID does not replace `curTID`; and a saturation spec that fills every ordinary slot, drives a **real** injected step-over failure, and proves both that the session re-enters the suspended gate (a retried `Continue` succeeds and reaches `ContinueProcess`) and that the `Paused` survived in the buffer. Ablating `eventBufReserve` to 0 fails it.
- A **real `Hub` + real engine** over the fault-injected backend proves the end-to-end property: after the injected failure the hub reports `suspended`, and a second `CmdContinue` actually reaches `Backend.ContinueProcess`. It lives in `internal/debugger` because the hub's own `fakeDebugger` cannot exercise asynchronous stop handling.
- `internal/dap/handler_test.go` — the halt surfaces as `stopped` reason=`pause` and leaves the session inspectable, and a halt during `restarting` is **not** treated as an entry stop (verified to fail if `Stepped` were used).

Every new test was verified non-vacuous by reverting the corresponding production change. Verified with `gofmt`/`goimports`, `go vet -tags bingonative`, and `go test -tags bingonative -race` on `internal/debugger`, `internal/hub`, `internal/dap` and `pkg/protocol` over repeated passes, plus randomized-order (`-ginkgo.randomize-all`) runs of the debugger suite.

## Reviews and known residuals

Two independent adversarial reviews were run, plus follow-up rounds. Their findings on `collectFrames` cost, the buffer-drop hole (both the one-slot and the zero-slot case), the `curTID` guess, an inaccurate StepOut comment, and the `locForPC` inconsistency are all incorporated above.

Deliberately **not** fixed here, and explicitly **not** claimed closed:

1. **A halt promises control, not a pristine tracee.** At site A there is no located stop, so the PC was never rewound off the trap: on amd64 RIP sits one byte past the `INT3` and a plain `Continue` would execute from mid-instruction. **`Kill`/`Restart` is the safe recovery there, not `Continue`** — that site's `EventError` now says so, so clients can see it. Elsewhere a partially applied breakpoint write can leave an untracked trap. Reconciling tracee byte state after such a write needs its own design; disabled-breakpoint protocol/state was explicitly out of scope.
2. **Five internal `ContinueProcess` errors are still ignored** in `handleStop` — the spurious-trap advance, `bpResumeContinue`, the successful `StepOut` continuation, the leftover-pause-signal suppression, and the ordinary-signal auto-resume. If one fails, the engine records `stateRunning` for a tracee that never resumed and emits nothing: the same class of liveness loss from the other direction. None has a confirmed backend reachability, so none is fixed and **no issue is filed yet**; this class is *not* globally closed by this PR.
3. A `StopBreakpoint` arriving while `steppingOverBP != nil` returns without reinstalling the step-over breakpoint or calling `endThreadStep()`. **Pre-existing on both the success and failure branches**, not the cause of the liveness loss fixed here, and no deterministic reproduction yet.
4. Two **pre-existing** comments carry a "releases the threads held" inaccuracy: the `endThreadStep` doc comment (`engine.go:141`) and the `StopSingleStep` rearm comment (`engine.go:642`). Left untouched to keep this diff scoped; worth a separate cleanup.

`AGENTS.md` is updated alongside: the rejected-resume and step-over invariants, the reserved-slot guarantee and why one slot suffices, the snapshot-cadence exception, the `handleStop` error-path rule, the safe-recovery guidance, the still-ignored `ContinueProcess` class, and the fault-injection test notes.
