### PR TITLE
fix(vscode): enter filtered tree from the matching end

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -919,7 +919,7 @@ target metadata, architecture, mode, and entitlements.
 The extension package version is the installed-runtime upgrade boundary:
 material shipped behavior changes must bump both `package.json` and the lockfile
 or VS Code can retain an older bundle under the same identity. The manifest test
-and package verifier pin the current version (**0.3.2**) in source and VSIX
+and package verifier pin the current version (**0.3.3**) in source and VSIX
 metadata.
 The root Run and Debug dropdown exposes exactly two `"type":"bingo"` choices:
 launch one of five progressive examples through a `pickString`, and join a
@@ -1010,8 +1010,13 @@ the 500-node rendering cap, re-lays out each match with at most four ancestors,
 and resets fit so a deep or previously capped match cannot remain invisible.
 Empty results keep Fit/zoom callbacks safe even without an SVG scene. SVG
 treeitems carry `aria-level`, sibling position/size, selection, and parent
-context; arrow navigation moves DOM focus with selection. Full-root model
-rerenders preserve focus through bounded literal identities for the session
+context; arrow navigation moves DOM focus with selection. A filter can hide the
+preserved selection, so navigation special-cases the absent index instead of
+letting `-1` flow into the wrap modulo, which lands on `len-2` in reverse and
+skips the last visible node: forward arrows enter the visible list at its first
+node and reverse arrows at its last, while a visible selection keeps ordinary
+wrap in both directions. Full-root model rerenders preserve focus through
+bounded literal identities for the session
 selector and controls, the two static element IDs, and numeric goroutine IDs,
 but only when `document.hasFocus()` was true before replacement; a blurred
 webview must never reclaim focus from the editor, and an identity absent from

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -21,8 +21,10 @@ just vscode-install
 
 This builds, verifies, and installs `dist/bingo-<platform>.vsix`. The graphical
 concurrency view debuted in 0.3.0; 0.3.1 added capability-safe managed-server
-reuse, and **0.3.2** preserves keyboard focus across telemetry rerenders without
-pulling focus back from the editor. Rerun the command to update, then run
+reuse, 0.3.2 preserves keyboard focus across telemetry rerenders without
+pulling focus back from the editor, and **0.3.3** enters a filtered spawn tree
+from the matching end so reverse arrow navigation reaches the last visible
+goroutine. Rerun the command to update, then run
 **Developer: Reload Window** once so the active extension host loads the new
 bundle. Package without installing with `just vscode-package`. Uninstall with:
 

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bingo",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bingo",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "ws": "8.18.3"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "bingo",
   "displayName": "bingo Debugger",
   "description": "Debug Go concurrency with bingo's DAP adapter and live goroutine visualization.",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "publisher": "bingosuite",
   "license": "MIT",
   "private": true,

--- a/editors/vscode/scripts/verify-package.mjs
+++ b/editors/vscode/scripts/verify-package.mjs
@@ -13,7 +13,7 @@ import { spawnSync } from "node:child_process";
 import { currentTarget } from "./platform.mjs";
 
 const target = currentTarget();
-const expectedExtensionVersion = "0.3.2";
+const expectedExtensionVersion = "0.3.3";
 const vsix = fileURLToPath(
   new URL(`../../../dist/bingo-${target}.vsix`, import.meta.url),
 );

--- a/editors/vscode/src/webviewApp.ts
+++ b/editors/vscode/src/webviewApp.ts
@@ -383,7 +383,13 @@ function renderGraph(
       (node) => node.goroutine.id === session.selectedGoroutine,
     );
     const direction = event.key === "ArrowDown" || event.key === "ArrowRight" ? 1 : -1;
