### PR TITLE
fix(debugger): share the inspection budget across Locals roots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1554,8 +1554,10 @@ are detected by a `mach_msg` receive loop.
   `interface {}` / `error` self-reference.
 - **Bounds & fallback (never error the stop):** `maxValueDepth=4`,
   `maxChildren=100` (overflow appended as a synthetic `… N more` node),
-  pointer-deref depth `1`, `maxStringBytes≈256`, and a **visited-address cycle
-  guard** (pointer targets) so self-referential structures can't infinite-loop.
+  pointer-deref depth `1`, `maxStringBytes≈256`, and an **active recursion-path
+  cycle guard** for pointer targets. Pointer addresses are removed as each
+  subtree unwinds, so self-referential structures terminate without suppressing
+  later sibling aliases to the same non-cyclic target.
   Those are *per-path* caps; on top of them a **shared global ceiling**
   (`maxTotalNodes=10000`, `maxTotalBytes=256 KiB`) is threaded through `formatCtx`
   and debited once per `formatNode` and by every read. Without it a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1560,13 +1560,16 @@ are detected by a `mach_msg` receive loop.
   later sibling aliases to the same non-cyclic target.
   Those are *per-path* caps; on top of them a **shared per-REQUEST ceiling**
   (`maxTotalNodes=10000`, `maxTotalBytes=256 KiB`) is threaded through **one**
-  `formatCtx` and debited once per `formatNode` and by every read. Without it a
-  collection-of-collections stays bounded only by the *product* of the width caps
-  (`[][][][]int` ≈ `maxChildren⁴` ≈ 10⁸ nodes, each its own `ReadMemory`), which
-  would wedge the single-threaded engine loop for a single `Locals`/`Evaluate`/
-  `variables` request. When either budget is exhausted the walk stops expanding
-  and appends **one** truncation node (`Value: "<truncated: inspection budget
-  exhausted>"`) — a per-path degradation, never an error on the stop.
+  `formatCtx` and debited once per emitted root/node. Bytes are reserved
+  **before** every backend read; a read that does not fit performs no I/O,
+  exhausts the request, and renders as truncated rather than unreadable. Without
+  these ceilings a collection-of-collections stays bounded only by the *product*
+  of the width caps (`[][][][]int` ≈ `maxChildren⁴` ≈ 10⁸ nodes, each its own
+  `ReadMemory`), which would wedge the single-threaded engine loop for a single
+  `Locals`/`Evaluate`/`variables` request. When either budget is exhausted the
+  walk stops expanding and appends **one** truncation node (`Value:
+  "<truncated: inspection budget exhausted>"`) — a per-path degradation, never
+  an error on the stop.
   **The ceiling is per request, NOT per root variable.** `LocalsForFrame` builds
   exactly one `formatCtx` (`newFormatCtx`) and renders every root through the
   shared `formatRequestRoots` loop; `formatTyped` is the single-root entry point
@@ -1575,11 +1578,13 @@ are detected by a `mach_msg` receive loop.
   ~400k nodes / ~396k `ReadMemory` calls and an 11s stall of the engine loop
   (issue #186). The root loop also checks the budget **between** roots and
   collapses every remaining root into exactly **one** trailing truncation node,
-  since a marker per elided root is itself unbounded on a frame with thousands of
-  locals. Cycle state stays strictly **path-local** across this sharing: every
-  `enterPointer` claim is balanced by its `defer leave()`, so `activePointers` is
-  empty again between roots and a later root aliasing an earlier root's address
-  still expands.
+  since a marker per elided root is itself unbounded on a frame with thousands
+  of locals. Roots that degrade before recursive formatting (notably
+  `<optimized out>`) debit the same node budget, so a large DIE list cannot
+  bypass the request ceiling. Cycle state stays strictly **path-local** across
+  this sharing: every `enterPointer` claim is balanced by its `defer leave()`,
+  so `activePointers` is empty again between roots and a later root aliasing an
+  earlier root's address still expands.
   Reads go through the backend's bulk `ReadMemory` (linux `process_vm_readv`,
   darwin `mach_vm_read`) sized per type — never per-byte. Any unreadable address
   degrades that one node to `<unreadable: …>`; an unknown/absent type degrades to
@@ -1589,8 +1594,9 @@ are detected by a `mach_msg` receive loop.
   ceiling is pinned by `TestFormatTypedBudget` (a pathological nested aggregate
   truncates to ~`maxTotalNodes`) and the request-wide one by
   [values_budget_test.go](internal/debugger/values_budget_test.go) (shared budget
-  across roots, carried-forward remainder, one root-level truncation marker, the
-  byte ceiling, cross-root aliases, bounded cycles, and `Evaluate` independence).
+  across production `formatEntry` roots, carried-forward remainder, one
+  root-level truncation marker, the hard pre-I/O byte ceiling, cross-root
+  aliases, bounded cycles, and `Evaluate` independence).
 - `subprogramVars` is a depth-aware walk of the full containing subprogram,
   not a flat scan to the first null DIE. Both `DW_TAG_lexical_block` and
   `DW_TAG_inlined_subroutine` define variable scope. The containing subprogram

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1558,23 +1558,39 @@ are detected by a `mach_msg` receive loop.
   cycle guard** for pointer targets. Pointer addresses are removed as each
   subtree unwinds, so self-referential structures terminate without suppressing
   later sibling aliases to the same non-cyclic target.
-  Those are *per-path* caps; on top of them a **shared global ceiling**
-  (`maxTotalNodes=10000`, `maxTotalBytes=256 KiB`) is threaded through `formatCtx`
-  and debited once per `formatNode` and by every read. Without it a
+  Those are *per-path* caps; on top of them a **shared per-REQUEST ceiling**
+  (`maxTotalNodes=10000`, `maxTotalBytes=256 KiB`) is threaded through **one**
+  `formatCtx` and debited once per `formatNode` and by every read. Without it a
   collection-of-collections stays bounded only by the *product* of the width caps
   (`[][][][]int` ≈ `maxChildren⁴` ≈ 10⁸ nodes, each its own `ReadMemory`), which
   would wedge the single-threaded engine loop for a single `Locals`/`Evaluate`/
   `variables` request. When either budget is exhausted the walk stops expanding
   and appends **one** truncation node (`Value: "<truncated: inspection budget
   exhausted>"`) — a per-path degradation, never an error on the stop.
+  **The ceiling is per request, NOT per root variable.** `LocalsForFrame` builds
+  exactly one `formatCtx` (`newFormatCtx`) and renders every root through the
+  shared `formatRequestRoots` loop; `formatTyped` is the single-root entry point
+  that starts its own budget (`EvaluateName`, tests). Giving each root its own
+  context multiplied the ceiling by the root count — 40 huge locals measured at
+  ~400k nodes / ~396k `ReadMemory` calls and an 11s stall of the engine loop
+  (issue #186). The root loop also checks the budget **between** roots and
+  collapses every remaining root into exactly **one** trailing truncation node,
+  since a marker per elided root is itself unbounded on a frame with thousands of
+  locals. Cycle state stays strictly **path-local** across this sharing: every
+  `enterPointer` claim is balanced by its `defer leave()`, so `activePointers` is
+  empty again between roots and a later root aliasing an earlier root's address
+  still expands.
   Reads go through the backend's bulk `ReadMemory` (linux `process_vm_readv`,
   darwin `mach_vm_read`) sized per type — never per-byte. Any unreadable address
   degrades that one node to `<unreadable: …>`; an unknown/absent type degrades to
   an 8-byte hex or `<optimized out>` — the surrounding tree and the stop are
   unaffected. The pure leaf-formatters (`formatInt/Uint/Float/Bool/Complex`) take
