### PR TITLE
fix(debugger): keep a linux step-over atomic against sibling stops

### DIFF
--- a/.github/workflows/debugger-e2e.yml
+++ b/.github/workflows/debugger-e2e.yml
@@ -125,6 +125,12 @@ jobs:
         if: always()
         run: go test -tags e2e -race -count=1 -v -timeout 900s ./test/integration -ginkgo.v -ginkgo.label-filter=overlap
 
+      # Same spec WITHOUT the race detector: removes the "-race changed the
+      # scheduling" objection to the reproduction.
+      - name: E2E overlap run 4 (no -race)
+        if: always()
+        run: go test -tags e2e -count=1 -v -timeout 900s ./test/integration -ginkgo.v -ginkgo.label-filter=overlap
+
   darwin-arm64:
     name: Darwin arm64 (Mach exceptions)
     runs-on: macos-14

--- a/.github/workflows/debugger-e2e.yml
+++ b/.github/workflows/debugger-e2e.yml
@@ -87,6 +87,44 @@ jobs:
       - name: E2E concurrency (goroutine/thread snapshot foundation)
         run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=concurrency
 
+  # TEMPORARY PROOF JOB — do not merge. workflow_dispatch only, so PR/push
+  # semantics of every other job are untouched. Drives the `overlap` label: a
+  # sibling thread's software-breakpoint stop delivered by Wait4(-1, WALL) while
+  # the engine is mid-step-over of another thread's breakpoint.
+  overlap-proof-linux-amd64:
+    name: PROOF overlap (sibling BP during step-over, ptrace)
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.5"
+
+      - name: Confirm native target
+        run: test "$(go env GOOS)/$(go env GOARCH)" = "linux/amd64"
+
+      - name: Environment
+        run: |
+          uname -a
+          nproc
+          cat /proc/sys/kernel/yama/ptrace_scope || true
+          go version
+
+      - name: E2E overlap run 1
+        run: go test -tags e2e -race -count=1 -v -timeout 900s ./test/integration -ginkgo.v -ginkgo.label-filter=overlap
+
+      - name: E2E overlap run 2
+        if: always()
+        run: go test -tags e2e -race -count=1 -v -timeout 900s ./test/integration -ginkgo.v -ginkgo.label-filter=overlap
+
+      - name: E2E overlap run 3
+        if: always()
+        run: go test -tags e2e -race -count=1 -v -timeout 900s ./test/integration -ginkgo.v -ginkgo.label-filter=overlap
+
   darwin-arm64:
     name: Darwin arm64 (Mach exceptions)
     runs-on: macos-14

--- a/.github/workflows/debugger-e2e.yml
+++ b/.github/workflows/debugger-e2e.yml
@@ -9,7 +9,9 @@ name: Debugger E2E
 # suite lives in ./test/integration and is split via Ginkgo labels into `basic`
 # (correctness), `churn` (multi-thread robustness), `pause` (async interrupt /
 # manual stop), `stepping` (StepInto/StepOut), `inspect`
-# (StackFrames/Locals/Goroutines), `breakpoints` (ClearBreakpoint), `kill`
+# (StackFrames/Locals/Goroutines), `breakpoints` (ClearBreakpoint), `overlap`
+# (a sibling thread's breakpoint stop landing during another thread's
+# step-over — linux-only, see #198), `kill`
 # (kill-while-running), `exit` (process exit status), `restart`, `fullstack`
 # (operations driven through the whole client → WebSocket → hub → debugger stack),
 # and `dap` (a real Debug Adapter Protocol client driving a session over TCP,
@@ -75,6 +77,9 @@ jobs:
       - name: E2E breakpoints (ClearBreakpoint)
         run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=breakpoints
 
+      - name: E2E overlap (sibling breakpoint during a step-over)
+        run: go test -tags e2e -race -count=1 -v -timeout 600s ./test/integration -ginkgo.label-filter=overlap
+
       - name: E2E kill (kill-while-running)
         run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=kill
 
@@ -86,50 +91,6 @@ jobs:
 
       - name: E2E concurrency (goroutine/thread snapshot foundation)
         run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=concurrency
-
-  # TEMPORARY PROOF JOB — do not merge. workflow_dispatch only, so PR/push
-  # semantics of every other job are untouched. Drives the `overlap` label: a
-  # sibling thread's software-breakpoint stop delivered by Wait4(-1, WALL) while
-  # the engine is mid-step-over of another thread's breakpoint.
-  overlap-proof-linux-amd64:
-    name: PROOF overlap (sibling BP during step-over, ptrace)
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 40
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.25.5"
-
-      - name: Confirm native target
-        run: test "$(go env GOOS)/$(go env GOARCH)" = "linux/amd64"
-
-      - name: Environment
-        run: |
-          uname -a
-          nproc
-          cat /proc/sys/kernel/yama/ptrace_scope || true
-          go version
-
-      - name: E2E overlap run 1
-        run: go test -tags e2e -race -count=1 -v -timeout 900s ./test/integration -ginkgo.v -ginkgo.label-filter=overlap
-
-      - name: E2E overlap run 2
-        if: always()
-        run: go test -tags e2e -race -count=1 -v -timeout 900s ./test/integration -ginkgo.v -ginkgo.label-filter=overlap
-
-      - name: E2E overlap run 3
-        if: always()
-        run: go test -tags e2e -race -count=1 -v -timeout 900s ./test/integration -ginkgo.v -ginkgo.label-filter=overlap
-
-      # Same spec WITHOUT the race detector: removes the "-race changed the
-      # scheduling" objection to the reproduction.
-      - name: E2E overlap run 4 (no -race)
-        if: always()
-        run: go test -tags e2e -count=1 -v -timeout 900s ./test/integration -ginkgo.v -ginkgo.label-filter=overlap
 
   darwin-arm64:
     name: Darwin arm64 (Mach exceptions)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,30 @@ If `bps.reinstall` ever fails after a single-step, **suspend instead of
 resuming**. Running without the trap is a runaway process; reporting the
 error lets the operator intervene.
 
