### PR TITLE
fix(server): bind default listeners to loopback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1180,6 +1180,12 @@ polling has no lifecycle effect. Positive idle durations below `1ms` or with a
 fractional millisecond are rejected so the timer and integer `timeoutMs` field
 always describe the exact same interval.
 
+**Listener safety.** The CLI and `just server` defaults bind management,
+WebSocket, and DAP endpoints to explicit IPv4 loopback. The protocols do not
+authenticate clients, and WebSocket clients without an `Origin` header are
+valid, so never restore wildcard defaults. Operators may explicitly choose a
+non-loopback address for trusted-network or externally authenticated setups.
+
 **Connect-or-start and ownership.** A frontend health-checks the known
 management address and reuses a compatible process; otherwise it starts bingo
 and lets listener binding arbitrate concurrent startup attempts. Frontends

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ drive a debug session over a TCP socket while BinGo's own visual clients observe
 Manual clients can start the server with a DAP listener:
 
 ```sh
-just server                       # builds + runs with -addr :6060 -dap-addr :4711
+just server                       # builds + runs both listeners on IPv4 loopback
 # or, from a prebuilt binary:
-bingo -addr :6060 -dap-addr :4711
+bingo -addr 127.0.0.1:6060 -dap-addr 127.0.0.1:4711
 ```
 
 `just server` starts both listeners with the defaults above; use `just server-ws`