-  raw bytes and are unit-tested without DWARF or a backend; the global ceiling is
-  pinned by `TestFormatTypedBudget` (a pathological nested aggregate truncates to
-  ~`maxTotalNodes`).
+  raw bytes and are unit-tested without DWARF or a backend; the single-root
+  ceiling is pinned by `TestFormatTypedBudget` (a pathological nested aggregate
+  truncates to ~`maxTotalNodes`) and the request-wide one by
+  [values_budget_test.go](internal/debugger/values_budget_test.go) (shared budget
+  across roots, carried-forward remainder, one root-level truncation marker, the
+  byte ceiling, cross-root aliases, bounded cycles, and `Evaluate` independence).
 - `subprogramVars` is a depth-aware walk of the full containing subprogram,
   not a flat scan to the first null DIE. Both `DW_TAG_lexical_block` and
   `DW_TAG_inlined_subroutine` define variable scope. The containing subprogram

--- a/internal/debugger/dwarf.go
+++ b/internal/debugger/dwarf.go
@@ -432,11 +432,18 @@ func (r *dwarfReader) LocalsForFrame(b Backend, pc, frameBase uint64) ([]protoco
 	if err != nil {
 		return nil, err
 	}
+	return r.formatLocalEntries(b, entries, frameBase), nil
+}
+
+// formatLocalEntries owns the production roots-to-formatEntry path separately
+// from DWARF discovery so its request-wide accounting can be tested without
+// manufacturing a complete .debug_info section.
+func (r *dwarfReader) formatLocalEntries(b Backend, entries []*dwarf.Entry, frameBase uint64) []protocol.Variable {
 	ctx := newFormatCtx(b)
 	return formatRequestRoots(ctx, len(entries), func(i int) protocol.Variable {
 		name, _ := entries[i].Val(dwarf.AttrName).(string)
 		return r.formatEntry(ctx, entries[i], name, frameBase)
-	}), nil
+	})
 }
 
 // EvaluateName resolves a single variable name — no dotted paths, indexing, or
