### PR TITLE
fix(client): stop correlating dual-purpose goroutine snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,6 +302,23 @@ automatic — is delivered exactly once on `Events()`, where a client treats the
 uniformly as telemetry. It must stay out of the correlated set: never route it
 through `sendAndWait`. See issue #187.
 
+Two consequences a caller must handle, both inherent to an id-less broadcast
+protocol rather than to this change:
+
+- **Delivery is best-effort.** The answer rides the shared `Events()` buffer,
+  which `readPump` drops from when the consumer stops draining, and a rejected
+  request answers with `EventError`(`CmdGoroutineSnapshot`) instead of a
+  snapshot. Anything that blocks waiting for a snapshot must handle both — see
+  `cmd/wsmon`'s `-once`, which fails fast on a rejection or a closed stream
+  rather than waiting forever.
+- **The answer is broadcast.** A query is fanned out to every client on the
+  session like any other event, and it carries empty `Created`/`Exited`. An
+  observer that renders "the latest snapshot's deltas" (as `cmd/wsmon`'s
+  lifecycle panel does) therefore blanks that panel until the next automatic
+  stop; an append-only timeline (the VS Code view) is unaffected. Making a query
+  addressable to its requester needs wire-level correlation and is deliberately
+  out of scope here — a candidate for a telemetry 1.3.
+
 `syncMu` serializes synchronous commands, but a timeout does **not** cancel the
 command already sent to the server. The pending queue therefore retains a
 timed-out request as retired reply debt until its matching confirmation or