@@ -65,7 +65,7 @@ Frontends can identify and reuse a compatible bingo process through
   "instanceId": "4dd4dfdd-7f55-41a5-bd95-c086ce6f3c2a",
   "dap": {
     "enabled": true,
-    "address": "0.0.0.0:4711",
+    "address": "127.0.0.1:4711",
     "sessionEventVersion": 1
   },
   "managedIdleShutdown": {
@@ -98,7 +98,7 @@ opt into server-owned idle shutdown:
 ```sh
 bingo -addr 127.0.0.1:6060 -dap-addr 127.0.0.1:4711 -idle-timeout 30s
 # equivalent development recipe:
-just server darwin arm64 :6060 :4711 -idle-timeout 30s
+just server darwin arm64 127.0.0.1:6060 127.0.0.1:4711 -idle-timeout 30s
 ```
 
 The timeout is armed at startup and whenever the last managed session
@@ -108,6 +108,10 @@ joined a session do not keep the process alive, so a process owner must allow
 enough grace for its health check and DAP handshake. A zero or omitted timeout
 disables idle shutdown. Positive values must be at least `1ms` and use whole
 milliseconds so the enforced duration exactly matches `timeoutMs`.
+
+The shipped CLI and `just server` defaults bind both protocols to IPv4
+loopback. Explicit non-loopback binds are unauthenticated and should only be
+used on trusted networks or behind an authenticated transport.
 
 ### VS Code companion extension
 

--- a/cmd/bingo/main.go
+++ b/cmd/bingo/main.go
@@ -97,7 +97,7 @@ func parseConfig(args []string, output io.Writer) (config, error) {
 	var cfg config
 	flags := flag.NewFlagSet("bingo", flag.ContinueOnError)
 	flags.SetOutput(output)
-	flags.StringVar(&cfg.addr, "addr", ":6060", "listen address (host:port)")
+	flags.StringVar(&cfg.addr, "addr", "127.0.0.1:6060", "listen address (host:port)")
 	flags.StringVar(&cfg.dapAddr, "dap-addr", "", "DAP listen address (host:port); empty disables the DAP server")
 	flags.DurationVar(&cfg.idleTimeout, "idle-timeout", 0, "exit after no managed sessions for this duration; 0 disables")
 	flags.BoolVar(&cfg.verbose, "v", false, "enable verbose (debug) logging")

--- a/cmd/bingo/main_test.go
+++ b/cmd/bingo/main_test.go
@@ -35,7 +35,7 @@ func TestParseConfigDefaultsToPersistentServer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse defaults: %v", err)
 	}
-	if cfg.addr != ":6060" || cfg.dapAddr != "" || cfg.idleTimeout != 0 || cfg.verbose {
+	if cfg.addr != "127.0.0.1:6060" || cfg.dapAddr != "" || cfg.idleTimeout != 0 || cfg.verbose {
 		t.Fatalf("unexpected defaults: %+v", cfg)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -63,7 +63,7 @@ type Server struct {
 	idleTimerHook func()
 }
 
-// New creates a Server that will listen on addr (e.g. ":6060").
+// New creates a Server that will listen on addr (e.g. "127.0.0.1:6060").
 func New(addr string, log *slog.Logger) *Server {
 	return newServer(addr, 0, log)
 }

--- a/justfile
+++ b/justfile
@@ -23,7 +23,7 @@ build OS=os_name ARCH=arch_name:
 #		 just run darwin arm64 							-> 	runs ./build/bingo/bingo_darwin_arm64 (MacOs specified, ARM64 specified)
 #		 just run linux amd64 -addr 127.0.0.1:6061 -v 	->  runs ./build/bingo/bingo_linux_amd64 -addr 127.0.0.1:6061 -v
 
-# ARGS:  -addr string    listen address (default ":6060")
+# ARGS:  -addr string    listen address (default "127.0.0.1:6060")
 #		 -idle-timeout duration
 #		                 exit after no managed sessions for this duration;
 #		                 omitted/0 keeps the server persistent; positive values
@@ -35,8 +35,8 @@ run OS=os_name ARCH=arch_name *ARGS="":
 
 # Default WS (-addr) and DAP (-dap-addr) listen addresses for the server recipes.
 # Override on the CLI, e.g. `just server darwin arm64 :7070 :4712`.
-ws_addr := ":6060"
-dap_addr := ":4711"
+ws_addr := "127.0.0.1:6060"
+dap_addr := "127.0.0.1:4711"
 
 # Build then run the server with EVERYTHING enabled: both the WebSocket (-addr)
 # and DAP (-dap-addr) listeners, using the standard defaults so a DAP driver

--- a/justfile
+++ b/justfile
@@ -34,7 +34,7 @@ run OS=os_name ARCH=arch_name *ARGS="":
 	./build/bingo/bingo_{{OS}}_{{ARCH}} {{ARGS}}
 
 # Default WS (-addr) and DAP (-dap-addr) listen addresses for the server recipes.
-# Override on the CLI, e.g. `just server darwin arm64 :7070 :4712`.
+# Override on the CLI, e.g. `just server darwin arm64 127.0.0.1:7070 127.0.0.1:4712`.
 ws_addr := "127.0.0.1:6060"
 dap_addr := "127.0.0.1:4711"
 


### PR DESCRIPTION
## Summary
- Default the CLI `-addr` flag, `internal/server.New`'s doc comment, and the justfile `server` recipe's `ws_addr`/`dap_addr` defaults to explicit IPv4 loopback (`127.0.0.1`) instead of the wildcard-binding `":port"` form.
- Neither the WebSocket nor DAP protocol authenticates clients, so a wildcard default exposed session creation and `Launch`/`Attach` (arbitrary command execution) to any network peer that could reach the host.
- Document the new default and the loopback-only safety invariant in README.md and AGENTS.md.

This is an isolated re-implementation of only the loopback-default slice from draft PR #152 (`xsachax-audit-server-lifecycle`), branched fresh from `main`. It deliberately excludes #152's DAP accept retry/backoff changes (issue #151), which are out of scope here.

## Validation
- `gofmt -l cmd/bingo/main.go cmd/bingo/main_test.go internal/server/server.go`, `go tool goimports -l .`, and `git diff --check 1ad972571323dcf30c2c70076e98a9d8ce9c90f3..HEAD` — clean
- `go vet -tags bingonative ./...` — pass
- `golangci-lint run --build-tags bingonative ./...` — 0 issues
- `go build -tags bingonative ./...` — pass
- `go test -tags bingonative -race -count=1 ./...` — all pass
- `go test -tags bingonative -race -count=20 ./cmd/bingo` — all 20 focused CLI repetitions pass
- `go run github.com/onsi/ginkgo/v2/ginkgo -race -tags=bingonative -repeat=10 ./internal/server` — all 10 focused server repetitions pass
- `just --color never --dry-run server` — emits `-addr 127.0.0.1:6060 -dap-addr 127.0.0.1:4711`
- Live smoke: the built server's management and DAP sockets were observed as IPv4-only `127.0.0.1:6060` and `127.0.0.1:4711`; `/api/health` advertised `127.0.0.1:4711`, with no wildcard or IPv6 listener

Fixes #150

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>