-    const next = visible[(current + direction + visible.length) % visible.length];
+    // A filtered-out selection leaves current at -1, which is not an index one
+    // step before the list: modulo arithmetic on it lands on len-2 in reverse
+    // and skips the last visible node. Enter the list from the matching end.
+    const next =
+      current < 0
+        ? visible[direction === 1 ? 0 : visible.length - 1]
+        : visible[(current + direction + visible.length) % visible.length];
     if (next !== undefined) {
       activeScene
         .querySelector<SVGGElement>(

--- a/editors/vscode/test/manifest.test.ts
+++ b/editors/vscode/test/manifest.test.ts
@@ -12,7 +12,7 @@ const manifest = requireRecord(
 const contributes = requireRecord(manifest.contributes);
 const debuggers = requireArray(contributes.debuggers);
 const debuggerContribution = requireRecord(debuggers[0]);
-const expectedExtensionVersion = "0.3.2";
+const expectedExtensionVersion = "0.3.3";
 
 describe("extension manifest", () => {
   it("versions the managed-server runtime as an installable upgrade", () => {

--- a/editors/vscode/test/webviewDom.test.ts
+++ b/editors/vscode/test/webviewDom.test.ts
@@ -83,6 +83,53 @@ function model(
   };
 }
 
+function pressArrow(dom: ReturnType<typeof testDOM>, key: string): void {
+  const viewport = dom.document.querySelector("#concurrency-tree");
+  assert.ok(viewport);
+  const event = new dom.window.Event("keydown", {
+    bubbles: true,
+    cancelable: true,
+  });
+  Object.defineProperty(event, "key", { value: key });
+  viewport.dispatchEvent(event);
+}
+
+function visibleGoids(document: Document): number[] {
+  return [...document.querySelectorAll<SVGGElement>(".tree-node")].map((node) =>
+    Number(node.dataset.goid),
+  );
+}
+
+/**
+ * Renders a tree whose selection (g1) is filtered out, leaving only visibleIDs
+ * rendered as roots so the ancestor chain cannot pull the selection back in.
+ */
+function filteredTree(visibleIDs: readonly number[]): {
+  readonly dom: ReturnType<typeof testDOM>;
+  readonly messages: Record<string, unknown>[];
+} {
+  const dom = testDOM();
+  const messages: Record<string, unknown>[] = [];
+  mountConcurrencyView(dom.document, {
+    postMessage: (message) => messages.push(message),
+  })(
+    model({
+      snapshot: snapshot([
+        goroutine(1, 0, { current: true }),
+        ...visibleIDs.map((id) => goroutine(id, 0, { waitReason: "needle" })),
+      ]),
+      selectedGoroutine: 1,
+    }),
+  );
+  const search = dom.document.querySelector<HTMLInputElement>(
+    "#bingo-goroutine-filter",
+  );
+  assert.ok(search);
+  search.value = "needle";
+  search.dispatchEvent(new dom.window.Event("input"));
+  return { dom, messages };
+}
+
 function multiSessionModel(
   activeDebugSessionId = "debug",
   revision = 1,
@@ -314,6 +361,78 @@ describe("concurrency webview DOM", () => {
       type: "selectGoroutine",
       id: 2,
     });
+  });
+
+  it("enters a filtered list from the matching end when the selection is hidden", () => {
+    const { dom, messages } = filteredTree([2, 3, 4]);
+    assert.deepEqual(visibleGoids(dom.document), [2, 3, 4]);
+    assert.equal(dom.document.querySelector(".tree-node.selected"), null);
+
+    for (const [key, expected] of [
+      ["ArrowUp", 4],
+      ["ArrowLeft", 4],
+      ["ArrowDown", 2],
+      ["ArrowRight", 2],
+    ] as const) {
+      pressArrow(dom, key);
+      assert.deepEqual(
+        messages.at(-1),
+        { type: "selectGoroutine", id: expected },
+        `${key} from a hidden selection should select g${String(expected)}`,
+      );
+      assert.equal(
+        dom.document.activeElement,
+        dom.document.querySelector(`[data-goid="${String(expected)}"]`),
+      );
+    }
+  });
+
+  it("enters a two-node filtered list from opposite ends", () => {
+    const { dom, messages } = filteredTree([2, 3]);
+    assert.deepEqual(visibleGoids(dom.document), [2, 3]);
+
+    pressArrow(dom, "ArrowUp");
+    assert.deepEqual(messages.at(-1), { type: "selectGoroutine", id: 3 });
+    pressArrow(dom, "ArrowDown");
+    assert.deepEqual(messages.at(-1), { type: "selectGoroutine", id: 2 });
+  });
+
+  it("enters a single-node filtered list from either end", () => {
+    const { dom, messages } = filteredTree([2]);
+    assert.deepEqual(visibleGoids(dom.document), [2]);
+
+    for (const key of ["ArrowUp", "ArrowLeft", "ArrowDown", "ArrowRight"] as const) {
+      pressArrow(dom, key);
+      assert.deepEqual(messages.at(-1), { type: "selectGoroutine", id: 2 });
+    }
+  });
+
+  it("wraps in both directions while the selection stays visible", () => {
+    const nodes = snapshot([
+      goroutine(1, 0, { current: true }),
+      goroutine(2, 0),
+      goroutine(3, 0),
+    ]);
+    for (const [selectedGoroutine, back, forward] of [
+      [1, 3, 2],
+      [2, 1, 3],
+      [3, 2, 1],
+    ] as const) {
+      const dom = testDOM();
+      const messages: Record<string, unknown>[] = [];
+      mountConcurrencyView(dom.document, {
+        postMessage: (message) => messages.push(message),
+      })(model({ snapshot: nodes, selectedGoroutine }));
+      assert.deepEqual(visibleGoids(dom.document), [1, 2, 3]);
+
+      pressArrow(dom, "ArrowUp");
+      assert.deepEqual(messages.at(-1), { type: "selectGoroutine", id: back });
+      pressArrow(dom, "ArrowDown");
+      assert.deepEqual(messages.at(-1), {
+        type: "selectGoroutine",
+        id: forward,
+      });
+    }
   });
 
   it("keeps matching descendants connected to visible ancestors", () => {


### PR DESCRIPTION
Fixes #185. Stacked on #171 (base `xsachax-fix-webview-focus-handling`), which is itself stacked on #134. Review only the top commit; the base PRs carry the rest.

## Problem

The concurrency tree keyboard handler in `editors/vscode/src/webviewApp.ts` resolved its position with `findIndex` over the visible nodes and advanced with a single modulo expression:

```ts
const next = visible[(current + direction + visible.length) % visible.length];
```

Filtering narrows the rendered tree but preserves `selectedGoroutine`, so a filtered-out selection makes `findIndex` return `-1`. The modulo then treats that sentinel as a real index one step before the list:

| Direction | Expression | Result |
| --- | --- | --- |
| Forward (`ArrowDown`/`ArrowRight`) | `(-1 + 1 + len) % len` | `0` — first visible node, correct by coincidence |
| Reverse (`ArrowUp`/`ArrowLeft`) | `(-1 - 1 + len) % len` | `len - 2` — **skips the last visible node** |

With visible `[2, 3, 4]` and hidden selection `1`, `ArrowUp` selected g3 and g4 was unreachable in one keypress. With two visible nodes reverse and forward returned the same node.

## Fix

Special-case the absent index so navigation enters the visible list from the matching end — forward at the first node, reverse at the last. A visible selection keeps ordinary wrap in both directions. Ancestor-connecting filter behavior, the empty-result early return, and the tree/viewport handlers are untouched.

## Verification

Reverting only the six-line source change against the new tests reproduces the reported symptom exactly (`ArrowUp from a hidden selection should select g4` → `actual id: 3`), and two of the four new specs fail; restoring it turns them green.

New DOM specs in `test/webviewDom.test.ts`:

- all four arrows against a hidden selection with three visible nodes, asserting both the posted `selectGoroutine` message and `document.activeElement`
- two visible nodes entered from opposite ends
- one visible node reachable from either end
- regression: ordinary wrap in both directions for every position while the selection stays visible

`npm --prefix editors/vscode run check` passes — lint, typecheck, 126 unit/DOM tests, bundle, and package list. The pinned Electron integration test (`npm run test:integration`) passes on three consecutive runs; its single failure was a cold-start flake on the first launch of a freshly downloaded VS Code, reproduced as passing on unmodified base source in the same environment.

## Version

This changes shipped webview behavior, so the extension package moves `0.3.2` → `0.3.3` consistently across `package.json`, `package-lock.json`, `test/manifest.test.ts`, `scripts/verify-package.mjs`, the extension README, and the `AGENTS.md` version pin. The AGENTS.md webview invariant paragraph now records the filtered-navigation rule.