@@ -470,6 +477,9 @@ func (r *dwarfReader) formatEntry(ctx *formatCtx, entry *dwarf.Entry, name strin
 	typ := r.varType(entry)
 	addr, ok := r.varAddress(entry, frameBase)
 	if !ok {
+		if !ctx.takeNode() {
+			return truncatedNode()
+		}
 		return protocol.Variable{Name: name, Type: typeDisplayName(typ), Value: optimizedOut}
 	}
 	return r.formatRoot(ctx, name, typ, addr)

--- a/internal/debugger/dwarf.go
+++ b/internal/debugger/dwarf.go
@@ -420,17 +420,23 @@ func frameLookupPC(pc uint64, frameIndex int) uint64 {
 // Children; see values.go. Only DW_OP_addr (0x03) and DW_OP_fbreg (0x91)
 // locations are evaluated — register-allocated variables come back as
 // "<optimized out>".
+//
+// Every root shares ONE formatCtx, so the node/byte ceiling bounds the whole
+// request rather than each root independently: a frame with many large
+// aggregates otherwise multiplied the ceiling by its root count and stalled the
+// single-threaded engine loop (issue #186). Once the budget is spent the loop
+// stops formatting and appends exactly one truncation node covering all
+// remaining roots — never one marker per elided root.
 func (r *dwarfReader) LocalsForFrame(b Backend, pc, frameBase uint64) ([]protocol.Variable, error) {
 	entries, err := r.subprogramVars(pc)
 	if err != nil {
 		return nil, err
 	}
-	var vars []protocol.Variable
-	for _, child := range entries {
-		name, _ := child.Val(dwarf.AttrName).(string)
-		vars = append(vars, r.formatEntry(b, child, name, frameBase))
-	}
-	return vars, nil
+	ctx := newFormatCtx(b)
+	return formatRequestRoots(ctx, len(entries), func(i int) protocol.Variable {
+		name, _ := entries[i].Val(dwarf.AttrName).(string)
+		return r.formatEntry(ctx, entries[i], name, frameBase)
+	}), nil
 }
 
 // EvaluateName resolves a single variable name — no dotted paths, indexing, or
@@ -438,7 +444,8 @@ func (r *dwarfReader) LocalsForFrame(b Backend, pc, frameBase uint64) ([]protoco
 // for a local or parameter in the subprogram containing pc. A bare global then
 // prefers the logical code package at pc before falling back to the whole image;
 // qualified globals use the whole-image lookup directly. The result is the same
-// bounded typed tree LocalsForFrame produces.
+// bounded typed tree LocalsForFrame produces, against a budget of its own (one
+// root per request).
 func (r *dwarfReader) EvaluateName(b Backend, pc, frameBase uint64, name string) (protocol.Variable, error) {
 	entries, err := r.subprogramVars(pc)
 	if err != nil {
@@ -446,7 +453,7 @@ func (r *dwarfReader) EvaluateName(b Backend, pc, frameBase uint64, name string)
 	}
 	for _, child := range entries {
 		if n, _ := child.Val(dwarf.AttrName).(string); n == name {
-			return r.formatEntry(b, child, name, frameBase), nil
+			return r.formatEntry(newFormatCtx(b), child, name, frameBase), nil
 		}
 	}
 	if addr, typ, ok := r.globalVar(pc, name); ok {
@@ -455,16 +462,17 @@ func (r *dwarfReader) EvaluateName(b Backend, pc, frameBase uint64, name string)
 	return protocol.Variable{}, fmt.Errorf("no variable named %q in scope", name)
 }
 
-// formatEntry renders one variable/parameter DIE. When its location can't be
-// evaluated (register-allocated, or an unsupported expr) it degrades to
-// "<optimized out>" while still reporting the type name.
-func (r *dwarfReader) formatEntry(b Backend, entry *dwarf.Entry, name string, frameBase uint64) protocol.Variable {
+// formatEntry renders one variable/parameter DIE against the caller's request
+// budget. When its location can't be evaluated (register-allocated, or an
+// unsupported expr) it degrades to "<optimized out>" while still reporting the
+// type name.
+func (r *dwarfReader) formatEntry(ctx *formatCtx, entry *dwarf.Entry, name string, frameBase uint64) protocol.Variable {
 	typ := r.varType(entry)
 	addr, ok := r.varAddress(entry, frameBase)
 	if !ok {
 		return protocol.Variable{Name: name, Type: typeDisplayName(typ), Value: optimizedOut}
 	}
-	return r.formatTyped(b, name, typ, addr)
+	return r.formatRoot(ctx, name, typ, addr)
 }
 
 // subprogramVars collects the variable and formal-parameter DIEs of the

--- a/internal/debugger/values.go
+++ b/internal/debugger/values.go
@@ -25,11 +25,11 @@ import (
 // path from running away, but a collection-of-collections is still bounded only
 // by their product (e.g. [][][][]int ≈ maxChildren⁴ nodes, each doing its own
 // ReadMemory). maxTotalNodes/maxTotalBytes add a SHARED ceiling across the whole
-// walk — threaded through formatCtx and debited once per node and by each read —
-// so one Locals/Evaluate/variables request can never wedge the single-threaded
-// engine loop no matter how deep or wide the target's data is. Exhausting either
-// budget degrades the subtree to a single truncation node; it never errors the
-// stop.
+// REQUEST — threaded through one formatCtx and debited once per node and by each
+// read — so one Locals/Evaluate/variables request can never wedge the
+// single-threaded engine loop no matter how deep or wide the target's data is,
+// nor how many root variables the frame has. Exhausting either budget degrades
+// the subtree to a single truncation node; it never errors the stop.
 const (
 	maxValueDepth  = 4    // aggregate nesting levels expanded
 	maxChildren    = 100  // fields/elements per aggregate before a "… N more" node
@@ -37,12 +37,12 @@ const (
 	maxStringBytes = 256  // bytes read from a string/[]byte before truncation
 	maxScalarBytes = 4096 // defensive cap on any single ReadMemory
 
-	maxTotalNodes = 10000      // nodes across ONE inspection before truncation
-	maxTotalBytes = 256 * 1024 // bytes read across ONE inspection before truncation
+	maxTotalNodes = 10000      // nodes across ONE request before truncation
+	maxTotalBytes = 256 * 1024 // bytes read across ONE request before truncation
 )
 
 // truncatedValue marks a node the eager walk refused to expand because the
-// shared per-inspection node/byte budget (formatCtx) was exhausted.
+// shared per-request node/byte budget (formatCtx) was exhausted.
 const truncatedValue = "<truncated: inspection budget exhausted>"
 
 // Variable.Kind classifier strings.
@@ -63,18 +63,38 @@ const (
 	kindInterface = "interface"
 )
 
-// formatCtx carries the per-inspection state shared across the whole recursive
-// walk. activePointers contains only the current recursion path; entries are
-// removed while unwinding so sibling aliases expand independently. depth and
-// ptrDepth are passed by value so a sibling's recursion budget is independent.
-// nodesLeft and bytesLeft are the shared GLOBAL ceiling (see the bounds block):
-// decremented once per formatNode and by each read, so a
-// collection-of-collections can't fan out unboundedly.
+// formatCtx carries the per-REQUEST state shared across every root variable's
+// recursive walk. One context serves a whole Locals request; Evaluate has a
+// single root and gets its own.
+//
+// activePointers contains only the current recursion path; entries are removed
+// while unwinding (the enterPointer/leave pairing) so sibling aliases — within a
+// root AND across roots — expand independently. Because every claim is balanced
+// by its defer, the map is empty again between roots: sharing the context must
+// never make a later root's alias look cyclic.
+//
+// depth and ptrDepth are passed by value so a sibling's recursion budget is
+// independent. nodesLeft and bytesLeft are the shared GLOBAL ceiling (see the
+// bounds block): decremented once per formatNode and by each read, and NOT reset
+// per root, so neither a collection-of-collections nor a frame full of large
+// locals can fan out unboundedly.
 type formatCtx struct {
 	b              Backend
 	activePointers map[uint64]bool
-	nodesLeft      int // remaining nodes for this inspection (shared)
-	bytesLeft      int // remaining bytes to read for this inspection (shared)
+	nodesLeft      int // remaining nodes for this request (shared across roots)
+	bytesLeft      int // remaining bytes to read for this request (shared across roots)
+}
+
+// newFormatCtx starts a fresh inspection budget. Callers that render several
+// root variables for one request (LocalsForFrame) must create exactly one and
+// reuse it; a per-root context would multiply the ceiling by the root count.
+func newFormatCtx(b Backend) *formatCtx {
+	return &formatCtx{
+		b:              b,
+		activePointers: map[uint64]bool{},
+		nodesLeft:      maxTotalNodes,
+		bytesLeft:      maxTotalBytes,
+	}
 }
 
 // read fetches n bytes at addr like readMem, additionally debiting the shared
@@ -86,7 +106,7 @@ func (ctx *formatCtx) read(addr uint64, n int) ([]byte, error) {
 }
 
 // budgetExhausted reports whether the shared node or byte ceiling for one
-// inspection has been reached. Once true the walk emits a single truncation node
+// request has been reached. Once true the walk emits a single truncation node
 // instead of recursing or reading further — degrading the subtree, never
 // erroring the stop.
 func (ctx *formatCtx) budgetExhausted() bool {
@@ -104,15 +124,36 @@ func (ctx *formatCtx) enterPointer(addr uint64) (leave func(), ok bool) {
 }
 
 // formatTyped renders the value of type typ stored at addr into a bounded
-// protocol.Variable tree rooted at name.
+// protocol.Variable tree rooted at name, using a budget of its own. It is the
+// single-root entry point (Evaluate, tests); multi-root callers must share one
+// context via formatRoot instead.
 func (r *dwarfReader) formatTyped(b Backend, name string, typ dwarf.Type, addr uint64) protocol.Variable {
-	ctx := &formatCtx{
-		b:              b,
-		activePointers: map[uint64]bool{},
-		nodesLeft:      maxTotalNodes,
-		bytesLeft:      maxTotalBytes,
-	}
+	return r.formatRoot(newFormatCtx(b), name, typ, addr)
+}
+
+// formatRoot renders one root variable against an existing request budget.
+func (r *dwarfReader) formatRoot(ctx *formatCtx, name string, typ dwarf.Type, addr uint64) protocol.Variable {
 	return r.formatNode(name, typ, addr, 0, 0, ctx)
+}
+
+// formatRequestRoots renders the roots of ONE inspection request against the
+// single shared budget in ctx, calling render for root i.
+//
+// The budget is checked between roots, not just inside a tree, so a frame full
+// of large aggregates stops at the global ceiling instead of spending a fresh
+// one per root. Elided roots collapse into exactly ONE trailing truncation node
+// — a marker per remaining root would itself be unbounded on a frame with
+// thousands of locals.
+func formatRequestRoots(ctx *formatCtx, roots int, render func(i int) protocol.Variable) []protocol.Variable {
+	var out []protocol.Variable
+	for i := 0; i < roots; i++ {
+		if ctx.budgetExhausted() {
+			out = append(out, truncatedNode())
+			break
+		}
+		out = append(out, render(i))
+	}
+	return out
 }
 
 func (r *dwarfReader) formatNode(name string, typ dwarf.Type, addr uint64, depth, ptrDepth int, ctx *formatCtx) protocol.Variable {
@@ -509,8 +550,9 @@ func moreNode(n int) protocol.Variable {
 	return protocol.Variable{Name: "…", Value: fmt.Sprintf("%d more", n)}
 }
 
-// truncatedNode is the single leaf a loop appends when the shared per-inspection
-// budget (formatCtx) is exhausted, standing in for every elided remaining child.
+// truncatedNode is the single leaf a loop appends when the shared per-request
+// budget (formatCtx) is exhausted, standing in for every elided remaining child
+// — or, at the root level, for every remaining root variable.
 func truncatedNode() protocol.Variable {
 	return protocol.Variable{Name: "…", Value: truncatedValue}
 }

--- a/internal/debugger/values.go
+++ b/internal/debugger/values.go
@@ -3,6 +3,7 @@ package debugger
 import (
 	"debug/dwarf"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -44,6 +45,8 @@ const (
 // truncatedValue marks a node the eager walk refused to expand because the
 // shared per-request node/byte budget (formatCtx) was exhausted.
 const truncatedValue = "<truncated: inspection budget exhausted>"
+
+var errInspectionBudgetExhausted = errors.New("inspection budget exhausted")
 
 // Variable.Kind classifier strings.
 const (
@@ -97,12 +100,27 @@ func newFormatCtx(b Backend) *formatCtx {
 	}
 }
 
-// read fetches n bytes at addr like readMem, additionally debiting the shared
-// byte budget so the whole eager walk can't over-read across many small nodes.
+// read reserves n bytes before touching the backend so maxTotalBytes is a hard
+// I/O ceiling. A read that does not fit exhausts the request: allowing later
+// smaller reads would make truncation depend on target layout after the first
+// value was already refused.
 func (ctx *formatCtx) read(addr uint64, n int) ([]byte, error) {
-	buf, err := readMem(ctx.b, addr, n)
-	ctx.bytesLeft -= len(buf)
-	return buf, err
+	if n <= 0 {
+		return nil, nil
+	}
+	if n > maxScalarBytes {
+		n = maxScalarBytes
+	}
+	if n > ctx.bytesLeft {
+		ctx.bytesLeft = 0
+		return nil, errInspectionBudgetExhausted
+	}
+	ctx.bytesLeft -= n
+	buf := make([]byte, n)
+	if err := ctx.b.ReadMemory(addr, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
 }
 
 // budgetExhausted reports whether the shared node or byte ceiling for one
@@ -111,6 +129,14 @@ func (ctx *formatCtx) read(addr uint64, n int) ([]byte, error) {
 // erroring the stop.
 func (ctx *formatCtx) budgetExhausted() bool {
 	return ctx.nodesLeft <= 0 || ctx.bytesLeft <= 0
+}
+
+func (ctx *formatCtx) takeNode() bool {
+	if ctx.budgetExhausted() {
+		return false
+	}
+	ctx.nodesLeft--
+	return true
 }
 
 // enterPointer claims addr for the current recursion path. A rejected claim
@@ -159,10 +185,9 @@ func formatRequestRoots(ctx *formatCtx, roots int, render func(i int) protocol.V
 func (r *dwarfReader) formatNode(name string, typ dwarf.Type, addr uint64, depth, ptrDepth int, ctx *formatCtx) protocol.Variable {
 	// Global budget guard: every node in the tree passes through here, so this
 	// single check bounds the total node count regardless of nesting shape.
-	if ctx.budgetExhausted() {
+	if !ctx.takeNode() {
 		return protocol.Variable{Name: name, Address: addr, Value: truncatedValue}
 	}
-	ctx.nodesLeft--
 	out := protocol.Variable{Name: name, Address: addr}
 	if typ == nil {
 		out.Value = r.hexFallback(ctx, addr, 8)
@@ -266,7 +291,7 @@ func (r *dwarfReader) formatPointer(out *protocol.Variable, t *dwarf.PtrType, ad
 	out.Kind = kindPtr
 	buf, err := ctx.read(addr, 8)
 	if err != nil {
-		out.Value = unreadable(err)
+		out.Value = readErrorValue(err)
 		return
 	}
 	p := binary.LittleEndian.Uint64(buf)
@@ -333,7 +358,7 @@ func (r *dwarfReader) formatSlice(out *protocol.Variable, t *dwarf.StructType, a
 	out.Kind = kindSlice
 	hdr, err := ctx.read(addr, 24) // {array *elem, len int, cap int}
 	if err != nil {
-		out.Value = unreadable(err)
+		out.Value = readErrorValue(err)
 		return
 	}
 	ptr := binary.LittleEndian.Uint64(hdr[0:8])
@@ -387,7 +412,7 @@ func (r *dwarfReader) formatElements(out *protocol.Variable, elemType dwarf.Type
 func (r *dwarfReader) readGoString(ctx *formatCtx, addr uint64) string {
 	hdr, err := ctx.read(addr, 16)
 	if err != nil {
-		return unreadable(err)
+		return readErrorValue(err)
 	}
 	ptr := binary.LittleEndian.Uint64(hdr[0:8])
 	length := int64(binary.LittleEndian.Uint64(hdr[8:16]))
@@ -401,7 +426,7 @@ func (r *dwarfReader) readGoString(ctx *formatCtx, addr uint64) string {
 	}
 	data, err := ctx.read(ptr, int(length))
 	if err != nil {
-		return unreadable(err)
+		return readErrorValue(err)
 	}
 	s := strconv.Quote(string(data))
 	if truncated {
@@ -415,7 +440,7 @@ func (r *dwarfReader) readGoString(ctx *formatCtx, addr uint64) string {
 func (r *dwarfReader) summaryPointer(ctx *formatCtx, addr uint64, display string) string {
 	buf, err := ctx.read(addr, 8)
 	if err != nil {
-		return unreadable(err)
+		return readErrorValue(err)
 	}
 	p := binary.LittleEndian.Uint64(buf)
 	if p == 0 {
@@ -429,7 +454,7 @@ func (r *dwarfReader) summaryPointer(ctx *formatCtx, addr uint64, display string
 func (r *dwarfReader) summaryInterface(ctx *formatCtx, addr uint64, display string) string {
 	buf, err := ctx.read(addr, 16)
 	if err != nil {
-		return unreadable(err)
+		return readErrorValue(err)
 	}
 	typ := binary.LittleEndian.Uint64(buf[0:8])
 	data := binary.LittleEndian.Uint64(buf[8:16])
@@ -448,7 +473,7 @@ func (r *dwarfReader) hexFallback(ctx *formatCtx, addr uint64, n int) string {
 	}
 	buf, err := ctx.read(addr, n)
 	if err != nil {
-		return unreadable(err)
+		return readErrorValue(err)
 	}
 	var u uint64
 	for i := len(buf) - 1; i >= 0; i-- {
@@ -466,7 +491,7 @@ func (r *dwarfReader) setScalar(out *protocol.Variable, ctx *formatCtx, addr uin
 	}
 	buf, err := ctx.read(addr, size)
 	if err != nil {
-		out.Value = unreadable(err)
+		out.Value = readErrorValue(err)
 		return
 	}
 	out.Value = fn(buf)
@@ -559,20 +584,11 @@ func truncatedNode() protocol.Variable {
 
 func unreadable(err error) string { return fmt.Sprintf("<unreadable: %v>", err) }
 
-// readMem reads exactly n bytes at addr, capping n defensively so a bogus DWARF
-// size can't trigger a huge allocation.
-func readMem(b Backend, addr uint64, n int) ([]byte, error) {
-	if n <= 0 {
-		return nil, nil
+func readErrorValue(err error) string {
+	if errors.Is(err, errInspectionBudgetExhausted) {
+		return truncatedValue
 	}
-	if n > maxScalarBytes {
-		n = maxScalarBytes
-	}
-	buf := make([]byte, n)
-	if err := b.ReadMemory(addr, buf); err != nil {
-		return nil, err
-	}
-	return buf, nil
+	return unreadable(err)
 }
 
 // sizeOf returns a type's byte size, or 8 as a safe default when unknown.

--- a/internal/debugger/values.go
+++ b/internal/debugger/values.go
@@ -21,7 +21,7 @@ import (
 // erroring the stop. See AGENTS.md → DWARF reader notes.
 
 // Bounds on the eager tree. The per-node depth (maxValueDepth) and per-aggregate
-// width (maxChildren) caps plus the visited-address cycle guard stop any single
+// width (maxChildren) caps plus the active-pointer cycle guard stop any single
 // path from running away, but a collection-of-collections is still bounded only
 // by their product (e.g. [][][][]int ≈ maxChildren⁴ nodes, each doing its own
 // ReadMemory). maxTotalNodes/maxTotalBytes add a SHARED ceiling across the whole
@@ -64,15 +64,17 @@ const (
 )
 
 // formatCtx carries the per-inspection state shared across the whole recursive
-// walk. b and visited are shared; depth/ptrDepth are passed by value so a
-// sibling's recursion budget is independent. nodesLeft and bytesLeft are the
-// shared GLOBAL ceiling (see the bounds block): decremented once per formatNode
-// and by each read, so a collection-of-collections can't fan out unboundedly.
+// walk. activePointers contains only the current recursion path; entries are
+// removed while unwinding so sibling aliases expand independently. depth and
+// ptrDepth are passed by value so a sibling's recursion budget is independent.
+// nodesLeft and bytesLeft are the shared GLOBAL ceiling (see the bounds block):
+// decremented once per formatNode and by each read, so a
+// collection-of-collections can't fan out unboundedly.
 type formatCtx struct {
-	b         Backend
-	visited   map[uint64]bool // addresses whose formatting has begun (cycle guard)
-	nodesLeft int             // remaining nodes for this inspection (shared)
-	bytesLeft int             // remaining bytes to read for this inspection (shared)
+	b              Backend
+	activePointers map[uint64]bool
+	nodesLeft      int // remaining nodes for this inspection (shared)
+	bytesLeft      int // remaining bytes to read for this inspection (shared)
 }
 
 // read fetches n bytes at addr like readMem, additionally debiting the shared
@@ -91,10 +93,25 @@ func (ctx *formatCtx) budgetExhausted() bool {
 	return ctx.nodesLeft <= 0 || ctx.bytesLeft <= 0
 }
 
+// enterPointer claims addr for the current recursion path. A rejected claim
+// returns no cleanup function, so a cycle cannot remove its ancestor's entry.
+func (ctx *formatCtx) enterPointer(addr uint64) (leave func(), ok bool) {
+	if ctx.activePointers[addr] {
+		return nil, false
+	}
+	ctx.activePointers[addr] = true
+	return func() { delete(ctx.activePointers, addr) }, true
+}
+
 // formatTyped renders the value of type typ stored at addr into a bounded
 // protocol.Variable tree rooted at name.
 func (r *dwarfReader) formatTyped(b Backend, name string, typ dwarf.Type, addr uint64) protocol.Variable {
-	ctx := &formatCtx{b: b, visited: map[uint64]bool{}, nodesLeft: maxTotalNodes, bytesLeft: maxTotalBytes}
+	ctx := &formatCtx{
+		b:              b,
+		activePointers: map[uint64]bool{},
+		nodesLeft:      maxTotalNodes,
+		bytesLeft:      maxTotalBytes,
+	}
 	return r.formatNode(name, typ, addr, 0, 0, ctx)
 }
 
@@ -218,13 +235,17 @@ func (r *dwarfReader) formatPointer(out *protocol.Variable, t *dwarf.PtrType, ad
 	}
 	out.Value = fmt.Sprintf("0x%x", p)
 	// One bounded dereference as a child, guarded against cycles and budget.
-	if ptrDepth >= maxPtrDeref || depth >= maxValueDepth || ctx.visited[p] {
+	if ptrDepth >= maxPtrDeref || depth >= maxValueDepth {
 		return
 	}
 	if _, ok := t.Type.(*dwarf.VoidType); ok {
 		return // unsafe.Pointer — nothing typed to deref
 	}
-	ctx.visited[p] = true
+	leave, ok := ctx.enterPointer(p)
+	if !ok {
+		return
+	}
+	defer leave()
 	child := r.formatNode("*"+out.Name, t.Type, p, depth+1, ptrDepth+1, ctx)
 	out.Children = []protocol.Variable{child}
 }

--- a/internal/debugger/values_budget_test.go
+++ b/internal/debugger/values_budget_test.go
@@ -1,0 +1,325 @@
+package debugger
+
+import (
+	"debug/dwarf"
+	"testing"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+// Request-scoped inspection budget: one Locals request shares a single
+// node/byte ceiling across ALL of its root variables (issue #186). These tests
+// drive formatRequestRoots — the exact loop LocalsForFrame uses — because
+// building synthetic *dwarf.Data for a whole subprogram is not feasible in a
+// unit test; real-DWARF coverage lives in the `inspect` E2E label.
+
+// countingBackend records read volume so a test can assert the walk did not
+// fan out into a per-root budget's worth of ReadMemory calls.
+type countingBackend struct {
+	readableBackend
+	reads int
+	bytes int
+}
+
+func (b *countingBackend) ReadMemory(_ uint64, dst []byte) error {
+	b.reads++
+	b.bytes += len(dst)
+	return nil
+}
+
+// deepArrayType is the pathological fixture from TestFormatTypedBudget:
+// [100][100][100][100]int, whose per-path width/depth caps alone still leave
+// ~10^8 potential nodes, so one root alone can exhaust the global ceiling.
+func deepArrayType() dwarf.Type {
+	arr := func(elem dwarf.Type, count int64) *dwarf.ArrayType {
+		return &dwarf.ArrayType{Type: elem, Count: count}
+	}
+	return arr(arr(arr(arr(testIntType(), 100), 100), 100), 100)
+}
+
+func countAllNodes(vars []protocol.Variable) int {
+	total := 0
+	for i := range vars {
+		total += countNodes(vars[i])
+	}
+	return total
+}
+
+// TestLocalsRequestSharesBudgetAcrossRoots is the #186 regression gate: before
+// the fix each root got a fresh maxTotalNodes/maxTotalBytes, so N huge locals
+// cost N× the ceiling (40 roots measured at ~400k nodes / ~396k reads). The
+// whole request must now stay at ONE ceiling.
+func TestLocalsRequestSharesBudgetAcrossRoots(t *testing.T) {
+	const roots = 40
+	nested := deepArrayType()
+	backend := &countingBackend{}
+	r := &dwarfReader{}
+	ctx := newFormatCtx(backend)
+
+	vars := formatRequestRoots(ctx, roots, func(i int) protocol.Variable {
+		return r.formatRoot(ctx, "root", nested, 0x1000)
+	})
+
+	total := countAllNodes(vars)
+	if total > maxTotalNodes+1000 {
+		t.Fatalf("request node count %d exceeds shared ceiling %d(+slack); budget reset per root",
+			total, maxTotalNodes)
+	}
+	// Every node reads at most a handful of times; a per-root budget would put
+	// this in the hundreds of thousands.
+	if backend.reads > maxTotalNodes+1000 {
+		t.Fatalf("ReadMemory calls %d exceed the shared node ceiling %d(+slack)",
+			backend.reads, maxTotalNodes)
+	}
+	if backend.bytes > maxTotalBytes+maxScalarBytes {
+		t.Fatalf("bytes read %d exceed the shared byte ceiling %d(+slack)",
+			backend.bytes, maxTotalBytes)
+	}
+	if len(vars) >= roots {
+		t.Fatalf("returned %d roots, want the loop to stop early once the budget was spent", len(vars))
+	}
+}
+
+// TestLocalsTruncatesRemainingRootsOnce pins the exact exhaustion behavior: the
+// elided roots collapse into ONE trailing truncation node, not one marker per
+// remaining root (which would itself be unbounded on a frame with thousands of
+// locals).
+func TestLocalsTruncatesRemainingRootsOnce(t *testing.T) {
+	const roots = 5000
+	nested := deepArrayType()
+	r := &dwarfReader{}
+	ctx := newFormatCtx(readableBackend{})
+
+	vars := formatRequestRoots(ctx, roots, func(i int) protocol.Variable {
+		return r.formatRoot(ctx, "root", nested, 0x1000)
+	})
+
+	if len(vars) == 0 {
+		t.Fatal("no roots returned")
+	}
+	rootMarkers := 0
+	for _, v := range vars {
+		if v.Value == truncatedValue && len(v.Children) == 0 && v.Name == "…" {
+			rootMarkers++
+		}
+	}
+	if rootMarkers != 1 {
+		t.Fatalf("root-level truncation markers = %d, want exactly 1 for %d elided roots",
+			rootMarkers, roots-len(vars)+1)
+	}
+	last := vars[len(vars)-1]
+	if last.Value != truncatedValue {
+		t.Fatalf("last root = %q, want the truncation marker %q", last.Value, truncatedValue)
+	}
+	if len(vars) > 10 {
+		t.Fatalf("returned %d roots for a budget one root already exhausts; expansion must stop promptly",
+			len(vars))
+	}
+}
+
+// TestLocalsLaterRootsSeeRemainingBudget proves the budget is carried forward
+// rather than reset: each successive root starts from what its predecessors
+// left behind, and the first root that finds nothing left is not formatted.
+func TestLocalsLaterRootsSeeRemainingBudget(t *testing.T) {
+	intType := testIntType()
+	arrType := &dwarf.ArrayType{Type: intType, Count: 100}
+	r := &dwarfReader{}
+	ctx := newFormatCtx(readableBackend{})
+
+	prev := ctx.nodesLeft
+	for i := 0; i < 5; i++ {
+		r.formatRoot(ctx, "root", arrType, 0x1000)
+		if ctx.nodesLeft >= prev {
+			t.Fatalf("root %d left nodesLeft=%d, want strictly less than the previous %d",
+				i, ctx.nodesLeft, prev)
+		}
+		if ctx.nodesLeft == maxTotalNodes {
+			t.Fatalf("root %d reset the budget to the full ceiling", i)
+		}
+		prev = ctx.nodesLeft
+	}
+	// 5 roots × 101 nodes consumed from the shared ceiling.
+	if want := maxTotalNodes - 5*101; ctx.nodesLeft != want {
+		t.Fatalf("nodesLeft = %d after 5 roots, want %d", ctx.nodesLeft, want)
+	}
+}
+
+// TestLocalsSiblingPointerAliasesAcrossRoots guards the #167 invariant under a
+// shared context: cycle state stays strictly path-local, so a later root
+// pointing at an address an earlier root already visited still expands.
+func TestLocalsSiblingPointerAliasesAcrossRoots(t *testing.T) {
+	ptrType := testPointerType("*int", testIntType())
+	backend := newValueMemoryBackend()
+	backend.seedUint64(0x1000, 0x2000)
+	backend.seedUint64(0x1008, 0x2000)
+	backend.seedUint64(0x2000, 42)
+
+	r := &dwarfReader{}
+	ctx := newFormatCtx(backend)
+	addrs := []uint64{0x1000, 0x1008}
+
+	vars := formatRequestRoots(ctx, len(addrs), func(i int) protocol.Variable {
+		v := r.formatRoot(ctx, "alias", ptrType, addrs[i])
+		if len(ctx.activePointers) != 0 {
+			t.Errorf("root %d leaked %d active pointer(s) into the next root",
+				i, len(ctx.activePointers))
+		}
+		return v
+	})
+
+	if len(vars) != 2 {
+		t.Fatalf("roots = %d, want 2", len(vars))
+	}
+	for _, v := range vars {
+		if len(v.Children) != 1 {
+			t.Fatalf("%s children = %d, want the aliased pointee to expand", v.Name, len(v.Children))
+		}
+		if got := v.Children[0].Value; got != "42" {
+			t.Errorf("%s pointee = %q, want 42", v.Name, got)
+		}
+	}
+}
+
+// TestLocalsSelfCycleStaysBoundedAcrossRoots checks a cyclic root neither runs
+// away nor poisons the roots after it.
+func TestLocalsSelfCycleStaysBoundedAcrossRoots(t *testing.T) {
+	nodeType := &dwarf.StructType{
+		CommonType: dwarf.CommonType{ByteSize: 8, Name: "node"},
+		StructName: "node",
+		Kind:       "struct",
+	}
+	nodePtr := testPointerType("*node", nodeType)
+	nodeType.Field = []*dwarf.StructField{{Name: "Next", Type: nodePtr, ByteOffset: 0}}
+
+	backend := newValueMemoryBackend()
+	backend.seedUint64(0x1000, 0x2000)
+	backend.seedUint64(0x2000, 0x2000)
+
+	r := &dwarfReader{}
+	ctx := newFormatCtx(backend)
+
+	vars := formatRequestRoots(ctx, 3, func(i int) protocol.Variable {
+		return r.formatRoot(ctx, "head", nodePtr, 0x1000)
+	})
+
+	if len(vars) != 3 {
+		t.Fatalf("roots = %d, want 3 (a bounded cycle must not exhaust the budget)", len(vars))
+	}
+	for i, v := range vars {
+		if total := countNodes(v); total > 4 {
+			t.Fatalf("root %d self-cycle node count = %d, want <= 4", i, total)
+		}
+		if len(v.Children) != 1 {
+			t.Fatalf("root %d expanded %d children, want the first hop", i, len(v.Children))
+		}
+	}
+}
+
+// filledBackend returns non-zero memory so Go string headers decode to a
+// non-nil pointer and an over-long length, making every string node pay the
+// maxStringBytes read. Used to hit the BYTE ceiling while node counts stay low.
+type filledBackend struct {
+	readableBackend
+	bytes int
+}
+
+func (b *filledBackend) ReadMemory(_ uint64, dst []byte) error {
+	for i := range dst {
+		dst[i] = 0x01
+	}
+	b.bytes += len(dst)
+	return nil
+}
+
+// TestLocalsByteCeilingStopsRequest exercises the byte half of the shared
+// ceiling independently: [100]string roots are cheap in nodes (101 each) but
+// expensive in bytes (~272 each), so the request must stop on bytesLeft.
+func TestLocalsByteCeilingStopsRequest(t *testing.T) {
+	stringType := &dwarf.StructType{
+		CommonType: dwarf.CommonType{ByteSize: 16, Name: "string"},
+		StructName: "string",
+		Kind:       "struct",
+	}
+	arrType := &dwarf.ArrayType{Type: stringType, Count: 100}
+
+	backend := &filledBackend{}
+	r := &dwarfReader{}
+	ctx := newFormatCtx(backend)
+
+	const roots = 200
+	vars := formatRequestRoots(ctx, roots, func(i int) protocol.Variable {
+		return r.formatRoot(ctx, "strings", arrType, 0x1000)
+	})
+
+	if nodes := countAllNodes(vars); nodes >= maxTotalNodes {
+		t.Fatalf("node count %d reached the node ceiling; this fixture must stop on bytes", nodes)
+	}
+	if ctx.bytesLeft > 0 {
+		t.Fatalf("bytesLeft = %d, want the byte ceiling to be the limiter", ctx.bytesLeft)
+	}
+	if backend.bytes > maxTotalBytes+maxScalarBytes {
+		t.Fatalf("bytes read %d exceed the shared byte ceiling %d(+one read)",
+			backend.bytes, maxTotalBytes)
+	}
+	if len(vars) >= roots {
+		t.Fatalf("returned %d roots, want the loop to stop once bytes ran out", len(vars))
+	}
+	if last := vars[len(vars)-1]; last.Value != truncatedValue {
+		t.Fatalf("last root = %q, want the truncation marker", last.Value)
+	}
+}
+
+// TestLocalsDegradesUnreadableRootsWithoutAbort keeps the per-node degradation
+// contract under a shared budget: an unreadable or untyped root renders as a
+// degraded node and the roots after it still format.
+func TestLocalsDegradesUnreadableRootsWithoutAbort(t *testing.T) {
+	backend := newValueMemoryBackend()
+	backend.seedUint64(0x3000, 7)
+
+	r := &dwarfReader{}
+	ctx := newFormatCtx(backend)
+	intType := testIntType()
+
+	vars := formatRequestRoots(ctx, 3, func(i int) protocol.Variable {
+		switch i {
+		case 0:
+			return r.formatRoot(ctx, "missing", intType, 0x9000) // unmapped
+		case 1:
+			return r.formatRoot(ctx, "untyped", nil, 0x9000) // unknown type
+		default:
+			return r.formatRoot(ctx, "ok", intType, 0x3000)
+		}
+	})
+
+	if len(vars) != 3 {
+		t.Fatalf("roots = %d, want 3", len(vars))
+	}
+	if got, want := vars[0].Value, "<unreadable: unreadable memory>"; got != want {
+		t.Errorf("unreadable root = %q, want %q", got, want)
+	}
+	if got, want := vars[1].Value, "<unreadable: unreadable memory>"; got != want {
+		t.Errorf("untyped root = %q, want %q", got, want)
+	}
+	if got := vars[2].Value; got != "7" {
+		t.Errorf("root after degraded ones = %q, want 7", got)
+	}
+}
+
+// TestEvaluateBudgetIsPerRequest pins that Evaluate — one root per request —
+// keeps a fresh ceiling, so it is unaffected by the Locals sharing and by any
+// earlier inspection.
+func TestEvaluateBudgetIsPerRequest(t *testing.T) {
+	nested := deepArrayType()
+	r := &dwarfReader{}
+
+	first := countNodes(r.formatTyped(readableBackend{}, "grid", nested, 0x1000))
+	second := countNodes(r.formatTyped(readableBackend{}, "grid", nested, 0x1000))
+
+	if first != second {
+		t.Fatalf("evaluate node counts differ across requests (%d then %d); the budget must reset per request",
+			first, second)
+	}
+	if first < maxTotalNodes {
+		t.Fatalf("evaluate expanded only %d nodes, want a full ceiling of %d", first, maxTotalNodes)
+	}
+}

--- a/internal/debugger/values_budget_test.go
+++ b/internal/debugger/values_budget_test.go
@@ -2,6 +2,7 @@ package debugger
 
 import (
 	"debug/dwarf"
+	"encoding/binary"
 	"testing"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
@@ -43,6 +44,98 @@ func countAllNodes(vars []protocol.Variable) int {
 		total += countNodes(vars[i])
 	}
 	return total
+}
+
+func localEntry(name string, addr *uint64) *dwarf.Entry {
+	entry := &dwarf.Entry{
+		Tag: dwarf.TagVariable,
+		Field: []dwarf.Field{
+			{Attr: dwarf.AttrName, Val: name},
+		},
+	}
+	if addr != nil {
+		expr := make([]byte, 9)
+		expr[0] = 0x03
+		binary.LittleEndian.PutUint64(expr[1:], *addr)
+		entry.Field = append(entry.Field, dwarf.Field{Attr: dwarf.AttrLocation, Val: expr})
+	}
+	return entry
+}
+
+// TestLocalsProductionPathChargesOptimizedOutRoots drives the exact
+// LocalsForFrame entries-to-formatEntry path. Optimized-out variables never
+// reach formatNode, but each emitted root must still spend one request node.
+func TestLocalsProductionPathChargesOptimizedOutRoots(t *testing.T) {
+	const roots = maxTotalNodes + 100
+	entries := make([]*dwarf.Entry, roots)
+	for i := range entries {
+		entries[i] = localEntry("optimized", nil)
+	}
+	backend := &countingBackend{}
+
+	vars := (&dwarfReader{}).formatLocalEntries(backend, entries, 0)
+
+	if got, want := len(vars), maxTotalNodes+1; got != want {
+		t.Fatalf("roots = %d, want %d budgeted roots plus one marker", got, want)
+	}
+	if last := vars[len(vars)-1]; last.Name != "…" || last.Value != truncatedValue {
+		t.Fatalf("last root = %#v, want one truncation marker", last)
+	}
+	if backend.reads != 0 {
+		t.Fatalf("optimized-out roots performed %d backend reads, want 0", backend.reads)
+	}
+}
+
+func TestFormatEntryChargesBestEffortRoots(t *testing.T) {
+	const (
+		missingAddr  = uint64(0x2000)
+		readableAddr = uint64(0x3000)
+	)
+	backend := newValueMemoryBackend()
+	backend.seedUint64(readableAddr, 7)
+	ctx := newFormatCtx(backend)
+	r := &dwarfReader{}
+
+	optimized := r.formatEntry(ctx, localEntry("optimized", nil), "optimized", 0)
+	unreadable := r.formatEntry(ctx, localEntry("unreadable", ptrTo(missingAddr)), "unreadable", 0)
+	unknown := r.formatEntry(ctx, localEntry("unknown", ptrTo(readableAddr)), "unknown", 0)
+
+	if optimized.Value != optimizedOut {
+		t.Fatalf("optimized root = %q, want %q", optimized.Value, optimizedOut)
+	}
+	if got, want := unreadable.Value, "<unreadable: unreadable memory>"; got != want {
+		t.Fatalf("unreadable root = %q, want %q", got, want)
+	}
+	if unknown.Value != "0x7" {
+		t.Fatalf("unknown root = %q, want 0x7", unknown.Value)
+	}
+	if got, want := ctx.nodesLeft, maxTotalNodes-3; got != want {
+		t.Fatalf("nodesLeft = %d, want %d after three best-effort roots", got, want)
+	}
+}
+
+func ptrTo(v uint64) *uint64 { return &v }
+
+// TestFormatEntryReservesBytesBeforeBackendRead mutation-locks the production
+// formatEntry path: a read that cannot fit must truncate without any backend I/O.
+func TestFormatEntryReservesBytesBeforeBackendRead(t *testing.T) {
+	const addr = uint64(0x3000)
+	backend := &countingBackend{}
+	ctx := newFormatCtx(backend)
+	ctx.bytesLeft = 1
+
+	got := (&dwarfReader{}).formatEntry(ctx, localEntry("value", ptrTo(addr)), "value", 0)
+
+	if got.Value != truncatedValue {
+		t.Fatalf("value = %q, want %q", got.Value, truncatedValue)
+	}
+	if backend.reads != 0 || backend.bytes != 0 {
+		t.Fatalf("backend reads=%d bytes=%d, want no I/O beyond the remaining byte budget",
+			backend.reads, backend.bytes)
+	}
+	if ctx.bytesLeft != 0 {
+		t.Fatalf("bytesLeft = %d, want exhausted after a refused read", ctx.bytesLeft)
+	}
 }
 
 // TestLocalsRequestSharesBudgetAcrossRoots is the #186 regression gate: before
@@ -257,8 +350,8 @@ func TestLocalsByteCeilingStopsRequest(t *testing.T) {
 	if ctx.bytesLeft > 0 {
 		t.Fatalf("bytesLeft = %d, want the byte ceiling to be the limiter", ctx.bytesLeft)
 	}
-	if backend.bytes > maxTotalBytes+maxScalarBytes {
-		t.Fatalf("bytes read %d exceed the shared byte ceiling %d(+one read)",
+	if backend.bytes > maxTotalBytes {
+		t.Fatalf("bytes read %d exceed the hard shared byte ceiling %d",
 			backend.bytes, maxTotalBytes)
 	}
 	if len(vars) >= roots {

--- a/internal/debugger/values_test.go
+++ b/internal/debugger/values_test.go
@@ -2,6 +2,8 @@ package debugger
 
 import (
 	"debug/dwarf"
+	"encoding/binary"
+	"errors"
 	"testing"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
@@ -23,6 +25,47 @@ func (readableBackend) SetRegisters(int, Registers) error     { return nil }
 func (readableBackend) Threads() ([]int, error)               { return []int{1}, nil }
 func (readableBackend) Wait() (StopEvent, error)              { return StopEvent{}, nil }
 
+type valueMemoryBackend struct {
+	readableBackend
+	mem map[uint64]byte
+}
+
+func newValueMemoryBackend() *valueMemoryBackend {
+	return &valueMemoryBackend{mem: make(map[uint64]byte)}
+}
+
+func (b *valueMemoryBackend) ReadMemory(addr uint64, dst []byte) error {
+	for i := range dst {
+		value, ok := b.mem[addr+uint64(i)]
+		if !ok {
+			return errors.New("unreadable memory")
+		}
+		dst[i] = value
+	}
+	return nil
+}
+
+func (b *valueMemoryBackend) seedUint64(addr, value uint64) {
+	buf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(buf, value)
+	for i := range buf {
+		b.mem[addr+uint64(i)] = buf[i]
+	}
+}
+
+func testIntType() *dwarf.IntType {
+	return &dwarf.IntType{BasicType: dwarf.BasicType{
+		CommonType: dwarf.CommonType{ByteSize: 8, Name: "int"},
+	}}
+}
+
+func testPointerType(name string, target dwarf.Type) *dwarf.PtrType {
+	return &dwarf.PtrType{
+		CommonType: dwarf.CommonType{ByteSize: 8, Name: name},
+		Type:       target,
+	}
+}
+
 func countNodes(v protocol.Variable) int {
 	n := 1
 	for i := range v.Children {
@@ -43,12 +86,137 @@ func hasTruncationNode(v protocol.Variable) bool {
 	return false
 }
 
+func TestFormatTypedExpandsSiblingPointerAliases(t *testing.T) {
+	intType := testIntType()
+	ptrType := testPointerType("*int", intType)
+	pairType := &dwarf.StructType{
+		CommonType: dwarf.CommonType{ByteSize: 16, Name: "pair"},
+		StructName: "pair",
+		Kind:       "struct",
+		Field: []*dwarf.StructField{
+			{Name: "Left", Type: ptrType, ByteOffset: 0},
+			{Name: "Right", Type: ptrType, ByteOffset: 8},
+		},
+	}
+	backend := newValueMemoryBackend()
+	backend.seedUint64(0x1000, 0x2000)
+	backend.seedUint64(0x1008, 0x2000)
+	backend.seedUint64(0x2000, 42)
+
+	root := (&dwarfReader{}).formatTyped(backend, "pair", pairType, 0x1000)
+
+	if len(root.Children) != 2 {
+		t.Fatalf("pair children = %d, want 2", len(root.Children))
+	}
+	for _, pointer := range root.Children {
+		if len(pointer.Children) != 1 {
+			t.Errorf("%s children = %d, want 1", pointer.Name, len(pointer.Children))
+			continue
+		}
+		if got := pointer.Children[0].Value; got != "42" {
+			t.Errorf("%s pointee = %q, want 42", pointer.Name, got)
+		}
+	}
+}
+
+func TestFormatCtxPointerPathOwnership(t *testing.T) {
+	ctx := &formatCtx{activePointers: make(map[uint64]bool)}
+
+	leaveAncestor, ok := ctx.enterPointer(0x2000)
+	if !ok {
+		t.Fatal("first pointer entry was rejected")
+	}
+	if leaveCycle, ok := ctx.enterPointer(0x2000); ok || leaveCycle != nil {
+		t.Fatal("cycle entry must not own ancestor cleanup")
+	}
+	if !ctx.activePointers[0x2000] {
+		t.Fatal("rejected cycle entry removed its ancestor")
+	}
+
+	leaveAncestor()
+	leaveAlias, ok := ctx.enterPointer(0x2000)
+	if !ok {
+		t.Fatal("sibling alias was rejected after ancestor unwound")
+	}
+	leaveAlias()
+}
+
+func TestFormatTypedPointerCyclesRemainBounded(t *testing.T) {
+	t.Run("self cycle", func(t *testing.T) {
+		nodeType := &dwarf.StructType{
+			CommonType: dwarf.CommonType{ByteSize: 8, Name: "node"},
+			StructName: "node",
+			Kind:       "struct",
+		}
+		nodePtr := testPointerType("*node", nodeType)
+		nodeType.Field = []*dwarf.StructField{
+			{Name: "Next", Type: nodePtr, ByteOffset: 0},
+		}
+		backend := newValueMemoryBackend()
+		backend.seedUint64(0x1000, 0x2000)
+		backend.seedUint64(0x2000, 0x2000)
+
+		root := (&dwarfReader{}).formatTyped(backend, "head", nodePtr, 0x1000)
+
+		if total := countNodes(root); total > 4 {
+			t.Fatalf("self-cycle node count = %d, want <= 4", total)
+		}
+	})
+
+	t.Run("mutual cycle", func(t *testing.T) {
+		leftType := &dwarf.StructType{
+			CommonType: dwarf.CommonType{ByteSize: 8, Name: "leftNode"},
+			StructName: "leftNode",
+			Kind:       "struct",
+		}
+		rightType := &dwarf.StructType{
+			CommonType: dwarf.CommonType{ByteSize: 8, Name: "rightNode"},
+			StructName: "rightNode",
+			Kind:       "struct",
+		}
+		leftType.Field = []*dwarf.StructField{
+			{Name: "Right", Type: testPointerType("*rightNode", rightType), ByteOffset: 0},
+		}
+		rightType.Field = []*dwarf.StructField{
+			{Name: "Left", Type: testPointerType("*leftNode", leftType), ByteOffset: 0},
+		}
+		backend := newValueMemoryBackend()
+		backend.seedUint64(0x2000, 0x3000)
+		backend.seedUint64(0x3000, 0x2000)
+
+		root := (&dwarfReader{}).formatTyped(backend, "left", leftType, 0x2000)
+
+		if total := countNodes(root); total > 5 {
+			t.Fatalf("mutual-cycle node count = %d, want <= 5", total)
+		}
+	})
+}
+
+func TestFormatTypedUnreadablePointerTarget(t *testing.T) {
+	backend := newValueMemoryBackend()
+	backend.seedUint64(0x1000, 0x2000)
+
+	root := (&dwarfReader{}).formatTyped(
+		backend,
+		"value",
+		testPointerType("*int", testIntType()),
+		0x1000,
+	)
+
+	if len(root.Children) != 1 {
+		t.Fatalf("pointer children = %d, want 1", len(root.Children))
+	}
+	if got, want := root.Children[0].Value, "<unreadable: unreadable memory>"; got != want {
+		t.Errorf("unreadable pointee = %q, want %q", got, want)
+	}
+}
+
 // TestFormatTypedBudget guards the shared per-inspection node/byte ceiling: a
 // pathologically wide, deep aggregate ([100][100][100][100]int, ~10^8 potential
 // nodes) must be truncated to O(maxTotalNodes) with a truncation node present,
 // so one Locals/Evaluate request can never wedge the single-threaded engine loop.
 func TestFormatTypedBudget(t *testing.T) {
-	intT := &dwarf.IntType{BasicType: dwarf.BasicType{CommonType: dwarf.CommonType{ByteSize: 8, Name: "int"}}}
+	intT := testIntType()
 	arr := func(elem dwarf.Type, count int64) *dwarf.ArrayType {
 		return &dwarf.ArrayType{Type: elem, Count: count}
 	}


### PR DESCRIPTION
Fixes #186. Also incorporates the still-needed prerequisite from #167 (fixes #165): path-local pointer-cycle semantics are required when one formatter context is shared across Locals roots.

## Problem

`maxTotalNodes = 10000` and `maxTotalBytes = 256 KiB` are request ceilings, but `LocalsForFrame` previously called `formatTyped` once per root. Each call allocated a fresh `formatCtx`, so one Locals request could consume `rootCount × maxTotalNodes` nodes and `rootCount × maxTotalBytes` bytes on the single engine loop thread.

The old persistent pointer `visited` set also suppressed later non-cyclic aliases. Sharing that set across roots would make the Locals fix regress alias expansion further.

## Fix

The three commits remain separate:

1. `fix(debugger): expand sibling pointer aliases` — tracks pointer targets only while their recursion path is active, preserving eager children for sibling and cross-root aliases while retaining cycle/depth limits.
2. `fix(debugger): share the inspection budget across Locals roots` — creates one `formatCtx` for the full Locals request, carries its remaining budget across every root, and collapses all elided roots into one trailing truncation marker. Evaluate remains one fresh budget per request.
3. `fix(debugger): enforce inspection budget ceilings` — charges optimized-out roots against the node budget and reserves bytes before backend I/O, so neither declared ceiling can be exceeded. Budget refusal renders as truncated; genuine backend failures remain unreadable.

The production `LocalsForFrame → formatLocalEntries → formatEntry` path is covered directly without manufacturing a complete DWARF section. Existing logical-package global lookup and lexical-scope traversal from current `main` are preserved.

## Final restack

Exact base: `1a25d95495b089680aa1a3759c50ce391a1a8c4f`

Exact head: `8ec5fb2fdc377f0ea8c9c25233c9e221c65b6a4c`

Patch-equivalent mapping, proven by both `git range-diff` and stable patch IDs:

- `67f20e3` → `b98f0b1`
- `13dce7d` → `1ca0649`
- `7389023` → `8ec5fb2`

No wire, DAP, VS Code extension, or platform-backend contract changes; current wire 1.4 and extension 0.4.1 remain unchanged.

## Validation on the exact published head

- repository-wide `go tool goimports -l .` and diff whitespace checks
- focused inspection tests repeated five times under `-race`
- targeted debugger/DAP `-race` suites
- full `go test -tags bingonative -race -count=1 ./...`
- full `go vet -tags bingonative ./...`
- Linux amd64 cross-build and cross-vet
- Linux-target `golangci-lint run`
- signed Darwin/arm64 real-backend `inspect` E2E: 2/2 specs passed
- signed full native Darwin/arm64 suite: 24 passed, 0 failed, 1 skipped
- independent exact-diff review: no findings

This PR remains draft and unmerged pending the complete GitHub matrix on the exact published head.