@@ -1657,6 +1674,16 @@ consumed the pending deltas — the following automatic snapshot diffed against
 the query, so goroutines created and exited in between appeared in neither
 (issue #187). Do not add a delta-bearing query path back: the wire payload is
 unchanged, and a client that wants deltas must read the automatic stream.
+
+The regression gate is the `concurrency`-labelled `declareBaselineOwnershipSpec`
+E2E, and it is deliberately shaped: a query at an ordinary breakpoint stop sees
+exactly the live set that stop's automatic snapshot already adopted, so adopting
+again would be a no-op and prove nothing. The spec instead **steps over a `go`
+statement** — steps are the one suspend that carries no automatic snapshot — so
+the query observes a goroutine the baseline has never seen, then asserts the
+NEXT automatic snapshot still reports it as created. It fails if the query is
+made lifecycle-tracking or the automatic path non-tracking; the unit tests
+around `snapshotFrom` pin the seam's semantics but cannot catch a rewiring.
 
 **Graceful fallback.** Every read is best-effort. `resolveGoLayout` marks the
 layout invalid if any required `g`/`gobuf`/`stack`/`m` offset is missing, and any

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,9 +308,13 @@ protocol rather than to this change:
 - **Delivery is best-effort.** The answer rides the shared `Events()` buffer,
   which `readPump` drops from when the consumer stops draining, and a rejected
   request answers with `EventError`(`CmdGoroutineSnapshot`) instead of a
-  snapshot. Anything that blocks waiting for a snapshot must handle both — see
-  `cmd/wsmon`'s `-once`, which fails fast on a rejection or a closed stream
-  rather than waiting forever.
+  snapshot. Anything that waits for a snapshot must handle both — and must not
+  treat that error as *its* answer: `EventError` is broadcast and carries no
+  requester, so it may be another client's rejection with a valid snapshot still
+  to come. Correlating it by kind is the same mistake as correlating the
+  snapshot itself. `cmd/wsmon`'s `-once` shows the intended shape: the rejection
+  is advisory, a later snapshot wins, and a `-timeout` deadline (not the error)
+  is what bounds the wait.
 - **The answer is broadcast.** A query is fanned out to every client on the
   session like any other event, and it carries empty `Created`/`Exited`. An
   observer that renders "the latest snapshot's deltas" (as `cmd/wsmon`'s

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,12 +276,31 @@ In [pkg/client](pkg/client/), the `Client` interface splits methods by what
 they wait for:
 
 - **Synchronous** (`Restart`, `SetBreakpoint`, `ClearBreakpoint`, `Locals`,
-  `Evaluate`, `StackFrames`, `Goroutines`, `GoroutineSnapshot`): block until
-  the matching confirmation event (or `EventError` for the same command kind)
-  arrives. Implemented via `sendAndWait` in [pkg/client/ws.go](pkg/client/ws.go).
-- **Fire-and-forget** (`Launch`, `Attach`, `Kill`, `Continue`, `Step*`, `Pause`):
-  return as soon as the command is on the wire. Results arrive asynchronously
-  on the `Events()` channel.
+  `Evaluate`, `StackFrames`, `Goroutines`): block until the matching
+  confirmation event (or `EventError` for the same command kind) arrives.
+  Implemented via `sendAndWait` in [pkg/client/ws.go](pkg/client/ws.go).
+- **Fire-and-forget** (`Launch`, `Attach`, `Kill`, `Continue`, `Step*`, `Pause`,
+  `RequestGoroutineSnapshot`): return as soon as the command is on the wire.
+  Results arrive asynchronously on the `Events()` channel.
+
+`RequestGoroutineSnapshot` is fire-and-forget **for a correctness reason, not
+convenience**: `EventGoroutineSnapshot` is the only dual-purpose frame in the
+protocol — the server also pushes it unsolicited on every entry/breakpoint/pause
+stop — so it can never be correlated to a request by kind. A synchronous
+`GoroutineSnapshot()` has no sound placement in the reply-debt model below, in
+either direction. *Retiring* a timed-out snapshot request as debt lets that debt
+silently swallow the next automatic push, permanently losing that stop's
+lifecycle deltas. *Discarding* it instead re-opens #144 for this kind: a stale
+reply — or any automatic push — then satisfies a later same-kind call. Even
+before any timeout, a plain in-flight call is satisfied by whichever snapshot
+lands first, which is usually a stop's automatic push. All three follow from one
+root: a frame that can exist with **no request** cannot be matched to one.
+
+So the fix is to remove the waiter, not to place it better. The request registers
+**no pending entry and no reply debt**, and every snapshot — requested or
+automatic — is delivered exactly once on `Events()`, where a client treats them
+uniformly as telemetry. It must stay out of the correlated set: never route it
+through `sendAndWait`. See issue #187.
 
 `syncMu` serializes synchronous commands, but a timeout does **not** cancel the
 command already sent to the server. The pending queue therefore retains a
@@ -297,16 +316,15 @@ continue timing out while that reply stream remains one response short. Keep the
 WebSocket open: disconnecting the last client tears down the hub/debuggee, while
 unrelated async events remain valid.
 
-`GoroutineSnapshot` is a temporary exception to timeout debt because
-`EventGoroutineSnapshot` is dual-purpose: it confirms `CmdGoroutineSnapshot`
-and is also pushed automatically after breakpoint, pause, and entry stops. A
-timed-out snapshot request is removed from the pending queue so it cannot consume
-the next unrelated telemetry snapshot. This preserves the stream, not
-correlation: while the legacy synchronous API exists, a genuinely late query
-reply or an unrelated automatic push can still satisfy a later in-flight
-`GoroutineSnapshot` waiter; without a waiter, either falls through to `Events()`.
-Issue #187 and stacked PR #192 remove the synchronous query surface and that
-ambiguity rather than expanding the exception here.
+Every command `sendAndWait` serves is a **genuine confirmation** — one that
+cannot exist without a request — so the timeout path above is uniform, with no
+per-kind exemption. Do not add one. `EventGoroutineSnapshot` is the only frame
+that breaks that property, and while a synchronous snapshot query existed it
+forced exactly such a carve-out (discard instead of retire). That carve-out
+preserved the telemetry stream but could not create correlation: with a waiter
+present, a genuinely late query reply or an unrelated automatic push could still
+satisfy a later in-flight call. Removing the waiter removed the ambiguity — the
+snapshot is now event-driven end to end and out of this model entirely.
 
 This is deliberately bounded by the id-less broadcast protocol. The queue
 preserves this client's ordered command stream; it cannot distinguish an
@@ -1592,7 +1610,10 @@ auto-emitted on exactly the suspends that can change the concurrency picture —
 single-step/step-over path from extra per-step memory reads. `emitBreakpointHit`
 / `emitPaused` build the snapshot **once**, embed its current goroutine in the
 stop event, then stream the same snapshot — one build, no double scan, no double
-delta pass. The one `EventPaused` that carries **no** snapshot is the internal
+delta pass. Because the event is dual-purpose (push *and* query answer), the
+SDK's request is fire-and-forget — `Client.RequestGoroutineSnapshot`, never a
+`sendAndWait` — and only the automatic ones carry lifecycle deltas. The one
+`EventPaused` that carries **no** snapshot is the internal
 async halt (`emitHaltedOnError`, see [step-over flow](#software-breakpoint-step-over-flow)):
 it is emitted on a backend error path, where a snapshot would push dozens of
 further reads through the backend that just failed. Observers keep their last
@@ -1622,6 +1643,20 @@ created/exited and adopts the new set. First snapshot returns nil deltas (a fres
 session must not report every goroutine as "created"). A **degraded** snapshot
 (runtime unreadable — e.g. the pre-init entry stop) does **not** touch
 `prevGoids`: an empty read must not look like every goroutine exited.
+
+**Automatic snapshots alone own the baseline.** `prevGoids` is the *only*
+lifecycle memory, so whoever advances it decides what the next automatic
+snapshot can report. The on-demand `CmdGoroutineSnapshot` path is therefore a
+pure observation: `engine.GoroutineSnapshot` calls `goroutineSnapshotQuery`
+(`buildSnapshot(false)`), which reports the same live picture with **empty
+Created/Exited** and leaves `prevGoids` untouched; only `goroutineSnapshot`
+(`buildSnapshot(true)`, used by `emitBreakpointHit` / `emitPaused` /
+`emitGoroutineSnapshot` at the entry stop) diffs and adopts. `snapshotFrom` is
+the single seam where the two differ. Before this split a manual refresh
+consumed the pending deltas — the following automatic snapshot diffed against
+the query, so goroutines created and exited in between appeared in neither
+(issue #187). Do not add a delta-bearing query path back: the wire payload is
+unchanged, and a client that wants deltas must read the automatic stream.
 
 **Graceful fallback.** Every read is best-effort. `resolveGoLayout` marks the
 layout invalid if any required `g`/`gobuf`/`stack`/`m` offset is missing, and any
@@ -3081,8 +3116,10 @@ through the justfile.
   it to `goLayout`/`resolveGoLayout`; a missing *required* offset invalidates the
   layout and falls back to the synthetic goroutine — keep new fields optional
   unless they're truly required. Preserve the streaming-cadence invariant
-  (snapshot on breakpoint/pause/entry, never per-step) and the degraded-snapshot
-  rule (don't touch `prevGoids` on an unreadable read).
+  (snapshot on breakpoint/pause/entry, never per-step), the degraded-snapshot
+  rule (don't touch `prevGoids` on an unreadable read), and the
+  automatic-snapshots-own-the-baseline rule (a `CmdGoroutineSnapshot` query
+  reports no deltas and never advances `prevGoids`).
 - **Breakpoint ids**: client-visible ids are the hub's session-stable logical
   ids (see
   [Breakpoint identity](#breakpoint-identity--hub-owned-logical-ids)). A new

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -19,7 +19,9 @@ import (
 
 // fullSnapshotNext renders the next EventGoroutineSnapshot in full rather than
 // as the usual one-line summary, so a user-typed `snapshot` gets the detailed
-// view. Shared between the REPL goroutine and the event printer.
+// view. It is a display preference, not correlation: the arm is consumed by
+// whichever snapshot arrives first and is cleared by any broadcast snapshot
+// error. Shared between the REPL goroutine and the event printer.
 var fullSnapshotNext atomic.Bool
 
 //nolint:gocognit,gocyclo // The CLI keeps command routing in one switch while commands are still small.
@@ -249,10 +251,14 @@ func main() {
 
 		case "snapshot", "snap":
 			// Fire-and-forget: the snapshot answers on the event stream, where
-			// automatic stop snapshots also arrive. fullSnapshotNext only
-			// changes how the next one is *rendered* (full instead of the
-			// one-line summary) — every snapshot is printed either way, so
-			// nothing is correlated or discarded.
+			// automatic stop snapshots also arrive. fullSnapshotNext is a
+			// display arm only — it selects the renderer for the NEXT snapshot,
+			// whichever that turns out to be. An automatic push (or another
+			// client's requested one) can consume the arm, and any broadcast
+			// snapshot error can disarm it, so the detailed view may land on a
+			// different snapshot than the one this command asked for. No
+			// snapshot data is lost either way: every one is printed, in order,
+			// in one form or the other.
 			fullSnapshotNext.Store(true)
 			if err := c.RequestGoroutineSnapshot(); err != nil {
 				fullSnapshotNext.Store(false)
@@ -344,8 +350,9 @@ func printAuxEvent(evt protocol.Event) {
 		var p protocol.ErrorPayload
 		if protocol.DecodeEventPayload(evt, &p) == nil {
 			if p.Command == protocol.CmdGoroutineSnapshot {
-				// A rejected request has no snapshot to render in full; leaving
-				// the flag armed would expand the next automatic push instead.
+				// Disarm on any broadcast snapshot rejection, including one
+				// caused by another client: EventError carries no requester, so
+				// leaving the arm set would expand an unrelated automatic push.
 				fullSnapshotNext.Store(false)
 			}
 			fmt.Printf("\n  [error] %s: %s\nbingo> ", p.Command, p.Message)

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -10,11 +10,17 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/bingosuite/bingo/pkg/client"
 	"github.com/bingosuite/bingo/pkg/protocol"
 	"github.com/chzyer/readline"
 )
+
+// fullSnapshotNext renders the next EventGoroutineSnapshot in full rather than
+// as the usual one-line summary, so a user-typed `snapshot` gets the detailed
+// view. Shared between the REPL goroutine and the event printer.
+var fullSnapshotNext atomic.Bool
 
 //nolint:gocognit,gocyclo // The CLI keeps command routing in one switch while commands are still small.
 func main() {
@@ -242,12 +248,17 @@ func main() {
 			}
 
 		case "snapshot", "snap":
-			snap, err := c.GoroutineSnapshot()
-			if err != nil {
+			// Fire-and-forget: the snapshot answers on the event stream, where
+			// automatic stop snapshots also arrive. fullSnapshotNext only
+			// changes how the next one is *rendered* (full instead of the
+			// one-line summary) — every snapshot is printed either way, so
+			// nothing is correlated or discarded.
+			fullSnapshotNext.Store(true)
+			if err := c.RequestGoroutineSnapshot(); err != nil {
+				fullSnapshotNext.Store(false)
 				printErr(err)
 				continue
 			}
-			printSnapshot(snap)
 
 		case "help", "h", "?":
 			printHelp()
@@ -332,6 +343,11 @@ func printAuxEvent(evt protocol.Event) {
 	case protocol.EventError:
 		var p protocol.ErrorPayload
 		if protocol.DecodeEventPayload(evt, &p) == nil {
+			if p.Command == protocol.CmdGoroutineSnapshot {
+				// A rejected request has no snapshot to render in full; leaving
+				// the flag armed would expand the next automatic push instead.
+				fullSnapshotNext.Store(false)
+			}
 			fmt.Printf("\n  [error] %s: %s\nbingo> ", p.Command, p.Message)
 		}
 
@@ -345,6 +361,12 @@ func printAuxEvent(evt protocol.Event) {
 	case protocol.EventGoroutineSnapshot:
 		var p protocol.GoroutineSnapshotPayload
 		if protocol.DecodeEventPayload(evt, &p) == nil {
+			if fullSnapshotNext.CompareAndSwap(true, false) {
+				fmt.Println()
+				printSnapshot(p)
+				fmt.Print("bingo> ")
+				return
+			}
 			msg := fmt.Sprintf("\n  [goroutines] %d live, %d threads, current G%d",
 				len(p.Goroutines), len(p.Threads), p.Current)
 			if len(p.Created) > 0 {
@@ -447,7 +469,7 @@ func printHelp() {
   locals [frame]             show local variables (default frame 0)
   bt / backtrace             show call stack
   goroutines / grs           list goroutines (with parent/start)
-  snapshot / snap            full concurrency snapshot (goroutines + threads + deltas)
+  snapshot / snap            request a full concurrency snapshot (printed when it arrives)
 
   help / h / ?               show this help
   quit / q / exit            disconnect and exit`)

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+// captureStdout runs fn with os.Stdout redirected and returns what it printed.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	original := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = original }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	return string(out)
+}
+
+func testSnapshotEvent(t *testing.T, seq uint64) protocol.Event {
+	t.Helper()
+
+	return protocol.MustEvent(protocol.EventGoroutineSnapshot, seq, protocol.GoroutineSnapshotPayload{
+		Goroutines: []protocol.Goroutine{
+			{ID: 1, Status: "running", Current: true},
+			{ID: 18, Status: "waiting", ParentID: 1},
+		},
+		Threads: []protocol.Thread{{ID: 4242, MID: 3, GoID: 1, Current: true}},
+		Current: 1,
+		Created: []int{18},
+	})
+}
+
+// The `snapshot` command arms a one-shot full render; every other snapshot —
+// including the automatic pushes — stays a one-line summary. Both are printed:
+// the flag only picks the renderer, it never consumes or correlates an event.
+func TestFullSnapshotNextRendersOnceThenSummarises(t *testing.T) {
+	t.Cleanup(func() { fullSnapshotNext.Store(false) })
+
+	fullSnapshotNext.Store(true)
+	full := captureStdout(t, func() { printEvent(testSnapshotEvent(t, 2)) })
+	if !strings.Contains(full, "goroutines: 2  threads: 1  current: G1") {
+		t.Fatalf("requested snapshot render = %q, want the full view", full)
+	}
+	if !strings.Contains(full, "created: [18]") {
+		t.Fatalf("requested snapshot render = %q, want the lifecycle deltas", full)
+	}
+	if fullSnapshotNext.Load() {
+		t.Fatal("fullSnapshotNext still armed after one snapshot")
+	}
+
+	summary := captureStdout(t, func() { printEvent(testSnapshotEvent(t, 3)) })
+	if !strings.Contains(summary, "[goroutines] 2 live, 1 threads, current G1") {
+		t.Fatalf("automatic snapshot render = %q, want the summary line", summary)
+	}
+	if strings.Contains(summary, "goroutines: 2  threads: 1") {
+		t.Fatalf("automatic snapshot render = %q, want no full view", summary)
+	}
+}
+
+// A rejected request (e.g. the process isn't suspended) must disarm the full
+// render, or the next automatic push would be expanded in its place.
+func TestSnapshotErrorDisarmsFullRender(t *testing.T) {
+	t.Cleanup(func() { fullSnapshotNext.Store(false) })
+
+	fullSnapshotNext.Store(true)
+	rejected := protocol.MustEvent(protocol.EventError, 2, protocol.ErrorPayload{
+		Command: protocol.CmdGoroutineSnapshot,
+		Message: "process not suspended",
+	})
+	if out := captureStdout(t, func() { printEvent(rejected) }); !strings.Contains(out, "process not suspended") {
+		t.Fatalf("error render = %q, want the server message", out)
+	}
+	if fullSnapshotNext.Load() {
+		t.Fatal("fullSnapshotNext still armed after a rejected request")
+	}
+
+	summary := captureStdout(t, func() { printEvent(testSnapshotEvent(t, 3)) })
+	if !strings.Contains(summary, "[goroutines] 2 live") {
+		t.Fatalf("automatic snapshot render = %q, want the summary line", summary)
+	}
+}

--- a/cmd/wsmon/main.go
+++ b/cmd/wsmon/main.go
@@ -69,13 +69,23 @@ func (c *config) validate() error {
 	return nil
 }
 
+// usageError reports a validation failure the same way the flag package reports
+// a parse failure: the message, then the flag SET's usage. It must be fs.Usage,
+// not the package-level flag.Usage — those are different functions, and
+// bindFlags installs the custom header on the set, so calling flag.Usage() here
+// would print the stock "Usage of <binary>:" instead and diverge from what a
+// parse error prints.
+func usageError(fs *flag.FlagSet, err error) {
+	_, _ = fmt.Fprintf(fs.Output(), "error: %v\n", err)
+	fs.Usage()
+}
+
 func main() {
 	cfg := bindFlags(flag.CommandLine)
 	flag.Parse()
 
 	if err := cfg.validate(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		flag.Usage()
+		usageError(flag.CommandLine, err)
 		os.Exit(2)
 	}
 

--- a/cmd/wsmon/main.go
+++ b/cmd/wsmon/main.go
@@ -72,13 +72,13 @@ func main() {
 		_ = c.Close()
 	}()
 
-	if snap, err := c.GoroutineSnapshot(); err == nil {
-		m.applySnapshot(snap)
-		m.render()
-		if *once {
-			return
-		}
-	} else if !*once {
+	// The snapshot answers on the event stream like every automatic push, so
+	// this is fire-and-forget; the render loop below applies whichever arrives
+	// first. -once therefore waits for the first snapshot event either way.
+	if err := c.RequestGoroutineSnapshot(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: request goroutine snapshot: %v\n", err)
+	}
+	if !*once {
 		m.render()
 	}
 

--- a/cmd/wsmon/main.go
+++ b/cmd/wsmon/main.go
@@ -1,11 +1,10 @@
 // Command wsmon joins an existing bingo WebSocket session and renders the
 // streaming goroutine/thread telemetry in a terminal.
 //
-//	wsmon -session id [-addr host:port] [-once]
+//	wsmon -session id [-addr host:port] [-once] [-timeout d]
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -36,8 +35,10 @@ func main() {
 	addr := flag.String("addr", "localhost:6060", "server address (host:port)")
 	sessionID := flag.String("session", "", "session ID to join")
 	once := flag.Bool("once", false, "print one snapshot then exit")
+	timeout := flag.Duration("timeout", 30*time.Second,
+		"with -once, how long to wait for a snapshot (0 waits forever)")
 	flag.Usage = func() {
-		_, _ = fmt.Fprintf(flag.CommandLine.Output(), "usage: wsmon -session <id> [-addr host:port] [-once]\n\n")
+		_, _ = fmt.Fprintf(flag.CommandLine.Output(), "usage: wsmon -session <id> [-addr host:port] [-once] [-timeout d]\n\n")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
@@ -84,7 +85,7 @@ func main() {
 		m.render()
 	}
 
-	if err := m.run(c.Events(), *once, m.render); err != nil {
+	if err := m.run(c.Events(), *once, *timeout, m.render); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
@@ -94,42 +95,63 @@ func main() {
 }
 
 // run drains events until the stream closes, -once has rendered its snapshot,
-// or the server rejects the snapshot request. render is injected so tests can
-// count redraws without terminal output.
+// or (under -once) the deadline expires. render is injected so tests can count
+// redraws without terminal output.
 //
-// A rejection is only fatal under -once: that mode blocks until a snapshot
-// arrives, and after a rejection none is coming, so the old code waited
-// forever. In live mode the monitor keeps observing — the next stop pushes a
-// snapshot on its own — and surfaces the rejection on the status line.
-func (m *monitor) run(events <-chan protocol.Event, once bool, render func()) error {
-	for evt := range events {
-		if msg, ok := snapshotRejection(evt); ok && once {
-			return fmt.Errorf("server rejected the snapshot request: %s", msg)
-		}
-
-		renderedSnapshot, redraw := m.applyEvent(evt)
-		if !redraw {
-			continue
-		}
-		if once && !renderedSnapshot {
-			continue
-		}
-		render()
-		if once && renderedSnapshot {
-			return nil
-		}
+// A snapshot rejection is ADVISORY, never fatal on its own: EventError is
+// broadcast, so an error naming CmdGoroutineSnapshot may belong to another
+// client entirely, and a valid snapshot can still arrive right after it (the
+// target reaching a stop pushes one unprompted). Attributing it to our request
+// would reintroduce exactly the correlate-by-kind mistake this command was
+// changed to avoid. So a later snapshot always wins; the last rejection seen is
+// only reported as context if the wait ends without one. The deadline is what
+// keeps -once bounded when our own request really was rejected.
+func (m *monitor) run(events <-chan protocol.Event, once bool, timeout time.Duration, render func()) error {
+	var deadline <-chan time.Time
+	if once && timeout > 0 {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		deadline = timer.C
 	}
 
-	if once {
-		return errors.New("connection closed before a snapshot arrived")
+	var lastRejection string
+	for {
+		select {
+		case evt, ok := <-events:
+			if !ok {
+				if once {
+					return fmt.Errorf("connection closed before a snapshot arrived%s",
+						rejectionContext(lastRejection))
+				}
+				return nil
+			}
+
+			if msg, rejected := snapshotRejection(evt); rejected {
+				lastRejection = msg
+			}
+
+			renderedSnapshot, redraw := m.applyEvent(evt)
+			if !redraw {
+				continue
+			}
+			if once && !renderedSnapshot {
+				continue
+			}
+			render()
+			if once && renderedSnapshot {
+				return nil
+			}
+
+		case <-deadline:
+			return fmt.Errorf("no snapshot within %s%s", timeout, rejectionContext(lastRejection))
+		}
 	}
-	return nil
 }
 
-// snapshotRejection reports a failed CmdGoroutineSnapshot. EventError is
-// broadcast to every client, so this cannot tell our own rejection from another
-// client's; under -once either means no snapshot is coming, which is why the
-// caller treats both the same rather than waiting for a reply it can't identify.
+// snapshotRejection reports a failed CmdGoroutineSnapshot seen on the stream.
+// EventError carries no requester, so this says only "some snapshot request was
+// rejected" — it can never be attributed to this client's request. Callers must
+// treat it as advisory context, not as an answer.
 func snapshotRejection(evt protocol.Event) (string, bool) {
 	if evt.Kind != protocol.EventError {
 		return "", false
@@ -139,6 +161,13 @@ func snapshotRejection(evt protocol.Event) (string, bool) {
 		return "", false
 	}
 	return p.Message, true
+}
+
+func rejectionContext(msg string) string {
+	if msg == "" {
+		return ""
+	}
+	return fmt.Sprintf(" (a snapshot request was rejected meanwhile: %s)", msg)
 }
 
 func (m *monitor) applyEvent(evt protocol.Event) (bool, bool) {

--- a/cmd/wsmon/main.go
+++ b/cmd/wsmon/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -76,27 +77,68 @@ func main() {
 	// this is fire-and-forget; the render loop below applies whichever arrives
 	// first. -once therefore waits for the first snapshot event either way.
 	if err := c.RequestGoroutineSnapshot(); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: request goroutine snapshot: %v\n", err)
+		fmt.Fprintf(os.Stderr, "error: request goroutine snapshot: %v\n", err)
+		os.Exit(1)
 	}
 	if !*once {
 		m.render()
 	}
 
-	for evt := range c.Events() {
+	if err := m.run(c.Events(), *once, m.render); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if !*once {
+		fmt.Println("\nconnection closed; monitor stopped")
+	}
+}
+
+// run drains events until the stream closes, -once has rendered its snapshot,
+// or the server rejects the snapshot request. render is injected so tests can
+// count redraws without terminal output.
+//
+// A rejection is only fatal under -once: that mode blocks until a snapshot
+// arrives, and after a rejection none is coming, so the old code waited
+// forever. In live mode the monitor keeps observing — the next stop pushes a
+// snapshot on its own — and surfaces the rejection on the status line.
+func (m *monitor) run(events <-chan protocol.Event, once bool, render func()) error {
+	for evt := range events {
+		if msg, ok := snapshotRejection(evt); ok && once {
+			return fmt.Errorf("server rejected the snapshot request: %s", msg)
+		}
+
 		renderedSnapshot, redraw := m.applyEvent(evt)
 		if !redraw {
 			continue
 		}
-		if *once && !renderedSnapshot {
+		if once && !renderedSnapshot {
 			continue
 		}
-		m.render()
-		if *once && renderedSnapshot {
-			return
+		render()
+		if once && renderedSnapshot {
+			return nil
 		}
 	}
 
-	fmt.Println("\nconnection closed; monitor stopped")
+	if once {
+		return errors.New("connection closed before a snapshot arrived")
+	}
+	return nil
+}
+
+// snapshotRejection reports a failed CmdGoroutineSnapshot. EventError is
+// broadcast to every client, so this cannot tell our own rejection from another
+// client's; under -once either means no snapshot is coming, which is why the
+// caller treats both the same rather than waiting for a reply it can't identify.
+func snapshotRejection(evt protocol.Event) (string, bool) {
+	if evt.Kind != protocol.EventError {
+		return "", false
+	}
+	var p protocol.ErrorPayload
+	if protocol.DecodeEventPayload(evt, &p) != nil || p.Command != protocol.CmdGoroutineSnapshot {
+		return "", false
+	}
+	return p.Message, true
 }
 
 func (m *monitor) applyEvent(evt protocol.Event) (bool, bool) {
@@ -186,6 +228,16 @@ func describeEvent(evt protocol.Event) (string, bool) {
 			return "", false
 		}
 		return fmt.Sprintf("Output %s: %s", p.Stream, oneLine(p.Content)), true
+
+	case protocol.EventError:
+		var p protocol.ErrorPayload
+		if protocol.DecodeEventPayload(evt, &p) != nil {
+			return "", false
+		}
+		if p.Command == protocol.CmdNone {
+			return fmt.Sprintf("Error: %s", oneLine(p.Message)), true
+		}
+		return fmt.Sprintf("Error %s: %s", p.Command, oneLine(p.Message)), true
 
 	default:
 		return "", false

--- a/cmd/wsmon/main.go
+++ b/cmd/wsmon/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -31,28 +32,57 @@ type monitor struct {
 	hasSnapshot bool
 }
 
-func main() {
-	addr := flag.String("addr", "localhost:6060", "server address (host:port)")
-	sessionID := flag.String("session", "", "session ID to join")
-	once := flag.Bool("once", false, "print one snapshot then exit")
-	timeout := flag.Duration("timeout", 30*time.Second,
+// config holds wsmon's parsed flags. bindFlags is shared with the tests so
+// validation runs against the real flag definitions rather than a copy.
+type config struct {
+	addr      string
+	sessionID string
+	once      bool
+	timeout   time.Duration
+}
+
+func bindFlags(fs *flag.FlagSet) *config {
+	cfg := &config{}
+	fs.StringVar(&cfg.addr, "addr", "localhost:6060", "server address (host:port)")
+	fs.StringVar(&cfg.sessionID, "session", "", "session ID to join")
+	fs.BoolVar(&cfg.once, "once", false, "print one snapshot then exit")
+	fs.DurationVar(&cfg.timeout, "timeout", 30*time.Second,
 		"with -once, how long to wait for a snapshot (0 waits forever)")
-	flag.Usage = func() {
-		_, _ = fmt.Fprintf(flag.CommandLine.Output(), "usage: wsmon -session <id> [-addr host:port] [-once] [-timeout d]\n\n")
-		flag.PrintDefaults()
+	fs.Usage = func() {
+		_, _ = fmt.Fprintf(fs.Output(), "usage: wsmon -session <id> [-addr host:port] [-once] [-timeout d]\n\n")
+		fs.PrintDefaults()
 	}
+	return cfg
+}
+
+// validate rejects usage errors that the flag package itself accepts.
+func (c *config) validate() error {
+	if strings.TrimSpace(c.sessionID) == "" {
+		return errors.New("-session is required")
+	}
+	if c.timeout < 0 {
+		// Only 0 means "wait forever". A negative duration would reach run's
+		// `timeout > 0` guard and silently do the same, so `-timeout -30s`
+		// would produce an unbounded wait while the flag documents otherwise.
+		return fmt.Errorf("-timeout must be >= 0 (0 waits forever), got %s", c.timeout)
+	}
+	return nil
+}
+
+func main() {
+	cfg := bindFlags(flag.CommandLine)
 	flag.Parse()
 
-	if strings.TrimSpace(*sessionID) == "" {
-		fmt.Fprintln(os.Stderr, "error: -session is required")
+	if err := cfg.validate(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		flag.Usage()
 		os.Exit(2)
 	}
 
-	fmt.Printf("joining session %s on %s...\n", *sessionID, *addr)
-	c, err := client.Join(*addr, *sessionID)
+	fmt.Printf("joining session %s on %s...\n", cfg.sessionID, cfg.addr)
+	c, err := client.Join(cfg.addr, cfg.sessionID)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: join session %s on %s: %v\n", *sessionID, *addr, err)
+		fmt.Fprintf(os.Stderr, "error: join session %s on %s: %v\n", cfg.sessionID, cfg.addr, err)
 		os.Exit(1)
 	}
 	defer func() { _ = c.Close() }()
@@ -81,15 +111,15 @@ func main() {
 		fmt.Fprintf(os.Stderr, "error: request goroutine snapshot: %v\n", err)
 		os.Exit(1)
 	}
-	if !*once {
+	if !cfg.once {
 		m.render()
 	}
 
-	if err := m.run(c.Events(), *once, *timeout, m.render); err != nil {
+	if err := m.run(c.Events(), cfg.once, cfg.timeout, m.render); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
-	if !*once {
+	if !cfg.once {
 		fmt.Println("\nconnection closed; monitor stopped")
 	}
 }

--- a/cmd/wsmon/main_test.go
+++ b/cmd/wsmon/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
@@ -63,5 +64,102 @@ func TestApplyEventOnlySnapshotsCountAsRendered(t *testing.T) {
 	}
 	if m.hasSnapshot {
 		t.Fatal("monitor recorded a snapshot it never received")
+	}
+}
+
+func snapshotErrorEvent(t *testing.T, seq uint64) protocol.Event {
+	t.Helper()
+
+	return protocol.MustEvent(protocol.EventError, seq, protocol.ErrorPayload{
+		Command: protocol.CmdGoroutineSnapshot,
+		Message: "process not suspended",
+	})
+}
+
+// -once used to wait forever when the server rejected the request: the reply it
+// was blocked on never came and EventError was ignored. It must now fail fast
+// with the server's reason so the caller can exit nonzero.
+func TestRunOnceFailsOnRejectedSnapshotRequest(t *testing.T) {
+	events := make(chan protocol.Event, 2)
+	events <- snapshotErrorEvent(t, 2)
+	close(events)
+
+	m := &monitor{clients: -1}
+	renders := 0
+	err := m.run(events, true, func() { renders++ })
+	if err == nil {
+		t.Fatal("run(-once) returned nil for a rejected snapshot request")
+	}
+	if !strings.Contains(err.Error(), "process not suspended") {
+		t.Fatalf("run error = %v, want the server's reason", err)
+	}
+	if renders != 0 {
+		t.Fatalf("renders = %d, want 0 (nothing to draw)", renders)
+	}
+}
+
+// A closed stream under -once is also a failure: the promised snapshot never
+// arrived, so exiting 0 would report success for empty output.
+func TestRunOnceFailsWhenStreamClosesWithoutSnapshot(t *testing.T) {
+	events := make(chan protocol.Event)
+	close(events)
+
+	m := &monitor{clients: -1}
+	err := m.run(events, true, func() {})
+	if err == nil || !strings.Contains(err.Error(), "connection closed") {
+		t.Fatalf("run error = %v, want a closed-stream failure", err)
+	}
+}
+
+// -once still succeeds on the happy path, rendering exactly the snapshot.
+func TestRunOnceRendersFirstSnapshotThenStops(t *testing.T) {
+	events := make(chan protocol.Event, 3)
+	events <- protocol.MustEvent(protocol.EventSessionState, 2, protocol.SessionStatePayload{
+		SessionID: "s1",
+		State:     protocol.StateSuspended,
+	})
+	events <- protocol.MustEvent(protocol.EventGoroutineSnapshot, 3, protocol.GoroutineSnapshotPayload{
+		Goroutines: []protocol.Goroutine{{ID: 1, Current: true}},
+		Current:    1,
+	})
+	close(events)
+
+	m := &monitor{clients: -1}
+	renders := 0
+	if err := m.run(events, true, func() { renders++ }); err != nil {
+		t.Fatalf("run(-once): %v", err)
+	}
+	if renders != 1 {
+		t.Fatalf("renders = %d, want exactly 1 (the snapshot)", renders)
+	}
+	if !m.hasSnapshot || m.snapshot.Current != 1 {
+		t.Fatalf("monitor snapshot = %+v, want the delivered one", m.snapshot)
+	}
+}
+
+// Live mode must not die on a rejection — the next stop pushes a snapshot on its
+// own — but it must surface the reason instead of swallowing it.
+func TestRunLiveSurvivesRejectionAndShowsReason(t *testing.T) {
+	events := make(chan protocol.Event, 2)
+	events <- snapshotErrorEvent(t, 2)
+	events <- protocol.MustEvent(protocol.EventGoroutineSnapshot, 3, protocol.GoroutineSnapshotPayload{
+		Goroutines: []protocol.Goroutine{{ID: 1, Current: true}},
+		Current:    1,
+	})
+	close(events)
+
+	m := &monitor{clients: -1}
+	renders := 0
+	if err := m.run(events, false, func() { renders++ }); err != nil {
+		t.Fatalf("run(live): %v", err)
+	}
+	if renders != 2 {
+		t.Fatalf("renders = %d, want 2 (the error line and the snapshot)", renders)
+	}
+	if !strings.Contains(m.lastEvent, "process not suspended") {
+		t.Fatalf("lastEvent = %q, want the rejection reason", m.lastEvent)
+	}
+	if !m.hasSnapshot {
+		t.Fatal("live mode dropped the snapshot that followed the rejection")
 	}
 }

--- a/cmd/wsmon/main_test.go
+++ b/cmd/wsmon/main_test.go
@@ -280,3 +280,67 @@ func TestRunTreatsOnlyZeroAsUnbounded(t *testing.T) {
 		t.Fatal("validate() accepted a negative -timeout, which run would treat as unbounded")
 	}
 }
+
+// -timeout 0 documents "wait forever", so run must arm no timer at all. A naive
+// implementation that always created one would call time.NewTimer(0), which
+// fires immediately and would fail this test with "no snapshot within 0s". The
+// snapshot is delivered only after a delay far longer than the deadlines the
+// other tests use, and the whole thing is bounded so a regression reports a
+// failure instead of hanging the suite.
+func TestRunOnceZeroTimeoutArmsNoDeadline(t *testing.T) {
+	events := make(chan protocol.Event)
+	renders := make(chan struct{}, 1)
+	result := make(chan error, 1)
+
+	go func() {
+		result <- m0().run(events, true, 0, func() { renders <- struct{}{} })
+	}()
+
+	select {
+	case err := <-result:
+		t.Fatalf("run returned early with %v; -timeout 0 must not arm a deadline", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	events <- snapshotPushEvent(t, 2, 3)
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("run(-once, timeout 0): %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not return after the snapshot arrived")
+	}
+	if len(renders) != 1 {
+		t.Fatalf("renders = %d, want exactly 1", len(renders))
+	}
+}
+
+// Live mode never arms a deadline either, whatever -timeout says.
+func TestRunLiveIgnoresTimeout(t *testing.T) {
+	events := make(chan protocol.Event)
+	result := make(chan error, 1)
+
+	go func() {
+		result <- m0().run(events, false, time.Nanosecond, func() {})
+	}()
+
+	select {
+	case err := <-result:
+		t.Fatalf("live run returned early with %v; -timeout must not apply without -once", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(events)
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("live run after stream close: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("live run did not return after the stream closed")
+	}
+}
+
+func m0() *monitor { return &monitor{clients: -1} }

--- a/cmd/wsmon/main_test.go
+++ b/cmd/wsmon/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
@@ -76,38 +77,88 @@ func snapshotErrorEvent(t *testing.T, seq uint64) protocol.Event {
 	})
 }
 
-// -once used to wait forever when the server rejected the request: the reply it
-// was blocked on never came and EventError was ignored. It must now fail fast
-// with the server's reason so the caller can exit nonzero.
-func TestRunOnceFailsOnRejectedSnapshotRequest(t *testing.T) {
-	events := make(chan protocol.Event, 2)
+func snapshotPushEvent(t *testing.T, seq uint64, current int) protocol.Event {
+	t.Helper()
+
+	return protocol.MustEvent(protocol.EventGoroutineSnapshot, seq, protocol.GoroutineSnapshotPayload{
+		Goroutines: []protocol.Goroutine{{ID: current, Current: true}},
+		Current:    current,
+	})
+}
+
+// The adversarial ordering: another client's snapshot request is rejected while
+// the target runs, then the target reaches a stop and pushes a snapshot to
+// everyone. EventError carries no requester, so treating it as OUR answer would
+// be correlation by kind — the very thing this command stopped doing. A later
+// snapshot must win.
+func TestRunOnceSucceedsWhenSnapshotFollowsBroadcastRejection(t *testing.T) {
+	events := make(chan protocol.Event, 3)
 	events <- snapshotErrorEvent(t, 2)
+	events <- snapshotPushEvent(t, 3, 7)
 	close(events)
 
 	m := &monitor{clients: -1}
 	renders := 0
-	err := m.run(events, true, func() { renders++ })
-	if err == nil {
-		t.Fatal("run(-once) returned nil for a rejected snapshot request")
+	if err := m.run(events, true, time.Minute, func() { renders++ }); err != nil {
+		t.Fatalf("run(-once) failed on an unrelated broadcast rejection: %v", err)
 	}
-	if !strings.Contains(err.Error(), "process not suspended") {
-		t.Fatalf("run error = %v, want the server's reason", err)
+	if renders != 1 {
+		t.Fatalf("renders = %d, want exactly 1 (the snapshot)", renders)
 	}
-	if renders != 0 {
-		t.Fatalf("renders = %d, want 0 (nothing to draw)", renders)
+	if !m.hasSnapshot || m.snapshot.Current != 7 {
+		t.Fatalf("monitor snapshot = %+v, want the pushed one", m.snapshot)
 	}
 }
 
-// A closed stream under -once is also a failure: the promised snapshot never
+// When no snapshot follows, -once must still terminate — bounded by the
+// deadline, not by guessing that the broadcast error was ours — and report the
+// rejection as context.
+func TestRunOnceDeadlineReportsObservedRejection(t *testing.T) {
+	events := make(chan protocol.Event, 1)
+	events <- snapshotErrorEvent(t, 2)
+	// Left open: the stream stays alive, so only the deadline can end the wait.
+
+	m := &monitor{clients: -1}
+	err := m.run(events, true, 50*time.Millisecond, func() {})
+	if err == nil {
+		t.Fatal("run(-once) returned nil despite never receiving a snapshot")
+	}
+	if !strings.Contains(err.Error(), "no snapshot within") {
+		t.Fatalf("run error = %v, want a deadline failure", err)
+	}
+	if !strings.Contains(err.Error(), "process not suspended") {
+		t.Fatalf("run error = %v, want the observed rejection as context", err)
+	}
+}
+
+// The deadline also bounds a silent server, with no rejection to report.
+func TestRunOnceDeadlineWithoutRejection(t *testing.T) {
+	events := make(chan protocol.Event)
+
+	m := &monitor{clients: -1}
+	err := m.run(events, true, 50*time.Millisecond, func() {})
+	if err == nil || !strings.Contains(err.Error(), "no snapshot within") {
+		t.Fatalf("run error = %v, want a deadline failure", err)
+	}
+	if strings.Contains(err.Error(), "rejected") {
+		t.Fatalf("run error = %v, want no rejection context when none was seen", err)
+	}
+}
+
+// A closed stream under -once is a failure too: the promised snapshot never
 // arrived, so exiting 0 would report success for empty output.
 func TestRunOnceFailsWhenStreamClosesWithoutSnapshot(t *testing.T) {
-	events := make(chan protocol.Event)
+	events := make(chan protocol.Event, 1)
+	events <- snapshotErrorEvent(t, 2)
 	close(events)
 
 	m := &monitor{clients: -1}
-	err := m.run(events, true, func() {})
+	err := m.run(events, true, time.Minute, func() {})
 	if err == nil || !strings.Contains(err.Error(), "connection closed") {
 		t.Fatalf("run error = %v, want a closed-stream failure", err)
+	}
+	if !strings.Contains(err.Error(), "process not suspended") {
+		t.Fatalf("run error = %v, want the observed rejection as context", err)
 	}
 }
 
@@ -118,15 +169,12 @@ func TestRunOnceRendersFirstSnapshotThenStops(t *testing.T) {
 		SessionID: "s1",
 		State:     protocol.StateSuspended,
 	})
-	events <- protocol.MustEvent(protocol.EventGoroutineSnapshot, 3, protocol.GoroutineSnapshotPayload{
-		Goroutines: []protocol.Goroutine{{ID: 1, Current: true}},
-		Current:    1,
-	})
+	events <- snapshotPushEvent(t, 3, 1)
 	close(events)
 
 	m := &monitor{clients: -1}
 	renders := 0
-	if err := m.run(events, true, func() { renders++ }); err != nil {
+	if err := m.run(events, true, time.Minute, func() { renders++ }); err != nil {
 		t.Fatalf("run(-once): %v", err)
 	}
 	if renders != 1 {
@@ -137,20 +185,17 @@ func TestRunOnceRendersFirstSnapshotThenStops(t *testing.T) {
 	}
 }
 
-// Live mode must not die on a rejection — the next stop pushes a snapshot on its
-// own — but it must surface the reason instead of swallowing it.
+// Live mode never applies a deadline and never dies on a rejection: it displays
+// the reason and keeps observing, because the next stop pushes a snapshot.
 func TestRunLiveSurvivesRejectionAndShowsReason(t *testing.T) {
 	events := make(chan protocol.Event, 2)
 	events <- snapshotErrorEvent(t, 2)
-	events <- protocol.MustEvent(protocol.EventGoroutineSnapshot, 3, protocol.GoroutineSnapshotPayload{
-		Goroutines: []protocol.Goroutine{{ID: 1, Current: true}},
-		Current:    1,
-	})
+	events <- snapshotPushEvent(t, 3, 1)
 	close(events)
 
 	m := &monitor{clients: -1}
 	renders := 0
-	if err := m.run(events, false, func() { renders++ }); err != nil {
+	if err := m.run(events, false, time.Millisecond, func() { renders++ }); err != nil {
 		t.Fatalf("run(live): %v", err)
 	}
 	if renders != 2 {

--- a/cmd/wsmon/main_test.go
+++ b/cmd/wsmon/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"io"
 	"strings"
@@ -344,3 +345,53 @@ func TestRunLiveIgnoresTimeout(t *testing.T) {
 }
 
 func m0() *monitor { return &monitor{clients: -1} }
+
+const usageHeader = "usage: wsmon -session <id> [-addr host:port] [-once] [-timeout d]"
+
+// bindFlags installs the custom usage on the FlagSet it is given, so anything
+// reporting a usage error must go through that set — see usageError.
+func TestBindFlagsInstallsCustomUsage(t *testing.T) {
+	var out bytes.Buffer
+	fs := flag.NewFlagSet("wsmon", flag.ContinueOnError)
+	fs.SetOutput(&out)
+	bindFlags(fs)
+
+	fs.Usage()
+
+	if got := out.String(); !strings.Contains(got, usageHeader) {
+		t.Fatalf("usage output = %q, want the custom header", got)
+	}
+	if got := out.String(); !strings.Contains(got, "-timeout") {
+		t.Fatalf("usage output = %q, want the flag defaults", got)
+	}
+}
+
+// A validation failure must print the same usage a parse failure does. Calling
+// the package-level flag.Usage() here instead of the set's own would silently
+// print the stock "Usage of <binary>:" header — the regression this pins.
+func TestUsageErrorUsesTheFlagSetUsage(t *testing.T) {
+	var out bytes.Buffer
+	fs := flag.NewFlagSet("wsmon", flag.ContinueOnError)
+	fs.SetOutput(&out)
+	cfg := bindFlags(fs)
+	if err := fs.Parse([]string{"-session", "s1", "-timeout", "-5s"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	err := cfg.validate()
+	if err == nil {
+		t.Fatal("validate() accepted a negative -timeout")
+	}
+	usageError(fs, err)
+
+	got := out.String()
+	if !strings.Contains(got, "error: -timeout must be >= 0") {
+		t.Fatalf("output = %q, want the validation message", got)
+	}
+	if !strings.Contains(got, usageHeader) {
+		t.Fatalf("output = %q, want the custom usage header, not the stock one", got)
+	}
+	if strings.Contains(got, "Usage of ") {
+		t.Fatalf("output = %q, want no stock flag-package header", got)
+	}
+}

--- a/cmd/wsmon/main_test.go
+++ b/cmd/wsmon/main_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+// wsmon no longer blocks on a snapshot reply: its request is fire-and-forget and
+// every snapshot — requested or automatic — arrives on the event stream. This
+// pins the stream path that both the live redraw and -once now depend on.
+func TestApplyEventRendersSnapshotsFromTheEventStream(t *testing.T) {
+	m := &monitor{clients: -1, lastEvent: "joined"}
+
+	evt := protocol.MustEvent(protocol.EventGoroutineSnapshot, 2, protocol.GoroutineSnapshotPayload{
+		Goroutines: []protocol.Goroutine{{ID: 1, Current: true}, {ID: 9, ParentID: 1}},
+		Threads:    []protocol.Thread{{ID: 7, GoID: 1, Current: true}},
+		Current:    1,
+		Created:    []int{9},
+	})
+
+	renderedSnapshot, redraw := m.applyEvent(evt)
+	if !renderedSnapshot || !redraw {
+		t.Fatalf("applyEvent(snapshot) = (%v, %v), want (true, true)", renderedSnapshot, redraw)
+	}
+	if !m.hasSnapshot || m.snapshot.Current != 1 || len(m.snapshot.Goroutines) != 2 {
+		t.Fatalf("monitor snapshot = %+v, want the streamed payload", m.snapshot)
+	}
+
+	// A later automatic snapshot replaces it; nothing is consumed as a reply.
+	next := protocol.MustEvent(protocol.EventGoroutineSnapshot, 3, protocol.GoroutineSnapshotPayload{
+		Goroutines: []protocol.Goroutine{{ID: 1, Current: true}},
+		Current:    1,
+		Exited:     []int{9},
+	})
+	if renderedSnapshot, redraw = m.applyEvent(next); !renderedSnapshot || !redraw {
+		t.Fatalf("applyEvent(second snapshot) = (%v, %v), want (true, true)", renderedSnapshot, redraw)
+	}
+	if len(m.snapshot.Exited) != 1 || m.snapshot.Exited[0] != 9 {
+		t.Fatalf("monitor exited delta = %v, want [9]", m.snapshot.Exited)
+	}
+}
+
+// Only snapshots satisfy -once; other traffic redraws at most.
+func TestApplyEventOnlySnapshotsCountAsRendered(t *testing.T) {
+	m := &monitor{clients: -1}
+
+	state := protocol.MustEvent(protocol.EventSessionState, 2, protocol.SessionStatePayload{
+		SessionID: "s1",
+		State:     protocol.StateSuspended,
+		Clients:   2,
+	})
+	if renderedSnapshot, redraw := m.applyEvent(state); renderedSnapshot || !redraw {
+		t.Fatalf("applyEvent(sessionState) = (%v, %v), want (false, true)", renderedSnapshot, redraw)
+	}
+	if m.state != protocol.StateSuspended || m.clients != 2 {
+		t.Fatalf("monitor state = %s clients = %d, want suspended/2", m.state, m.clients)
+	}
+
+	continued := protocol.MustEvent(protocol.EventContinued, 3, protocol.ContinuedPayload{})
+	if renderedSnapshot, redraw := m.applyEvent(continued); renderedSnapshot || redraw {
+		t.Fatalf("applyEvent(continued) = (%v, %v), want (false, false)", renderedSnapshot, redraw)
+	}
+	if m.hasSnapshot {
+		t.Fatal("monitor recorded a snapshot it never received")
+	}
+}

--- a/cmd/wsmon/main_test.go
+++ b/cmd/wsmon/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -206,5 +208,75 @@ func TestRunLiveSurvivesRejectionAndShowsReason(t *testing.T) {
 	}
 	if !m.hasSnapshot {
 		t.Fatal("live mode dropped the snapshot that followed the rejection")
+	}
+}
+
+// The flag package accepts a negative duration, and run's `timeout > 0` guard
+// would then treat it exactly like 0 — an unbounded wait, which is the opposite
+// of what -timeout documents and what -once needs. Parse through the real flag
+// definitions so this cannot drift from main.
+func TestConfigValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "defaults with a session", args: []string{"-session", "s1"}},
+		{name: "zero waits forever", args: []string{"-session", "s1", "-timeout", "0"}},
+		{name: "positive timeout", args: []string{"-session", "s1", "-timeout", "5s"}},
+		{
+			name:    "negative timeout",
+			args:    []string{"-session", "s1", "-timeout", "-30s"},
+			wantErr: "-timeout must be >= 0",
+		},
+		{
+			name:    "negative nanosecond",
+			args:    []string{"-session", "s1", "-timeout", "-1ns"},
+			wantErr: "-timeout must be >= 0",
+		},
+		{
+			name:    "missing session",
+			args:    []string{"-once"},
+			wantErr: "-session is required",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := flag.NewFlagSet("wsmon", flag.ContinueOnError)
+			fs.SetOutput(io.Discard)
+			cfg := bindFlags(fs)
+			if err := fs.Parse(tc.args); err != nil {
+				t.Fatalf("parse %v: %v", tc.args, err)
+			}
+
+			err := cfg.validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("validate() = %v, want an error containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// A negative duration must never reach run: it would disarm the deadline and
+// hang -once forever. This pins the guard the validation protects.
+func TestRunTreatsOnlyZeroAsUnbounded(t *testing.T) {
+	fs := flag.NewFlagSet("wsmon", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	cfg := bindFlags(fs)
+	if err := fs.Parse([]string{"-session", "s1", "-once", "-timeout", "-30s"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.timeout >= 0 {
+		t.Fatalf("timeout = %s, want the negative value the flag package accepts", cfg.timeout)
+	}
+	if err := cfg.validate(); err == nil {
+		t.Fatal("validate() accepted a negative -timeout, which run would treat as unbounded")
 	}
 }

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -132,6 +132,7 @@ In another terminal, join the **same session id** read-only and watch it update:
 go run ./cmd/wsmon -addr localhost:6060 -session <session-id>
 # one-shot (print a single snapshot and exit): add -once
 # bound the one-shot wait (default 30s, 0 = wait forever): -timeout 5s
+# a negative -timeout is rejected, so a typo can't silently mean "forever"
 ```
 
 `wsmon` sends one on-demand snapshot request on join and then renders whatever
@@ -157,11 +158,12 @@ repaints with the new round's workers — the plumbing, end to end.
 - `wsmon` is a pure observer: it never sends run-control commands, so it cannot
   disturb the DAP driver. Many `wsmon` + DAP clients can share one session.
   `-once` waits for the first snapshot and is bounded by `-timeout` (default
-  30s, `0` waits forever), so a rejected request can't hang it. A broadcast
-  `EventError` naming `GoroutineSnapshot` is advisory only — it may be another
-  client's rejection, and a snapshot can still follow — so a later snapshot
-  always wins and the rejection is reported only as context if the wait times
-  out or the connection closes first.
+  30s, `0` waits forever; negatives are rejected rather than silently meaning
+  forever), so a rejected request can't hang it. A broadcast `EventError` naming
+  `GoroutineSnapshot` is advisory only — it may be another client's rejection,
+  and a snapshot can still follow — so a later snapshot always wins and the
+  rejection is reported only as context if the wait times out or the connection
+  closes first.
 - The graphical observer is also read-only. It sends exactly one on-demand
   snapshot request after joining and on explicit Refresh only. On-demand
   requests are never correlated to their answer: every snapshot — requested or

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -133,12 +133,18 @@ go run ./cmd/wsmon -addr localhost:6060 -session <session-id>
 # one-shot (print a single snapshot and exit): add -once
 ```
 
+`wsmon` sends one on-demand snapshot request on join and then renders whatever
+arrives on the event stream — the request is fire-and-forget, so with `-once` it
+prints the first snapshot that lands (the requested one, or an automatic stop
+snapshot if the tracee is running and stops first).
+
 `wsmon` redraws in place on every `EventGoroutineSnapshot`, showing:
 
 - the **goroutine spawn tree** built from `ParentID` (the `go` statement that
   spawned each goroutine), with the current goroutine marked;
 - the **OS thread set** (runtime M's) and which goroutine each is running;
-- the **created / exited** goid deltas since the previous snapshot;
+- the **created / exited** goid deltas since the previous automatic snapshot
+  (an on-demand request answers with the live picture and no deltas);
 - the **last stop event** (breakpoint / pause / step / exit) and session state.
 
 Each time you Continue in the driver and hit the breakpoint again, `wsmon`
@@ -149,7 +155,10 @@ repaints with the new round's workers — the plumbing, end to end.
 - `wsmon` is a pure observer: it never sends run-control commands, so it cannot
   disturb the DAP driver. Many `wsmon` + DAP clients can share one session.
 - The graphical observer is also read-only. It sends exactly one on-demand
-  snapshot request after joining and on explicit Refresh only.
+  snapshot request after joining and on explicit Refresh only. On-demand
+  requests are never correlated to their answer: every snapshot — requested or
+  automatic — arrives as a push on the event stream, and only automatic ones
+  carry lifecycle deltas (a refresh cannot consume the next stop's).
 - Snapshots stream on **breakpoint / pause / entry**, not per single-step (steps
   stay cheap). Use the driver's breakpoints/continue to advance between frames.
 - If the tracee is a stripped binary or stopped before runtime init, the snapshot

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -131,12 +131,14 @@ In another terminal, join the **same session id** read-only and watch it update:
 ```sh
 go run ./cmd/wsmon -addr localhost:6060 -session <session-id>
 # one-shot (print a single snapshot and exit): add -once
+# bound the one-shot wait (default 30s, 0 = wait forever): -timeout 5s
 ```
 
 `wsmon` sends one on-demand snapshot request on join and then renders whatever
 arrives on the event stream — the request is fire-and-forget, so with `-once` it
 prints the first snapshot that lands (the requested one, or an automatic stop
-snapshot if the tracee is running and stops first).
+snapshot if the tracee is running and stops first) and gives up after
+`-timeout`.
 
 `wsmon` redraws in place on every `EventGoroutineSnapshot`, showing:
 
@@ -154,8 +156,12 @@ repaints with the new round's workers — the plumbing, end to end.
 
 - `wsmon` is a pure observer: it never sends run-control commands, so it cannot
   disturb the DAP driver. Many `wsmon` + DAP clients can share one session.
-  `-once` fails fast (nonzero) if the server rejects the snapshot request or the
-  connection closes first, rather than waiting for a snapshot that is not coming.
+  `-once` waits for the first snapshot and is bounded by `-timeout` (default
+  30s, `0` waits forever), so a rejected request can't hang it. A broadcast
+  `EventError` naming `GoroutineSnapshot` is advisory only — it may be another
+  client's rejection, and a snapshot can still follow — so a later snapshot
+  always wins and the rejection is reported only as context if the wait times
+  out or the connection closes first.
 - The graphical observer is also read-only. It sends exactly one on-demand
   snapshot request after joining and on explicit Refresh only. On-demand
   requests are never correlated to their answer: every snapshot — requested or

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -154,11 +154,18 @@ repaints with the new round's workers — the plumbing, end to end.
 
 - `wsmon` is a pure observer: it never sends run-control commands, so it cannot
   disturb the DAP driver. Many `wsmon` + DAP clients can share one session.
+  `-once` fails fast (nonzero) if the server rejects the snapshot request or the
+  connection closes first, rather than waiting for a snapshot that is not coming.
 - The graphical observer is also read-only. It sends exactly one on-demand
   snapshot request after joining and on explicit Refresh only. On-demand
   requests are never correlated to their answer: every snapshot — requested or
   automatic — arrives as a push on the event stream, and only automatic ones
   carry lifecycle deltas (a refresh cannot consume the next stop's).
+- A requested snapshot is **broadcast to every client** on the session, deltas
+  empty. `wsmon`'s lifecycle panel shows the latest snapshot's deltas, so another
+  client's refresh blanks it until the next stop; the VS Code timeline appends,
+  so it is unaffected. Addressing a query to its requester needs wire-level
+  correlation — out of scope for the current protocol.
 - Snapshots stream on **breakpoint / pause / entry**, not per single-step (steps
   stay cheap). Use the driver's breakpoints/continue to advance between frames.
 - If the tracee is a stripped binary or stopped before runtime init, the snapshot

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -214,7 +214,7 @@ dropped.
 
 `pkg/client` splits methods by what they wait for. Synchronous methods
 (`Restart`, `SetBreakpoint`, `ClearBreakpoint`, `Locals`, `Evaluate`,
-`StackFrames`, `Goroutines`, `GoroutineSnapshot`) block on their confirmation
+`StackFrames`, `Goroutines`) block on their confirmation
 event **or** an `EventError` for the same command kind — see
 [`sendAndWait` / `routeToPending`](../pkg/client/ws.go). An `EventError` whose
 `Command` matches is turned back into a Go `error` for the caller:
@@ -239,15 +239,16 @@ events. The client must not close the whole connection as timeout recovery
 because a last-client disconnect tears down the session and debuggee, while
 unrelated asynchronous events remain valid.
 
-`GoroutineSnapshot` is the temporary exception. Its confirmation event is also
-unsolicited telemetry emitted after breakpoint, pause, and entry stops, so a
-timed-out snapshot request is discarded instead of retired as debt. Otherwise
-the next auto-pushed snapshot would disappear into the retired query. This
-preserves telemetry but cannot create correlation: while the legacy synchronous
-API exists, either a genuinely late query reply or an automatic push can satisfy
-a later in-flight snapshot waiter; with no waiter, either reaches `Events()`.
-Issue #187 and stacked PR #192 remove the synchronous query and that ambiguity
-rather than redesigning its semantics here.
+This model covers genuine confirmations only — events that cannot exist without
+a request. `EventGoroutineSnapshot` is not one: the server also pushes it after
+every breakpoint, pause, and entry stop. While a synchronous snapshot query
+existed it needed a per-kind carve-out in the timeout path, and neither side of
+that carve-out is sound — retiring the request as debt swallows the next
+auto-pushed snapshot, while discarding it preserves the stream but restores the
+#144 ambiguity, letting a late reply or an automatic push satisfy a later
+in-flight call. Removing the waiter removed the dilemma: the request is
+fire-and-forget and its answer is ordinary telemetry on `Events()`. Do not
+reintroduce an exemption here.
 
 This fence covers only the serialized command stream sent by that client.
 Confirmation events carry no request ID and are broadcast to every client, so
@@ -256,9 +257,13 @@ indistinguishable. That multi-driver limitation requires wire-level correlation
 IDs rather than more client-side guessing.
 
 Fire-and-forget methods (`Launch`, `Attach`, `Kill`, `Continue`, `Step*`,
-`Pause`) return once the command is on the wire; their results — including
-asynchronous `EventError`s with `Command == CmdNone` — arrive on `Events()` and
-are printed by the CLI's event loop.
+`Pause`, `RequestGoroutineSnapshot`) return once the command is on the wire;
+their results — including asynchronous `EventError`s with `Command == CmdNone` —
+arrive on `Events()` and are printed by the CLI's event loop.
+`RequestGoroutineSnapshot` belongs here because `EventGoroutineSnapshot` is also
+pushed unsolicited on every stop: correlating it by kind would let an automatic
+push answer the request, or let a timed-out request's reply debt swallow an
+automatic push (issue #187). It registers no pending entry at all.
 
 ## 8. Propagating errors to clients: typed `EventError`
 
@@ -322,4 +327,4 @@ server-side `slog` output and map to short client-facing messages there. The
 | Methods not on the `Debugger` interface          | Keep unexported on `engine`; return errors up the synchronous chain to the loop               |
 | Server → WebSocket client error                  | Broadcast a typed `EventError`; message text is intentionally surfaced (local tool)           |
 | Incompatible WebSocket envelope                  | Close only that peer with code 1002; never broadcast or allocate a hub sequence                |
-| Timed-out synchronous client command             | Retain ordered reply debt, except discard the dual-purpose snapshot query to preserve telemetry |
+| Timed-out synchronous client command             | Retain ordered reply debt; consume its late reply/error before notifying a newer waiter       |

--- a/internal/debugger/debugger.go
+++ b/internal/debugger/debugger.go
@@ -78,10 +78,12 @@ type Debugger interface {
 	StackFrames() ([]protocol.Frame, error)
 	Goroutines() ([]protocol.Goroutine, error)
 
-	// GoroutineSnapshot returns the full concurrency picture — every goroutine
-	// (with parent linkage), every OS thread, the current goroutine, and the
-	// created/exited lifecycle deltas since the previous snapshot. Requires the
-	// process to be suspended.
+	// GoroutineSnapshot returns the full concurrency picture on demand — every
+	// goroutine (with parent linkage), every OS thread, and the current
+	// goroutine. Requires the process to be suspended. It is a pure
+	// observation: it reports no created/exited deltas and does not advance the
+	// lifecycle baseline, which the automatic entry/breakpoint/pause snapshots
+	// alone own.
 	GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error)
 
 	// Events delivers async notifications. Closed on shutdown; caller must drain.

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -579,19 +579,20 @@ func (e *engine) Goroutines() ([]protocol.Goroutine, error) {
 	return goroutines, err
 }
 
-// GoroutineSnapshot returns the full concurrency picture on demand: every
-// goroutine (with parent linkage for a spawn tree), every OS thread, the
-// current goroutine, and the created/exited lifecycle deltas since the previous
-// snapshot. Only valid while suspended (the tracee must be stopped for the
-// memory reads to be race-free). Like the auto-streamed snapshots it advances
-// the lifecycle-delta baseline.
+// GoroutineSnapshot answers an on-demand snapshot request: every goroutine
+// (with parent linkage for a spawn tree), every OS thread, and the current
+// goroutine. Only valid while suspended (the tracee must be stopped for the
+// memory reads to be race-free). Unlike the auto-streamed stop snapshots it is
+// a pure observation — it reports no created/exited deltas and does not advance
+// the lifecycle baseline, so a refresh can't consume the deltas the next
+// automatic snapshot must report.
 func (e *engine) GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error) {
 	var snap protocol.GoroutineSnapshotPayload
 	err := e.dispatch(func() error {
 		if err := e.requireSuspended(); err != nil {
 			return err
 		}
-		snap = e.goroutineSnapshot()
+		snap = e.goroutineSnapshotQuery()
 		return nil
 	})
 	return snap, err
@@ -1567,9 +1568,10 @@ func (e *engine) emitBreakpointHit(bp *breakpointEntry, stop StopEvent) {
 	e.emit(protocol.EventGoroutineSnapshot, snap)
 }
 
-// emitGoroutineSnapshot builds and streams a standalone concurrency snapshot.
-// Used at the entry stop and on the CmdGoroutineSnapshot on-demand path. It is
-// a non-suspending event, so the hub forwards it without gating.
+// emitGoroutineSnapshot builds and streams a standalone concurrency snapshot at
+// the launch/attach entry stop, which has no stop event of its own to piggyback
+// on. It is an automatic snapshot, so it seeds the lifecycle baseline. It is a
+// non-suspending event, so the hub forwards it without gating.
 func (e *engine) emitGoroutineSnapshot() {
 	e.emit(protocol.EventGoroutineSnapshot, e.goroutineSnapshot())
 }

--- a/internal/debugger/export_test.go
+++ b/internal/debugger/export_test.go
@@ -3,7 +3,10 @@ package debugger
 
 import (
 	"fmt"
+	"sort"
 	"sync"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
 )
 
 func ExportedTrapInstruction() []byte {
@@ -301,4 +304,38 @@ func (b *ExportedGateBackend) completeStepThreadExit() error {
 		return b.Complete()
 	}
 	return nil
+}
+
+// ExportedSnapshotFrom assembles a snapshot payload around a pre-built
+// goroutine list, bypassing the runtime memory scan, so tests can pin the
+// lifecycle split: trackLifecycle=true is the automatic stop path (diffs and
+// adopts the baseline), false is the on-demand query path. Runs on the engine
+// loop thread, like the real callers.
+func ExportedSnapshotFrom(d Debugger, gs []protocol.Goroutine, trackLifecycle bool) protocol.GoroutineSnapshotPayload {
+	e := d.(*engine)
+	var snap protocol.GoroutineSnapshotPayload
+	if err := e.dispatch(func() error {
+		snap = e.snapshotFrom(gs, 0, trackLifecycle)
+		return nil
+	}); err != nil {
+		panic("ExportedSnapshotFrom: " + err.Error())
+	}
+	return snap
+}
+
+// ExportedPrevGoids returns the remembered live goid set (the lifecycle-delta
+// baseline), sorted. Nil before the first automatic snapshot.
+func ExportedPrevGoids(d Debugger) []int {
+	e := d.(*engine)
+	var ids []int
+	if err := e.dispatch(func() error {
+		for id := range e.prevGoids {
+			ids = append(ids, id)
+		}
+		sort.Ints(ids)
+		return nil
+	}); err != nil {
+		panic("ExportedPrevGoids: " + err.Error())
+	}
+	return ids
 }

--- a/internal/debugger/goroutines.go
+++ b/internal/debugger/goroutines.go
@@ -418,11 +418,25 @@ func (e *engine) readGoroutines() ([]protocol.Goroutine, error) {
 	return []protocol.Goroutine{e.syntheticGoroutine(pc)}, nil
 }
 
-// goroutineSnapshot builds the full concurrency picture and computes the
-// created/exited deltas against the previous snapshot. It updates the engine's
-// remembered live set, so successive snapshots report only what changed. Runs
-// on the engine loop thread; prevGoids needs no synchronization.
+// goroutineSnapshot builds the automatic stop snapshot: the full concurrency
+// picture plus the created/exited deltas against the previous automatic
+// snapshot, adopting the new live set as the next baseline. Only the automatic
+// stops (entry, breakpoint hit, pause) own that baseline. Runs on the engine
+// loop thread; prevGoids needs no synchronization.
 func (e *engine) goroutineSnapshot() protocol.GoroutineSnapshotPayload {
+	return e.buildSnapshot(true)
+}
+
+// goroutineSnapshotQuery answers an on-demand CmdGoroutineSnapshot. It reports
+// the same live picture but is a pure observation: Created/Exited stay empty and
+// prevGoids is untouched, so a refresh between two stops cannot consume the
+// deltas the next automatic snapshot must report (they are only remembered
+// once, in prevGoids, and would otherwise be lost).
+func (e *engine) goroutineSnapshotQuery() protocol.GoroutineSnapshotPayload {
+	return e.buildSnapshot(false)
+}
+
+func (e *engine) buildSnapshot(trackLifecycle bool) protocol.GoroutineSnapshotPayload {
 	sp, pc := e.liveRegisters()
 
 	gs, ok := e.buildGoroutineList(sp, pc)
@@ -434,7 +448,13 @@ func (e *engine) goroutineSnapshot() protocol.GoroutineSnapshotPayload {
 			Goroutines: []protocol.Goroutine{e.syntheticGoroutine(pc)},
 		}
 	}
+	return e.snapshotFrom(gs, pc, trackLifecycle)
+}
 
+// snapshotFrom assembles the payload around an already-built goroutine list.
+// trackLifecycle is the single point where an automatic snapshot's ownership of
+// the lifecycle baseline differs from a query's read-only view.
+func (e *engine) snapshotFrom(gs []protocol.Goroutine, livePC uint64, trackLifecycle bool) protocol.GoroutineSnapshotPayload {
 	var current int
 	live := make(map[int]struct{}, len(gs))
 	for _, g := range gs {
@@ -444,21 +464,22 @@ func (e *engine) goroutineSnapshot() protocol.GoroutineSnapshotPayload {
 		}
 	}
 
-	created, exited := e.diffGoids(live)
-
-	return protocol.GoroutineSnapshotPayload{
+	snap := protocol.GoroutineSnapshotPayload{
 		Goroutines: gs,
-		Threads:    e.readThreads(current, pc),
+		Threads:    e.readThreads(current, livePC),
 		Current:    current,
-		Created:    created,
-		Exited:     exited,
 	}
+	if trackLifecycle {
+		snap.Created, snap.Exited = e.diffGoids(live)
+	}
+	return snap
 }
 
-// diffGoids compares the current live goid set against the previous snapshot's
-// and returns the created (new) and exited (gone) goids, then adopts the new
-// set. Returns nil slices on the first snapshot so a fresh session doesn't
-// report every existing goroutine as "created".
+// diffGoids compares the current live goid set against the previous automatic
+// snapshot's and returns the created (new) and exited (gone) goids, then adopts
+// the new set. Returns nil slices on the first snapshot so a fresh session
+// doesn't report every existing goroutine as "created". Only reached from the
+// automatic stop path — see goroutineSnapshotQuery.
 func (e *engine) diffGoids(live map[int]struct{}) (created, exited []int) {
 	if e.prevGoids != nil {
 		for id := range live {

--- a/internal/debugger/goroutines_lifecycle_test.go
+++ b/internal/debugger/goroutines_lifecycle_test.go
@@ -27,6 +27,10 @@ func newLifecycleEngine(t *testing.T) debugger.Debugger {
 // A query between two automatic snapshots must neither consume the pending
 // deltas nor fabricate its own: the second automatic snapshot has to report
 // everything that changed since the first one.
+// The wiring — that engine.GoroutineSnapshot actually reaches the query path —
+// is pinned by the concurrency E2E (declareBaselineOwnershipSpec), which is the
+// only place a query can observe a live set the automatic baseline has not
+// adopted. These tests pin the seam's semantics; they cannot catch a rewiring.
 func TestQuerySnapshotDoesNotConsumeLifecycleDeltas(t *testing.T) {
 	d := newLifecycleEngine(t)
 

--- a/internal/debugger/goroutines_lifecycle_test.go
+++ b/internal/debugger/goroutines_lifecycle_test.go
@@ -1,0 +1,118 @@
+package debugger_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bingosuite/bingo/internal/debugger"
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+func goroutineSet(ids ...int) []protocol.Goroutine {
+	gs := make([]protocol.Goroutine, 0, len(ids))
+	for _, id := range ids {
+		gs = append(gs, protocol.Goroutine{ID: id, Status: "running"})
+	}
+	return gs
+}
+
+func newLifecycleEngine(t *testing.T) debugger.Debugger {
+	t.Helper()
+
+	d := debugger.NewWithBackend(newFakeBackend(), nil)
+	t.Cleanup(func() { _ = d.Kill() })
+	return d
+}
+
+// A query between two automatic snapshots must neither consume the pending
+// deltas nor fabricate its own: the second automatic snapshot has to report
+// everything that changed since the first one.
+func TestQuerySnapshotDoesNotConsumeLifecycleDeltas(t *testing.T) {
+	d := newLifecycleEngine(t)
+
+	first := debugger.ExportedSnapshotFrom(d, goroutineSet(1, 2), true)
+	if len(first.Created) != 0 || len(first.Exited) != 0 {
+		t.Fatalf("first automatic snapshot deltas = %v/%v, want empty baseline",
+			first.Created, first.Exited)
+	}
+	if got := debugger.ExportedPrevGoids(d); !reflect.DeepEqual(got, []int{1, 2}) {
+		t.Fatalf("baseline after first automatic snapshot = %v, want [1 2]", got)
+	}
+
+	// On-demand query taken at a moment when 2 is gone and 3 exists.
+	query := debugger.ExportedSnapshotFrom(d, goroutineSet(1, 3), false)
+	if len(query.Created) != 0 || len(query.Exited) != 0 {
+		t.Fatalf("query snapshot deltas = %v/%v, want none", query.Created, query.Exited)
+	}
+	if !reflect.DeepEqual(query.Goroutines, goroutineSet(1, 3)) {
+		t.Fatalf("query snapshot goroutines = %+v, want the live set", query.Goroutines)
+	}
+	if got := debugger.ExportedPrevGoids(d); !reflect.DeepEqual(got, []int{1, 2}) {
+		t.Fatalf("baseline after query = %v, want it untouched at [1 2]", got)
+	}
+
+	// The next automatic snapshot still reports everything since the first one.
+	second := debugger.ExportedSnapshotFrom(d, goroutineSet(1, 3), true)
+	if !reflect.DeepEqual(second.Created, []int{3}) {
+		t.Fatalf("second automatic snapshot created = %v, want [3]", second.Created)
+	}
+	if !reflect.DeepEqual(second.Exited, []int{2}) {
+		t.Fatalf("second automatic snapshot exited = %v, want [2]", second.Exited)
+	}
+	if got := debugger.ExportedPrevGoids(d); !reflect.DeepEqual(got, []int{1, 3}) {
+		t.Fatalf("baseline after second automatic snapshot = %v, want [1 3]", got)
+	}
+}
+
+// Repeated queries stay read-only: no query may seed the baseline either, or
+// the first automatic snapshot after a fresh session would lose its deltas.
+func TestQuerySnapshotNeverSeedsLifecycleBaseline(t *testing.T) {
+	d := newLifecycleEngine(t)
+
+	for i := 0; i < 3; i++ {
+		if snap := debugger.ExportedSnapshotFrom(d, goroutineSet(1, 2), false); len(snap.Created)+len(snap.Exited) != 0 {
+			t.Fatalf("query %d deltas = %v/%v, want none", i, snap.Created, snap.Exited)
+		}
+	}
+	if got := debugger.ExportedPrevGoids(d); got != nil {
+		t.Fatalf("baseline after queries = %v, want nil (unseeded)", got)
+	}
+
+	// The first automatic snapshot is still a baseline, not a delta report.
+	first := debugger.ExportedSnapshotFrom(d, goroutineSet(1, 2), true)
+	if len(first.Created)+len(first.Exited) != 0 {
+		t.Fatalf("first automatic snapshot deltas = %v/%v, want empty baseline",
+			first.Created, first.Exited)
+	}
+	next := debugger.ExportedSnapshotFrom(d, goroutineSet(1, 2, 5), true)
+	if !reflect.DeepEqual(next.Created, []int{5}) {
+		t.Fatalf("automatic snapshot created = %v, want [5]", next.Created)
+	}
+}
+
+// The on-demand command must still be answerable and must still refuse to read
+// a process that isn't suspended.
+func TestGoroutineSnapshotCommandRequiresSuspended(t *testing.T) {
+	d := newLifecycleEngine(t)
+
+	if _, err := d.GoroutineSnapshot(); err == nil {
+		t.Fatal("GoroutineSnapshot while not suspended: want error")
+	}
+
+	debugger.ExportedForceSuspended(d)
+	snap, err := d.GoroutineSnapshot()
+	if err != nil {
+		t.Fatalf("GoroutineSnapshot while suspended: %v", err)
+	}
+	// Without DWARF the runtime is unreadable, so the query degrades to the
+	// synthetic goroutine — and a degraded read must not touch the baseline.
+	if len(snap.Goroutines) != 1 {
+		t.Fatalf("degraded query goroutines = %+v, want the synthetic one", snap.Goroutines)
+	}
+	if len(snap.Created)+len(snap.Exited) != 0 {
+		t.Fatalf("degraded query deltas = %v/%v, want none", snap.Created, snap.Exited)
+	}
+	if got := debugger.ExportedPrevGoids(d); got != nil {
+		t.Fatalf("baseline after degraded query = %v, want nil", got)
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -65,6 +65,13 @@ type Client interface {
 	// correlated to a request by kind. Every snapshot, requested or automatic,
 	// is delivered on Events(). Requested snapshots carry no created/exited
 	// deltas; only the automatic ones do.
+	//
+	// Delivery is best-effort: like every event it goes through the shared
+	// Events() buffer, which drops when a caller stops draining, and a rejected
+	// request answers with EventError (Command == CmdGoroutineSnapshot) rather
+	// than a snapshot. A caller that blocks waiting for one must handle both.
+	// The answer is also broadcast to every client on the session, so other
+	// observers see this refresh — with empty deltas — as an ordinary snapshot.
 	RequestGoroutineSnapshot() error
 
 	Close() error

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -58,10 +58,14 @@ type Client interface {
 	StackFrames() ([]protocol.Frame, error)
 	Goroutines() ([]protocol.Goroutine, error)
 
-	// GoroutineSnapshot blocks until the server returns the full concurrency
-	// snapshot: every goroutine (with parent linkage), every OS thread, the
-	// current goroutine, and the created/exited lifecycle deltas.
-	GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error)
+	// RequestGoroutineSnapshot asks the server for a full concurrency snapshot.
+	// Fire-and-forget like Pause: it returns as soon as the command is sent.
+	// EventGoroutineSnapshot is dual-purpose — the server also pushes it
+	// automatically on every entry/breakpoint/pause stop — so it can never be
+	// correlated to a request by kind. Every snapshot, requested or automatic,
+	// is delivered on Events(). Requested snapshots carry no created/exited
+	// deltas; only the automatic ones do.
+	RequestGoroutineSnapshot() error
 
 	Close() error
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -69,7 +69,10 @@ type Client interface {
 	// Delivery is best-effort: like every event it goes through the shared
 	// Events() buffer, which drops when a caller stops draining, and a rejected
 	// request answers with EventError (Command == CmdGoroutineSnapshot) rather
-	// than a snapshot. A caller that blocks waiting for one must handle both.
+	// than a snapshot. A caller that waits for one must handle both — and must
+	// not read that error as its own answer: it is broadcast and carries no
+	// requester, so it may be another client's rejection with a valid snapshot
+	// still coming. Bound such a wait with a deadline, not with the error.
 	// The answer is also broadcast to every client on the session, so other
 	// observers see this refresh — with empty deltas — as an ordinary snapshot.
 	RequestGoroutineSnapshot() error

--- a/pkg/client/ws.go
+++ b/pkg/client/ws.go
@@ -252,13 +252,7 @@ func (c *wsClient) sendAndWait(cmd protocol.Command, wantKind protocol.EventKind
 		}
 		return evt, nil
 	case <-time.After(syncTimeout):
-		if cmd.Kind == protocol.CmdGoroutineSnapshot && wantKind == protocol.EventGoroutineSnapshot {
-			// Snapshot events are also unsolicited telemetry; debt would consume
-			// the next auto-pushed snapshot instead of delivering it to Events.
-			c.discardPending(req)
-		} else {
-			c.retirePending(req)
-		}
+		c.retirePending(req)
 		return protocol.Event{}, fmt.Errorf("timeout waiting for %s response", wantKind)
 	case <-c.done:
 		c.discardPending(req)
@@ -486,20 +480,18 @@ func (c *wsClient) Goroutines() ([]protocol.Goroutine, error) {
 	return p.Goroutines, nil
 }
 
-func (c *wsClient) GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error) {
+// RequestGoroutineSnapshot sends CmdGoroutineSnapshot and returns once it is on
+// the wire. It deliberately does not use sendAndWait: EventGoroutineSnapshot is
+// also pushed unsolicited on every entry/breakpoint/pause stop, so a kind-keyed
+// pending entry would let an automatic push satisfy this call (and, after a
+// timeout, let this call's reply debt swallow an automatic push). The snapshot
+// arrives on Events() like every other one.
+func (c *wsClient) RequestGoroutineSnapshot() error {
 	cmd, err := newCommand(protocol.CmdGoroutineSnapshot, struct{}{})
 	if err != nil {
-		return protocol.GoroutineSnapshotPayload{}, err
+		return err
 	}
-	evt, err := c.sendAndWait(cmd, protocol.EventGoroutineSnapshot)
-	if err != nil {
-		return protocol.GoroutineSnapshotPayload{}, err
-	}
-	var p protocol.GoroutineSnapshotPayload
-	if err := protocol.DecodeEventPayload(evt, &p); err != nil {
-		return protocol.GoroutineSnapshotPayload{}, fmt.Errorf("decode GoroutineSnapshot: %w", err)
-	}
-	return p, nil
+	return c.send(cmd)
 }
 
 // Close disconnects from the server. Safe to call multiple times.

--- a/pkg/client/ws_pending_test.go
+++ b/pkg/client/ws_pending_test.go
@@ -381,25 +381,30 @@ func TestUnresolvedReplyDebtMakesLaterRequestTimeout(t *testing.T) {
 	}
 }
 
-func TestTimedOutGoroutineSnapshotDoesNotConsumeAutoSnapshot(t *testing.T) {
+// The synchronous snapshot query this test was written against is gone; the
+// telemetry guarantee it protected is not. A snapshot request that is never
+// answered leaves no pending entry and no reply debt behind, so a later stop's
+// breakpoint event and its auto-pushed snapshot both reach Events() intact and
+// in order — there is nothing left that could absorb either of them.
+func TestUnansweredGoroutineSnapshotRequestDoesNotConsumeAutoSnapshot(t *testing.T) {
 	useSyncTimeout(t, 100*time.Millisecond)
 	h := newLoopbackClient(t)
 
-	result := make(chan error, 1)
-	go func() {
-		_, err := h.client.GoroutineSnapshot()
-		result <- err
-	}()
+	if err := h.client.RequestGoroutineSnapshot(); err != nil {
+		t.Fatalf("RequestGoroutineSnapshot: %v", err)
+	}
 	assertCommandKind(t, h.readCommand(t), protocol.CmdGoroutineSnapshot)
 
-	select {
-	case err := <-result:
-		if err == nil || !strings.Contains(err.Error(), "timeout") {
-			t.Fatalf("GoroutineSnapshot error = %v, want timeout", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("GoroutineSnapshot did not return")
+	h.client.pendingMu.Lock()
+	pending := len(h.client.pending)
+	h.client.pendingMu.Unlock()
+	if pending != 0 {
+		t.Fatalf("pending entries after snapshot request = %d, want 0", pending)
 	}
+
+	// Well past the old synchronous deadline, so a debt-based implementation
+	// would have had its retired entry armed by now.
+	time.Sleep(2 * syncTimeout)
 
 	h.writeEvent(t, protocol.MustEvent(
 		protocol.EventBreakpointHit,

--- a/pkg/client/ws_snapshot_test.go
+++ b/pkg/client/ws_snapshot_test.go
@@ -1,0 +1,160 @@
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+func snapshotEvent(t *testing.T, seq uint64, current int, created []int) protocol.Event {
+	t.Helper()
+
+	return protocol.MustEvent(protocol.EventGoroutineSnapshot, seq, protocol.GoroutineSnapshotPayload{
+		Goroutines: []protocol.Goroutine{{ID: current, Current: true}},
+		Current:    current,
+		Created:    created,
+	})
+}
+
+func awaitSnapshot(t *testing.T, events <-chan protocol.Event) protocol.GoroutineSnapshotPayload {
+	t.Helper()
+
+	evt := awaitEvent(t, events)
+	if evt.Kind != protocol.EventGoroutineSnapshot {
+		t.Fatalf("event kind = %s, want %s", evt.Kind, protocol.EventGoroutineSnapshot)
+	}
+	var p protocol.GoroutineSnapshotPayload
+	if err := protocol.DecodeEventPayload(evt, &p); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	return p
+}
+
+func pendingCount(c *wsClient) int {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	return len(c.pending)
+}
+
+// The request must return as soon as the command is on the wire — before any
+// reply — and register nothing that a later event could be matched against.
+func TestRequestGoroutineSnapshotReturnsAfterWireWrite(t *testing.T) {
+	useSyncTimeout(t, 100*time.Millisecond)
+	h := newLoopbackClient(t)
+
+	done := make(chan error, 1)
+	go func() { done <- h.client.RequestGoroutineSnapshot() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RequestGoroutineSnapshot: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RequestGoroutineSnapshot did not return before its reply")
+	}
+	assertCommandKind(t, h.readCommand(t), protocol.CmdGoroutineSnapshot)
+	if got := pendingCount(h.client); got != 0 {
+		t.Fatalf("pending entries after request = %d, want 0", got)
+	}
+
+	// Long past any synchronous timeout, the reply still arrives as an event.
+	time.Sleep(2 * syncTimeout)
+	h.writeEvent(t, snapshotEvent(t, 2, 7, nil))
+	if snap := awaitSnapshot(t, h.client.Events()); snap.Current != 7 {
+		t.Fatalf("snapshot current = %d, want 7", snap.Current)
+	}
+	if got := pendingCount(h.client); got != 0 {
+		t.Fatalf("pending entries after reply = %d, want 0", got)
+	}
+}
+
+// Automatic pushes around a requested snapshot must all be delivered, in order,
+// with none consumed as a reply and none duplicated.
+func TestAutomaticSnapshotsAroundRequestAllReachEvents(t *testing.T) {
+	h := newLoopbackClient(t)
+
+	h.writeEvent(t, snapshotEvent(t, 2, 1, nil)) // automatic: entry stop
+	if err := h.client.RequestGoroutineSnapshot(); err != nil {
+		t.Fatalf("RequestGoroutineSnapshot: %v", err)
+	}
+	assertCommandKind(t, h.readCommand(t), protocol.CmdGoroutineSnapshot)
+	h.writeEvent(t, snapshotEvent(t, 3, 2, nil))      // the query's reply
+	h.writeEvent(t, snapshotEvent(t, 4, 3, []int{3})) // automatic: breakpoint hit
+
+	for _, want := range []int{1, 2, 3} {
+		if snap := awaitSnapshot(t, h.client.Events()); snap.Current != want {
+			t.Fatalf("snapshot current = %d, want %d", snap.Current, want)
+		}
+	}
+	if got := pendingCount(h.client); got != 0 {
+		t.Fatalf("pending entries = %d, want 0", got)
+	}
+}
+
+// Reply debt from an unrelated timed-out synchronous call must never claim a
+// snapshot: snapshots are not correlated confirmations.
+func TestReplyDebtDoesNotSwallowAutomaticSnapshot(t *testing.T) {
+	useSyncTimeout(t, 100*time.Millisecond)
+	h := newLoopbackClient(t)
+
+	first := callSetBreakpoint(h.client, "first.go", 10)
+	assertCommandKind(t, h.readCommand(t), protocol.CmdSetBreakpoint)
+	if result := awaitBreakpoint(t, first); result.err == nil {
+		t.Fatal("first SetBreakpoint: want timeout")
+	}
+	if got := pendingCount(h.client); got != 1 {
+		t.Fatalf("retired reply debt = %d entries, want 1", got)
+	}
+
+	h.writeEvent(t, snapshotEvent(t, 2, 5, []int{5}))
+	snap := awaitSnapshot(t, h.client.Events())
+	if snap.Current != 5 || len(snap.Created) != 1 {
+		t.Fatalf("snapshot = %+v, want the automatic push intact", snap)
+	}
+
+	// The debt is still outstanding and still owned by SetBreakpoint alone.
+	if got := pendingCount(h.client); got != 1 {
+		t.Fatalf("reply debt after snapshot = %d entries, want it untouched at 1", got)
+	}
+	h.writeEvent(t, protocol.MustEvent(protocol.EventBreakpointSet, 3, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{ID: 1, Location: protocol.Location{File: "first.go", Line: 10}},
+	}))
+	deadline := time.Now().Add(2 * time.Second)
+	for pendingCount(h.client) != 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("stale SetBreakpoint confirmation never consumed its reply debt")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// A snapshot request must not disturb an in-flight synchronous call of another
+// kind, and an automatic push landing in between must not satisfy it.
+func TestSnapshotTrafficDoesNotDisturbSynchronousCall(t *testing.T) {
+	h := newLoopbackClient(t)
+
+	result := callSetBreakpoint(h.client, "main.go", 42)
+	assertCommandKind(t, h.readCommand(t), protocol.CmdSetBreakpoint)
+
+	if err := h.client.RequestGoroutineSnapshot(); err != nil {
+		t.Fatalf("RequestGoroutineSnapshot: %v", err)
+	}
+	assertCommandKind(t, h.readCommand(t), protocol.CmdGoroutineSnapshot)
+	h.writeEvent(t, snapshotEvent(t, 2, 9, nil))
+	h.writeEvent(t, protocol.MustEvent(protocol.EventBreakpointSet, 3, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{ID: 4, Location: protocol.Location{File: "main.go", Line: 42}},
+	}))
+
+	got := awaitBreakpoint(t, result)
+	if got.err != nil {
+		t.Fatalf("SetBreakpoint: %v", got.err)
+	}
+	if got.breakpoint.ID != 4 {
+		t.Fatalf("breakpoint = %+v, want its own confirmation", got.breakpoint)
+	}
+	if snap := awaitSnapshot(t, h.client.Events()); snap.Current != 9 {
+		t.Fatalf("snapshot current = %d, want 9", snap.Current)
+	}
+}

--- a/pkg/protocol/payload.go
+++ b/pkg/protocol/payload.go
@@ -152,13 +152,16 @@ type GoroutinesPayload struct {
 // picture (breakpoint hit, pause, launch/attach entry) and on demand via
 // CmdGoroutineSnapshot. Unlike EventGoroutines — which answers a single DAP
 // `threads` request and carries goroutines only — this event is not tied to a
-// request, so it also carries the thread list and the lifecycle deltas.
+// request, so it also carries the thread list and the lifecycle deltas. Created
+// and Exited are populated on the automatic snapshots only; an on-demand query
+// answers with the live picture and empty deltas so it cannot consume what the
+// next automatic snapshot must report.
 type GoroutineSnapshotPayload struct {
 	Goroutines []Goroutine `json:"goroutines"`
 	Threads    []Thread    `json:"threads"`
 	Current    int         `json:"current,omitempty"` // goid of the current goroutine, 0 if unknown
-	Created    []int       `json:"created,omitempty"` // goids new since the previous snapshot
-	Exited     []int       `json:"exited,omitempty"`  // goids gone since the previous snapshot
+	Created    []int       `json:"created,omitempty"` // goids new since the previous automatic snapshot
+	Exited     []int       `json:"exited,omitempty"`  // goids gone since the previous automatic snapshot
 }
 
 type SessionStatePayload struct {

--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -89,9 +89,12 @@ const (
 	// with parent linkage, OS threads, current goroutine, and created/exited
 	// lifecycle deltas). It is emitted automatically on every suspend that can
 	// change that picture — breakpoint hit, pause, and launch/attach entry —
-	// and on demand in response to CmdGoroutineSnapshot. It is NOT a suspending
-	// event: it follows a suspending event (or answers a query) and never gates
-	// the hub. See AGENTS.md → goroutine snapshot streaming.
+	// and on demand in response to CmdGoroutineSnapshot. Being dual-purpose it
+	// cannot be correlated to a request: clients must treat every one of them
+	// as an unsolicited push. Only the automatic ones carry lifecycle deltas.
+	// It is NOT a suspending event: it follows a suspending event (or answers a
+	// query) and never gates the hub. See AGENTS.md → goroutine snapshot
+	// streaming.
 	EventGoroutineSnapshot EventKind = "GoroutineSnapshot"
 
 	EventSessionState EventKind = "SessionState"
@@ -144,6 +147,8 @@ const (
 	// (answered with EventGoroutineSnapshot). The same snapshot is also pushed
 	// automatically on each suspend, so a UI only needs this to refresh out of
 	// band (e.g. right after connecting). Requires the process to be suspended.
+	// It is a pure observation: the answer carries no created/exited deltas and
+	// does not advance the lifecycle baseline that the automatic snapshots own.
 	CmdGoroutineSnapshot CommandKind = "GoroutineSnapshot"
 
 	// CmdRestart kills the current process (if any) and relaunches the last

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -317,6 +317,112 @@ func main() {
 }
 `
 
+// snapshotBaselineTargetSrc isolates the ONE window in which an on-demand
+// snapshot can differ from the last automatic one: a suspend that carries no
+// automatic snapshot. Steps are exactly that (emitStepped never scans allgs), so
+// stepping over a `go` statement creates a goroutine the automatic baseline has
+// never seen.
+//
+//	go parked() <- BP_SPAWN, stop #1: automatic snapshot adopts a baseline
+//	               WITHOUT parked, then one StepOver executes the statement
+//	tick()      <- BP_SNAPTICK, stop #2: parked MUST appear in the Created delta
+//
+// parked blocks forever on an unclosed channel so it is unambiguously alive at
+// both the on-demand query and the next automatic snapshot.
+const snapshotBaselineTargetSrc = `package main
+
+import "time"
+
+var hold = make(chan struct{})
+
+func parked() {
+	<-hold
+}
+
+func tick() {
+	time.Sleep(time.Millisecond) // BP_SNAPTICK
+}
+
+func main() {
+	go parked() // BP_SPAWN
+	for i := 0; i < 100000; i++ {
+		tick() // keep the process alive for teardown
+	}
+}
+`
+
+// declareBaselineOwnershipSpec is the mutation gate for "automatic snapshots
+// alone own the lifecycle baseline" (issue #187). Asserting it needs a query
+// whose live set DIFFERS from the last automatic snapshot's, which only happens
+// at a suspend that carried no automatic snapshot — i.e. after a step. So the
+// sequence is: automatic baseline at a breakpoint on the `go` statement, one
+// StepOver to execute it (creating a goroutine off the automatic stream), an
+// on-demand query, then continue to the next automatic snapshot.
+//
+// It fails on either ablation of the split:
+//   - engine.GoroutineSnapshot reverted to the tracking path: the query returns
+//     the new goid in Created AND adopts it, so the next automatic snapshot no
+//     longer reports it.
+//   - the automatic path made non-tracking: no baseline is ever adopted, so the
+//     automatic snapshot's Created is empty.
+func declareBaselineOwnershipSpec() {
+	It("keeps lifecycle deltas with automatic snapshots across an on-demand query", Label("concurrency"), func() {
+		src := snapshotBaselineTargetSrc
+		bin := buildTarget("snapshot_baseline_target", src)
+
+		h := newE2EHarness(bin)
+		h.waitFor(15*time.Second, protocol.EventStepped) // initial launch stop
+
+		_, err := h.d.SetBreakpoint("snapshot_baseline_target.go", markerLine(src, "// BP_SPAWN"))
+		Expect(err).NotTo(HaveOccurred(), "SetBreakpoint on the spawn line")
+
+		Expect(h.d.Continue()).To(Succeed(), "Continue to the spawn line")
+		hit := h.waitFor(15*time.Second,
+			protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+		Expect(hit.Kind).To(Equal(protocol.EventBreakpointHit), "spawn-line breakpoint hit")
+
+		baselineEvt := h.waitFor(15*time.Second, protocol.EventGoroutineSnapshot)
+		var baseline protocol.GoroutineSnapshotPayload
+		Expect(json.Unmarshal(baselineEvt.Payload, &baseline)).To(Succeed(), "decode baseline snapshot")
+		Expect(findByStart(baseline.Goroutines, "main.parked")).To(BeNil(),
+			"parked must not exist yet at the baseline stop")
+
+		// The `go` statement runs during a StepOver, which emits Stepped with no
+		// snapshot — so parked is born entirely off the automatic stream. This
+		// is the only state an automatic baseline can be missing.
+		Expect(h.d.StepOver()).To(Succeed(), "StepOver the spawn statement")
+		stepped := h.waitFor(15*time.Second,
+			protocol.EventStepped, protocol.EventProcessExited, protocol.EventError)
+		Expect(stepped.Kind).To(Equal(protocol.EventStepped), "the spawn statement executed via a step")
+
+		onDemand, err := h.d.GoroutineSnapshot()
+		Expect(err).NotTo(HaveOccurred(), "GoroutineSnapshot on demand")
+		parked := findByStart(onDemand.Goroutines, "main.parked")
+		Expect(parked).NotTo(BeNil(),
+			"the on-demand query must observe the goroutine created since the baseline")
+		Expect(onDemand.Created).To(BeEmpty(),
+			"a query reports no created delta (it does not own the baseline)")
+		Expect(onDemand.Exited).To(BeEmpty(), "a query reports no exited delta")
+		parkedID := parked.ID
+
+		_, err = h.d.SetBreakpoint("snapshot_baseline_target.go", markerLine(src, "// BP_SNAPTICK"))
+		Expect(err).NotTo(HaveOccurred(), "SetBreakpoint on the tick line")
+
+		Expect(h.d.Continue()).To(Succeed(), "Continue to the next automatic stop")
+		hit = h.waitFor(15*time.Second,
+			protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+		Expect(hit.Kind).To(Equal(protocol.EventBreakpointHit), "tick breakpoint hit")
+
+		nextEvt := h.waitFor(15*time.Second, protocol.EventGoroutineSnapshot)
+		var next protocol.GoroutineSnapshotPayload
+		Expect(json.Unmarshal(nextEvt.Payload, &next)).To(Succeed(), "decode next automatic snapshot")
+		Expect(findByStart(next.Goroutines, "main.parked")).NotTo(BeNil(),
+			"parked is still alive at the next stop")
+		Expect(next.Created).To(ContainElement(parkedID),
+			"the automatic snapshot still owns the delta the query observed but must not consume")
+	})
+}
+
 // declareBasicStepOverSpec adds the continue+step-over acceptance spec to the
 // enclosing Ginkgo container. It is the correctness gate: set a breakpoint on a
 // line that calls a function, repeatedly Continue to it and StepOver the call,
@@ -942,8 +1048,7 @@ func declareConcurrencySpec() {
 		// The auto-streamed EventGoroutineSnapshot that follows each breakpoint
 		// hit is the delta-bearing one: its Created/Exited are computed relative
 		// to the previous AUTOMATIC snapshot, and only those snapshots advance
-		// that baseline. An on-demand GoroutineSnapshot() between hits is a pure
-		// observation and cannot disturb it (asserted below).
+		// that baseline (declareBaselineOwnershipSpec pins that ownership).
 		nextSnapshot := func(stop string) protocol.GoroutineSnapshotPayload {
 			GinkgoHelper()
 			Expect(h.d.Continue()).To(Succeed(), "Continue to %s", stop)
@@ -1009,9 +1114,12 @@ func declareConcurrencySpec() {
 		workerID, leafID := worker.ID, leaf.ID
 
 		// An on-demand query taken BETWEEN two automatic snapshots returns a
-		// coherent live picture but owns no lifecycle state: it reports no
-		// deltas of its own and must leave the next automatic snapshot's deltas
-		// (asserted at stop #3 below) measured against stop #2.
+		// coherent live picture and reports no deltas of its own. NOTE: at this
+		// stop the live set equals the last automatic snapshot's, so adopting it
+		// would be a no-op — this asserts the query's shape, not baseline
+		// ownership. declareBaselineOwnershipSpec is the discriminating test:
+		// it steps past a `go` statement first, so the query sees a set the
+		// baseline has never seen.
 		onDemand, err := h.d.GoroutineSnapshot()
 		Expect(err).NotTo(HaveOccurred(), "GoroutineSnapshot on demand")
 		Expect(onDemand.Goroutines).NotTo(BeEmpty(), "on-demand snapshot has goroutines")

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -940,9 +940,10 @@ func declareConcurrencySpec() {
 		Expect(err).NotTo(HaveOccurred(), "SetBreakpoint on tick")
 
 		// The auto-streamed EventGoroutineSnapshot that follows each breakpoint
-		// hit is the delta-bearing one (its Created/Exited are computed relative
-		// to the previous auto snapshot). We must NOT call GoroutineSnapshot()
-		// on-demand between hits, as that would advance the delta baseline.
+		// hit is the delta-bearing one: its Created/Exited are computed relative
+		// to the previous AUTOMATIC snapshot, and only those snapshots advance
+		// that baseline. An on-demand GoroutineSnapshot() between hits is a pure
+		// observation and cannot disturb it (asserted below).
 		nextSnapshot := func(stop string) protocol.GoroutineSnapshotPayload {
 			GinkgoHelper()
 			Expect(h.d.Continue()).To(Succeed(), "Continue to %s", stop)
@@ -1007,6 +1008,19 @@ func declareConcurrencySpec() {
 
 		workerID, leafID := worker.ID, leaf.ID
 
+		// An on-demand query taken BETWEEN two automatic snapshots returns a
+		// coherent live picture but owns no lifecycle state: it reports no
+		// deltas of its own and must leave the next automatic snapshot's deltas
+		// (asserted at stop #3 below) measured against stop #2.
+		onDemand, err := h.d.GoroutineSnapshot()
+		Expect(err).NotTo(HaveOccurred(), "GoroutineSnapshot on demand")
+		Expect(onDemand.Goroutines).NotTo(BeEmpty(), "on-demand snapshot has goroutines")
+		Expect(onDemand.Current).To(BeNumerically(">", 0), "on-demand current goid resolved")
+		Expect(findByStart(onDemand.Goroutines, "main.worker")).NotTo(BeNil(),
+			"on-demand snapshot sees the live worker")
+		Expect(onDemand.Created).To(BeEmpty(), "a query reports no created delta")
+		Expect(onDemand.Exited).To(BeEmpty(), "a query reports no exited delta")
+
 		// --- stop #3: children released and reaped ---
 		exited := nextSnapshot("exited")
 		Expect(exited.Exited).To(ContainElement(workerID), "worker in exited delta")
@@ -1015,12 +1029,6 @@ func declareConcurrencySpec() {
 			"worker gone from the live set")
 		Expect(findByStart(exited.Goroutines, "main.leaf")).To(BeNil(),
 			"leaf gone from the live set")
-
-		// The on-demand snapshot command returns a coherent live picture too.
-		onDemand, err := h.d.GoroutineSnapshot()
-		Expect(err).NotTo(HaveOccurred(), "GoroutineSnapshot on demand")
-		Expect(onDemand.Goroutines).NotTo(BeEmpty(), "on-demand snapshot has goroutines")
-		Expect(onDemand.Current).To(BeNumerically(">", 0), "on-demand current goid resolved")
 	})
 }
 

--- a/test/integration/debugger_e2e_darwin_arm64_test.go
+++ b/test/integration/debugger_e2e_darwin_arm64_test.go
@@ -57,6 +57,7 @@ var _ = Describe("Darwin arm64 debugger backend (Mach exceptions) E2E", Label("d
 	declareExitCodeSpec()
 	declareAttachSpec()
 	declareConcurrencySpec()
+	declareBaselineOwnershipSpec()
 	declareFullStackSpec()
 	declareRestartSpec()
 	declareDAPSpec()

--- a/test/integration/debugger_e2e_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_linux_amd64_test.go
@@ -37,6 +37,7 @@ var _ = Describe("Linux amd64 debugger backend (ptrace) E2E", Label("linux"), fu
 	declareExitCodeSpec()
 	declareAttachSpec()
 	declareConcurrencySpec()
+	declareBaselineOwnershipSpec()
 	declareFullStackSpec()
 	declareRestartSpec()
 	declareDAPSpec()


### PR DESCRIPTION
Fixes #187.

Restacked directly onto exact `origin/main` `2c294461f74f37b785b5beda60fa77cfc56a26c6`. **Six commits — review all of them**; the first is the structural fix and the rest close review findings against it.

| commit | what |
| --- | --- |
| `b6ee9bc` | fire-and-forget snapshot request; on-demand queries stop owning lifecycle baseline |
| `956e333` | mutation-discriminating E2E gate for baseline ownership |
| `68ac826` | `cmd/wsmon -once`: snapshot rejections become advisory and waiting becomes bounded |
| `84adbc7` | reject a negative `-timeout` instead of silently waiting forever |
| `06046d1` | pin that only a zero `-timeout` is indefinite |
| `f5353f7` | print custom usage on validation failures |

## The fix

- `EventGoroutineSnapshot` is dual-purpose: it is pushed automatically on entry/breakpoint/pause and also answers `CmdGoroutineSnapshot`. It therefore cannot be correlated safely to a request by kind.
- Synchronous `Client.GoroutineSnapshot()` is replaced by fire-and-forget `Client.RequestGoroutineSnapshot() error`. It returns after the command reaches the wire, registers no pending waiter or reply debt, and every snapshot is delivered exactly once through `Events()`.
- The snapshot-specific timeout-debt carve-out is removed. Every command still served by `sendAndWait` now has a genuine request-only confirmation and follows the uniform reply-debt rules from #148.
- On-demand queries return the live picture with empty `Created`/`Exited` and never advance `prevGoids`. Only automatic entry/breakpoint/pause snapshots diff and adopt the lifecycle baseline. Degraded snapshots still leave the baseline untouched, and breakpoint/pause stops still build once and reuse that snapshot.
- Reference clients are migrated. `cmd/cli` arms one full render for `snap`; `cmd/wsmon` treats a broadcast snapshot rejection as advisory because it cannot identify the requester.
- **No payload shape, event kind, command kind, or protocol version change.** `internal/hub`, `internal/dap`, and the VS Code extension are untouched.

## `cmd/wsmon -once`

- A snapshot rejection is advisory; a later snapshot always wins.
- `-once` uses `-timeout` (default `30s`) to bound a rejected/no-response request.
- `-timeout 0` is the only indefinite mode and creates no timer.
- Negative durations are rejected with exit 2 and the custom usage text.
- Timeout/closed-stream errors include the last advisory rejection when present.
- Live mode never arms the deadline and keeps observing after rejections.

## Preservation proof

`git range-diff 8dd7593..257793d 2c29446..f5353f7` maps all six commits in order. Commits 2–6 have identical stable patch IDs. Commit 1 had conflicts only in `AGENTS.md` and `internal/debugger/export_test.go`, where current-main documentation and debugger test helpers were retained additively; excluding those two additive files, the old and restacked functional patches have the identical stable patch ID `d227f9b72308e2aa3060ce87e6cb5e7c200cfcc9` and identical stats. Current-main changes from #148/#193 and later debugger/hub/DAP fixes remain present.

## Validation at exact published head `f5353f745b24da00cc28d0ab84fa04d11b96569b`

- `gofmt`, `go tool goimports`, and `git diff --check` clean
- targeted tagged race tests: `pkg/client`, `cmd/cli`, `cmd/wsmon`, `internal/debugger`
- signed targeted Darwin `concurrency` E2E: 2/2
- `go test -tags bingonative -race -count=1 ./...`
- `go vet -tags bingonative ./...`
- `go vet -tags 'e2e bingonative' ./test/integration`
- Linux/amd64-context `golangci-lint`: 0 issues
- Linux/amd64 cross-builds for bingo/wsmon and relevant client/CLI/wsmon/debugger/E2E test binaries
- full signed `just e2e-darwin`: **23/23** (current main has one more spec than the earlier 22/22 baseline)
- independent code review: no high-confidence findings

The PR remains **OPEN/DRAFT**.