### PR TITLE
fix(debugger): resolve CreatedLoc at the go statement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1657,10 +1657,14 @@ are detected by a `mach_msg` receive loop.
   registers so arm64 leaves SP unmoved and amd64's retaddr push is already in the
   FP rule) and walking the saved-FP chain (`fp = *fp`). `walkStack` preserves
   saved return PCs, but every non-top frame uses `returnPC-1` for function/line/
-  scope and CFI lookup (underflow guarded): the saved PC is after CALL/BL and can
-  equal an exclusive lexical/FDE boundary, while one byte back lies within the
-  call instruction on both supported architectures. The top frame's live PC is
-  never adjusted. Missing/uncovered CFI degrades gracefully to the old `FP + 16`
+  scope and CFI lookup, via the shared `returnLookupPC` primitive
+  (`frameLookupPC` = "top frame untouched, otherwise `returnLookupPC`"): the
+  saved PC is after CALL/BL and can equal an exclusive lexical/FDE boundary,
+  while one byte back lies within the call instruction on both supported
+  architectures. The top frame's live PC is never adjusted, and `locationForPC`
+  itself is never globally shifted — only known return addresses go through
+  `returnLookupPC` (the goroutine snapshot's `g.gopc` is the other caller).
+  Missing/uncovered CFI degrades gracefully to the old `FP + 16`
   heuristic (`cfaFallbackFromFP`) rather than erroring the stop. The reader is
   arch-generic (maps SP/FP DWARF register
   numbers by `runtime.GOARCH` — arm64 SP=31/FP=29, amd64 RSP=7/RBP=6) and
@@ -1915,6 +1919,19 @@ event embeds the same ID-0 unknown — `currentGoroutineFrom` must never borrow 
 first real goroutine. This preserves honest behavior for stripped binaries,
 attach-without-DWARF, pre-runtime-init entry stops, zeroed/unreadable registers,
 and scheduler-stack stops whose `m.curg` cannot be resolved.
+
+**`CreatedLoc` is a normalized return address.** The runtime fills `g.gopc` from
+`sys.GetCallerPC()`, so it is the address the `go` call returns to, not the `go`
+statement. DWARF lookups are byte-granular half-open intervals, so the raw value
+can resolve to the statement *after* the spawn (and does in the `concurrency`
+fixture); `readGoroutine` therefore runs gopc through the same `returnLookupPC`
+primitive the caller-frame walk uses (see the
+DWARF reader notes). `gopc == 0` stays 0 — extra-M/cgo-callback goroutines can
+have a positive goid and no call site, and an unconditional decrement would
+underflow into an unmapped high address. `StartLoc` (startpc) is a function
+entry, not a return address, and is deliberately NOT adjusted. The `concurrency`
+E2E pins the resolved lines against the fixture's `// SPAWN_WORKER` /
+`// SPAWN_LEAF` markers.
 
 **Coherent metadata reads — the half degradation can't cover.** Degradation
 answers reads that *fail*. It cannot answer reads that all *succeed* while

--- a/internal/debugger/caller_frame_test.go
+++ b/internal/debugger/caller_frame_test.go
@@ -44,8 +44,13 @@ func TestFrameLookupPC(t *testing.T) {
 	if got := frameLookupPC(0x1000, 0); got != 0x1000 {
 		t.Fatalf("top frame lookup PC = %#x, want live PC %#x", got, uint64(0x1000))
 	}
-	if got := frameLookupPC(0x2000, 1); got != 0x1fff {
-		t.Fatalf("caller lookup PC = %#x, want call PC %#x", got, uint64(0x1fff))
+	if got := frameLookupPC(0x1000, -1); got != 0x1000 {
+		t.Fatalf("negative frame lookup PC = %#x, want live PC %#x", got, uint64(0x1000))
+	}
+	for _, frameIndex := range []int{1, 2, 7} {
+		if got, want := frameLookupPC(0x2000, frameIndex), returnLookupPC(0x2000); got != want {
+			t.Fatalf("frame %d lookup PC = %#x, want call PC %#x", frameIndex, got, want)
+		}
 	}
 	if got := frameLookupPC(0, 1); got != 0 {
 		t.Fatalf("zero caller PC underflowed to %#x", got)
@@ -57,6 +62,18 @@ func TestFrameLookupPC(t *testing.T) {
 	}
 	if classifyScopePC(frameLookupPC(0x2010, 1), discontiguous, nil) != scopePCInside {
 		t.Fatal("adjusted caller PC should be inside the second discontiguous range")
+	}
+}
+
+func TestReturnLookupPC(t *testing.T) {
+	if got := returnLookupPC(0); got != 0 {
+		t.Fatalf("zero PC = %#x, want 0 (no call site recorded)", got)
+	}
+	if got := returnLookupPC(0x4a2b10); got != 0x4a2b0f {
+		t.Fatalf("return address lookup PC = %#x, want %#x", got, uint64(0x4a2b0f))
+	}
+	if got := returnLookupPC(1); got != 0 {
+		t.Fatalf("minimal non-zero PC = %#x, want 0", got)
 	}
 }
 

--- a/internal/debugger/dwarf.go
+++ b/internal/debugger/dwarf.go
@@ -402,15 +402,29 @@ func (r *dwarfReader) FramesForStack(pcs []uint64) []protocol.Frame {
 	return frames
 }
 
-// frameLookupPC converts a saved return PC to the call instruction it belongs
-// to. DWARF ranges are byte intervals, so subtracting one works for both amd64's
-// variable-width CALL and arm64's fixed-width BL. The top frame carries a live
-// PC rather than a return address and must remain unchanged.
-func frameLookupPC(pc uint64, frameIndex int) uint64 {
-	if frameIndex > 0 && pc > 0 {
-		return pc - 1
+// returnLookupPC converts a saved return address into a PC that lies inside the
+// call instruction which produced it. DWARF ranges and line rows are byte-
+// granular half-open intervals, so a raw return address can sit exactly on an
+// exclusive upper bound and resolve to the *following* statement; backing up one
+// byte lands inside the call on both amd64's variable-width CALL and arm64's
+// fixed-width BL. A zero PC means "no call site recorded" (a runtime-created or
+// cgo-callback goroutine has no `go` statement) and must stay zero rather than
+// underflow to the top of the address space.
+func returnLookupPC(pc uint64) uint64 {
+	if pc == 0 {
+		return 0
 	}
-	return pc
+	return pc - 1
+}
+
+// frameLookupPC applies returnLookupPC to every non-top frame. Frame 0 carries a
+// live PC rather than a return address and must remain unchanged; a negative
+// index is not a caller frame either, so it is left alone too.
+func frameLookupPC(pc uint64, frameIndex int) uint64 {
+	if frameIndex <= 0 {
+		return pc
+	}
+	return returnLookupPC(pc)
 }
 
 // LocalsForFrame returns type-aware, bounded variable trees for every local and

--- a/internal/debugger/goroutines.go
+++ b/internal/debugger/goroutines.go
@@ -306,7 +306,9 @@ func (e *engine) readGoroutine(l *goLayout, gptr, liveSP, livePC uint64) gorouti
 		g.StartLoc = e.locForPC(startpc)
 	}
 	if gopc, ok := e.readU64(gptr + uint64(l.gGopc)); ok {
-		g.CreatedLoc = e.locForPC(gopc)
+		// gopc is captured by the runtime with sys.GetCallerPC(), so it is the
+		// return address of the `go` statement's call, not the statement itself.
+		g.CreatedLoc = e.locForPC(returnLookupPC(gopc))
 	}
 	if header.status == 4 { // waiting
 		if wr, ok := e.readU8(gptr + uint64(l.gWaitreason)); ok {

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -1089,6 +1089,8 @@ func bpID(evt protocol.Event) int {
 func declareConcurrencySpec() {
 	It("streams a goroutine spawn tree, threads, and lifecycle deltas", Label("concurrency"), func() {
 		lineTick := markerLine(concurrencyTargetSrc, "// BP_TICK")
+		lineSpawnWorker := markerLine(concurrencyTargetSrc, "// SPAWN_WORKER")
+		lineSpawnLeaf := markerLine(concurrencyTargetSrc, "// SPAWN_LEAF")
 		bin := buildTarget("concurrency_target", concurrencyTargetSrc)
 
 		h := newE2EHarness(bin)
@@ -1161,10 +1163,15 @@ func declareConcurrencySpec() {
 			"leaf parent is the worker goroutine")
 
 		// Creation site (the `go` statement) and start function per goroutine.
+		// The line assertions are the regression gate for gopc normalization:
+		// the runtime records gopc as the `go` call's return address, so an
+		// unadjusted lookup resolves to the statement AFTER the spawn.
 		Expect(worker.StartLoc.Function).To(Equal("main.worker"), "worker start function")
 		Expect(worker.CreatedLoc.Function).To(Equal("main.spawnAll"), "worker created in spawnAll")
+		Expect(worker.CreatedLoc.Line).To(Equal(lineSpawnWorker), "worker created at the go statement")
 		Expect(leaf.StartLoc.Function).To(Equal("main.leaf"), "leaf start function")
 		Expect(leaf.CreatedLoc.Function).To(Equal("main.worker"), "leaf created in worker")
+		Expect(leaf.CreatedLoc.Line).To(Equal(lineSpawnLeaf), "leaf created at the go statement")
 
 		// Lifecycle: both children are new since the baseline stop.
 		Expect(spawned.Created).To(ContainElement(worker.ID), "worker in created delta")


### PR DESCRIPTION
Fixes #195

## Summary

`Goroutine.CreatedLoc` is intended to identify the `go` statement that spawned
the goroutine. The runtime records `g.gopc` with `sys.GetCallerPC()`, so the raw
value is the return address after that call. Passing it directly to bingo's
byte-granular, half-open DWARF lookup can resolve the following statement.

This change:

- extracts `returnLookupPC`, which maps `0 -> 0` and every other PC to `pc - 1`;
- keeps caller-frame lookup on that shared primitive;
- applies it only to `g.gopc` before resolving `CreatedLoc`;
- leaves `StartLoc`, live stop PCs, and parked `gobuf.pc` locations unchanged;
- pins both spawn lines in the real concurrency fixture.

The zero guard is required because runtime-created and cgo-callback goroutines
can have a positive goid with no recorded call site.

## Final restack and prerequisite audit

Restacked onto exact `origin/main`
`ece6eb271b62e4103ba7987804ca28286ce3466b` after PR #190 merged.

PR #177 is fully landed. Its accepted commits map exactly by stable patch ID and
`range-diff`:

- `e3cafde0fc0b6bb3fee13706ef87b70b681c3790` -> `22e42146ac99f696be24ccb1a08648b6e23e80e0`
- `16bf04de0b44b8a8fa2805faf94f6ff1961c0045` -> `1238edf656ecd0b1540bd3740a5ee142c1632896`
- `3a8114bd6d15d7534d962f25286472d1afc8bfd2` -> `e82dc386ea8c9653082f38fc5c34a80dc5b3d65b`

No prerequisite commit is repeated. The sole accepted PR #197 commit maps:

- original `15f557697131b0fd002d8c2c1101ec67dbbf9a7d`
- prior restack `cce8061981b7b4d579ba99dd754e32b91b204c16`
- final restack `c90f311be072f6e5240f33bda7d4e488da8b5925`

The prior and final commits have the identical stable patch ID
`9d744679c8a45fec1876d2c4280e57364ab2fa2d`, and `range-diff` maps them exactly
(`cce8061 = c90f311`). Current telemetry wire 1.4 and the landed Linux wait
ownership changes remain untouched.

## Validation

- focused `returnLookupPC` / `frameLookupPC` race tests
- real signed Darwin concurrency negative control: reverting only the
  `g.gopc` normalization fails `37 != 36`; restoring it passes both concurrency
  specs
- `go test -tags bingonative -race -count=1 ./internal/debugger ./internal/dap ./pkg/protocol`
- `go test -tags bingonative -race -count=1 ./...`
- `go vet -tags bingonative ./...`
- `go vet -tags 'e2e bingonative' ./test/integration`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build ./...`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 golangci-lint run ./...`
- full native `just e2e-darwin`: 24 passed, 0 failed, 1 platform-irrelevant skip
- independent final review: no significant findings

The exact-head GitHub matrix is fully green:

- Debugger E2E run:
  https://github.com/bingosuite/bingo/actions/runs/31784013117
  - Linux amd64 ptrace: passed, including the landed wait-ownership path
  - Full-stack Linux amd64: passed
  - hosted Darwin compile/codesign jobs: passed; execution is intentionally
    skipped there
- Go build/lint/vet and unit tests: passed
- VS Code linux-x64 and darwin-arm64 package jobs: passed
- CodeQL, SonarCloud, and Darwin gate policy tests: passed
- `Darwin E2E verified` succeeded for exact head
  `c90f311be072f6e5240f33bda7d4e488da8b5925`

## Stack status

This is a one-commit PR directly on current `main`. PR #190 contains the Linux
wait fix that previously blocked readiness, so no further prerequisite rebase is
required. The PR remains draft and unmerged pending human review.