+**A step-over must be atomic with respect to the breakpoint it disarmed.**
+Between step 1 and step 3 the trap is gone from tracee memory *and* from the
+breakpoint table, and `steppingOverBP` (a single slot) is the only reference to
+it. Any other thread's stop delivered in that window is therefore poison: it
+overwrites `lastBP`, and the next resume overwrites `steppingOverBP`, silently
+orphaning a breakpoint that can then never fire or be cleared; worse, a sibling
+parked on that same address misses the table lookup, so `handleStop` takes the
+spurious-SIGTRAP path, skips `rewindToBreakpoint`, and resumes it one byte into
+the restored instruction (issue #198). Two things keep this closed, and both
+must be preserved:
+
+- **Backends must not deliver another thread's stop while a step is in flight.**
+  linux does this with a targeted `wait4` (see Backend quirks → Linux); darwin's
+  `Wait` only lets a trap on the stepping thread drive step completion.
+- **`handleStop`'s `StopBreakpoint` branch reinstalls `steppingOverBP` before
+  the table lookup** (mirroring `StopSignal`), so a backend that can still
+  deliver such a stop — darwin's `BINGO_DARWIN_ATOMIC_STEPOVER=0` ablation path
+  does — degrades to a correctly-reported sibling hit rather than a lost
+  breakpoint. Reinstalling *before* `bps.atAddr` is load-bearing: it is what
+  makes the same-address case resolve to a real hit instead of the
+  spurious-SIGTRAP path.
+
+The `overlap`-labelled E2E is the regression gate.
+
 ## Architecture-specific traps
 
 Per-arch in [trap_amd64.go](internal/debugger/trap_amd64.go) and
@@ -440,7 +464,19 @@ are detected by a `mach_msg` receive loop.
   the tracer. Each new thread's initial `SIGSTOP` is resumed **individually** —
   never a group-continue, which would let a thread parked at a breakpoint run
   away (the "parking the thread group" hazard).
-- `Wait` uses `Wait4(-1, …, WALL)` to receive events for any thread.
+- `Wait` uses `Wait4(-1, …, WALL)` to receive events for any thread — **except
+  while a single-step is in flight, when it targets `stepTID` specifically**
+  (`waitTarget`). ptrace stops are per-thread and bingo does not stop the world,
+  so siblings keep running and can be sitting in their own unreaped INT3 stops;
+  a process-wide wait would *consume* one inside the step-over window, where the
+  stepped breakpoint is disarmed and untabled and the engine cannot yet act on
+  it (issue #198 — see Software-breakpoint step-over flow). Targeting the
+  stepping thread leaves those statuses queued in the kernel: nothing is lost,
+  and they surface on the very next process-wide wait with the trap reinstalled.
+  `ECHILD` from the targeted wait means the stepping thread is gone, so it
+  clears the step state and falls back to `Wait4(-1)` rather than reporting the
+  whole tracee exited — the waitLoop must stay the sole reaper of every thread's
+  death for Kill (#111).
   `PTRACE_EVENT_*` stops are absorbed (resumed and looped) and never surface
   to the engine — except the **main thread's** `PTRACE_EVENT_EXIT`, which is the
   one exit the engine needs. Because `PTRACE_O_TRACEEXIT` stops the leader
@@ -1340,7 +1376,9 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   `pause` (async-interrupt / manual-stop round-trip), `stepping`
   (StepInto crosses into a callee, StepOut returns to the caller), `inspect`
   (StackFrames chain + Locals + Goroutines at a breakpoint), `breakpoints`
-  (a cleared breakpoint stops firing), `kill` (Kill terminates a
+  (a cleared breakpoint stops firing), `overlap` (linux-only: a sibling
+  thread's breakpoint stop must not land inside another thread's step-over and
+  orphan the disarmed breakpoint — issue #198), `kill` (Kill terminates a
   freely-running tracee), `exit` (EventProcessExited reports the tracee's real
   exit code), `attach` (attach by PID to an already-running tracee — one the
   debugger did not launch — then breakpoint it), `concurrency` (the

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -419,6 +419,10 @@ func (b *linuxBackend) Threads() ([]int, error) {
 // PTRACE_EVENT stops (clone/exec/exit) are handled internally and don't
 // surface to the engine.
 //
+// While a single-step is in flight the wait is TARGETED at the stepping thread
+// rather than at any thread. See the waitTarget comment: a step-over must be
+// atomic with respect to the breakpoint it has disarmed.
+//
 // wait4 runs on the calling (waitLoop) thread, NOT the tracer thread: waiting
 // for a tracee is legal from any thread of the tracer process, and keeping it
 // off the tracer thread lets the engine issue control ops concurrently. Every
@@ -430,8 +434,19 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 	for {
 		var ws syscall.WaitStatus
 		// WALL includes clone()d threads.
-		tid, err := syscall.Wait4(-1, &ws, syscall.WALL, nil)
+		target := b.waitTarget()
+		tid, err := syscall.Wait4(target, &ws, syscall.WALL, nil)
 		if err != nil {
+			// The stepping thread is gone (it died, or a Kill already reaped
+			// it), so the targeted wait can never complete. Drop back to the
+			// process-wide wait rather than reporting the whole tracee exited:
+			// on a Kill the waitLoop is the sole legitimate reaper of every
+			// thread's death (#111), and it can only do that with pid -1.
+			if target != -1 && isNoChildProcess(err) {
+				b.stepping = false
+				b.stepTID = 0
+				continue
+			}
 			if isNoChildProcess(err) {
 				return StopEvent{Reason: StopExited, TID: b.pid}, nil
 			}
@@ -605,6 +620,31 @@ func (b *linuxBackend) recordStop(tid int) {
 	if tid != 0 {
 		b.lastStopTID = tid
 	}
+}
+
+// waitTarget is the pid argument for wait4: the stepping thread while a
+// single-step is in flight, otherwise -1 (any thread).
+//
+// A step-over must be ATOMIC with respect to the breakpoint it has disarmed.
+// engine.resumeFromBreakpoint restores the original bytes, drops the entry from
+// the breakpoint table and single-steps one thread; only the resulting
+// StopSingleStep puts the trap back. ptrace stops are per-thread and bingo does
+// not stop the world, so sibling threads keep running and can be sitting in
+// their own unreaped INT3 stops. A process-wide wait4 during that window
+// CONSUMES such a status and hands the engine a StopBreakpoint it cannot act on
+// yet: the half-stepped breakpoint is disarmed and untabled, so it is silently
+// orphaned, and a sibling parked on that same address finds no table entry and
+// is resumed one byte into the restored instruction (#198).
+//
+// Waiting on the stepping thread specifically leaves those sibling statuses
+// queued in the kernel — nothing is lost. They surface on the very next
+// process-wide wait, by which time the trap has been reinstalled and the engine
+// reports them normally.
+func (b *linuxBackend) waitTarget() int {
+	if b.stepping && b.stepTID != 0 {
+		return b.stepTID
+	}
+	return -1
 }
 
 func isNoSuchProcess(err error) bool {

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -588,6 +588,25 @@ func (e *engine) handleStop(stop StopEvent) {
 
 	case StopBreakpoint:
 		e.setState(stateSuspended)
+		// A stop on a thread OTHER than the one being stepped can still reach
+		// here on a backend that reaps any thread's status mid-step-over (the
+		// darwin BINGO_DARWIN_ATOMIC_STEPOVER=0 ablation path does; linux's
+		// targeted wait normally prevents it). At that moment the stepped-over
+		// breakpoint is disarmed and out of the table, and only StopSingleStep
+		// would put it back — so without this it is orphaned for good, and a
+		// sibling parked on that same address finds no table entry below and is
+		// resumed one byte into the restored instruction. Rearming BEFORE the
+		// lookup avoids both. Mirrors the StopSignal branch. See #198.
+		if sob := e.steppingOverBP; sob != nil {
+			e.steppingOverBP = nil
+			if rerr := e.bps.reinstall(e.backend, sob); rerr != nil {
+				e.endThreadStep()
+				e.emitError(protocol.CmdNone,
+					fmt.Errorf("reinstall breakpoint 0x%x after a sibling stop: %w", sob.addr, rerr))
+				return
+			}
+			e.endThreadStep()
+		}
 		var err error
 		stop, err = e.populateBreakpointStop(stop)
 		if err != nil {

--- a/test/integration/debugger_e2e_overlap_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_overlap_linux_amd64_test.go
@@ -1,7 +1,7 @@
 //go:build e2e && linux && amd64
 
-// Regression spec for #198: a sibling thread's software-breakpoint stop must not
-// be allowed to land in the middle of another thread's step-over.
+// Regression spec for #198: a sibling thread's software-breakpoint stop must
+// never land in the middle of another thread's step-over.
 //
 // Linux ptrace stops are PER-THREAD and bingo does not stop the world, so
 // sibling threads keep running while the engine is suspended and can be sitting
@@ -26,34 +26,46 @@
 //
 // WHAT THIS SPEC ASSERTS
 //
-// After every stop, BOTH breakpoints must still be installed. The probe
+// After EVERY stop, both breakpoints must still be installed. The probe
 // re-issues SetBreakpoint: breakpointTable.set consults byAddr BEFORE it reads
 // or writes tracee memory, so success means the entry is gone — it cannot be an
 // artifact of the probe itself. A detection is corroborated read-only by
 // ClearBreakpoint on the ORIGINAL id (clear consults byID before any write).
+// The session must also stay live: no error, no hang, and the tracee runs to a
+// clean exit with every marker thread having completed every iteration.
 //
-// NON-VACUITY. The spec parks one pinned thread on MARK_A and N pinned siblings
-// on MARK_B (so siblings also cover the same-address case), releases them
-// together so they race to their traps inside one running window, and records
-// how many threads are in ptrace tracing-stop AND parked ON a marker
-// instruction — addresses resolved from the target's own DWARF, matched at addr
-// or addr+1 since an amd64 INT3 stop leaves RIP one byte past the trap. A run
-// in which that never reached two is rejected: it never set up the race and
-// proves nothing. It is asserted once over the whole run rather than per cycle,
-// because a sibling that took an unrelated ptrace event while the engine was
-// suspended is only resumed when the next Backend.Wait absorbs it, so an
-// individual cycle can legitimately start with the siblings not yet re-parked.
+// WHAT IT DELIBERATELY DOES NOT ASSERT
 //
-// TARGET SEQUENCING. Every marker thread must exist and be parked BEFORE the
-// first suspend: a thread that clones while the engine is suspended stops at
-// PTRACE_EVENT_CLONE with no waitLoop to reap it and freezes for the whole
-// suspend. The target therefore publishes ready.<pid> only once every marker
-// thread is up.
+// Not the number of hits. While a trap is lifted for a step-over, another
+// thread can execute that very address and sail through it. That is an inherent
+// property of software breakpoints without a stop-the-world, it predates this
+// spec, and it is out of scope here — so the spec counts stops for
+// non-vacuity but never requires a particular total.
+//
+// NON-VACUITY
+//
+// One pinned thread hammers MARK_A while N pinned siblings hammer MARK_B, so
+// siblings also cover the same-address case. At every stop the spec snapshots
+// /proc/<pid>/task/*/status plus each thread's stopped PC from
+// /proc/<pid>/task/<tid>/syscall, and counts threads that are in ptrace
+// tracing-stop AND parked ON a marker instruction — addresses resolved from the
+// target's own DWARF, matched at addr or addr+1 since an amd64 INT3 stop leaves
+// RIP one byte past the trap. A run in which that never reached two never set up
+// the race and is rejected: it would prove nothing.
+//
+// TARGET SEQUENCING
+//
+// Every marker thread must exist and be parked BEFORE the first suspend: a
+// thread that clones while the engine is suspended stops at PTRACE_EVENT_CLONE
+// with no waitLoop to reap it and freezes for the whole suspend. The target
+// therefore parks every thread on a single `start` gate and publishes
+// ready.<pid> only once they are all up; the harness opens the gate while the
+// tracee is still running.
 //
 // Tuning:
 //
-//	BINGO_E2E_OVERLAP_ITERS    (default 24) cycles
-//	BINGO_E2E_OVERLAP_SIBLINGS (default 4)  sibling threads parked on MARK_B
+//	BINGO_E2E_OVERLAP_ITERS    (default 30) marker calls per thread
+//	BINGO_E2E_OVERLAP_SIBLINGS (default 4)  sibling threads on MARK_B
 
 package integration
 
@@ -78,17 +90,14 @@ import (
 
 // overlapTargetSrc runs one "A" thread and NB "B" sibling threads, each pinned
 // with runtime.LockOSThread so a marker's INT3 always faults on the same OS
-// thread. Both markers are //go:noinline and place the marked statement SECOND
-// in the function: Go 1.25.5 folds a function's first statement into the
-// prologue's func-decl line, leaving it is_stmt=false and unresolvable by
+// thread. All of them are released together and then hammer their markers in a
+// tight loop, so at any moment several are parked in unreaped INT3 stops while
+// the engine steps another one off its trap.
+//
+// Both markers are //go:noinline and place the marked statement SECOND in the
+// function: Go 1.25.5 folds a function's first statement into the prologue's
+// func-decl line, leaving it is_stmt=false and unresolvable by
 // dwarfReader.PCForFileLine.
-//
-// The harness owns all sequencing through files in a shared directory:
-//
-//	ready.<pid>  written by the target once every marker thread is parked
-//	goA.<i>      released by the harness -> thread A runs markerA
-//	gateB.<i>    released by the harness -> every sibling runs markerB
-//	finished     written by the target after all cycles complete
 const overlapTargetSrc = `package main
 
 import (
@@ -136,6 +145,7 @@ func main() {
 	// Safety net: never outlive the harness if it abandons us mid-run.
 	go func() { time.Sleep(240 * time.Second); os.Exit(0) }()
 
+	start := filepath.Join(dir, "start")
 	var wg sync.WaitGroup
 	var up int32
 
@@ -144,8 +154,8 @@ func main() {
 		defer wg.Done()
 		runtime.LockOSThread()
 		atomic.AddInt32(&up, 1)
+		waitFile(start)
 		for i := 0; i < iters; i++ {
-			waitFile(filepath.Join(dir, "goA."+strconv.Itoa(i)))
 			markerA(i)
 		}
 	}()
@@ -156,17 +166,17 @@ func main() {
 			defer wg.Done()
 			runtime.LockOSThread()
 			atomic.AddInt32(&up, 1)
+			waitFile(start)
 			for i := 0; i < iters; i++ {
-				waitFile(filepath.Join(dir, "gateB."+strconv.Itoa(i)))
 				markerB(i)
 			}
 		}()
 	}
 
 	// Publish readiness only once every marker thread exists and is parked on
-	// its first gate. A clone that happens while the debugger is suspended
-	// stops the cloning thread at PTRACE_EVENT_CLONE with no waitLoop to reap
-	// it, freezing the target for the whole suspend.
+	// the gate. A clone that happens while the debugger is suspended stops the
+	// cloning thread at PTRACE_EVENT_CLONE with no waitLoop to reap it,
+	// freezing the target for the whole suspend.
 	for atomic.LoadInt32(&up) < int32(nb+1) {
 		time.Sleep(time.Millisecond)
 	}
@@ -187,9 +197,10 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap", Label("li
 			lineB := markerLine(overlapTargetSrc, "// MARK_B")
 			srcFile := targetName + ".go"
 
-			iters := envInt("BINGO_E2E_OVERLAP_ITERS", 24)
+			iters := envInt("BINGO_E2E_OVERLAP_ITERS", 30)
 			siblings := envInt("BINGO_E2E_OVERLAP_SIBLINGS", 4)
-			perCycle := siblings + 1
+			markerThreads := siblings + 1
+			maxStops := markerThreads*iters + 50
 
 			coord := GinkgoT().TempDir()
 			bin := buildTarget(targetName, overlapTargetSrc)
@@ -202,10 +213,9 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap", Label("li
 			ev := awaitEvent(d.Events(), 20*time.Second, protocol.EventStepped)
 			j.logf("launch entry stop: %s", ev.Kind)
 
-			// Resolve the marker addresses straight from the target's own DWARF
-			// so the /proc non-vacuity check can assert that the parked threads
-			// really are sitting on the breakpoint instructions, rather than
-			// merely being in some tracing-stop.
+			// Resolve the marker addresses from the target's own DWARF so the
+			// non-vacuity check can assert the parked threads really are sitting
+			// on the breakpoint instructions, not merely in some tracing-stop.
 			addrA := elfAddrForLine(bin, srcFile, lineA)
 			addrB := elfAddrForLine(bin, srcFile, lineB)
 			trapPCs := map[uint64]string{
@@ -221,190 +231,152 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap", Label("li
 			j.logf("armed bpA id=%d line=%d, bpB id=%d line=%d",
 				bpA.ID, bpA.Location.Line, bpB.ID, bpB.Location.Line)
 
-			// Resume and let the runtime bring every marker thread up. The
-			// tracee must be RUNNING for this: clone events are only absorbed
-			// by Backend.Wait, which only runs while a waitLoop is in flight.
+			// Resume so the runtime can bring every marker thread up: clone
+			// events are only absorbed by Backend.Wait, which only runs while a
+			// waitLoop is in flight.
 			mustContinue(d, "Continue to spin up marker threads")
 			pid := waitForReady(coord, 40*time.Second)
-			j.logf("target ready, pid=%d, all %d marker threads parked", pid, perCycle)
+			j.logf("target ready, pid=%d, %d marker threads parked on the gate", pid, markerThreads)
+
+			// Open the gate while the tracee is running: every marker thread is
+			// released at once and they then hammer the two breakpoints, so
+			// several sit in unreaped INT3 stops whenever one is being stepped.
+			touch(filepath.Join(coord, "start"))
 
 			var (
-				orphanCycles int
-				maxStopped   int
+				stops        int
+				hitsA, hitsB int
 				maxAtTrap    int
-				overlapReady int // stops taken with >=2 threads parked on a marker
-				totalStops   int
+				overlapReady int
 			)
 
-			for i := 0; i < iters; i++ {
-				// Release thread A and every sibling together, so they race to
-				// their traps inside one running window. Whichever Wait4 reaps
-				// first is reported; the rest sit in unreaped INT3 stops — the
-				// precondition for the overlap.
-				touch(filepath.Join(coord, "goA."+strconv.Itoa(i)))
-				touch(filepath.Join(coord, "gateB."+strconv.Itoa(i)))
+			for {
+				ev = awaitEvent(d.Events(), 30*time.Second,
+					protocol.EventBreakpointHit, protocol.EventProcessExited,
+					protocol.EventError)
+				if ev.Kind == protocol.EventProcessExited {
+					j.logf("tracee exited after %d stops", stops)
+					break
+				}
+				Expect(ev.Kind).To(Equal(protocol.EventBreakpointHit),
+					"stop %d: expected BreakpointHit, got %s: %s\n%s",
+					stops, ev.Kind, ev.Payload, j.dump())
 
-				hitsA, hitsB := 0, 0
-				for k := 0; k < perCycle; k++ {
-					// Cycle 0 stop 0 needs no resume: the tracee is already
-					// running from the readiness Continue above.
-					if i > 0 || k > 0 {
-						mustContinue(d, "Continue cycle %d stop %d", i, k)
-					}
+				stops++
+				Expect(stops).To(BeNumerically("<=", maxStops),
+					"runaway stop count — the tracee should have exited by now\n%s", j.dump())
 
-					ev = awaitEvent(d.Events(), 30*time.Second,
-						protocol.EventBreakpointHit, protocol.EventProcessExited,
-						protocol.EventError)
-					Expect(ev.Kind).To(Equal(protocol.EventBreakpointHit),
-						"cycle %d stop %d: expected BreakpointHit, got %s: %s\n%s",
-						i, k, ev.Kind, ev.Payload, j.dump())
+				line := hitLine(ev)
+				switch line {
+				case lineA:
+					hitsA++
+				case lineB:
+					hitsB++
+				default:
+					Fail(fmt.Sprintf("stop %d: stopped at unexpected line %d\n%s",
+						stops, line, j.dump()))
+				}
 
-					line := hitLine(ev)
-					switch line {
-					case lineA:
-						hitsA++
-					case lineB:
-						hitsB++
-					default:
-						Fail(fmt.Sprintf("cycle %d stop %d: stopped at unexpected line %d\n%s",
-							i, k, line, j.dump()))
-					}
-
-					if k == 0 {
-						// NON-VACUITY MEASUREMENT. It is not enough that some
-						// threads are in tracing-stop: they must be parked ON a
-						// marker instruction. An amd64 INT3 stop leaves RIP one
-						// byte past the trap, so accept addr and addr+1.
-						//
-						// This is recorded per stop and asserted ONCE at the end
-						// rather than per cycle: a sibling that took an unrelated
-						// ptrace event while the engine was suspended is only
-						// resumed when the next Backend.Wait absorbs it, so an
-						// individual cycle can legitimately start with the
-						// siblings not yet re-parked. That is a cycle where no
-						// overlap is possible — not a failure.
-						states, stopped := waitForMarkerStops(pid, trapPCs, perCycle, 2*time.Second)
-						atTrap := countAtTrap(pid, states, trapPCs)
-						totalStops++
-						if stopped > maxStopped {
-							maxStopped = stopped
-						}
-						if atTrap > maxAtTrap {
-							maxAtTrap = atTrap
-						}
-						if atTrap >= 2 {
-							overlapReady++
-						}
-						j.logf("cycle %d: first stop at line %d; tracing-stopped=%d atMarkerPC=%d of %d marker threads\n%s",
-							i, line, stopped, atTrap, perCycle, renderStates(pid, states, trapPCs))
-					}
-
-					// THE PROBE. Every stop is a resting point at which BOTH
-					// breakpoints must still be installed. The previous resume
-					// stepped one of them over; if a sibling stop was delivered
-					// during that step-over, the stepped-over entry was dropped
-					// from the table and never reinstalled.
-					armedA := probeArmed(d, srcFile, lineA)
-					armedB := probeArmed(d, srcFile, lineB)
-					if !armedA || !armedB {
-						orphanCycles++
-						lost, lostLine, lostID := "A (MARK_A)", lineA, bpA.ID
-						if armedA {
-							lost, lostLine, lostID = "B (MARK_B)", lineB, bpB.ID
-						}
-						// Independent, strictly READ-ONLY corroboration:
-						// breakpointTable.clear looks the id up in byID before
-						// touching memory, so "not found" confirms the ORIGINAL
-						// entry is gone from the table — it is not an artifact
-						// of the SetBreakpoint probe above.
-						clearErr := d.ClearBreakpoint(lostID)
-						states, _ := procThreadStates(pid)
-						Fail(fmt.Sprintf(
-							"breakpoint %s was silently orphaned by a sibling stop during a step-over (cycle %d, stop %d of %d)\n\n"+
-								"OBSERVED\n"+
-								"  The resume that led to this stop began a step-over of a software\n"+
-								"  breakpoint: engine.resumeFromBreakpoint (internal/debugger/engine.go:1031)\n"+
-								"  set steppingOverBP, called bps.removeFromTable(bp) and restored the\n"+
-								"  original bytes, then PTRACE_SINGLESTEPped that thread.\n"+
-								"  Wait4(-1, WALL) then returned a DIFFERENT thread's pending INT3 stop\n"+
-								"  (backend_linux_amd64.go:523 classifies it StopBreakpoint because\n"+
-								"  tid != stepTID). handleStop's StopBreakpoint branch\n"+
-								"  (engine.go:589-636) has no steppingOverBP guard, so it overwrote\n"+
-								"  lastBP/lastBPTID and emitted this BreakpointHit while steppingOverBP\n"+
-								"  still held the half-stepped breakpoint. Only the StopSingleStep\n"+
-								"  branch reinstalls it, and it never ran.\n\n"+
-								"  Probe: SetBreakpoint(%s:%d) SUCCEEDED. It must return\n"+
-								"  errBreakpointExists while the entry is in breakpointTable.byAddr, so\n"+
-								"  breakpoint %s is disarmed in tracee memory and gone from the table.\n"+
-								"  Read-only corroboration: ClearBreakpoint(id=%d) on the ORIGINAL entry\n"+
-								"  returned %v (breakpointTable.clear consults byID before touching\n"+
-								"  memory, so this is independent of the SetBreakpoint probe).\n"+
-								"  The next Continue assigns steppingOverBP to this stop's breakpoint,\n"+
-								"  destroying the last reference to it: it can never fire or be cleared\n"+
-								"  again.\n\n"+
-								"EXPECTED\n"+
-								"  Both breakpoints remain installed across a step-over, regardless of\n"+
-								"  which thread Wait4 reports next.\n\n"+
-								"STATE\n"+
-								"  stop line=%d  armedA=%v armedB=%v  tracing-stopped=%d\n"+
-								"  cycle=%d/%d stop=%d/%d hitsA=%d hitsB=%d\n"+
-								"  MARK_A=0x%x MARK_B=0x%x\n"+
-								"  /proc thread states:\n%s\n"+
-								"HARNESS JOURNAL\n%s",
-							lost, i, k, perCycle,
-							srcFile, lostLine, lost, lostID, clearErr,
-							line, armedA, armedB, countStopped(states),
-							i, iters, k, perCycle, hitsA, hitsB,
-							addrA, addrB,
-							renderStates(pid, states, trapPCs), j.dump()))
+				// Non-vacuity: snapshot who else is parked ON a marker right
+				// now, i.e. whose INT3 stop is pending while the resume below
+				// steps this thread off its trap.
+				states, stopped := procThreadStates(pid)
+				atTrap := countAtTrap(pid, states, trapPCs)
+				if atTrap > maxAtTrap {
+					maxAtTrap = atTrap
+				}
+				if atTrap >= 2 {
+					overlapReady++
+					if overlapReady <= 3 || overlapReady%25 == 0 {
+						j.logf("stop %d at line %d: tracing-stopped=%d atMarkerPC=%d (overlap #%d)\n%s",
+							stops, line, stopped, atTrap, overlapReady,
+							renderStates(pid, states, trapPCs))
 					}
 				}
 
-				Expect(hitsA).To(Equal(1),
-					"cycle %d: exactly one MARK_A hit (got %d)\n%s", i, hitsA, j.dump())
-				Expect(hitsB).To(Equal(siblings),
-					"cycle %d: exactly %d MARK_B hits (got %d)\n%s",
-					i, siblings, hitsB, j.dump())
+				// THE INVARIANT. Every stop is a resting point at which BOTH
+				// breakpoints must still be installed. The resume that produced
+				// this stop stepped one of them over; if a sibling stop was
+				// delivered during that step-over, the stepped-over entry was
+				// dropped from the table and never reinstalled.
+				armedA := probeArmed(d, srcFile, lineA)
+				armedB := probeArmed(d, srcFile, lineB)
+				if !armedA || !armedB {
+					lost, lostLine, lostID := "A (MARK_A)", lineA, bpA.ID
+					if armedA {
+						lost, lostLine, lostID = "B (MARK_B)", lineB, bpB.ID
+					}
+					// Independent, strictly READ-ONLY corroboration:
+					// breakpointTable.clear looks the id up in byID before
+					// touching memory, so "not found" confirms the ORIGINAL
+					// entry is gone — not an artifact of the probe above.
+					clearErr := d.ClearBreakpoint(lostID)
+					post, _ := procThreadStates(pid)
+					Fail(fmt.Sprintf(
+						"breakpoint %s was silently orphaned by a sibling stop during a step-over "+
+							"(stop %d, at line %d)\n\n"+
+							"OBSERVED\n"+
+							"  The resume that led to this stop began a step-over:\n"+
+							"  engine.resumeFromBreakpoint set steppingOverBP, called\n"+
+							"  bps.removeFromTable(bp), restored the original bytes and\n"+
+							"  PTRACE_SINGLESTEPped that thread. A DIFFERENT thread's pending INT3\n"+
+							"  stop was then reported (Wait4 classifies it StopBreakpoint because\n"+
+							"  tid != stepTID), and handleStop's StopBreakpoint branch overwrote\n"+
+							"  lastBP/lastBPTID while steppingOverBP still held the half-stepped\n"+
+							"  breakpoint. Only StopSingleStep reinstalls it, and it never ran.\n\n"+
+							"  Probe: SetBreakpoint(%s:%d) SUCCEEDED. It must return\n"+
+							"  errBreakpointExists while the entry is in breakpointTable.byAddr, so\n"+
+							"  breakpoint %s is disarmed in tracee memory and gone from the table.\n"+
+							"  Read-only corroboration: ClearBreakpoint(id=%d) on the ORIGINAL entry\n"+
+							"  returned %v.\n"+
+							"  The next Continue assigns steppingOverBP to this stop's breakpoint,\n"+
+							"  destroying the last reference to it: it can never fire or be cleared\n"+
+							"  again.\n\n"+
+							"EXPECTED\n"+
+							"  Both breakpoints remain installed across a step-over, regardless of\n"+
+							"  which thread Wait4 reports next.\n\n"+
+							"STATE\n"+
+							"  armedA=%v armedB=%v  stops=%d hitsA=%d hitsB=%d\n"+
+							"  atMarkerPC(max)=%d overlapReady=%d\n"+
+							"  MARK_A=0x%x MARK_B=0x%x\n"+
+							"  /proc thread states:\n%s\n"+
+							"HARNESS JOURNAL\n%s",
+						lost, stops, line,
+						srcFile, lostLine, lost, lostID, clearErr,
+						armedA, armedB, stops, hitsA, hitsB,
+						maxAtTrap, overlapReady, addrA, addrB,
+						renderStates(pid, post, trapPCs), j.dump()))
+				}
+
+				mustContinue(d, "Continue after stop %d", stops)
 			}
 
-			// GLOBAL NON-VACUITY GATE: the spec is only meaningful if the
-			// scenario it claims to test actually occurred — sibling threads
-			// parked in their own INT3 stops while a step-over ran. Asserted
-			// once, over the whole run, so a single unlucky cycle cannot make
-			// the spec flaky, but a run that never set up the race cannot pass
-			// silently either.
+			// NON-VACUITY GATE: the spec only means something if the scenario it
+			// claims to test actually occurred — sibling threads parked in their
+			// own INT3 stops while a step-over ran.
 			Expect(maxAtTrap).To(BeNumerically(">=", 2),
-				"NON-VACUITY FAILED — no stop in %d cycles ever had two threads parked ON a marker "+
+				"NON-VACUITY FAILED — across %d stops no two threads were ever parked ON a marker "+
 					"instruction (MARK_A=0x%x MARK_B=0x%x), so no step-over could overlap a pending "+
 					"sibling breakpoint stop and this run proves nothing\n%s",
-				iters, addrA, addrB, j.dump())
+				stops, addrA, addrB, j.dump())
 			Expect(overlapReady).To(BeNumerically(">=", 1),
-				"NON-VACUITY FAILED — not one of %d cycles began with the overlap precondition met\n%s",
-				totalStops, j.dump())
+				"NON-VACUITY FAILED — not one of %d stops had the overlap precondition met\n%s",
+				stops, j.dump())
+			Expect(hitsA).To(BeNumerically(">=", 1), "MARK_A was hit at least once\n%s", j.dump())
+			Expect(hitsB).To(BeNumerically(">=", 1), "MARK_B was hit at least once\n%s", j.dump())
 
-			// Every cycle survived: both breakpoints still armed, target runs
-			// to a clean exit, and every marker thread completed every cycle.
-			Expect(probeArmed(d, srcFile, lineA)).To(BeTrue(), "BP A armed at end\n%s", j.dump())
-			Expect(probeArmed(d, srcFile, lineB)).To(BeTrue(), "BP B armed at end\n%s", j.dump())
-
-			mustContinue(d, "final Continue")
-			ev = awaitEvent(d.Events(), 40*time.Second,
-				protocol.EventProcessExited, protocol.EventBreakpointHit, protocol.EventError)
-			Expect(ev.Kind).To(Equal(protocol.EventProcessExited),
-				"target runs to completion after the last cycle, got %s: %s\n%s",
-				ev.Kind, ev.Payload, j.dump())
+			// Liveness: the tracee ran to completion with every marker thread
+			// finishing every iteration, and both breakpoints survived.
 			Expect(fileExists(filepath.Join(coord, "finished"))).To(BeTrue(),
-				"every marker thread completed all %d cycles", iters)
+				"every marker thread completed all %d iterations\n%s", iters, j.dump())
 
-			AddReportEntry("overlap-cycles", iters)
-			AddReportEntry("overlap-siblings", siblings)
-			AddReportEntry("overlap-orphans", orphanCycles)
-			AddReportEntry("overlap-tracing-stopped-max", maxStopped)
+			AddReportEntry("overlap-stops", stops)
+			AddReportEntry("overlap-hits", fmt.Sprintf("A=%d B=%d", hitsA, hitsB))
 			AddReportEntry("overlap-at-marker-pc-max", maxAtTrap)
-			AddReportEntry("overlap-ready-cycles", fmt.Sprintf("%d/%d", overlapReady, totalStops))
+			AddReportEntry("overlap-ready-stops", fmt.Sprintf("%d/%d", overlapReady, stops))
 			GinkgoWriter.Printf(
-				"overlap summary: cycles=%d siblings=%d orphans=%d stopped(max)=%d atMarkerPC(max)=%d overlapReady=%d/%d\n",
-				iters, siblings, orphanCycles, maxStopped, maxAtTrap, overlapReady, totalStops)
+				"overlap summary: stops=%d hitsA=%d hitsB=%d atMarkerPC(max)=%d overlapReady=%d/%d\n",
+				stops, hitsA, hitsB, maxAtTrap, overlapReady, stops)
 		})
 })
 
@@ -504,8 +476,8 @@ func fileExists(p string) bool {
 }
 
 // waitForReady blocks until the target publishes ready.<pid>, which it only
-// does once every marker thread is created, pinned and parked on its first
-// gate. Returns the tracee pid.
+// does once every marker thread is created, pinned and parked on the gate.
+// Returns the tracee pid.
 func waitForReady(dir string, timeout time.Duration) int {
 	GinkgoHelper()
 	deadline := time.Now().Add(timeout)
@@ -574,22 +546,6 @@ func countStopped(states []threadState) int {
 	return n
 }
 
-// waitForMarkerStops polls /proc until at least want threads are parked ON a
-// marker instruction, returning the final snapshot and the tracing-stop count.
-// It never fails the spec — the caller records and asserts, so the snapshot can
-// be included in a report. Bounded and early-exiting: a cycle in which the
-// siblings have not re-parked is a legitimate no-overlap cycle, not a hang.
-func waitForMarkerStops(pid int, trapPCs map[uint64]string, want int, timeout time.Duration) ([]threadState, int) {
-	deadline := time.Now().Add(timeout)
-	for {
-		states, stopped := procThreadStates(pid)
-		if countAtTrap(pid, states, trapPCs) >= want || time.Now().After(deadline) {
-			return states, stopped
-		}
-		time.Sleep(2 * time.Millisecond)
-	}
-}
-
 // procPC reads the stopped thread's instruction pointer from
 // /proc/<pid>/task/<tid>/syscall, whose last field is the PC. It is only
 // meaningful for a stopped task; "running" or an unreadable file yields 0.
@@ -645,10 +601,10 @@ func renderStates(pid int, states []threadState, trapPCs map[uint64]string) stri
 
 // elfAddrForLine resolves file:line to a text address by reading the target
 // binary's own DWARF line table, mirroring dwarfReader.PCForFileLine (first
-// is-stmt row whose file name has the given suffix). Go test binaries and
-// targets are non-PIE, so the DWARF address is also the runtime address, which
-// is what /proc reports. Test-side only — it exists so the non-vacuity check
-// can name the exact instruction the parked threads must be sitting on.
+// is-stmt row whose file name has the given suffix). Go targets are non-PIE, so
+// the DWARF address is also the runtime address, which is what /proc reports.
+// Test-side only — it exists so the non-vacuity check can name the exact
+// instruction the parked threads must be sitting on.
 func elfAddrForLine(bin, file string, line int) uint64 {
 	GinkgoHelper()
 	f, err := elf.Open(bin)

--- a/test/integration/debugger_e2e_overlap_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_overlap_linux_amd64_test.go
@@ -1,0 +1,575 @@
+//go:build e2e && linux && amd64
+
+// TEMPORARY PROOF SPEC — do not merge.
+//
+// Goal: prove (or refute) on a real ptrace backend that a SIBLING thread's
+// software-breakpoint stop, delivered by Wait4(-1, WALL) while the engine is
+// mid-step-over of ANOTHER thread's breakpoint, corrupts the engine's one-slot
+// step-over state and orphans the breakpoint being stepped over.
+//
+// Mechanism under test (internal/debugger, read at 0509b53):
+//
+//	engine.resumeFromBreakpoint (engine.go:1031) starts the step-over of BP-A:
+//	    bp := e.lastBP; e.lastBP = nil
+//	    e.steppingOverBP = bp          <- one slot
+//	    e.bps.removeFromTable(bp)      <- A leaves byID/byAddr
+//	    WriteMemory(bp.addr, original) <- A's INT3 is DISARMED in memory
+//	    SingleStep(tidA)               <- backend: stepping=true, stepTID=tidA
+//
+//	Linux ptrace stops are PER-THREAD and bingo does not stop the world, so a
+//	sibling thread B can hit its own armed INT3 while the engine is suspended at
+//	A. That stop sits pending (no waitLoop is running while suspended). The very
+//	next Wait4(-1, WALL) can therefore return B's stop BEFORE A's single-step
+//	trap. backend_linux_amd64.go:523 correctly classifies it (tid != stepTID) as
+//	StopBreakpoint.
+//
+//	engine.handleStop's StopBreakpoint branch (engine.go:589-636) has NO
+//	`steppingOverBP != nil` guard. It unconditionally does:
+//	    e.lastBP = bpB; e.lastBPTID = tidB; emitBreakpointHit(bpB)
+//	leaving e.steppingOverBP == bpA. bpA is now: disarmed in tracee memory,
+//	absent from the breakpoint table, and reachable only through steppingOverBP
+//	— which the next Continue (resumeFromBreakpoint for bpB) overwrites,
+//	permanently losing it.
+//
+// Detection without touching production code: while suspended at B, re-issue
+// SetBreakpoint(fileA, lineA). breakpointTable.set returns errBreakpointExists
+// iff bpA is still in byAddr.
+//
+//	err != nil ("already installed")  => bpA survived  => HEALTHY ordering
+//	err == nil                        => bpA orphaned  => BUG REPRODUCED
+//
+// Corroborating evidence: the engine's own debug log prints
+// `StopBreakpoint ... steppingOverBP=true` on exactly the overlapping stop, so
+// the spec runs with a debug-level logger wired to GinkgoWriter.
+//
+// Non-vacuity: before the load-bearing Continue, the spec waits for every B
+// thread's ack file AND polls /proc/<pid>/task/*/status until at least
+// (1 + NB) threads report ptrace tracing-stop ('t'/'T'). That proves A and all
+// B siblings are genuinely stopped at their traps before the step-over starts.
+//
+// Tuning:
+//
+//	BINGO_E2E_OVERLAP_ITERS    (default 24) cycles
+//	BINGO_E2E_OVERLAP_SIBLINGS (default 4)  sibling threads parked on BP-B
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/bingosuite/bingo/internal/debugger"
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+// overlapTargetSrc drives one "A" thread and NB "B" sibling threads, every one
+// of them pinned with runtime.LockOSThread so a given marker's INT3 always
+// faults on the same OS thread. Both markers are //go:noinline leaves with a
+// single statement line, so the breakpoint address is unambiguous.
+//
+// The harness owns all sequencing through files in a shared directory:
+//
+//	goA.<i>      released by the harness  -> thread A runs markerA and traps
+//	gateB.<i>    released by the harness  -> every B thread wakes
+//	ackB.<i>.<k> written by B thread k    -> proves B is past the gate and is
+//	                                         about to execute markerB
+//
+// Thread A is started and pinned FIRST, before any B thread exists. Linux
+// __ptrace_link head-inserts each auto-attached clone into the tracer's
+// ->ptraced list, so wait4(-1) scans the NEWEST tracee first; making A's M the
+// oldest of the marker threads biases wait4 towards reporting a pending sibling
+// B stop ahead of A's single-step trap, which is the ordering under test.
+const overlapTargetSrc = `package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var sink int64
+
+//go:noinline
+func markerA(i int) int {
+	v := i*2 + 1 // MARK_A
+	return v
+}
+
+//go:noinline
+func markerB(i int) int {
+	v := i*3 + 2 // MARK_B
+	return v
+}
+
+func waitFile(p string) {
+	for {
+		if _, err := os.Stat(p); err == nil {
+			return
+		}
+		time.Sleep(200 * time.Microsecond)
+	}
+}
+
+func touch(p string) { _ = os.WriteFile(p, []byte("x"), 0o644) }
+
+func main() {
+	dir := os.Args[1]
+	iters, _ := strconv.Atoi(os.Args[2])
+	nb, _ := strconv.Atoi(os.Args[3])
+
+	// Safety net: never outlive the harness if it abandons us mid-run.
+	go func() { time.Sleep(240 * time.Second); os.Exit(0) }()
+
+	touch(filepath.Join(dir, "pid."+strconv.Itoa(os.Getpid())))
+
+	var wg sync.WaitGroup
+	ready := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runtime.LockOSThread()
+		close(ready)
+		for i := 0; i < iters; i++ {
+			waitFile(filepath.Join(dir, "goA."+strconv.Itoa(i)))
+			atomic.AddInt64(&sink, int64(markerA(i)))
+		}
+	}()
+	<-ready
+	time.Sleep(100 * time.Millisecond)
+
+	for k := 0; k < nb; k++ {
+		wg.Add(1)
+		go func(k int) {
+			defer wg.Done()
+			runtime.LockOSThread()
+			for i := 0; i < iters; i++ {
+				waitFile(filepath.Join(dir, "gateB."+strconv.Itoa(i)))
+				touch(filepath.Join(dir, "ackB."+strconv.Itoa(i)+"."+strconv.Itoa(k)))
+				atomic.AddInt64(&sink, int64(markerB(i)))
+			}
+		}(k)
+		time.Sleep(30 * time.Millisecond)
+	}
+
+	wg.Wait()
+	touch(filepath.Join(dir, "finished"))
+	os.Exit(0)
+}
+`
+
+var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", Label("linux"), func() {
+	It("keeps the stepped-over breakpoint armed when a sibling breakpoint lands mid-step-over",
+		Label("overlap"), func() {
+			const targetName = "overlap_target"
+			lineA := markerLine(overlapTargetSrc, "// MARK_A")
+			lineB := markerLine(overlapTargetSrc, "// MARK_B")
+			srcFile := targetName + ".go"
+
+			iters := envInt("BINGO_E2E_OVERLAP_ITERS", 24)
+			siblings := envInt("BINGO_E2E_OVERLAP_SIBLINGS", 4)
+
+			coord := GinkgoT().TempDir()
+			bin := buildTarget(targetName, overlapTargetSrc)
+
+			j := &journal{}
+			j.logf("target=%s lineA=%d lineB=%d iters=%d siblings=%d coord=%s",
+				bin, lineA, lineB, iters, siblings, coord)
+
+			d := newOverlapDebugger(bin, []string{coord, strconv.Itoa(iters), strconv.Itoa(siblings)})
+			ev := awaitEvent(d.Events(), 20*time.Second, protocol.EventStepped)
+			j.logf("launch entry stop: %s", ev.Kind)
+
+			bpA, err := d.SetBreakpoint(srcFile, lineA)
+			Expect(err).NotTo(HaveOccurred(), "SetBreakpoint A")
+			Expect(bpA.Location.Line).To(Equal(lineA), "BP A resolved to MARK_A")
+			bpB, err := d.SetBreakpoint(srcFile, lineB)
+			Expect(err).NotTo(HaveOccurred(), "SetBreakpoint B")
+			Expect(bpB.Location.Line).To(Equal(lineB), "BP B resolved to MARK_B")
+			j.logf("armed bpA id=%d line=%d, bpB id=%d line=%d",
+				bpA.ID, bpA.Location.Line, bpB.ID, bpB.Location.Line)
+
+			// The target writes pid.<pid> as its very first action, but it only
+			// runs once the entry stop is released, so resolve the pid lazily
+			// after the first Continue.
+			pid := 0
+
+			var (
+				overlapCycles int // cycles where a sibling stop landed mid-step-over
+				healthyCycles int
+			)
+
+			for i := 0; i < iters; i++ {
+				// --- release thread A and stop it at MARK_A -------------------
+				touch(filepath.Join(coord, "goA."+strconv.Itoa(i)))
+				j.logf("cycle %d: released goA.%d, Continue -> expect BP A", i, i)
+				Expect(d.Continue()).To(Succeed(), "Continue to A #%d", i)
+
+				ev = awaitEvent(d.Events(), 25*time.Second,
+					protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+				Expect(ev.Kind).To(Equal(protocol.EventBreakpointHit),
+					"cycle %d: expected BreakpointHit at A, got %s: %s\n%s",
+					i, ev.Kind, ev.Payload, j.dump())
+				Expect(hitLine(ev)).To(Equal(lineA),
+					"cycle %d: stopped at MARK_A\n%s", i, j.dump())
+
+				if pid == 0 {
+					pid = waitForPID(coord, 20*time.Second)
+					j.logf("tracee pid=%d", pid)
+				}
+
+				// Same invariant, mirrored: reaching A can itself overlap the
+				// step-over of the PREVIOUS cycle's sibling stop (A is running
+				// while the engine single-steps a B thread off MARK_B), which
+				// would orphan BP B by the identical mechanism.
+				if !probeArmed(d, srcFile, lineB) {
+					overlapCycles++
+					post, _ := procThreadStates(pid)
+					Fail(fmt.Sprintf(
+						"BUG REPRODUCED (cycle-entry variant) on cycle %d/%d\n\n"+
+							"Thread A's breakpoint stop was reported while the engine was still\n"+
+							"mid-step-over of the previous cycle's sibling BP B. handleStop's\n"+
+							"StopBreakpoint branch (internal/debugger/engine.go:589-636) overwrote\n"+
+							"lastBP with BP A while steppingOverBP still held BP B, so BP B was left\n"+
+							"disarmed and removed from the breakpoint table: SetBreakpoint(%s:%d)\n"+
+							"succeeded where it must have returned errBreakpointExists.\n\n"+
+							"cycles: overlap=%d healthy=%d\n"+
+							"/proc thread states at detection:\n%s\n"+
+							"harness journal:\n%s",
+						i, iters, srcFile, lineB, overlapCycles, healthyCycles,
+						renderStates(post), j.dump()))
+				}
+
+				// --- park every sibling on MARK_B ----------------------------
+				touch(filepath.Join(coord, "gateB."+strconv.Itoa(i)))
+				acks := waitForAcks(coord, i, siblings, 25*time.Second)
+				Expect(acks).To(Equal(siblings),
+					"cycle %d: all %d sibling threads must pass the gate (got %d acks)\n%s",
+					i, siblings, acks, j.dump())
+
+				// LOAD-BEARING SYNCHRONISATION: do not resume A until A and
+				// every sibling are genuinely in ptrace tracing-stop.
+				states, stopped := waitForTracingStops(pid, siblings+1, 25*time.Second)
+				j.logf("cycle %d: /proc tracing-stopped=%d (want >=%d)\n%s",
+					i, stopped, siblings+1, renderStates(states))
+				Expect(stopped).To(BeNumerically(">=", siblings+1),
+					"cycle %d: NON-VACUITY FAILED — need A + %d siblings in tracing-stop before Continue, saw %d\n%s\n%s",
+					i, siblings, stopped, renderStates(states), j.dump())
+
+				// --- the load-bearing Continue -------------------------------
+				// This disarms A, PTRACE_SINGLESTEPs A, then Wait4(-1, WALL)
+				// races A's step trap against the already-pending sibling stops.
+				j.logf("cycle %d: Continue from A (step-over of bpA begins, %d sibling stops pending)",
+					i, siblings)
+				Expect(d.Continue()).To(Succeed(), "Continue from A #%d", i)
+
+				ev = awaitEvent(d.Events(), 25*time.Second,
+					protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+				Expect(ev.Kind).To(Equal(protocol.EventBreakpointHit),
+					"cycle %d: expected a sibling BreakpointHit after resuming A, got %s: %s\n%s",
+					i, ev.Kind, ev.Payload, j.dump())
+				Expect(hitLine(ev)).To(Equal(lineB),
+					"cycle %d: the post-resume stop is a sibling at MARK_B\n%s", i, j.dump())
+
+				// --- THE PROBE ------------------------------------------------
+				armed := probeArmed(d, srcFile, lineA)
+				if armed {
+					healthyCycles++
+					j.logf("cycle %d: bpA still armed after the sibling stop (A's step trap won the wait4 race)", i)
+				} else {
+					overlapCycles++
+					post, _ := procThreadStates(pid)
+					Fail(fmt.Sprintf(
+						"BUG REPRODUCED on cycle %d/%d\n\n"+
+							"Observed: while the engine was mid-step-over of BP A (steppingOverBP=bpA,\n"+
+							"A disarmed in memory and removed from the breakpoint table), Wait4(-1, WALL)\n"+
+							"returned a SIBLING thread's pending StopBreakpoint at MARK_B. handleStop's\n"+
+							"StopBreakpoint branch (internal/debugger/engine.go:589-636) has no\n"+
+							"steppingOverBP guard, so it overwrote lastBP/lastBPTID with the sibling's and\n"+
+							"emitted BreakpointHit. Re-issuing SetBreakpoint(%s:%d) then SUCCEEDED, which is\n"+
+							"only possible if BP A is no longer in breakpointTable.byAddr — i.e. BP A has\n"+
+							"been silently disarmed and orphaned. The next Continue overwrites\n"+
+							"steppingOverBP with the sibling's entry, losing the only remaining reference\n"+
+							"to BP A permanently.\n\n"+
+							"Expected: BP A stays armed (SetBreakpoint returns errBreakpointExists).\n\n"+
+							"cycles: overlap=%d healthy=%d\n"+
+							"/proc thread states at detection:\n%s\n"+
+							"harness journal:\n%s",
+						i, iters, srcFile, lineA, overlapCycles, healthyCycles,
+						renderStates(post), j.dump()))
+				}
+
+				// --- drain the remaining sibling stops -----------------------
+				for k := 1; k < siblings; k++ {
+					Expect(d.Continue()).To(Succeed(), "drain sibling %d cycle %d", k, i)
+					ev = awaitEvent(d.Events(), 25*time.Second,
+						protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+					Expect(ev.Kind).To(Equal(protocol.EventBreakpointHit),
+						"cycle %d drain %d: expected BreakpointHit, got %s: %s\n%s",
+						i, k, ev.Kind, ev.Payload, j.dump())
+					Expect(hitLine(ev)).To(Equal(lineB),
+						"cycle %d drain %d: sibling stop at MARK_B\n%s", i, k, j.dump())
+
+					if !probeArmed(d, srcFile, lineB) {
+						overlapCycles++
+						post, _ := procThreadStates(pid)
+						Fail(fmt.Sprintf(
+							"BUG REPRODUCED (sibling-drain variant) on cycle %d drain %d\n\n"+
+								"BP B was orphaned by the same one-slot steppingOverBP overwrite while\n"+
+								"stepping one sibling off MARK_B with other siblings' stops still pending.\n"+
+								"SetBreakpoint(%s:%d) succeeded, so BP B is gone from byAddr.\n\n"+
+								"cycles: overlap=%d healthy=%d\n"+
+								"/proc thread states at detection:\n%s\n"+
+								"harness journal:\n%s",
+							i, k, srcFile, lineB, overlapCycles, healthyCycles,
+							renderStates(post), j.dump()))
+					}
+				}
+
+				j.logf("cycle %d complete (overlap=%d healthy=%d)", i, overlapCycles, healthyCycles)
+			}
+
+			// Every cycle survived: both breakpoints must still be armed and the
+			// target must run to a clean exit.
+			Expect(probeArmed(d, srcFile, lineA)).To(BeTrue(), "BP A armed at end\n%s", j.dump())
+			Expect(probeArmed(d, srcFile, lineB)).To(BeTrue(), "BP B armed at end\n%s", j.dump())
+
+			Expect(d.Continue()).To(Succeed(), "final Continue")
+			ev = awaitEvent(d.Events(), 30*time.Second,
+				protocol.EventProcessExited, protocol.EventBreakpointHit, protocol.EventError)
+			Expect(ev.Kind).To(Equal(protocol.EventProcessExited),
+				"target runs to completion after the last cycle, got %s: %s\n%s",
+				ev.Kind, ev.Payload, j.dump())
+			Expect(fileExists(filepath.Join(coord, "finished"))).To(BeTrue(),
+				"both marker threads completed all %d cycles", iters)
+
+			AddReportEntry("overlap-cycles", iters)
+			AddReportEntry("overlap-siblings", siblings)
+			AddReportEntry("overlap-detected", overlapCycles)
+			AddReportEntry("overlap-healthy-ordering", healthyCycles)
+			GinkgoWriter.Printf(
+				"OVERLAP PROOF SUMMARY: cycles=%d siblings=%d detected=%d healthy=%d\n",
+				iters, siblings, overlapCycles, healthyCycles)
+		})
+})
+
+// newOverlapDebugger launches bin with args under the real native backend and a
+// debug-level logger wired to GinkgoWriter, so the engine's own
+// `StopBreakpoint ... steppingOverBP=<bool>` trace lands in the CI log next to
+// the harness journal. Registers a bounded Kill cleanup.
+func newOverlapDebugger(bin string, args []string) debugger.Debugger {
+	GinkgoHelper()
+	log := slog.New(slog.NewTextHandler(GinkgoWriter, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	d := debugger.New(log)
+	Expect(d.Launch(bin, args, nil)).To(Succeed(), "Launch overlap target")
+	DeferCleanup(func() {
+		done := make(chan struct{})
+		go func() { _ = d.Kill(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			AddReportEntry("kill-timeout", "Kill did not return within 10s (backend may be wedged)")
+		}
+	})
+	return d
+}
+
+// probeArmed reports whether a breakpoint is still installed at file:line, by
+// re-issuing SetBreakpoint and reading the outcome:
+//
+//	errBreakpointExists -> still in breakpointTable.byAddr (armed)  -> true
+//	nil error           -> the address was free, so it has been orphaned; the
+//	                       freshly-created entry is cleared again so the probe
+//	                       leaves the tracee exactly as it found it -> false
+//
+// Any other error fails the spec: it means the probe itself is unreliable.
+func probeArmed(d debugger.Debugger, file string, line int) bool {
+	GinkgoHelper()
+	bp, err := d.SetBreakpoint(file, line)
+	if err != nil {
+		Expect(err.Error()).To(ContainSubstring("already installed"),
+			"probe SetBreakpoint(%s:%d) returned an unexpected error", file, line)
+		return true
+	}
+	// Orphaned: undo the probe's side effect so the failure report describes the
+	// engine's own state, not the probe's.
+	_ = d.ClearBreakpoint(bp.ID)
+	return false
+}
+
+func hitLine(ev protocol.Event) int {
+	GinkgoHelper()
+	var hit protocol.BreakpointHitPayload
+	Expect(json.Unmarshal(ev.Payload, &hit)).To(Succeed(), "decode BreakpointHit payload")
+	return hit.Breakpoint.Location.Line
+}
+
+// --- coordination files ---
+
+func touch(p string) {
+	GinkgoHelper()
+	Expect(os.WriteFile(p, []byte("x"), 0o600)).To(Succeed(), "touch %s", p)
+}
+
+func fileExists(p string) bool {
+	_, err := os.Stat(p)
+	return err == nil
+}
+
+// waitForPID resolves the tracee's pid from the pid.<pid> file the target
+// writes as its first action.
+func waitForPID(dir string, timeout time.Duration) int {
+	GinkgoHelper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		matches, _ := filepath.Glob(filepath.Join(dir, "pid.*"))
+		if len(matches) == 1 {
+			n, err := strconv.Atoi(strings.TrimPrefix(filepath.Base(matches[0]), "pid."))
+			if err == nil && n > 0 {
+				return n
+			}
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	Fail(fmt.Sprintf("TIMEOUT after %s waiting for the target to publish its pid", timeout))
+	return 0
+}
+
+// waitForAcks blocks until every sibling has written its ack for cycle i,
+// returning how many were seen. An ack is written immediately before markerB,
+// so it proves the sibling is past the gate and about to execute the trap.
+func waitForAcks(dir string, cycle, want int, timeout time.Duration) int {
+	deadline := time.Now().Add(timeout)
+	for {
+		got := 0
+		for k := 0; k < want; k++ {
+			if fileExists(filepath.Join(dir,
+				fmt.Sprintf("ackB.%d.%d", cycle, k))) {
+				got++
+			}
+		}
+		if got >= want || time.Now().After(deadline) {
+			return got
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// --- /proc thread-state inspection ---
+
+type threadState struct {
+	TID   string
+	Name  string
+	State string
+}
+
+// stopped reports whether the thread is in ptrace tracing-stop. Linux renders
+// this as 't (tracing stop)' on modern kernels and 'T (tracing stop)' on older
+// ones; accept both.
+func (t threadState) stopped() bool {
+	return strings.HasPrefix(t.State, "t") || strings.HasPrefix(t.State, "T")
+}
+
+func procThreadStates(pid int) ([]threadState, error) {
+	entries, err := os.ReadDir(fmt.Sprintf("/proc/%d/task", pid))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]threadState, 0, len(entries))
+	for _, e := range entries {
+		tid := e.Name()
+		raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/task/%s/status", pid, tid))
+		if err != nil {
+			continue
+		}
+		ts := threadState{TID: tid}
+		for _, ln := range strings.Split(string(raw), "\n") {
+			switch {
+			case strings.HasPrefix(ln, "Name:"):
+				ts.Name = strings.TrimSpace(strings.TrimPrefix(ln, "Name:"))
+			case strings.HasPrefix(ln, "State:"):
+				ts.State = strings.TrimSpace(strings.TrimPrefix(ln, "State:"))
+			}
+		}
+		out = append(out, ts)
+	}
+	return out, nil
+}
+
+func countStopped(states []threadState) int {
+	n := 0
+	for _, s := range states {
+		if s.stopped() {
+			n++
+		}
+	}
+	return n
+}
+
+// waitForTracingStops polls /proc until at least want threads report
+// tracing-stop, returning the final snapshot and count. It never fails the
+// spec — the caller asserts, so the snapshot can be included in the report.
+func waitForTracingStops(pid, want int, timeout time.Duration) ([]threadState, int) {
+	deadline := time.Now().Add(timeout)
+	var states []threadState
+	for {
+		s, err := procThreadStates(pid)
+		if err == nil {
+			states = s
+			if countStopped(states) >= want {
+				return states, countStopped(states)
+			}
+		}
+		if time.Now().After(deadline) {
+			return states, countStopped(states)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+func renderStates(states []threadState) string {
+	var b strings.Builder
+	for _, s := range states {
+		fmt.Fprintf(&b, "  tid=%-8s state=%-20s name=%s\n", s.TID, s.State, s.Name)
+	}
+	if b.Len() == 0 {
+		return "  <no /proc data>\n"
+	}
+	return b.String()
+}
+
+// --- harness journal ---
+
+// journal records the harness's own actions so a failure report can show what
+// the test did, in order, alongside the engine's debug log.
+type journal struct {
+	start time.Time
+	lines []string
+}
+
+func (j *journal) logf(format string, args ...any) {
+	if j.start.IsZero() {
+		j.start = time.Now()
+	}
+	line := fmt.Sprintf("[%8.3fs] %s", time.Since(j.start).Seconds(),
+		fmt.Sprintf(format, args...))
+	j.lines = append(j.lines, line)
+	GinkgoWriter.Println(line)
+}
+
+func (j *journal) dump() string {
+	return strings.Join(j.lines, "\n")
+}

--- a/test/integration/debugger_e2e_overlap_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_overlap_linux_amd64_test.go
@@ -104,13 +104,15 @@ var sink int64
 
 //go:noinline
 func markerA(i int) int {
-	v := i*2 + 1 // MARK_A
+	v := i * 2
+	atomic.AddInt64(&sink, int64(v)) // MARK_A
 	return v
 }
 
 //go:noinline
 func markerB(i int) int {
-	v := i*3 + 2 // MARK_B
+	v := i * 3
+	atomic.AddInt64(&sink, int64(v)) // MARK_B
 	return v
 }
 
@@ -145,7 +147,7 @@ func main() {
 		close(ready)
 		for i := 0; i < iters; i++ {
 			waitFile(filepath.Join(dir, "goA."+strconv.Itoa(i)))
-			atomic.AddInt64(&sink, int64(markerA(i)))
+			markerA(i)
 		}
 	}()
 	<-ready
@@ -159,7 +161,7 @@ func main() {
 			for i := 0; i < iters; i++ {
 				waitFile(filepath.Join(dir, "gateB."+strconv.Itoa(i)))
 				touch(filepath.Join(dir, "ackB."+strconv.Itoa(i)+"."+strconv.Itoa(k)))
-				atomic.AddInt64(&sink, int64(markerB(i)))
+				markerB(i)
 			}
 		}(k)
 		time.Sleep(30 * time.Millisecond)

--- a/test/integration/debugger_e2e_overlap_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_overlap_linux_amd64_test.go
@@ -240,9 +240,10 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 
 			var (
 				orphanCycles int
-				minStopped   = 1 << 30
 				maxStopped   int
-				minAtTrap    = 1 << 30
+				maxAtTrap    int
+				overlapReady int // stops taken with >=2 threads parked on a marker
+				totalStops   int
 			)
 
 			for i := 0; i < iters; i++ {
@@ -280,28 +281,32 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 					}
 
 					if k == 0 {
-						// LOAD-BEARING NON-VACUITY CHECK. It is not enough that
-						// some threads are in tracing-stop: they must be parked
-						// ON the marker instructions. An amd64 INT3 stop leaves
-						// RIP one byte past the trap, so accept addr and addr+1.
-						states, stopped := waitForTracingStops(pid, perCycle, 5*time.Second)
+						// NON-VACUITY MEASUREMENT. It is not enough that some
+						// threads are in tracing-stop: they must be parked ON a
+						// marker instruction. An amd64 INT3 stop leaves RIP one
+						// byte past the trap, so accept addr and addr+1.
+						//
+						// This is recorded per stop and asserted ONCE at the end
+						// rather than per cycle: a sibling that took an unrelated
+						// ptrace event while the engine was suspended is only
+						// resumed when the next Backend.Wait absorbs it, so an
+						// individual cycle can legitimately start with the
+						// siblings not yet re-parked. That is a cycle where no
+						// overlap is possible — not a failure.
+						states, stopped := waitForMarkerStops(pid, trapPCs, perCycle, 2*time.Second)
 						atTrap := countAtTrap(pid, states, trapPCs)
-						if stopped < minStopped {
-							minStopped = stopped
-						}
+						totalStops++
 						if stopped > maxStopped {
 							maxStopped = stopped
 						}
-						if atTrap < minAtTrap {
-							minAtTrap = atTrap
+						if atTrap > maxAtTrap {
+							maxAtTrap = atTrap
+						}
+						if atTrap >= 2 {
+							overlapReady++
 						}
 						j.logf("cycle %d: first stop at line %d; tracing-stopped=%d atMarkerPC=%d of %d marker threads\n%s",
 							i, line, stopped, atTrap, perCycle, renderStates(pid, states, trapPCs))
-						Expect(atTrap).To(BeNumerically(">=", 2),
-							"cycle %d: NON-VACUITY FAILED — fewer than two threads are parked ON a marker "+
-								"instruction (MARK_A=0x%x MARK_B=0x%x), so the step-over that follows "+
-								"cannot overlap a pending sibling breakpoint stop\n%s\n%s",
-							i, addrA, addrB, renderStates(pid, states, trapPCs), j.dump())
 					}
 
 					// THE PROBE. Every stop is a resting point at which BOTH
@@ -372,6 +377,21 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 					i, siblings, hitsB, j.dump())
 			}
 
+			// GLOBAL NON-VACUITY GATE: the spec is only meaningful if the
+			// scenario it claims to test actually occurred — sibling threads
+			// parked in their own INT3 stops while a step-over ran. Asserted
+			// once, over the whole run, so a single unlucky cycle cannot make
+			// the spec flaky, but a run that never set up the race cannot pass
+			// silently either.
+			Expect(maxAtTrap).To(BeNumerically(">=", 2),
+				"NON-VACUITY FAILED — no stop in %d cycles ever had two threads parked ON a marker "+
+					"instruction (MARK_A=0x%x MARK_B=0x%x), so no step-over could overlap a pending "+
+					"sibling breakpoint stop and this run proves nothing\n%s",
+				iters, addrA, addrB, j.dump())
+			Expect(overlapReady).To(BeNumerically(">=", 1),
+				"NON-VACUITY FAILED — not one of %d cycles began with the overlap precondition met\n%s",
+				totalStops, j.dump())
+
 			// Every cycle survived: both breakpoints still armed, target runs
 			// to a clean exit, and every marker thread completed every cycle.
 			Expect(probeArmed(d, srcFile, lineA)).To(BeTrue(), "BP A armed at end\n%s", j.dump())
@@ -389,12 +409,12 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 			AddReportEntry("overlap-cycles", iters)
 			AddReportEntry("overlap-siblings", siblings)
 			AddReportEntry("overlap-orphans", orphanCycles)
-			AddReportEntry("overlap-tracing-stopped-min", minStopped)
 			AddReportEntry("overlap-tracing-stopped-max", maxStopped)
-			AddReportEntry("overlap-at-marker-pc-min", minAtTrap)
+			AddReportEntry("overlap-at-marker-pc-max", maxAtTrap)
+			AddReportEntry("overlap-ready-cycles", fmt.Sprintf("%d/%d", overlapReady, totalStops))
 			GinkgoWriter.Printf(
-				"OVERLAP PROOF SUMMARY: cycles=%d siblings=%d orphans=%d stopped(min/max)=%d/%d atMarkerPC(min)=%d\n",
-				iters, siblings, orphanCycles, minStopped, maxStopped, minAtTrap)
+				"OVERLAP PROOF SUMMARY: cycles=%d siblings=%d orphans=%d stopped(max)=%d atMarkerPC(max)=%d overlapReady=%d/%d\n",
+				iters, siblings, orphanCycles, maxStopped, maxAtTrap, overlapReady, totalStops)
 		})
 })
 
@@ -564,14 +584,16 @@ func countStopped(states []threadState) int {
 	return n
 }
 
-// waitForTracingStops polls /proc until at least want threads report
-// tracing-stop, returning the final snapshot and count. It never fails the
-// spec — the caller asserts, so the snapshot can be included in the report.
-func waitForTracingStops(pid, want int, timeout time.Duration) ([]threadState, int) {
+// waitForMarkerStops polls /proc until at least want threads are parked ON a
+// marker instruction, returning the final snapshot and the tracing-stop count.
+// It never fails the spec — the caller records and asserts, so the snapshot can
+// be included in a report. Bounded and early-exiting: a cycle in which the
+// siblings have not re-parked is a legitimate no-overlap cycle, not a hang.
+func waitForMarkerStops(pid int, trapPCs map[uint64]string, want int, timeout time.Duration) ([]threadState, int) {
 	deadline := time.Now().Add(timeout)
 	for {
 		states, stopped := procThreadStates(pid)
-		if stopped >= want || time.Now().After(deadline) {
+		if countAtTrap(pid, states, trapPCs) >= want || time.Now().After(deadline) {
 			return states, stopped
 		}
 		time.Sleep(2 * time.Millisecond)

--- a/test/integration/debugger_e2e_overlap_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_overlap_linux_amd64_test.go
@@ -2,55 +2,68 @@
 
 // TEMPORARY PROOF SPEC — do not merge.
 //
-// Goal: prove (or refute) on a real ptrace backend that a SIBLING thread's
-// software-breakpoint stop, delivered by Wait4(-1, WALL) while the engine is
-// mid-step-over of ANOTHER thread's breakpoint, corrupts the engine's one-slot
-// step-over state and orphans the breakpoint being stepped over.
+// Question: on linux/amd64, can a SIBLING thread's software-breakpoint stop,
+// delivered by Wait4(-1, WALL) while the engine is mid-step-over of ANOTHER
+// thread's breakpoint, corrupt the engine's one-slot step-over state and orphan
+// the breakpoint being stepped over?
 //
-// Mechanism under test (internal/debugger, read at 0509b53):
+// Mechanism under test (internal/debugger @ 0509b53):
 //
-//	engine.resumeFromBreakpoint (engine.go:1031) starts the step-over of BP-A:
+//	engine.resumeFromBreakpoint (engine.go:1031) begins the step-over of BP-A:
 //	    bp := e.lastBP; e.lastBP = nil
-//	    e.steppingOverBP = bp          <- one slot
+//	    e.steppingOverBP = bp          <- ONE SLOT
 //	    e.bps.removeFromTable(bp)      <- A leaves byID/byAddr
-//	    WriteMemory(bp.addr, original) <- A's INT3 is DISARMED in memory
+//	    WriteMemory(bp.addr, original) <- A's INT3 is DISARMED in tracee memory
 //	    SingleStep(tidA)               <- backend: stepping=true, stepTID=tidA
 //
-//	Linux ptrace stops are PER-THREAD and bingo does not stop the world, so a
-//	sibling thread B can hit its own armed INT3 while the engine is suspended at
-//	A. That stop sits pending (no waitLoop is running while suspended). The very
-//	next Wait4(-1, WALL) can therefore return B's stop BEFORE A's single-step
-//	trap. backend_linux_amd64.go:523 correctly classifies it (tid != stepTID) as
-//	StopBreakpoint.
+//	Only handleStop's StopSingleStep branch (engine.go:638-727) ever reinstalls
+//	steppingOverBP. But linux ptrace stops are PER-THREAD and bingo does not stop
+//	the world, so sibling threads keep running while the engine is "suspended"
+//	and can be sitting in their own unreaped INT3 stops. The next
+//	Wait4(-1, WALL) may therefore return a sibling's StopBreakpoint BEFORE A's
+//	single-step trap; backend_linux_amd64.go:523 correctly classifies it as a
+//	breakpoint (tid != stepTID).
 //
-//	engine.handleStop's StopBreakpoint branch (engine.go:589-636) has NO
-//	`steppingOverBP != nil` guard. It unconditionally does:
-//	    e.lastBP = bpB; e.lastBPTID = tidB; emitBreakpointHit(bpB)
-//	leaving e.steppingOverBP == bpA. bpA is now: disarmed in tracee memory,
-//	absent from the breakpoint table, and reachable only through steppingOverBP
-//	— which the next Continue (resumeFromBreakpoint for bpB) overwrites,
-//	permanently losing it.
+//	handleStop's StopBreakpoint branch (engine.go:589-636) has NO
+//	`steppingOverBP != nil` guard. It unconditionally overwrites lastBP/lastBPTID
+//	and emits BreakpointHit, leaving steppingOverBP == bpA. BP-A is now disarmed
+//	in memory AND absent from the table, reachable only via steppingOverBP —
+//	which the very next Continue (resumeFromBreakpoint for the sibling)
+//	overwrites, losing BP-A permanently.
 //
-// Detection without touching production code: while suspended at B, re-issue
-// SetBreakpoint(fileA, lineA). breakpointTable.set returns errBreakpointExists
-// iff bpA is still in byAddr.
+// DETECTOR (no production hooks): after every stop, re-issue SetBreakpoint on
+// BOTH marker lines. breakpointTable.set returns errBreakpointExists iff the
+// address is still in byAddr.
 //
-//	err != nil ("already installed")  => bpA survived  => HEALTHY ordering
-//	err == nil                        => bpA orphaned  => BUG REPRODUCED
+//	error "already installed" => still armed  => healthy
+//	nil error                 => ORPHANED     => bug reproduced
 //
-// Corroborating evidence: the engine's own debug log prints
-// `StopBreakpoint ... steppingOverBP=true` on exactly the overlapping stop, so
-// the spec runs with a debug-level logger wired to GinkgoWriter.
+// The probe undoes itself (ClearBreakpoint) in the orphaned case so the report
+// describes the engine's state, not the probe's.
 //
-// Non-vacuity: before the load-bearing Continue, the spec waits for every B
-// thread's ack file AND polls /proc/<pid>/task/*/status until at least
-// (1 + NB) threads report ptrace tracing-stop ('t'/'T'). That proves A and all
-// B siblings are genuinely stopped at their traps before the step-over starts.
+// CORROBORATION: the engine's own debug log prints
+// `StopBreakpoint ... steppingOverBP=<bool>`; the spec runs with a debug logger
+// wired to GinkgoWriter, so an overlapping stop is visible as
+// steppingOverBP=true directly in the CI log.
+//
+// NON-VACUITY: (a) after the first stop of each cycle the spec polls
+// /proc/<pid>/task/*/status and requires at least two threads in ptrace
+// tracing-stop, logging every thread's state and stopped PC
+// (/proc/<pid>/task/<tid>/syscall); (b) every cycle must yield exactly one
+// MARK_A hit and exactly `siblings` MARK_B hits, which can only happen if all
+// of those threads genuinely reached their traps.
+//
+// TARGET SEQUENCING (learned empirically, run 31323125619/31323315712): every
+// marker thread must exist and be parked BEFORE the first suspend. A thread that
+// clones while the engine is suspended stops at PTRACE_EVENT_CLONE with no
+// waitLoop to reap it and freezes for the whole suspend, so the target publishes
+// `ready.<pid>` only once every marker thread is up, and the harness releases
+// A and all siblings together while the tracee is running.
 //
 // Tuning:
 //
 //	BINGO_E2E_OVERLAP_ITERS    (default 24) cycles
-//	BINGO_E2E_OVERLAP_SIBLINGS (default 4)  sibling threads parked on BP-B
+//	BINGO_E2E_OVERLAP_SIBLINGS (default 4)  sibling threads parked on MARK_B
 
 package integration
 
@@ -71,23 +84,19 @@ import (
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
 
-// overlapTargetSrc drives one "A" thread and NB "B" sibling threads, every one
-// of them pinned with runtime.LockOSThread so a given marker's INT3 always
-// faults on the same OS thread. Both markers are //go:noinline leaves with a
-// single statement line, so the breakpoint address is unambiguous.
+// overlapTargetSrc runs one "A" thread and NB "B" sibling threads, each pinned
+// with runtime.LockOSThread so a marker's INT3 always faults on the same OS
+// thread. Both markers are //go:noinline and place the marked statement SECOND
+// in the function: Go 1.25.5 folds a function's first statement into the
+// prologue's func-decl line, leaving it is_stmt=false and unresolvable by
+// dwarfReader.PCForFileLine.
 //
 // The harness owns all sequencing through files in a shared directory:
 //
-//	goA.<i>      released by the harness  -> thread A runs markerA and traps
-//	gateB.<i>    released by the harness  -> every B thread wakes
-//	ackB.<i>.<k> written by B thread k    -> proves B is past the gate and is
-//	                                         about to execute markerB
-//
-// Thread A is started and pinned FIRST, before any B thread exists. Linux
-// __ptrace_link head-inserts each auto-attached clone into the tracer's
-// ->ptraced list, so wait4(-1) scans the NEWEST tracee first; making A's M the
-// oldest of the marker threads biases wait4 towards reporting a pending sibling
-// B stop ahead of A's single-step trap, which is the ordering under test.
+//	ready.<pid>  written by the target once every marker thread is parked
+//	goA.<i>      released by the harness -> thread A runs markerA
+//	gateB.<i>    released by the harness -> every sibling runs markerB
+//	finished     written by the target after all cycles complete
 const overlapTargetSrc = `package main
 
 import (
@@ -135,37 +144,42 @@ func main() {
 	// Safety net: never outlive the harness if it abandons us mid-run.
 	go func() { time.Sleep(240 * time.Second); os.Exit(0) }()
 
-	touch(filepath.Join(dir, "pid."+strconv.Itoa(os.Getpid())))
-
 	var wg sync.WaitGroup
-	ready := make(chan struct{})
+	var up int32
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		runtime.LockOSThread()
-		close(ready)
+		atomic.AddInt32(&up, 1)
 		for i := 0; i < iters; i++ {
 			waitFile(filepath.Join(dir, "goA."+strconv.Itoa(i)))
 			markerA(i)
 		}
 	}()
-	<-ready
-	time.Sleep(100 * time.Millisecond)
 
 	for k := 0; k < nb; k++ {
 		wg.Add(1)
-		go func(k int) {
+		go func() {
 			defer wg.Done()
 			runtime.LockOSThread()
+			atomic.AddInt32(&up, 1)
 			for i := 0; i < iters; i++ {
 				waitFile(filepath.Join(dir, "gateB."+strconv.Itoa(i)))
-				touch(filepath.Join(dir, "ackB."+strconv.Itoa(i)+"."+strconv.Itoa(k)))
 				markerB(i)
 			}
-		}(k)
-		time.Sleep(30 * time.Millisecond)
+		}()
 	}
+
+	// Publish readiness only once every marker thread exists and is parked on
+	// its first gate. A clone that happens while the debugger is suspended
+	// stops the cloning thread at PTRACE_EVENT_CLONE with no waitLoop to reap
+	// it, freezing the target for the whole suspend.
+	for atomic.LoadInt32(&up) < int32(nb+1) {
+		time.Sleep(time.Millisecond)
+	}
+	time.Sleep(250 * time.Millisecond)
+	touch(filepath.Join(dir, "ready."+strconv.Itoa(os.Getpid())))
 
 	wg.Wait()
 	touch(filepath.Join(dir, "finished"))
@@ -174,7 +188,7 @@ func main() {
 `
 
 var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", Label("linux"), func() {
-	It("keeps the stepped-over breakpoint armed when a sibling breakpoint lands mid-step-over",
+	It("keeps both breakpoints armed when a sibling breakpoint lands mid-step-over",
 		Label("overlap"), func() {
 			const targetName = "overlap_target"
 			lineA := markerLine(overlapTargetSrc, "// MARK_A")
@@ -183,6 +197,7 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 
 			iters := envInt("BINGO_E2E_OVERLAP_ITERS", 24)
 			siblings := envInt("BINGO_E2E_OVERLAP_SIBLINGS", 4)
+			perCycle := siblings + 1
 
 			coord := GinkgoT().TempDir()
 			bin := buildTarget(targetName, overlapTargetSrc)
@@ -196,175 +211,158 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 			j.logf("launch entry stop: %s", ev.Kind)
 
 			bpA, err := d.SetBreakpoint(srcFile, lineA)
-			Expect(err).NotTo(HaveOccurred(), "SetBreakpoint A")
-			Expect(bpA.Location.Line).To(Equal(lineA), "BP A resolved to MARK_A")
+			Expect(err).NotTo(HaveOccurred(), "SetBreakpoint A (MARK_A)")
 			bpB, err := d.SetBreakpoint(srcFile, lineB)
-			Expect(err).NotTo(HaveOccurred(), "SetBreakpoint B")
-			Expect(bpB.Location.Line).To(Equal(lineB), "BP B resolved to MARK_B")
+			Expect(err).NotTo(HaveOccurred(), "SetBreakpoint B (MARK_B)")
 			j.logf("armed bpA id=%d line=%d, bpB id=%d line=%d",
 				bpA.ID, bpA.Location.Line, bpB.ID, bpB.Location.Line)
 
-			// The target writes pid.<pid> as its very first action, but it only
-			// runs once the entry stop is released, so resolve the pid lazily
-			// after the first Continue.
-			pid := 0
+			// Resume and let the runtime bring every marker thread up. The
+			// tracee must be RUNNING for this: clone events are only absorbed
+			// by Backend.Wait, which only runs while a waitLoop is in flight.
+			Expect(d.Continue()).To(Succeed(), "Continue to spin up marker threads")
+			pid := waitForReady(coord, 40*time.Second)
+			j.logf("target ready, pid=%d, all %d marker threads parked", pid, perCycle)
 
 			var (
-				overlapCycles int // cycles where a sibling stop landed mid-step-over
-				healthyCycles int
+				orphanCycles int
+				minStopped   = 1 << 30
+				maxStopped   int
 			)
 
 			for i := 0; i < iters; i++ {
-				// --- release thread A and stop it at MARK_A -------------------
+				// Release thread A and every sibling together, so they race to
+				// their traps inside one running window. Whichever Wait4 reaps
+				// first is reported; the rest sit in unreaped INT3 stops — the
+				// precondition for the overlap.
 				touch(filepath.Join(coord, "goA."+strconv.Itoa(i)))
-				j.logf("cycle %d: released goA.%d, Continue -> expect BP A", i, i)
-				Expect(d.Continue()).To(Succeed(), "Continue to A #%d", i)
-
-				ev = awaitEvent(d.Events(), 25*time.Second,
-					protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
-				Expect(ev.Kind).To(Equal(protocol.EventBreakpointHit),
-					"cycle %d: expected BreakpointHit at A, got %s: %s\n%s",
-					i, ev.Kind, ev.Payload, j.dump())
-				Expect(hitLine(ev)).To(Equal(lineA),
-					"cycle %d: stopped at MARK_A\n%s", i, j.dump())
-
-				if pid == 0 {
-					pid = waitForPID(coord, 20*time.Second)
-					j.logf("tracee pid=%d", pid)
-				}
-
-				// Same invariant, mirrored: reaching A can itself overlap the
-				// step-over of the PREVIOUS cycle's sibling stop (A is running
-				// while the engine single-steps a B thread off MARK_B), which
-				// would orphan BP B by the identical mechanism.
-				if !probeArmed(d, srcFile, lineB) {
-					overlapCycles++
-					post, _ := procThreadStates(pid)
-					Fail(fmt.Sprintf(
-						"BUG REPRODUCED (cycle-entry variant) on cycle %d/%d\n\n"+
-							"Thread A's breakpoint stop was reported while the engine was still\n"+
-							"mid-step-over of the previous cycle's sibling BP B. handleStop's\n"+
-							"StopBreakpoint branch (internal/debugger/engine.go:589-636) overwrote\n"+
-							"lastBP with BP A while steppingOverBP still held BP B, so BP B was left\n"+
-							"disarmed and removed from the breakpoint table: SetBreakpoint(%s:%d)\n"+
-							"succeeded where it must have returned errBreakpointExists.\n\n"+
-							"cycles: overlap=%d healthy=%d\n"+
-							"/proc thread states at detection:\n%s\n"+
-							"harness journal:\n%s",
-						i, iters, srcFile, lineB, overlapCycles, healthyCycles,
-						renderStates(post), j.dump()))
-				}
-
-				// --- park every sibling on MARK_B ----------------------------
 				touch(filepath.Join(coord, "gateB."+strconv.Itoa(i)))
-				acks := waitForAcks(coord, i, siblings, 25*time.Second)
-				Expect(acks).To(Equal(siblings),
-					"cycle %d: all %d sibling threads must pass the gate (got %d acks)\n%s",
-					i, siblings, acks, j.dump())
 
-				// LOAD-BEARING SYNCHRONISATION: do not resume A until A and
-				// every sibling are genuinely in ptrace tracing-stop.
-				states, stopped := waitForTracingStops(pid, siblings+1, 25*time.Second)
-				j.logf("cycle %d: /proc tracing-stopped=%d (want >=%d)\n%s",
-					i, stopped, siblings+1, renderStates(states))
-				Expect(stopped).To(BeNumerically(">=", siblings+1),
-					"cycle %d: NON-VACUITY FAILED — need A + %d siblings in tracing-stop before Continue, saw %d\n%s\n%s",
-					i, siblings, stopped, renderStates(states), j.dump())
+				hitsA, hitsB := 0, 0
+				for k := 0; k < perCycle; k++ {
+					// Cycle 0 stop 0 needs no resume: the tracee is already
+					// running from the readiness Continue above.
+					if i > 0 || k > 0 {
+						Expect(d.Continue()).To(Succeed(),
+							"Continue cycle %d stop %d", i, k)
+					}
 
-				// --- the load-bearing Continue -------------------------------
-				// This disarms A, PTRACE_SINGLESTEPs A, then Wait4(-1, WALL)
-				// races A's step trap against the already-pending sibling stops.
-				j.logf("cycle %d: Continue from A (step-over of bpA begins, %d sibling stops pending)",
-					i, siblings)
-				Expect(d.Continue()).To(Succeed(), "Continue from A #%d", i)
-
-				ev = awaitEvent(d.Events(), 25*time.Second,
-					protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
-				Expect(ev.Kind).To(Equal(protocol.EventBreakpointHit),
-					"cycle %d: expected a sibling BreakpointHit after resuming A, got %s: %s\n%s",
-					i, ev.Kind, ev.Payload, j.dump())
-				Expect(hitLine(ev)).To(Equal(lineB),
-					"cycle %d: the post-resume stop is a sibling at MARK_B\n%s", i, j.dump())
-
-				// --- THE PROBE ------------------------------------------------
-				armed := probeArmed(d, srcFile, lineA)
-				if armed {
-					healthyCycles++
-					j.logf("cycle %d: bpA still armed after the sibling stop (A's step trap won the wait4 race)", i)
-				} else {
-					overlapCycles++
-					post, _ := procThreadStates(pid)
-					Fail(fmt.Sprintf(
-						"BUG REPRODUCED on cycle %d/%d\n\n"+
-							"Observed: while the engine was mid-step-over of BP A (steppingOverBP=bpA,\n"+
-							"A disarmed in memory and removed from the breakpoint table), Wait4(-1, WALL)\n"+
-							"returned a SIBLING thread's pending StopBreakpoint at MARK_B. handleStop's\n"+
-							"StopBreakpoint branch (internal/debugger/engine.go:589-636) has no\n"+
-							"steppingOverBP guard, so it overwrote lastBP/lastBPTID with the sibling's and\n"+
-							"emitted BreakpointHit. Re-issuing SetBreakpoint(%s:%d) then SUCCEEDED, which is\n"+
-							"only possible if BP A is no longer in breakpointTable.byAddr — i.e. BP A has\n"+
-							"been silently disarmed and orphaned. The next Continue overwrites\n"+
-							"steppingOverBP with the sibling's entry, losing the only remaining reference\n"+
-							"to BP A permanently.\n\n"+
-							"Expected: BP A stays armed (SetBreakpoint returns errBreakpointExists).\n\n"+
-							"cycles: overlap=%d healthy=%d\n"+
-							"/proc thread states at detection:\n%s\n"+
-							"harness journal:\n%s",
-						i, iters, srcFile, lineA, overlapCycles, healthyCycles,
-						renderStates(post), j.dump()))
-				}
-
-				// --- drain the remaining sibling stops -----------------------
-				for k := 1; k < siblings; k++ {
-					Expect(d.Continue()).To(Succeed(), "drain sibling %d cycle %d", k, i)
-					ev = awaitEvent(d.Events(), 25*time.Second,
-						protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+					ev = awaitEvent(d.Events(), 30*time.Second,
+						protocol.EventBreakpointHit, protocol.EventProcessExited,
+						protocol.EventError)
 					Expect(ev.Kind).To(Equal(protocol.EventBreakpointHit),
-						"cycle %d drain %d: expected BreakpointHit, got %s: %s\n%s",
+						"cycle %d stop %d: expected BreakpointHit, got %s: %s\n%s",
 						i, k, ev.Kind, ev.Payload, j.dump())
-					Expect(hitLine(ev)).To(Equal(lineB),
-						"cycle %d drain %d: sibling stop at MARK_B\n%s", i, k, j.dump())
 
-					if !probeArmed(d, srcFile, lineB) {
-						overlapCycles++
-						post, _ := procThreadStates(pid)
+					line := hitLine(ev)
+					switch line {
+					case lineA:
+						hitsA++
+					case lineB:
+						hitsB++
+					default:
+						Fail(fmt.Sprintf("cycle %d stop %d: stopped at unexpected line %d\n%s",
+							i, k, line, j.dump()))
+					}
+
+					if k == 0 {
+						// LOAD-BEARING NON-VACUITY CHECK: at least one sibling
+						// must already be parked in its own tracing-stop before
+						// the step-over that follows.
+						states, stopped := waitForTracingStops(pid, perCycle, 10*time.Second)
+						if stopped < minStopped {
+							minStopped = stopped
+						}
+						if stopped > maxStopped {
+							maxStopped = stopped
+						}
+						j.logf("cycle %d: first stop at line %d; tracing-stopped=%d of %d marker threads\n%s",
+							i, line, stopped, perCycle, renderStates(pid, states))
+						Expect(stopped).To(BeNumerically(">=", 2),
+							"cycle %d: NON-VACUITY FAILED — no sibling was parked in a tracing-stop, "+
+								"so the step-over that follows cannot overlap anything\n%s\n%s",
+							i, renderStates(pid, states), j.dump())
+					}
+
+					// THE PROBE. Every stop is a resting point at which BOTH
+					// breakpoints must still be installed. The previous resume
+					// stepped one of them over; if a sibling stop was delivered
+					// during that step-over, the stepped-over entry was dropped
+					// from the table and never reinstalled.
+					armedA := probeArmed(d, srcFile, lineA)
+					armedB := probeArmed(d, srcFile, lineB)
+					if !armedA || !armedB {
+						orphanCycles++
+						lost, lostLine := "A (MARK_A)", lineA
+						if armedA {
+							lost, lostLine = "B (MARK_B)", lineB
+						}
+						states, _ := procThreadStates(pid)
 						Fail(fmt.Sprintf(
-							"BUG REPRODUCED (sibling-drain variant) on cycle %d drain %d\n\n"+
-								"BP B was orphaned by the same one-slot steppingOverBP overwrite while\n"+
-								"stepping one sibling off MARK_B with other siblings' stops still pending.\n"+
-								"SetBreakpoint(%s:%d) succeeded, so BP B is gone from byAddr.\n\n"+
-								"cycles: overlap=%d healthy=%d\n"+
-								"/proc thread states at detection:\n%s\n"+
-								"harness journal:\n%s",
-							i, k, srcFile, lineB, overlapCycles, healthyCycles,
-							renderStates(post), j.dump()))
+							"BUG REPRODUCED — breakpoint %s silently orphaned (cycle %d, stop %d of %d)\n\n"+
+								"OBSERVED\n"+
+								"  The resume that led to this stop began a step-over of a software\n"+
+								"  breakpoint: engine.resumeFromBreakpoint (internal/debugger/engine.go:1031)\n"+
+								"  set steppingOverBP, called bps.removeFromTable(bp) and restored the\n"+
+								"  original bytes, then PTRACE_SINGLESTEPped that thread.\n"+
+								"  Wait4(-1, WALL) then returned a DIFFERENT thread's pending INT3 stop\n"+
+								"  (backend_linux_amd64.go:523 classifies it StopBreakpoint because\n"+
+								"  tid != stepTID). handleStop's StopBreakpoint branch\n"+
+								"  (engine.go:589-636) has no steppingOverBP guard, so it overwrote\n"+
+								"  lastBP/lastBPTID and emitted this BreakpointHit while steppingOverBP\n"+
+								"  still held the half-stepped breakpoint. Only the StopSingleStep\n"+
+								"  branch reinstalls it, and it never ran.\n\n"+
+								"  Probe: SetBreakpoint(%s:%d) SUCCEEDED. It must return\n"+
+								"  errBreakpointExists while the entry is in breakpointTable.byAddr, so\n"+
+								"  breakpoint %s is disarmed in tracee memory and gone from the table.\n"+
+								"  The next Continue assigns steppingOverBP to this stop's breakpoint,\n"+
+								"  destroying the last reference to it: it can never fire or be cleared\n"+
+								"  again.\n\n"+
+								"EXPECTED\n"+
+								"  Both breakpoints remain installed across a step-over, regardless of\n"+
+								"  which thread Wait4 reports next.\n\n"+
+								"STATE\n"+
+								"  stop line=%d  armedA=%v armedB=%v  tracing-stopped=%d\n"+
+								"  cycle=%d/%d stop=%d/%d hitsA=%d hitsB=%d\n"+
+								"  /proc thread states:\n%s\n"+
+								"HARNESS JOURNAL\n%s",
+							lost, i, k, perCycle,
+							srcFile, lostLine, lost,
+							line, armedA, armedB, countStopped(states),
+							i, iters, k, perCycle, hitsA, hitsB,
+							renderStates(pid, states), j.dump()))
 					}
 				}
 
-				j.logf("cycle %d complete (overlap=%d healthy=%d)", i, overlapCycles, healthyCycles)
+				Expect(hitsA).To(Equal(1),
+					"cycle %d: exactly one MARK_A hit (got %d)\n%s", i, hitsA, j.dump())
+				Expect(hitsB).To(Equal(siblings),
+					"cycle %d: exactly %d MARK_B hits (got %d)\n%s",
+					i, siblings, hitsB, j.dump())
 			}
 
-			// Every cycle survived: both breakpoints must still be armed and the
-			// target must run to a clean exit.
+			// Every cycle survived: both breakpoints still armed, target runs
+			// to a clean exit, and every marker thread completed every cycle.
 			Expect(probeArmed(d, srcFile, lineA)).To(BeTrue(), "BP A armed at end\n%s", j.dump())
 			Expect(probeArmed(d, srcFile, lineB)).To(BeTrue(), "BP B armed at end\n%s", j.dump())
 
 			Expect(d.Continue()).To(Succeed(), "final Continue")
-			ev = awaitEvent(d.Events(), 30*time.Second,
+			ev = awaitEvent(d.Events(), 40*time.Second,
 				protocol.EventProcessExited, protocol.EventBreakpointHit, protocol.EventError)
 			Expect(ev.Kind).To(Equal(protocol.EventProcessExited),
 				"target runs to completion after the last cycle, got %s: %s\n%s",
 				ev.Kind, ev.Payload, j.dump())
 			Expect(fileExists(filepath.Join(coord, "finished"))).To(BeTrue(),
-				"both marker threads completed all %d cycles", iters)
+				"every marker thread completed all %d cycles", iters)
 
 			AddReportEntry("overlap-cycles", iters)
 			AddReportEntry("overlap-siblings", siblings)
-			AddReportEntry("overlap-detected", overlapCycles)
-			AddReportEntry("overlap-healthy-ordering", healthyCycles)
+			AddReportEntry("overlap-orphans", orphanCycles)
+			AddReportEntry("overlap-tracing-stopped-min", minStopped)
+			AddReportEntry("overlap-tracing-stopped-max", maxStopped)
 			GinkgoWriter.Printf(
-				"OVERLAP PROOF SUMMARY: cycles=%d siblings=%d detected=%d healthy=%d\n",
-				iters, siblings, overlapCycles, healthyCycles)
+				"OVERLAP PROOF SUMMARY: cycles=%d siblings=%d orphans=%d stopped(min/max)=%d/%d\n",
+				iters, siblings, orphanCycles, minStopped, maxStopped)
 		})
 })
 
@@ -389,15 +387,15 @@ func newOverlapDebugger(bin string, args []string) debugger.Debugger {
 	return d
 }
 
-// probeArmed reports whether a breakpoint is still installed at file:line, by
-// re-issuing SetBreakpoint and reading the outcome:
+// probeArmed reports whether a breakpoint is still installed at file:line by
+// re-issuing SetBreakpoint:
 //
-//	errBreakpointExists -> still in breakpointTable.byAddr (armed)  -> true
-//	nil error           -> the address was free, so it has been orphaned; the
-//	                       freshly-created entry is cleared again so the probe
-//	                       leaves the tracee exactly as it found it -> false
+//	errBreakpointExists -> still in breakpointTable.byAddr -> true
+//	nil error           -> the address was free, so the entry was orphaned; the
+//	                       accidental new entry is cleared again so the failure
+//	                       report describes the engine's state, not the probe's
 //
-// Any other error fails the spec: it means the probe itself is unreliable.
+// Any other error fails the spec: the probe itself must be trustworthy.
 func probeArmed(d debugger.Debugger, file string, line int) bool {
 	GinkgoHelper()
 	bp, err := d.SetBreakpoint(file, line)
@@ -406,8 +404,6 @@ func probeArmed(d debugger.Debugger, file string, line int) bool {
 			"probe SetBreakpoint(%s:%d) returned an unexpected error", file, line)
 		return true
 	}
-	// Orphaned: undo the probe's side effect so the failure report describes the
-	// engine's own state, not the probe's.
 	_ = d.ClearBreakpoint(bp.ID)
 	return false
 }
@@ -431,43 +427,24 @@ func fileExists(p string) bool {
 	return err == nil
 }
 
-// waitForPID resolves the tracee's pid from the pid.<pid> file the target
-// writes as its first action.
-func waitForPID(dir string, timeout time.Duration) int {
+// waitForReady blocks until the target publishes ready.<pid>, which it only
+// does once every marker thread is created, pinned and parked on its first
+// gate. Returns the tracee pid.
+func waitForReady(dir string, timeout time.Duration) int {
 	GinkgoHelper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		matches, _ := filepath.Glob(filepath.Join(dir, "pid.*"))
+		matches, _ := filepath.Glob(filepath.Join(dir, "ready.*"))
 		if len(matches) == 1 {
-			n, err := strconv.Atoi(strings.TrimPrefix(filepath.Base(matches[0]), "pid."))
+			n, err := strconv.Atoi(strings.TrimPrefix(filepath.Base(matches[0]), "ready."))
 			if err == nil && n > 0 {
 				return n
 			}
 		}
 		time.Sleep(2 * time.Millisecond)
 	}
-	Fail(fmt.Sprintf("TIMEOUT after %s waiting for the target to publish its pid", timeout))
+	Fail(fmt.Sprintf("TIMEOUT after %s waiting for the target to park every marker thread", timeout))
 	return 0
-}
-
-// waitForAcks blocks until every sibling has written its ack for cycle i,
-// returning how many were seen. An ack is written immediately before markerB,
-// so it proves the sibling is past the gate and about to execute the trap.
-func waitForAcks(dir string, cycle, want int, timeout time.Duration) int {
-	deadline := time.Now().Add(timeout)
-	for {
-		got := 0
-		for k := 0; k < want; k++ {
-			if fileExists(filepath.Join(dir,
-				fmt.Sprintf("ackB.%d.%d", cycle, k))) {
-				got++
-			}
-		}
-		if got >= want || time.Now().After(deadline) {
-			return got
-		}
-		time.Sleep(time.Millisecond)
-	}
 }
 
 // --- /proc thread-state inspection ---
@@ -485,10 +462,10 @@ func (t threadState) stopped() bool {
 	return strings.HasPrefix(t.State, "t") || strings.HasPrefix(t.State, "T")
 }
 
-func procThreadStates(pid int) ([]threadState, error) {
+func procThreadStates(pid int) ([]threadState, int) {
 	entries, err := os.ReadDir(fmt.Sprintf("/proc/%d/task", pid))
 	if err != nil {
-		return nil, err
+		return nil, 0
 	}
 	out := make([]threadState, 0, len(entries))
 	for _, e := range entries {
@@ -508,7 +485,7 @@ func procThreadStates(pid int) ([]threadState, error) {
 		}
 		out = append(out, ts)
 	}
-	return out, nil
+	return out, countStopped(out)
 }
 
 func countStopped(states []threadState) int {
@@ -526,26 +503,37 @@ func countStopped(states []threadState) int {
 // spec — the caller asserts, so the snapshot can be included in the report.
 func waitForTracingStops(pid, want int, timeout time.Duration) ([]threadState, int) {
 	deadline := time.Now().Add(timeout)
-	var states []threadState
 	for {
-		s, err := procThreadStates(pid)
-		if err == nil {
-			states = s
-			if countStopped(states) >= want {
-				return states, countStopped(states)
-			}
-		}
-		if time.Now().After(deadline) {
-			return states, countStopped(states)
+		states, stopped := procThreadStates(pid)
+		if stopped >= want || time.Now().After(deadline) {
+			return states, stopped
 		}
 		time.Sleep(2 * time.Millisecond)
 	}
 }
 
-func renderStates(states []threadState) string {
+// procPC reads the stopped thread's instruction pointer from
+// /proc/<pid>/task/<tid>/syscall, whose last field is the PC. It is only
+// meaningful for a stopped task; "running" or an unreadable file yields "".
+// Purely diagnostic: it lets a reader confirm that the parked siblings all sit
+// at the same marker address.
+func procPC(pid int, tid string) string {
+	raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/task/%s/syscall", pid, tid))
+	if err != nil {
+		return ""
+	}
+	fields := strings.Fields(string(raw))
+	if len(fields) < 2 {
+		return ""
+	}
+	return fields[len(fields)-1]
+}
+
+func renderStates(pid int, states []threadState) string {
 	var b strings.Builder
 	for _, s := range states {
-		fmt.Fprintf(&b, "  tid=%-8s state=%-20s name=%s\n", s.TID, s.State, s.Name)
+		fmt.Fprintf(&b, "  tid=%-8s state=%-18s pc=%-20s name=%s\n",
+			s.TID, s.State, procPC(pid, s.TID), s.Name)
 	}
 	if b.Len() == 0 {
 		return "  <no /proc data>\n"
@@ -555,8 +543,8 @@ func renderStates(states []threadState) string {
 
 // --- harness journal ---
 
-// journal records the harness's own actions so a failure report can show what
-// the test did, in order, alongside the engine's debug log.
+// journal records the harness's own actions so a failure report shows what the
+// test did, in order, alongside the engine's debug log.
 type journal struct {
 	start time.Time
 	lines []string

--- a/test/integration/debugger_e2e_overlap_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_overlap_linux_amd64_test.go
@@ -1,64 +1,54 @@
 //go:build e2e && linux && amd64
 
-// TEMPORARY PROOF SPEC — do not merge.
+// Regression spec for #198: a sibling thread's software-breakpoint stop must not
+// be allowed to land in the middle of another thread's step-over.
 //
-// Question: on linux/amd64, can a SIBLING thread's software-breakpoint stop,
-// delivered by Wait4(-1, WALL) while the engine is mid-step-over of ANOTHER
-// thread's breakpoint, corrupt the engine's one-slot step-over state and orphan
-// the breakpoint being stepped over?
+// Linux ptrace stops are PER-THREAD and bingo does not stop the world, so
+// sibling threads keep running while the engine is suspended and can be sitting
+// in their own unreaped INT3 stops. engine.resumeFromBreakpoint then begins a
+// step-over that is only safe if it completes atomically:
 //
-// Mechanism under test (internal/debugger @ 0509b53):
+//	bp := e.lastBP; e.lastBP = nil
+//	e.steppingOverBP = bp          <- ONE SLOT
+//	e.bps.removeFromTable(bp)      <- the entry leaves byID/byAddr
+//	WriteMemory(bp.addr, original) <- the INT3 is DISARMED in tracee memory
+//	SingleStep(tid)                <- only the resulting StopSingleStep rearms it
 //
-//	engine.resumeFromBreakpoint (engine.go:1031) begins the step-over of BP-A:
-//	    bp := e.lastBP; e.lastBP = nil
-//	    e.steppingOverBP = bp          <- ONE SLOT
-//	    e.bps.removeFromTable(bp)      <- A leaves byID/byAddr
-//	    WriteMemory(bp.addr, original) <- A's INT3 is DISARMED in tracee memory
-//	    SingleStep(tidA)               <- backend: stepping=true, stepTID=tidA
+// Before the fix, a process-wide Wait4(-1, WALL) could CONSUME a sibling's
+// already-pending INT3 status inside that window. handleStop's StopBreakpoint
+// branch then overwrote lastBP/lastBPTID while steppingOverBP still held the
+// half-stepped entry, and the next Continue overwrote that last reference: the
+// breakpoint was disarmed, absent from the table, and could never fire or be
+// cleared again. When the sibling had parked on the SAME address being stepped,
+// the table lookup missed, the "spurious SIGTRAP" path skipped
+// rewindToBreakpoint, and the thread was resumed one byte into the restored
+// multi-byte instruction.
 //
-//	Only handleStop's StopSingleStep branch (engine.go:638-727) ever reinstalls
-//	steppingOverBP. But linux ptrace stops are PER-THREAD and bingo does not stop
-//	the world, so sibling threads keep running while the engine is "suspended"
-//	and can be sitting in their own unreaped INT3 stops. The next
-//	Wait4(-1, WALL) may therefore return a sibling's StopBreakpoint BEFORE A's
-//	single-step trap; backend_linux_amd64.go:523 correctly classifies it as a
-//	breakpoint (tid != stepTID).
+// WHAT THIS SPEC ASSERTS
 //
-//	handleStop's StopBreakpoint branch (engine.go:589-636) has NO
-//	`steppingOverBP != nil` guard. It unconditionally overwrites lastBP/lastBPTID
-//	and emits BreakpointHit, leaving steppingOverBP == bpA. BP-A is now disarmed
-//	in memory AND absent from the table, reachable only via steppingOverBP —
-//	which the very next Continue (resumeFromBreakpoint for the sibling)
-//	overwrites, losing BP-A permanently.
+// After every stop, BOTH breakpoints must still be installed. The probe
+// re-issues SetBreakpoint: breakpointTable.set consults byAddr BEFORE it reads
+// or writes tracee memory, so success means the entry is gone — it cannot be an
+// artifact of the probe itself. A detection is corroborated read-only by
+// ClearBreakpoint on the ORIGINAL id (clear consults byID before any write).
 //
-// DETECTOR (no production hooks): after every stop, re-issue SetBreakpoint on
-// BOTH marker lines. breakpointTable.set returns errBreakpointExists iff the
-// address is still in byAddr.
+// NON-VACUITY. The spec parks one pinned thread on MARK_A and N pinned siblings
+// on MARK_B (so siblings also cover the same-address case), releases them
+// together so they race to their traps inside one running window, and records
+// how many threads are in ptrace tracing-stop AND parked ON a marker
+// instruction — addresses resolved from the target's own DWARF, matched at addr
+// or addr+1 since an amd64 INT3 stop leaves RIP one byte past the trap. A run
+// in which that never reached two is rejected: it never set up the race and
+// proves nothing. It is asserted once over the whole run rather than per cycle,
+// because a sibling that took an unrelated ptrace event while the engine was
+// suspended is only resumed when the next Backend.Wait absorbs it, so an
+// individual cycle can legitimately start with the siblings not yet re-parked.
 //
-//	error "already installed" => still armed  => healthy
-//	nil error                 => ORPHANED     => bug reproduced
-//
-// The probe undoes itself (ClearBreakpoint) in the orphaned case so the report
-// describes the engine's state, not the probe's.
-//
-// CORROBORATION: the engine's own debug log prints
-// `StopBreakpoint ... steppingOverBP=<bool>`; the spec runs with a debug logger
-// wired to GinkgoWriter, so an overlapping stop is visible as
-// steppingOverBP=true directly in the CI log.
-//
-// NON-VACUITY: (a) after the first stop of each cycle the spec polls
-// /proc/<pid>/task/*/status and requires at least two threads in ptrace
-// tracing-stop, logging every thread's state and stopped PC
-// (/proc/<pid>/task/<tid>/syscall); (b) every cycle must yield exactly one
-// MARK_A hit and exactly `siblings` MARK_B hits, which can only happen if all
-// of those threads genuinely reached their traps.
-//
-// TARGET SEQUENCING (learned empirically, run 31323125619/31323315712): every
-// marker thread must exist and be parked BEFORE the first suspend. A thread that
-// clones while the engine is suspended stops at PTRACE_EVENT_CLONE with no
-// waitLoop to reap it and freezes for the whole suspend, so the target publishes
-// `ready.<pid>` only once every marker thread is up, and the harness releases
-// A and all siblings together while the tracee is running.
+// TARGET SEQUENCING. Every marker thread must exist and be parked BEFORE the
+// first suspend: a thread that clones while the engine is suspended stops at
+// PTRACE_EVENT_CLONE with no waitLoop to reap it and freezes for the whole
+// suspend. The target therefore publishes ready.<pid> only once every marker
+// thread is up.
 //
 // Tuning:
 //
@@ -189,7 +179,7 @@ func main() {
 }
 `
 
-var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", Label("linux"), func() {
+var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap", Label("linux"), func() {
 	It("keeps both breakpoints armed when a sibling breakpoint lands mid-step-over",
 		Label("overlap"), func() {
 			const targetName = "overlap_target"
@@ -330,7 +320,7 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 						clearErr := d.ClearBreakpoint(lostID)
 						states, _ := procThreadStates(pid)
 						Fail(fmt.Sprintf(
-							"BUG REPRODUCED — breakpoint %s silently orphaned (cycle %d, stop %d of %d)\n\n"+
+							"breakpoint %s was silently orphaned by a sibling stop during a step-over (cycle %d, stop %d of %d)\n\n"+
 								"OBSERVED\n"+
 								"  The resume that led to this stop began a step-over of a software\n"+
 								"  breakpoint: engine.resumeFromBreakpoint (internal/debugger/engine.go:1031)\n"+
@@ -413,7 +403,7 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 			AddReportEntry("overlap-at-marker-pc-max", maxAtTrap)
 			AddReportEntry("overlap-ready-cycles", fmt.Sprintf("%d/%d", overlapReady, totalStops))
 			GinkgoWriter.Printf(
-				"OVERLAP PROOF SUMMARY: cycles=%d siblings=%d orphans=%d stopped(max)=%d atMarkerPC(max)=%d overlapReady=%d/%d\n",
+				"overlap summary: cycles=%d siblings=%d orphans=%d stopped(max)=%d atMarkerPC(max)=%d overlapReady=%d/%d\n",
 				iters, siblings, orphanCycles, maxStopped, maxAtTrap, overlapReady, totalStops)
 		})
 })

--- a/test/integration/debugger_e2e_overlap_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_overlap_linux_amd64_test.go
@@ -68,6 +68,8 @@
 package integration
 
 import (
+	"debug/dwarf"
+	"debug/elf"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -210,6 +212,18 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 			ev := awaitEvent(d.Events(), 20*time.Second, protocol.EventStepped)
 			j.logf("launch entry stop: %s", ev.Kind)
 
+			// Resolve the marker addresses straight from the target's own DWARF
+			// so the /proc non-vacuity check can assert that the parked threads
+			// really are sitting on the breakpoint instructions, rather than
+			// merely being in some tracing-stop.
+			addrA := elfAddrForLine(bin, srcFile, lineA)
+			addrB := elfAddrForLine(bin, srcFile, lineB)
+			trapPCs := map[uint64]string{
+				addrA: "MARK_A", addrA + 1: "MARK_A+1(post-INT3)",
+				addrB: "MARK_B", addrB + 1: "MARK_B+1(post-INT3)",
+			}
+			j.logf("marker addresses from DWARF: MARK_A=0x%x MARK_B=0x%x", addrA, addrB)
+
 			bpA, err := d.SetBreakpoint(srcFile, lineA)
 			Expect(err).NotTo(HaveOccurred(), "SetBreakpoint A (MARK_A)")
 			bpB, err := d.SetBreakpoint(srcFile, lineB)
@@ -220,7 +234,7 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 			// Resume and let the runtime bring every marker thread up. The
 			// tracee must be RUNNING for this: clone events are only absorbed
 			// by Backend.Wait, which only runs while a waitLoop is in flight.
-			Expect(d.Continue()).To(Succeed(), "Continue to spin up marker threads")
+			mustContinue(d, "Continue to spin up marker threads")
 			pid := waitForReady(coord, 40*time.Second)
 			j.logf("target ready, pid=%d, all %d marker threads parked", pid, perCycle)
 
@@ -228,6 +242,7 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 				orphanCycles int
 				minStopped   = 1 << 30
 				maxStopped   int
+				minAtTrap    = 1 << 30
 			)
 
 			for i := 0; i < iters; i++ {
@@ -243,8 +258,7 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 					// Cycle 0 stop 0 needs no resume: the tracee is already
 					// running from the readiness Continue above.
 					if i > 0 || k > 0 {
-						Expect(d.Continue()).To(Succeed(),
-							"Continue cycle %d stop %d", i, k)
+						mustContinue(d, "Continue cycle %d stop %d", i, k)
 					}
 
 					ev = awaitEvent(d.Events(), 30*time.Second,
@@ -266,22 +280,28 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 					}
 
 					if k == 0 {
-						// LOAD-BEARING NON-VACUITY CHECK: at least one sibling
-						// must already be parked in its own tracing-stop before
-						// the step-over that follows.
-						states, stopped := waitForTracingStops(pid, perCycle, 10*time.Second)
+						// LOAD-BEARING NON-VACUITY CHECK. It is not enough that
+						// some threads are in tracing-stop: they must be parked
+						// ON the marker instructions. An amd64 INT3 stop leaves
+						// RIP one byte past the trap, so accept addr and addr+1.
+						states, stopped := waitForTracingStops(pid, perCycle, 5*time.Second)
+						atTrap := countAtTrap(pid, states, trapPCs)
 						if stopped < minStopped {
 							minStopped = stopped
 						}
 						if stopped > maxStopped {
 							maxStopped = stopped
 						}
-						j.logf("cycle %d: first stop at line %d; tracing-stopped=%d of %d marker threads\n%s",
-							i, line, stopped, perCycle, renderStates(pid, states))
-						Expect(stopped).To(BeNumerically(">=", 2),
-							"cycle %d: NON-VACUITY FAILED — no sibling was parked in a tracing-stop, "+
-								"so the step-over that follows cannot overlap anything\n%s\n%s",
-							i, renderStates(pid, states), j.dump())
+						if atTrap < minAtTrap {
+							minAtTrap = atTrap
+						}
+						j.logf("cycle %d: first stop at line %d; tracing-stopped=%d atMarkerPC=%d of %d marker threads\n%s",
+							i, line, stopped, atTrap, perCycle, renderStates(pid, states, trapPCs))
+						Expect(atTrap).To(BeNumerically(">=", 2),
+							"cycle %d: NON-VACUITY FAILED — fewer than two threads are parked ON a marker "+
+								"instruction (MARK_A=0x%x MARK_B=0x%x), so the step-over that follows "+
+								"cannot overlap a pending sibling breakpoint stop\n%s\n%s",
+							i, addrA, addrB, renderStates(pid, states, trapPCs), j.dump())
 					}
 
 					// THE PROBE. Every stop is a resting point at which BOTH
@@ -293,10 +313,16 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 					armedB := probeArmed(d, srcFile, lineB)
 					if !armedA || !armedB {
 						orphanCycles++
-						lost, lostLine := "A (MARK_A)", lineA
+						lost, lostLine, lostID := "A (MARK_A)", lineA, bpA.ID
 						if armedA {
-							lost, lostLine = "B (MARK_B)", lineB
+							lost, lostLine, lostID = "B (MARK_B)", lineB, bpB.ID
 						}
+						// Independent, strictly READ-ONLY corroboration:
+						// breakpointTable.clear looks the id up in byID before
+						// touching memory, so "not found" confirms the ORIGINAL
+						// entry is gone from the table — it is not an artifact
+						// of the SetBreakpoint probe above.
+						clearErr := d.ClearBreakpoint(lostID)
 						states, _ := procThreadStates(pid)
 						Fail(fmt.Sprintf(
 							"BUG REPRODUCED — breakpoint %s silently orphaned (cycle %d, stop %d of %d)\n\n"+
@@ -315,6 +341,9 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 								"  Probe: SetBreakpoint(%s:%d) SUCCEEDED. It must return\n"+
 								"  errBreakpointExists while the entry is in breakpointTable.byAddr, so\n"+
 								"  breakpoint %s is disarmed in tracee memory and gone from the table.\n"+
+								"  Read-only corroboration: ClearBreakpoint(id=%d) on the ORIGINAL entry\n"+
+								"  returned %v (breakpointTable.clear consults byID before touching\n"+
+								"  memory, so this is independent of the SetBreakpoint probe).\n"+
 								"  The next Continue assigns steppingOverBP to this stop's breakpoint,\n"+
 								"  destroying the last reference to it: it can never fire or be cleared\n"+
 								"  again.\n\n"+
@@ -324,13 +353,15 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 								"STATE\n"+
 								"  stop line=%d  armedA=%v armedB=%v  tracing-stopped=%d\n"+
 								"  cycle=%d/%d stop=%d/%d hitsA=%d hitsB=%d\n"+
+								"  MARK_A=0x%x MARK_B=0x%x\n"+
 								"  /proc thread states:\n%s\n"+
 								"HARNESS JOURNAL\n%s",
 							lost, i, k, perCycle,
-							srcFile, lostLine, lost,
+							srcFile, lostLine, lost, lostID, clearErr,
 							line, armedA, armedB, countStopped(states),
 							i, iters, k, perCycle, hitsA, hitsB,
-							renderStates(pid, states), j.dump()))
+							addrA, addrB,
+							renderStates(pid, states, trapPCs), j.dump()))
 					}
 				}
 
@@ -346,7 +377,7 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 			Expect(probeArmed(d, srcFile, lineA)).To(BeTrue(), "BP A armed at end\n%s", j.dump())
 			Expect(probeArmed(d, srcFile, lineB)).To(BeTrue(), "BP B armed at end\n%s", j.dump())
 
-			Expect(d.Continue()).To(Succeed(), "final Continue")
+			mustContinue(d, "final Continue")
 			ev = awaitEvent(d.Events(), 40*time.Second,
 				protocol.EventProcessExited, protocol.EventBreakpointHit, protocol.EventError)
 			Expect(ev.Kind).To(Equal(protocol.EventProcessExited),
@@ -360,9 +391,10 @@ var _ = Describe("Linux amd64 sibling-breakpoint / step-over overlap (PROOF)", L
 			AddReportEntry("overlap-orphans", orphanCycles)
 			AddReportEntry("overlap-tracing-stopped-min", minStopped)
 			AddReportEntry("overlap-tracing-stopped-max", maxStopped)
+			AddReportEntry("overlap-at-marker-pc-min", minAtTrap)
 			GinkgoWriter.Printf(
-				"OVERLAP PROOF SUMMARY: cycles=%d siblings=%d orphans=%d stopped(min/max)=%d/%d\n",
-				iters, siblings, orphanCycles, minStopped, maxStopped)
+				"OVERLAP PROOF SUMMARY: cycles=%d siblings=%d orphans=%d stopped(min/max)=%d/%d atMarkerPC(min)=%d\n",
+				iters, siblings, orphanCycles, minStopped, maxStopped, minAtTrap)
 		})
 })
 
@@ -395,17 +427,51 @@ func newOverlapDebugger(bin string, args []string) debugger.Debugger {
 //	                       accidental new entry is cleared again so the failure
 //	                       report describes the engine's state, not the probe's
 //
-// Any other error fails the spec: the probe itself must be trustworthy.
+// The membership check in breakpointTable.set happens BEFORE it reads or writes
+// tracee memory, so the observation itself cannot be an artifact of the probe.
+// Any other error fails the spec: the probe must be trustworthy.
+//
+// Bounded: a wedged engine must fail the spec, not hang it.
 func probeArmed(d debugger.Debugger, file string, line int) bool {
 	GinkgoHelper()
-	bp, err := d.SetBreakpoint(file, line)
-	if err != nil {
-		Expect(err.Error()).To(ContainSubstring("already installed"),
-			"probe SetBreakpoint(%s:%d) returned an unexpected error", file, line)
-		return true
+	type result struct {
+		bp  protocol.Breakpoint
+		err error
 	}
-	_ = d.ClearBreakpoint(bp.ID)
-	return false
+	ch := make(chan result, 1)
+	go func() {
+		bp, err := d.SetBreakpoint(file, line)
+		ch <- result{bp, err}
+	}()
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			Expect(r.err.Error()).To(ContainSubstring("already installed"),
+				"probe SetBreakpoint(%s:%d) returned an unexpected error", file, line)
+			return true
+		}
+		_ = d.ClearBreakpoint(r.bp.ID)
+		return false
+	case <-time.After(20 * time.Second):
+		Fail(fmt.Sprintf("TIMEOUT after 20s in probe SetBreakpoint(%s:%d) — engine wedged", file, line))
+		return false
+	}
+}
+
+// mustContinue issues Continue with a watchdog. awaitEvent bounds the wait for
+// the resulting event, but a wedged engine loop would otherwise hang inside the
+// synchronous dispatch itself, with no timeout at all.
+func mustContinue(d debugger.Debugger, format string, args ...any) {
+	GinkgoHelper()
+	ch := make(chan error, 1)
+	go func() { ch <- d.Continue() }()
+	select {
+	case err := <-ch:
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf(format, args...))
+	case <-time.After(20 * time.Second):
+		Fail(fmt.Sprintf("TIMEOUT after 20s in Continue (%s) — engine wedged",
+			fmt.Sprintf(format, args...)))
+	}
 }
 
 func hitLine(ev protocol.Event) int {
@@ -514,31 +580,100 @@ func waitForTracingStops(pid, want int, timeout time.Duration) ([]threadState, i
 
 // procPC reads the stopped thread's instruction pointer from
 // /proc/<pid>/task/<tid>/syscall, whose last field is the PC. It is only
-// meaningful for a stopped task; "running" or an unreadable file yields "".
-// Purely diagnostic: it lets a reader confirm that the parked siblings all sit
-// at the same marker address.
-func procPC(pid int, tid string) string {
+// meaningful for a stopped task; "running" or an unreadable file yields 0.
+func procPC(pid int, tid string) uint64 {
 	raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/task/%s/syscall", pid, tid))
 	if err != nil {
-		return ""
+		return 0
 	}
 	fields := strings.Fields(string(raw))
 	if len(fields) < 2 {
-		return ""
+		return 0
 	}
-	return fields[len(fields)-1]
+	pc, err := strconv.ParseUint(strings.TrimPrefix(fields[len(fields)-1], "0x"), 16, 64)
+	if err != nil {
+		return 0
+	}
+	return pc
 }
 
-func renderStates(pid int, states []threadState) string {
+// countAtTrap counts threads that are BOTH in tracing-stop AND parked on a
+// marker instruction. This is what makes the non-vacuity guard meaningful: an
+// unrelated SIGURG / clone-event / group stop lands on some other PC and is not
+// counted.
+func countAtTrap(pid int, states []threadState, trapPCs map[uint64]string) int {
+	n := 0
+	for _, s := range states {
+		if !s.stopped() {
+			continue
+		}
+		if _, ok := trapPCs[procPC(pid, s.TID)]; ok {
+			n++
+		}
+	}
+	return n
+}
+
+func renderStates(pid int, states []threadState, trapPCs map[uint64]string) string {
 	var b strings.Builder
 	for _, s := range states {
-		fmt.Fprintf(&b, "  tid=%-8s state=%-18s pc=%-20s name=%s\n",
-			s.TID, s.State, procPC(pid, s.TID), s.Name)
+		pc := procPC(pid, s.TID)
+		at := trapPCs[pc]
+		if at == "" {
+			at = "-"
+		}
+		fmt.Fprintf(&b, "  tid=%-8s state=%-18s pc=0x%-14x at=%-20s name=%s\n",
+			s.TID, s.State, pc, at, s.Name)
 	}
 	if b.Len() == 0 {
 		return "  <no /proc data>\n"
 	}
 	return b.String()
+}
+
+// elfAddrForLine resolves file:line to a text address by reading the target
+// binary's own DWARF line table, mirroring dwarfReader.PCForFileLine (first
+// is-stmt row whose file name has the given suffix). Go test binaries and
+// targets are non-PIE, so the DWARF address is also the runtime address, which
+// is what /proc reports. Test-side only — it exists so the non-vacuity check
+// can name the exact instruction the parked threads must be sitting on.
+func elfAddrForLine(bin, file string, line int) uint64 {
+	GinkgoHelper()
+	f, err := elf.Open(bin)
+	Expect(err).NotTo(HaveOccurred(), "open target ELF")
+	defer func() { _ = f.Close() }()
+
+	data, err := f.DWARF()
+	Expect(err).NotTo(HaveOccurred(), "read target DWARF")
+
+	rd := data.Reader()
+	for {
+		entry, err := rd.Next()
+		if err != nil || entry == nil {
+			break
+		}
+		if entry.Tag != dwarf.TagCompileUnit {
+			continue
+		}
+		lr, err := data.LineReader(entry)
+		if err != nil || lr == nil {
+			continue
+		}
+		var le dwarf.LineEntry
+		for {
+			if err := lr.Next(&le); err != nil {
+				break
+			}
+			if le.Line != line || !le.IsStmt || le.File == nil {
+				continue
+			}
+			if strings.HasSuffix(le.File.Name, file) {
+				return le.Address
+			}
+		}
+	}
+	Fail(fmt.Sprintf("no DWARF is-stmt address for %s:%d in %s", file, line, bin))
+	return 0
 }
 
 // --- harness journal ---


### PR DESCRIPTION
Fixes #198.

## The bug

`engine.resumeFromBreakpoint` restores a breakpoint's original bytes, drops the entry from the breakpoint table and single-steps one thread; only the resulting `StopSingleStep` puts the trap back. Linux ptrace stops are per-thread and bingo does not stop the world, so siblings keep running while the engine is suspended and can be sitting in their own unreaped `INT3` stops.

A process-wide `Wait4(-1, WALL)` **consumed** such a status inside that window and handed the engine a `StopBreakpoint` it could not act on. `handleStop`'s `StopBreakpoint` branch overwrote `lastBP`/`lastBPTID` while `steppingOverBP` still held the half-stepped entry, and the next `Continue` overwrote that last reference. Two harms:

1. **Silent, unrecoverable loss of a user breakpoint** — disarmed in memory, gone from `byID`/`byAddr`: never fires again, and `ClearBreakpoint` returns `not found`.
2. **Mid-instruction resume** — when the sibling had parked on the *same* address being stepped, the table lookup missed, so `handleStop` took the spurious-SIGTRAP path, which skips `rewindToBreakpoint`, and the thread was resumed one byte into the restored multi-byte instruction.

This is a **shared-engine** gap, not a linux quirk: darwin's default backend papers over it in `Wait`, but its `BINGO_DARWIN_ATOMIC_STEPOVER=0` ablation path returns exactly the same shape.

## The fix

**Backend — the root cause.** While a single-step is in flight, target `wait4` at the stepping thread instead of any thread (`waitTarget`). Sibling statuses then stay queued in the kernel — nothing is lost — and surface on the next process-wide wait with the trap reinstalled. `ECHILD` from the targeted wait means the stepping thread is gone, so it clears the step state and falls back to `Wait4(-1)`: the waitLoop must remain the sole reaper of every thread's death for `Kill` (#111).

**Engine — defense in depth.** Reinstall an in-flight `steppingOverBP` in the `StopBreakpoint` branch, mirroring the existing `StopSignal` branch. Backends that can still deliver a sibling stop mid-step-over then degrade to a correctly-reported hit instead of a lost breakpoint. Rearming **before** `bps.atAddr` is load-bearing — it is what makes the same-address case resolve to a real hit rather than the spurious-SIGTRAP path — so it must not be reordered below the lookup.

## Evidence: A/B on native hosted CI

Identical `overlap` spec, ubuntu-24.04, real ptrace.

| Branch | Production code | `E2E overlap` |
| --- | --- | --- |
| [`scratch-198-unfixed`](https://github.com/bingosuite/bingo/tree/scratch-198-unfixed) ([run](https://github.com/bingosuite/bingo/actions/runs/31325539248)) | `main` @ `0509b53` | **fails in 2.7s** |
| this branch ([run](https://github.com/bingosuite/bingo/actions/runs/31325537802)) | with the fix | **passes** |

Unfixed control, verbatim:

```
DEBUG StopBreakpoint pc=0x4b00be found=false steppingOverBP=true
WARN  spurious SIGTRAP — advancing PC past BRK and resuming pc=0x4b00be   (x2)
DEBUG StopBreakpoint pc=0x4b007e found=true  steppingOverBP=true
[FAILED] breakpoint B (MARK_B) was silently orphaned by a sibling stop during a step-over
  Probe: SetBreakpoint(overlap_target.go:25) SUCCEEDED.
  Read-only corroboration: ClearBreakpoint(id=2) returned "breakpoint 2 not found".
  armedA=true armedB=false   atMarkerPC(max)=4
```

With the fix, all four jobs are green and **every existing spec still passes** (basic, churn, pause, stepping, inspect, breakpoints, kill, exit, attach, concurrency, fullstack, restart, dap; darwin compiles + codesigns). The new spec reports `stops=150 hitsA=30 hitsB=120 atMarkerPC(max)=4 overlapReady=120/150` — i.e. 120 of 150 stops genuinely had a sibling parked on a marker instruction, and every one of the 150 marker calls was caught.

The bug also reproduced 4/4 and 3/4 on earlier runs ([31324476072](https://github.com/bingosuite/bingo/actions/runs/31324476072), [31323980359](https://github.com/bingosuite/bingo/actions/runs/31323980359)), including **without `-race`**.

## The test

`overlap`-labelled, linux-only, wired into the existing `Linux amd64 (ptrace)` job. One pinned thread hammers `MARK_A` while N pinned siblings hammer `MARK_B` (so siblings also cover the same-address case). After **every** stop it asserts both breakpoints are still installed; `breakpointTable.set` consults `byAddr` before touching tracee memory, so a successful `SetBreakpoint` cannot be an artifact of the probe, and a detection is corroborated read-only via `ClearBreakpoint` on the original id.

Non-vacuity is enforced, not assumed: at every stop it reads `/proc/<pid>/task/*/status` plus each thread's stopped PC from `/proc/<pid>/task/<tid>/syscall` and counts threads parked **on** a marker instruction — addresses resolved from the target's own DWARF, matched at `addr` or `addr+1` since an amd64 `INT3` stop leaves RIP one byte past the trap. A run that never reached two is rejected.

## Notes for review

- The pre-existing spurious-SIGTRAP pass is only PC-neutral **on amd64**, because `archRewindPC` (−1) and `len(archTrapInstruction())` (+1) cancel. A future linux/arm64 backend would advance by 4 and skip an instruction. Flagged in the commit message and worth its own issue if that port ever happens.
- **Out of scope, deliberately:** while a trap is lifted for a step-over, a thread executing that same address can still miss the breakpoint. That is inherent to software breakpoints without a stop-the-world and predates this change, so the spec counts hits for non-vacuity but never requires a particular total.
- Two independent adversarial reviews confirmed the causal chain and the detector. They split on the remedy — one accepted the engine-side rearm alone, the other blocked it as incomplete because it abandons an in-flight `PTRACE_SINGLESTEP`. This PR takes the union: fix the root cause in the backend *and* keep the engine rearm for backends that can still deliver such a stop.
- `AGENTS.md` is updated in the same commit (step-over atomicity invariant, the linux targeted wait, and the new label), per the repo's drift rule.
- `scratch-198-unfixed` is the A/B control branch and can be deleted after review.
