### PR TITLE
fix(hub): own stable logical breakpoint ids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1368,9 +1368,24 @@ no-breakpoint target, not a clear-then-continue.
 id (`installedID`). After `EventRestarted`, reconcile its exact source-path/line
 keys from `RestartedPayload` before replying: retained entries adopt the fresh
 debugger id, while discarded entries are removed and emit a `breakpoint` changed
-event with their prior DAP id and `verified:false`. A line with an op in flight
-is skipped — that op still owns the line and its confirmation is still queued.
-Do not reset `setQ`/`clearQ`; those FIFOs still own any in-flight confirmations.
+event with their prior DAP id and `verified:false`. A line with an operation in
+flight is re-identified **too** — correlation rides the queued `*bpOp`, not
+`installedID`, so adopting the fresh id cannot desynchronise the FIFOs, whereas
+keeping the pre-restart id would strand the line on an identifier the new engine
+never issued (the already-marshalled clear fails, retain-on-failure reissues that
+dead id forever, and the real new breakpoint becomes unremovable). Only a line
+with `installedID == 0` is skipped: it owns no identity yet, so a payload entry
+for it describes another driver's breakpoint. Do not reset `setQ`/`clearQ`; those
+FIFOs still own any in-flight confirmations.
+
+**This transaction depends on reliable ordinary-command delivery** (#160 / #162).
+There are deliberately no adapter-side timeouts — inventing one would mask
+command loss and could fire against a merely slow debugger. A silently dropped
+`SetBreakpoint`/`ClearBreakpoint` therefore produces no confirmation, which now
+latches that line's `pending` forever: no further operation can be issued for it
+and the owning request is never answered. The adapter side of the contract is
+covered here (it blocks rather than drops, and wire order matches slot-reservation
+order); the hub side is `injectCommand`'s admission.
 
 ### Server wiring + multi-client discovery
 
@@ -1513,8 +1528,9 @@ translator keeps DAP entirely outside the hub — a strictly additive package.
   breakpoint transaction: a rejected clear retains the id and fails its request,
   partial clear failure, a superseded pending set clears exactly once, an
   overlapping pending set issues one command, set→remove→re-add leaves one live
-  breakpoint, cross-source independence, restart around an in-flight op,
-  exactly-once responses). Run with the normal
+  breakpoint, cross-source independence, restart re-identification with an
+  in-flight operation, no-drop/in-order command delivery, exactly-once
+  responses). Run with the normal
   `go test -tags bingonative ./internal/dap/...`.
 - E2E: label `dap` in [test/integration](test/integration/) — a real go-dap
   client over TCP through the WHOLE stack (client → TCP →

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1328,8 +1328,18 @@ legitimately disagree:
   `EventBreakpointSet` and dropped **only** by a confirmed
   `EventBreakpointCleared`. Never on intent.
 - `desired` — the newest request's intent for that line (latest wins).
-- `pending` — the single in-flight `bpOp` for that line. One op per line at a
+- `pending` — the single LIVE `bpOp` for that line. One live op per line at a
   time is what keeps the id-less `setQ`/`clearQ` FIFOs unambiguous.
+
+An operation is **abandoned** when a restart discards its line: it stops being
+that line's `pending` op (so the line can converge again immediately instead of
+latching behind a removal that already happened), but it keeps its place in the
+FIFO, because the debugger will still answer it and that answer must pop the head
+it reserved or every later confirmation correlates to the wrong request.
+`liveLineLocked` is the gate — it matches the popped op against the line's
+current `pending`, so an abandoned (or superseded, or forgotten) op's answer does
+exactly one thing: pop. It never settles waiters, fails owners, or writes state
+that now belongs to a re-identified line.
 
 `advanceLineLocked` is the convergence loop: it issues the one command the
 installed/desired gap calls for, or settles everyone parked on the line when the
@@ -1343,6 +1353,9 @@ two already agree. Every confirmation re-enters it, which yields the invariants:
   leave a breakpoint the client can never remove — `breakpointTable.clear` keeps
   the entry when the memory write fails, so the trap really is still armed. The
   failure path deliberately does not re-enter the loop; a new request retries.
+  That no-retry rule is justified **only** while the line is still armed: with
+  nothing armed there is nothing to retry and nothing to report, so the removal
+  completes successfully and the line resumes converging rather than stalling.
 - A **pending Set superseded before it confirms** is cancelled on confirm: the id
   is recorded as a fact (the trap IS armed) but `desired` stays false, so the
   next advance clears it immediately. It is never committed as desired state.
@@ -1375,8 +1388,12 @@ keeping the pre-restart id would strand the line on an identifier the new engine
 never issued (the already-marshalled clear fails, retain-on-failure reissues that
 dead id forever, and the real new breakpoint becomes unremovable). Only a line
 with `installedID == 0` is skipped: it owns no identity yet, so a payload entry
-for it describes another driver's breakpoint. Do not reset `setQ`/`clearQ`; those
-FIFOs still own any in-flight confirmations.
+for it describes another driver's breakpoint. A **discarded** line goes further:
+it abandons its in-flight operation (see above) — the command was addressed to a
+breakpoint the relaunched process no longer has, so its answer can only be stale,
+and leaving it live would latch the line behind a removal that already happened.
+Do not reset `setQ`/`clearQ`; those FIFOs still own any in-flight confirmations,
+abandoned ones included.
 
 **This transaction depends on reliable ordinary-command delivery** (#160 / #162).
 There are deliberately no adapter-side timeouts — inventing one would mask
@@ -1529,8 +1546,9 @@ translator keeps DAP entirely outside the hub — a strictly additive package.
   partial clear failure, a superseded pending set clears exactly once, an
   overlapping pending set issues one command, set→remove→re-add leaves one live
   breakpoint, cross-source independence, restart re-identification with an
-  in-flight operation, no-drop/in-order command delivery, exactly-once
-  responses). Run with the normal
+  in-flight operation, a discarded line abandoning its operation (later set,
+  already-satisfied removal, late stale success), no-drop/in-order command
+  delivery, exactly-once responses). Run with the normal
   `go test -tags bingonative ./internal/dap/...`.
 - E2E: label `dap` in [test/integration](test/integration/) — a real go-dap
   client over TCP through the WHOLE stack (client → TCP →

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1318,18 +1318,59 @@ connection on sustained overload. Never replace overload eviction with an
 uncorrelated bingo error event — the adapter cannot identify a dropped tail
 slot, so such an event could consume the wrong FIFO head.
 
-**setBreakpoints is replace-all** (`breakpoints.go`): diff the requested lines
-for a source against `bpByFile` — clear removed, set new, keep unchanged — and
-respond once every slot in the request resolves, in request order. Clearing the
-breakpoint the process is currently parked on is supported by the engine and
-pinned by the native `breakpoints` acceptance test on both platforms.
+**setBreakpoints is a replace-all TRANSACTION** (`breakpoints.go`): a request
+records the source's latest-wins intent and is answered only once every operation
+it owns has been confirmed. `bpByFile` is `file → line → *bpLine`, and `bpLine`
+deliberately keeps three things apart, because pipelined requests make them
+legitimately disagree:
 
-`bpByFile` keeps the stable DAP id separate from the debugger's internal id.
-After `EventRestarted`, reconcile its exact source-path/line keys from
-`RestartedPayload` before replying: retained entries adopt the fresh debugger
-id, while discarded entries are removed and emit a `breakpoint` changed event
-with their prior DAP id and `verified:false`. Do not reset `setQ`/`clearQ`;
-those FIFOs still own any in-flight confirmations.
+- `installedID` — an installed FACT. Written **only** by a confirmed
+  `EventBreakpointSet` and dropped **only** by a confirmed
+  `EventBreakpointCleared`. Never on intent.
+- `desired` — the newest request's intent for that line (latest wins).
+- `pending` — the single in-flight `bpOp` for that line. One op per line at a
+  time is what keeps the id-less `setQ`/`clearQ` FIFOs unambiguous.
+
+`advanceLineLocked` is the convergence loop: it issues the one command the
+installed/desired gap calls for, or settles everyone parked on the line when the
+two already agree. Every confirmation re-enters it, which yields the invariants:
+
+- A **removal is owned by the request that caused it** (`openClears` +
+  `clearOwners`), so a response never precedes its own clears. A remove-all no
+  longer reports success while the `ClearBreakpoint` is still in flight.
+- A **rejected clear retains the mapping** and fails the originating request
+  (`clearFailure` → an error `setBreakpoints` response). Forgetting the id would
+  leave a breakpoint the client can never remove — `breakpointTable.clear` keeps
+  the entry when the memory write fails, so the trap really is still armed. The
+  failure path deliberately does not re-enter the loop; a new request retries.
+- A **pending Set superseded before it confirms** is cancelled on confirm: the id
+  is recorded as a fact (the trap IS armed) but `desired` stays false, so the
+  next advance clears it immediately. It is never committed as desired state.
+- An **overlapping request wanting an already-pending line attaches** to that op
+  (another `setWaiter`) instead of issuing a duplicate `CmdSetBreakpoint`, which
+  the engine would reject with `errBreakpointExists` — and whose failure handling
+  used to delete the entry holding the live id.
+- **Exactly one response per request** (`bpRequest.ready()` claims the right to
+  answer; slots and obligations settle on different goroutines), and requests are
+  answered in `reqSeq` order so a later request's view lands last.
+- Sources are independent; the id-less FIFO limitation is unchanged.
+
+Breakpoint commands are staged in `outbox` and drained by `flushCommands`
+(serialised by `flushMu`) rather than enqueued directly: both the DAP read loop
+and the hub write pump produce them, and the FIFOs only correlate if the wire
+order matches the order slots were reserved under `mu`.
+
+Clearing the breakpoint the process is currently parked on re-arms it through the
+engine's step-off path (see the clearbp spec), so the e2e continue-to-exit uses a
+no-breakpoint target, not a clear-then-continue.
+
+`bpLine` keeps the stable DAP id (`dapID`) separate from the debugger's internal
+id (`installedID`). After `EventRestarted`, reconcile its exact source-path/line
+keys from `RestartedPayload` before replying: retained entries adopt the fresh
+debugger id, while discarded entries are removed and emit a `breakpoint` changed
+event with their prior DAP id and `verified:false`. A line with an op in flight
+is skipped — that op still owns the line and its confirmation is still queued.
+Do not reset `setQ`/`clearQ`; those FIFOs still own any in-flight confirmations.
 
 ### Server wiring + multi-client discovery
 
@@ -1463,11 +1504,17 @@ translator keeps DAP entirely outside the hub — a strictly additive package.
 ### Tests
 
 - Unit: [internal/dap/translate_test.go](internal/dap/translate_test.go) (pure
-  translators) and [internal/dap/handler_test.go](internal/dap/handler_test.go)
+  translators), [internal/dap/handler_test.go](internal/dap/handler_test.go)
   (full handshake over loopback TCP + a fake `Session`/`Provider` + a command
   recorder: handshake→breakpoint, own-continue-suppressed, out-of-band-continue-
   surfaced, setBreakpoints diff/FIFO, stackTrace/variables correlation,
-  step→stopped=step, disconnect-terminates). Run with the normal
+  step→stopped=step, disconnect-terminates), and
+  [internal/dap/breakpoints_test.go](internal/dap/breakpoints_test.go) (the
+  breakpoint transaction: a rejected clear retains the id and fails its request,
+  partial clear failure, a superseded pending set clears exactly once, an
+  overlapping pending set issues one command, set→remove→re-add leaves one live
+  breakpoint, cross-source independence, restart around an in-flight op,
+  exactly-once responses). Run with the normal
   `go test -tags bingonative ./internal/dap/...`.
 - E2E: label `dap` in [test/integration](test/integration/) — a real go-dap
   client over TCP through the WHOLE stack (client → TCP →

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -826,13 +826,15 @@ gone once killed:
   Launch, or the session was started via `Attach` — mirrors Delve's
   `canRestart`: there's no "same binary" to relaunch for an attached process).
   Set on `CmdLaunch` success, cleared on `CmdAttach` success.
-- `h.restartBreakpoints map[int]protocol.Location` — id → location for every
-  breakpoint currently believed installed. Updated on `CmdSetBreakpoint` /
-  `CmdClearBreakpoint` success, reset on `CmdLaunch`/`CmdAttach`. Restart
-  reinstalls these (sorted by id for determinism) via `SetBreakpoint` on the
-  new `Debugger`, which re-resolves each `file:line` through DWARF against the
-  new process image — addresses aren't reused directly since a relaunch can
-  shift the load address.
+- `h.bps *breakpointIDs` — the logical-id table (see
+  [Breakpoint identity](#breakpoint-identity--hub-owned-logical-ids)). Restart
+  walks `sortedLogical()` for determinism, re-`SetBreakpoint`s each retained
+  location on the new `Debugger` (which re-resolves `file:line` through DWARF
+  against the new process image — addresses aren't reused directly since a
+  relaunch can shift the load address), `bind`s the logical id to the fresh
+  physical id, and reports the **same logical ids** in `RestartedPayload`.
+  Locations that no longer resolve lose their mapping and are reported in
+  `Discarded`.
 
 **Routing quirk**: `CmdRestart` intentionally does **not** go through
 `resumeCh` like `CmdContinue`/`CmdStep*`. `resumeCh` is only ever drained
@@ -860,6 +862,86 @@ see [Suspend/resume protocol](#suspendresume-protocol).
 suspending one — the new process's suspended state (if any, e.g. break-on-
 entry) is reported the normal way via `EventStepped`/`EventBreakpointHit` once
 the relaunched process actually reaches that point.
+
+## Breakpoint identity — hub-owned logical ids
+
+Source: [internal/hub/breakpoints.go](internal/hub/breakpoints.go).
+
+**Client-visible breakpoint ids are hub-owned logical ids, never raw engine
+ids.** `breakpointTable.nextID` (`internal/debugger/breakpoint.go`) restarts at
+1 in every engine, so a physical id only means anything to the engine that
+issued it — and Restart replaces that engine. A command can be *generated*
+against one engine and *injected* after it has been replaced: the DAP adapter
+marshals a `ClearBreakpoint` and its hub read pump is descheduled between
+`Handler.ReadMessage` and `injectCommand`
+([internal/hub/client.go](internal/hub/client.go)) while another client
+completes a Restart. The stale physical id then names a *different* breakpoint
+in the fresh process and disarms the wrong trap (issue #200).
+
+An epoch stamped at `injectCommand` is **provably insufficient** — provenance is
+bound when the Handler generates the bytes, but injection happens after the
+Restart and would read the new epoch. So the hub owns identity instead:
+
+- `breakpointIDs.next` is monotonic for the **whole hub lifetime**. `reset()`
+  (a fresh `Launch`/`Attach`) drops the mappings but deliberately does **not**
+  rewind the high-water mark; re-minting is exactly what would let a delayed
+  command from a previous target alias a breakpoint in the new one.
+- `byLogical` maps logical → `{physicalID, loc}`; `byPhysical` is the reverse
+  lookup engine-generated events need. `dropPhysical` only deletes a reverse
+  entry while it still points at the given logical id, so re-homing on Restart
+  cannot clobber another breakpoint's lookup.
+- `CmdSetBreakpoint` installs, then mints a logical id and broadcasts
+  `EventBreakpointSet` with it (`Hub.setBreakpoint`).
+- `CmdClearBreakpoint` (`Hub.clearBreakpoint`) rejects an unknown logical id
+  **without touching the debugger** — that is the load-bearing half of the fix —
+  translates a known one to the active physical id, and only `untrack`s after
+  the debugger confirms. **No optimistic deletion:** a rejected clear leaves the
+  trap armed (`breakpointTable.clear` keeps its entry when the memory write
+  fails), so the client must keep being able to name it.
+- `Hub.localizeBreakpointIDs` rewrites the physical id in an engine-generated
+  `EventBreakpointHit` to the logical id before broadcast. It runs on both
+  broadcast paths in `handleEvent` (the initial event and the suspended
+  wait-loop's `nextEvt`). The step-over/step-out sentinels (`<stepover-next>`,
+  `<stepout-return>`) report `EventStepped` and carry no breakpoint id, so they
+  are unaffected; the test-only `<direct-addr>` sentinel does emit
+  `EventBreakpointHit` and is translated like any other.
+- A hit can **race its own clear**. The engine emits into a buffered channel and
+  `engine.ClearBreakpoint` has no suspend guard, so `Run`'s `select` may execute
+  a queued clear before draining a hit that was generated first. `untrack`
+  therefore `retire`s the physical id, and `logicalFor` consults that record so
+  the late hit still reports the id the client held instead of a number it was
+  never told about. The record is per-engine (dropped by `reset()`) and bounded
+  by `retiredCap`; only a very recent retirement can still be in flight.
+- A physical id that is neither live nor retired is **adopted** rather than
+  passed through (`logicalFor`): passing it through could collide with a logical
+  id naming a different breakpoint. This keeps raw `hub.New` hubs (tests /
+  single-session, where a debugger may be driven directly) coherent. An adopted
+  mapping is **not** `installed`, so `installedLogical` excludes it from
+  `sortedRestartTargets` — the hub never armed it and must not arm it on the
+  replacement process.
+
+Every protocol surface carrying a breakpoint id is covered:
+`BreakpointSetPayload.Breakpoint.ID`, `BreakpointClearedPayload.ID`,
+`BreakpointHitPayload.Breakpoint.ID`, `RestartedPayload.Breakpoints[].ID`, and
+the inbound `ClearBreakpointPayload.ID`. Because breakpoint ids cross this
+translation boundary, `CmdSetBreakpoint`/`CmdClearBreakpoint` are **absent from
+the generic `dispatch`** in [dispatcher.go](internal/hub/dispatcher.go) —
+`Hub.dispatchCommand` routes them to the hub methods, and reaching `dispatch`
+with one means routing was bypassed, so it errors rather than handing a
+client-supplied id to the engine.
+
+The wire shape is unchanged (ids were already opaque ints); only ownership and
+lifetime changed, so `protocol.Version` stays at 1.2. On the DAP side this makes
+the positional `setQ`/`clearQ` FIFOs correlate confirmations that match the
+actual physical effect, and `reconcileRestartBreakpointsLocked` a self-consistent
+re-identification.
+
+Regression coverage:
+[internal/dap/hublogicalbp_test.go](internal/dap/hublogicalbp_test.go) drives a
+**real** `hub.Hub` + **real** `dap.Handler` with a gating `hub.WSConn`
+interposed at the `ReadMessage` → read-pump boundary; it holds a generated
+clear, restarts via a second client, releases it, and asserts the correct
+physical breakpoint was disarmed (plus an in-order negative control).
 
 ## Pause — async interrupt
 
@@ -2008,6 +2090,15 @@ through the justfile.
   unless they're truly required. Preserve the streaming-cadence invariant
   (snapshot on breakpoint/pause/entry, never per-step) and the degraded-snapshot
   rule (don't touch `prevGoids` on an unreadable read).
+- **Breakpoint ids**: client-visible ids are the hub's session-stable logical
+  ids (see
+  [Breakpoint identity](#breakpoint-identity--hub-owned-logical-ids)). A new
+  protocol surface carrying a breakpoint id must be translated in
+  [internal/hub/breakpoints.go](internal/hub/breakpoints.go) — outbound
+  physical→logical, inbound logical→physical — and an unknown inbound id must be
+  rejected without reaching the debugger. Never rewind
+  `breakpointIDs.next`, never delete a mapping before the debugger confirms the
+  removal, and never leak a raw engine id to clients.
 - **Suspend/resume sets**: update both `suspendingEvents` and
   `resumingCommands` in [hub.go](internal/hub/hub.go), and the matching
   hub_test cases.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -828,7 +828,9 @@ gone once killed:
   Set on `CmdLaunch` success, cleared on `CmdAttach` success.
 - `h.bps *breakpointIDs` — the logical-id table (see
   [Breakpoint identity](#breakpoint-identity--hub-owned-logical-ids)). Restart
-  walks `sortedLogical()` for determinism, re-`SetBreakpoint`s each retained
+  `reset`s it, then walks the `sortedRestartTargets()` snapshot (the
+  `installedLogical()` set, sorted for determinism) taken *before* the reset,
+  re-`SetBreakpoint`s each retained
   location on the new `Debugger` (which re-resolves `file:line` through DWARF
   against the new process image — addresses aren't reused directly since a
   relaunch can shift the load address), `bind`s the logical id to the fresh
@@ -883,7 +885,8 @@ bound when the Handler generates the bytes, but injection happens after the
 Restart and would read the new epoch. So the hub owns identity instead:
 
 - `breakpointIDs.next` is monotonic for the **whole hub lifetime**. `reset()`
-  (a fresh `Launch`/`Attach`) drops the mappings but deliberately does **not**
+  (a fresh `Launch`/`Attach`, and the engine swap inside `Restart`) drops the
+  mappings but deliberately does **not**
   rewind the high-water mark; re-minting is exactly what would let a delayed
   command from a previous target alias a breakpoint in the new one.
 - `byLogical` maps logical → `{physicalID, loc}`; `byPhysical` is the reverse
@@ -905,13 +908,31 @@ Restart and would read the new epoch. So the hub owns identity instead:
   `<stepout-return>`) report `EventStepped` and carry no breakpoint id, so they
   are unaffected; the test-only `<direct-addr>` sentinel does emit
   `EventBreakpointHit` and is translated like any other.
-- A hit can **race its own clear**. The engine emits into a buffered channel and
+- A hit can **race its own clear**, and a cleared breakpoint can be **resurrected
+  by the engine**. The engine emits into a buffered channel and
   `engine.ClearBreakpoint` has no suspend guard, so `Run`'s `select` may execute
-  a queued clear before draining a hit that was generated first. `untrack`
-  therefore `retire`s the physical id, and `logicalFor` consults that record so
-  the late hit still reports the id the client held instead of a number it was
-  never told about. The record is per-engine (dropped by `reset()`) and bounded
-  by `retiredCap`; only a very recent retirement can still be in flight.
+  a queued clear before draining a hit that was generated first; separately,
+  clearing the breakpoint the tracee is *parked on* is re-armed under the **same
+  physical id** by the step-off path (`resumeFromBreakpoint` replays the
+  `e.lastBP` it stashed at hit time rather than re-reading the table, and
+  `breakpointTable.reinstall` re-adds the entry under its original id). `untrack`
+  therefore `retire`s the pair into a **bidirectional tombstone**:
+  `retiredLogical` (physical→logical) lets `logicalFor` report a late or
+  resurrected hit under the id the client held instead of a number it was never
+  told about, and `retiredPhysical` (logical→physical) lets `physicalForClear`
+  keep honouring a `CmdClearBreakpoint` for that id. Without the second
+  direction a resurrected trap is reported under a logical id that
+  `CmdClearBreakpoint` then rejects (it is no longer in `byLogical`) *and*
+  `CmdSetBreakpoint` cannot replace (the engine still holds the address, so it
+  fails `errBreakpointExists`) — a phantom breakpoint that is permanently
+  neither removable nor settable. A tombstone-clear is deliberately **not**
+  consumed (`untrack` no-ops on an already-retired id) because the tracee may
+  still be parked there and resurrect it again.
+  The record is per-engine and bounded
+  by `retiredCap`; only a very recent retirement can still be in flight. It is
+  safe precisely because `breakpointTable.set` never reuses a physical id within
+  one engine, and because `reset()` purges it on every Launch/Attach/Restart — a
+  tombstone that outlived its engine would reintroduce exactly the #200 alias.
 - A physical id that is neither live nor retired is **adopted** rather than
   passed through (`logicalFor`): passing it through could collide with a logical
   id naming a different breakpoint. This keeps raw `hub.New` hubs (tests /
@@ -919,6 +940,22 @@ Restart and would read the new epoch. So the hub owns identity instead:
   mapping is **not** `installed`, so `installedLogical` excludes it from
   `sortedRestartTargets` — the hub never armed it and must not arm it on the
   replacement process.
+- A fresh out-of-band `Launch`/`Attach` (a *second* client relaunching a session
+  another client is driving) invalidates every logical id: the mappings are
+  reset while the high-water mark advances, so an id minted against the previous
+  target can never name a breakpoint in the new one. A client still holding old
+  ids gets a clean `EventError` ("breakpoint N not found") on its next
+  `CmdClearBreakpoint` instead of silently disarming a stranger's breakpoint —
+  the pre-fix behaviour, where a raw physical id aliased whatever the fresh
+  engine had compacted into that slot. It is therefore a strict improvement, not
+  a regression, but it is **not** transparent: a DAP adapter whose `bpLine`s
+  still record the pre-Launch ids believes lines are armed that the new process
+  does not have, and only discovers it when a later removal fails. `CmdRestart`
+  is the supported way to relaunch while *preserving* ids, and it is what the
+  DAP `restart` request maps to; a client that drives `CmdLaunch` directly on a
+  shared session owns the reconciliation. An explicit invalidation event is
+  deliberately out of scope here — it is a new protocol surface, and #200 is
+  about not corrupting the ids that *do* survive.
 
 Every protocol surface carrying a breakpoint id is covered:
 `BreakpointSetPayload.Breakpoint.ID`, `BreakpointClearedPayload.ID`,
@@ -941,7 +978,13 @@ Regression coverage:
 **real** `hub.Hub` + **real** `dap.Handler` with a gating `hub.WSConn`
 interposed at the `ReadMessage` → read-pump boundary; it holds a generated
 clear, restarts via a second client, releases it, and asserts the correct
-physical breakpoint was disarmed (plus an in-order negative control).
+physical breakpoint was disarmed (plus an in-order negative control). The held
+request runs on its own goroutine and **must** be joined before the test
+returns — it reports through `t`, which panics the package once the test has
+completed. [internal/hub/breakpoints_test.go](internal/hub/breakpoints_test.go)
+covers the tombstone from both ends: a step-off-resurrected breakpoint stays
+clearable under the id the client holds, and a retired id never reaches a
+replacement engine.
 
 ## Pause — async interrupt
 

--- a/internal/dap/breakpoints.go
+++ b/internal/dap/breakpoints.go
@@ -173,7 +173,11 @@ func (h *Handler) failClearLocked(file string, line int, msg string) []*bpReques
 		return nil
 	}
 	ready := st.dischargeOwners(msg)
-	return append(ready, st.resolveSlots()...)
+	ready = append(ready, st.resolveSlots()...)
+	// Only reachable when the line is no longer armed (a restart discarded it
+	// under the in-flight clear); a still-armed line is retained by gc.
+	h.gcLineLocked(file, line)
+	return ready
 }
 
 // gcLineLocked forgets a line the adapter has no reason to remember: unwanted,

--- a/internal/dap/breakpoints.go
+++ b/internal/dap/breakpoints.go
@@ -1,17 +1,24 @@
 package dap
 
 import (
+	"sort"
+
 	godap "github.com/google/go-dap"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
 
-// onSetBreakpoints reconciles the debugger's breakpoints for one source with
-// the complete set the client requested (DAP replace-all semantics). It diffs
-// against bpByFile: lines no longer wanted are cleared, new lines are set, and
-// unchanged lines keep their existing id. The response lists one breakpoint per
-// requested line, in request order — pending ones are filled in as their
-// EventBreakpointSet confirmations arrive (see events.go onBreakpointSet).
+// onSetBreakpoints applies DAP replace-all semantics for one source as a
+// transaction over the lines of that source.
+//
+// The request records its intent (latest wins) and then parks on the lines it
+// touches: a slot per requested line, and a removal obligation per line it drops
+// that is still armed or still has an operation in flight. Nothing is answered
+// until every one of those has settled, so a request can never report success
+// while a clear it caused is unconfirmed — which is what makes a rejected clear
+// reportable at all. Convergence itself is driven by advanceLineLocked, one
+// in-flight operation per line, so a line whose Set is already pending attaches
+// the new slot instead of issuing a duplicate.
 //
 // The FIFO correlation assumes the DAP client is the sole breakpoint driver for
 // this session; a WebSocket client concurrently setting breakpoints on the same
@@ -24,66 +31,256 @@ func (h *Handler) onSetBreakpoints(req *godap.SetBreakpointsRequest) {
 		file = src.Name
 	}
 
-	desired := make(map[int]bool, len(req.Arguments.Breakpoints))
-	for _, b := range req.Arguments.Breakpoints {
-		desired[b.Line] = true
-	}
-
-	reqObj := &bpRequest{reqSeq: req.Seq}
-	var clears, sets [][]byte
+	r := &bpRequest{reqSeq: req.Seq}
 
 	h.mu.Lock()
-	current := h.bpByFile[file]
-	if current == nil {
-		current = make(map[int]breakpointState)
-		h.bpByFile[file] = current
+	lines := h.bpByFile[file]
+	if lines == nil {
+		lines = make(map[int]*bpLine)
+		h.bpByFile[file] = lines
 	}
 
-	// Clear breakpoints no longer requested.
-	for line, state := range current {
-		if desired[line] {
-			continue
-		}
-		delete(current, line)
-		if state.debuggerID == 0 {
-			continue // never confirmed; nothing to clear on the debugger
-		}
-		h.clearQ = append(h.clearQ, state.debuggerID)
-		if cmd, err := marshalCommand(protocol.CmdClearBreakpoint, protocol.ClearBreakpointPayload{ID: state.debuggerID}); err == nil {
-			clears = append(clears, cmd)
-		}
-	}
-
-	// Set new lines; keep unchanged ones as already-verified.
+	wanted := make(map[int]bool, len(req.Arguments.Breakpoints))
 	for _, b := range req.Arguments.Breakpoints {
-		slot := &bpSlot{req: reqObj, file: file, line: b.Line}
-		reqObj.slots = append(reqObj.slots, slot)
-
-		if state, ok := current[b.Line]; ok && state.debuggerID != 0 {
-			slot.resolved = true
-			slot.bp = godap.Breakpoint{Id: state.dapID, Verified: true, Line: b.Line, Source: &src}
-			continue
-		}
-
-		current[b.Line] = breakpointState{} // pending sentinel, replaced on confirmation
-		h.setQ = append(h.setQ, slot)
-		if cmd, err := marshalCommand(protocol.CmdSetBreakpoint, protocol.SetBreakpointPayload{File: file, Line: b.Line}); err == nil {
-			sets = append(sets, cmd)
+		wanted[b.Line] = true
+		if lines[b.Line] == nil {
+			lines[b.Line] = &bpLine{}
 		}
 	}
-	allResolved := reqObj.done()
+	for line, st := range lines {
+		st.desired = wanted[line]
+	}
+
+	// One slot per requested line, in request order. A repeated line, or a line
+	// whose Set is already in flight, simply parks another waiter on it.
+	for _, b := range req.Arguments.Breakpoints {
+		slot := &bpSlot{req: r, line: b.Line, source: src}
+		r.slots = append(r.slots, slot)
+		st := lines[b.Line]
+		st.failure = ""
+		st.setWaiters = append(st.setWaiters, slot)
+	}
+
+	// Every dropped line that is still armed — or whose in-flight Set is about
+	// to arm it — is this request's obligation to remove.
+	touched := sortedLines(lines)
+	for _, line := range touched {
+		st := lines[line]
+		if st.desired || (st.installedID == 0 && st.pending == nil) {
+			continue
+		}
+		st.clearOwners = append(st.clearOwners, r)
+		r.openClears++
+	}
+
+	var ready []*bpRequest
+	for _, line := range touched {
+		ready = append(ready, h.advanceLineLocked(file, line)...)
+	}
+	// A request that neither installs nor removes anything (an empty request
+	// for a source with nothing armed) settles on nobody's behalf.
+	if r.ready() {
+		ready = append(ready, r)
+	}
 	h.mu.Unlock()
 
-	for _, c := range clears {
-		h.enqueue(c)
+	h.flushCommands()
+	h.respond(ready)
+}
+
+// sortedLines orders a source's lines so command issue and response assembly are
+// deterministic regardless of map iteration order.
+func sortedLines(lines map[int]*bpLine) []int {
+	out := make([]int, 0, len(lines))
+	for line := range lines {
+		out = append(out, line)
 	}
-	for _, c := range sets {
-		h.enqueue(c)
+	sort.Ints(out)
+	return out
+}
+
+// advanceLineLocked drives one line toward its desired state, issuing the single
+// command the gap calls for; when installed and desired already agree it settles
+// everyone parked on the line instead. A line with an operation in flight is
+// left alone — that operation owns it, and its completion re-enters here, which
+// is how a Set superseded before it confirmed gets cleared the moment its id
+// arrives. Caller MUST hold h.mu.
+func (h *Handler) advanceLineLocked(file string, line int) []*bpRequest {
+	st := h.bpByFile[file][line]
+	if st == nil || st.pending != nil {
+		return nil
 	}
 
-	// A request with only unchanged (or empty) breakpoints has no pending
-	// confirmations, so respond immediately.
-	if allResolved {
-		h.sendSetBreakpointsResponse(reqObj)
+	switch {
+	case st.desired && st.installedID == 0:
+		cmd, err := marshalCommand(protocol.CmdSetBreakpoint, protocol.SetBreakpointPayload{File: file, Line: line})
+		if err != nil {
+			st.desired = false
+			st.failure = err.Error()
+			return h.settleLineLocked(file, line)
+		}
+		st.pending = &bpOp{file: file, line: line}
+		h.setQ = append(h.setQ, st.pending)
+		h.queueCommandLocked(cmd)
+
+	case !st.desired && st.installedID != 0:
+		cmd, err := marshalCommand(protocol.CmdClearBreakpoint, protocol.ClearBreakpointPayload{ID: st.installedID})
+		if err != nil {
+			return h.failClearLocked(file, line, err.Error())
+		}
+		st.pending = &bpOp{file: file, line: line}
+		h.clearQ = append(h.clearQ, st.pending)
+		h.queueCommandLocked(cmd)
+
+	default:
+		return h.settleLineLocked(file, line)
 	}
+	return nil
+}
+
+// settleLineLocked answers everyone parked on a converged line. Removal
+// obligations are discharged once the line is actually gone — or once a later
+// request re-desired it, which supersedes the removal under latest-wins.
+// Caller MUST hold h.mu.
+func (h *Handler) settleLineLocked(file string, line int) []*bpRequest {
+	st := h.bpByFile[file][line]
+	if st == nil {
+		return nil
+	}
+	ready := st.resolveSlots()
+	if st.installedID == 0 || st.desired {
+		ready = append(ready, st.dischargeOwners("")...)
+	}
+	h.gcLineLocked(file, line)
+	return ready
+}
+
+// failClearLocked completes the removal obligations on a line whose clear could
+// not be issued or was rejected, failing their requests. It deliberately does
+// NOT re-enter the convergence loop: the line is still armed and still unwanted,
+// so advancing it again would retry a failing clear forever. The retained
+// mapping means the next setBreakpoints for the source can retry it.
+//
+// Slots parked on the line are answered here too, unconditionally. A failed
+// clear ends the line's only in-flight operation, so this is the last thing that
+// will happen to it until a new request arrives — anything still waiting would
+// otherwise wait forever. That includes an earlier pipelined request whose Set
+// this clear was cancelling: its breakpoint really is armed, so the line's
+// current identity is a truthful answer for it. Caller MUST hold h.mu.
+func (h *Handler) failClearLocked(file string, line int, msg string) []*bpRequest {
+	st := h.bpByFile[file][line]
+	if st == nil {
+		return nil
+	}
+	ready := st.dischargeOwners(msg)
+	return append(ready, st.resolveSlots()...)
+}
+
+// gcLineLocked forgets a line the adapter has no reason to remember: unwanted,
+// nothing armed, nothing in flight, nobody waiting. A line that is still armed
+// is ALWAYS retained even when unwanted — dropping its debugger id would leave a
+// breakpoint no later request could ever remove. Caller MUST hold h.mu.
+func (h *Handler) gcLineLocked(file string, line int) {
+	lines := h.bpByFile[file]
+	st := lines[line]
+	if st == nil {
+		return
+	}
+	if st.desired || st.installedID != 0 || st.pending != nil {
+		return
+	}
+	if len(st.setWaiters) > 0 || len(st.clearOwners) > 0 {
+		return
+	}
+	delete(lines, line)
+}
+
+// resolveSlots answers every requested slot parked on the line from its current
+// installed identity. Caller MUST hold h.mu.
+func (st *bpLine) resolveSlots() []*bpRequest {
+	if len(st.setWaiters) == 0 {
+		return nil
+	}
+	var ready []*bpRequest
+	for _, slot := range st.setWaiters {
+		slot.resolved = true
+		slot.bp = st.breakpoint(slot)
+		if slot.req.ready() {
+			ready = append(ready, slot.req)
+		}
+	}
+	st.setWaiters = nil
+	return ready
+}
+
+// dischargeOwners completes the removal obligations parked on the line. A
+// non-empty failure marks each owning request failed. Caller MUST hold h.mu.
+func (st *bpLine) dischargeOwners(failure string) []*bpRequest {
+	if len(st.clearOwners) == 0 {
+		return nil
+	}
+	var ready []*bpRequest
+	for _, r := range st.clearOwners {
+		if failure != "" && r.clearFailure == "" {
+			r.clearFailure = failure
+		}
+		r.openClears--
+		if r.ready() {
+			ready = append(ready, r)
+		}
+	}
+	st.clearOwners = nil
+	return ready
+}
+
+// breakpoint renders the line's installed identity as the DAP breakpoint
+// reported for one requested slot. The debugger may resolve a request to a
+// different line than asked, so a confirmed location wins over the requested one.
+func (st *bpLine) breakpoint(slot *bpSlot) godap.Breakpoint {
+	source := slot.source
+	if st.installedID == 0 {
+		return godap.Breakpoint{Verified: false, Line: slot.line, Source: &source, Message: st.failure}
+	}
+	line := slot.line
+	resolved := &source
+	if st.loc.Line != 0 {
+		line = st.loc.Line
+	}
+	if s := dapSource(st.loc); s != nil {
+		resolved = s
+	}
+	return godap.Breakpoint{Id: st.dapID, Verified: true, Line: line, Source: resolved}
+}
+
+// respond answers completed requests in request order. Two pipelined requests
+// can complete on the same confirmation, and a DAP client applies responses as
+// they arrive, so the later request must be answered last or an older view of
+// the source would land on top of the authoritative one.
+func (h *Handler) respond(ready []*bpRequest) {
+	if len(ready) == 0 {
+		return
+	}
+	sort.SliceStable(ready, func(i, j int) bool { return ready[i].reqSeq < ready[j].reqSeq })
+	for _, r := range ready {
+		h.sendSetBreakpointsResponse(r)
+	}
+}
+
+// sendSetBreakpointsResponse answers one setBreakpoints request. A request whose
+// removal was rejected by the debugger is failed rather than answered success:
+// its breakpoints are still armed, so reporting the requested state would be a
+// lie the client has no other way to detect.
+func (h *Handler) sendSetBreakpointsResponse(r *bpRequest) {
+	if r.clearFailure != "" {
+		h.send(h.errorResponse(r.reqSeq, "setBreakpoints", "clear breakpoint failed: "+r.clearFailure))
+		return
+	}
+	bps := make([]godap.Breakpoint, len(r.slots))
+	for i, s := range r.slots {
+		bps[i] = s.bp
+	}
+	h.send(&godap.SetBreakpointsResponse{
+		Response: h.response(r.reqSeq, "setBreakpoints"),
+		Body:     godap.SetBreakpointsResponseBody{Breakpoints: bps},
+	})
 }

--- a/internal/dap/breakpoints.go
+++ b/internal/dap/breakpoints.go
@@ -156,28 +156,32 @@ func (h *Handler) settleLineLocked(file string, line int) []*bpRequest {
 }
 
 // failClearLocked completes the removal obligations on a line whose clear could
-// not be issued or was rejected, failing their requests. It deliberately does
-// NOT re-enter the convergence loop: the line is still armed and still unwanted,
-// so advancing it again would retry a failing clear forever. The retained
-// mapping means the next setBreakpoints for the source can retry it.
+// not be issued or was rejected.
 //
-// Slots parked on the line are answered here too, unconditionally. A failed
-// clear ends the line's only in-flight operation, so this is the last thing that
-// will happen to it until a new request arrives — anything still waiting would
-// otherwise wait forever. That includes an earlier pipelined request whose Set
-// this clear was cancelling: its breakpoint really is armed, so the line's
-// current identity is a truthful answer for it. Caller MUST hold h.mu.
+// While the line is still armed this is the end of the road for it: re-entering
+// the convergence loop would retry a failing clear forever, so the rejection is
+// reported to the requests that asked for the removal and the mapping is
+// retained (the next setBreakpoints for the source can retry it). Slots parked
+// on the line are answered from that armed identity — including an earlier
+// pipelined request whose Set this clear was cancelling, whose breakpoint really
+// is armed. Nothing else will touch the line until a new request arrives, so
+// anything left waiting here would wait forever.
+//
+// If nothing is armed there is neither anything to retry nor anything to report:
+// the removal these requests asked for did happen, so they are completed rather
+// than failed, and the line is free to converge on whatever the newest request
+// wants. Caller MUST hold h.mu.
 func (h *Handler) failClearLocked(file string, line int, msg string) []*bpRequest {
 	st := h.bpByFile[file][line]
 	if st == nil {
 		return nil
 	}
-	ready := st.dischargeOwners(msg)
-	ready = append(ready, st.resolveSlots()...)
-	// Only reachable when the line is no longer armed (a restart discarded it
-	// under the in-flight clear); a still-armed line is retained by gc.
-	h.gcLineLocked(file, line)
-	return ready
+	if st.installedID != 0 {
+		ready := st.dischargeOwners(msg)
+		return append(ready, st.resolveSlots()...)
+	}
+	ready := st.dischargeOwners("")
+	return append(ready, h.advanceLineLocked(file, line)...)
 }
 
 // gcLineLocked forgets a line the adapter has no reason to remember: unwanted,

--- a/internal/dap/breakpoints_test.go
+++ b/internal/dap/breakpoints_test.go
@@ -1,0 +1,473 @@
+package dap
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	godap "github.com/google/go-dap"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+// These specs pin the setBreakpoints transaction: installed facts versus
+// latest-wins intent, request-owned removals, and exactly one response per
+// request under pipelining. See AGENTS.md → DAP (breakpoint transaction).
+
+var bpSource = godap.Source{Path: "/x/main.go", Name: "main.go"}
+var otherSource = godap.Source{Path: "/x/other.go", Name: "other.go"}
+
+// suspendedHarness runs the handshake and parks the adapter at a breakpoint,
+// the state a client sets breakpoints from.
+func suspendedHarness(t *testing.T) *harness {
+	t.Helper()
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	hh.inject(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{Goroutine: protocol.Goroutine{ID: 1}})
+	_ = recvType[*godap.StoppedEvent](hh)
+	return hh
+}
+
+func setBreakpointsFor(source godap.Source, lines ...int) *godap.SetBreakpointsRequest {
+	bps := make([]godap.SourceBreakpoint, len(lines))
+	for i, line := range lines {
+		bps[i] = godap.SourceBreakpoint{Line: line}
+	}
+	return &godap.SetBreakpointsRequest{Arguments: godap.SetBreakpointsArguments{
+		Source:      source,
+		Breakpoints: bps,
+	}}
+}
+
+func (hh *harness) confirmSet(source godap.Source, line, id int) {
+	hh.t.Helper()
+	hh.inject(protocol.EventBreakpointSet, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{ID: id, Location: protocol.Location{File: source.Path, Line: line}},
+	})
+}
+
+// installBreakpoint drives one line to a confirmed install and consumes its
+// response, leaving the source with exactly that breakpoint armed.
+func (hh *harness) installBreakpoint(source godap.Source, lines []int, ids []int) {
+	hh.t.Helper()
+	hh.sendReq("setBreakpoints", setBreakpointsFor(source, lines...))
+	hh.cmds.waitForCommands(hh.t, protocol.CmdSetBreakpoint, len(lines))
+	for i, line := range lines {
+		hh.confirmSet(source, line, ids[i])
+	}
+	_ = recvType[*godap.SetBreakpointsResponse](hh)
+}
+
+// clearIDs decodes the ClearBreakpoint commands the handler has issued so far.
+func (hh *harness) clearIDs(count int) []int {
+	hh.t.Helper()
+	cmds := hh.cmds.waitForCommands(hh.t, protocol.CmdClearBreakpoint, count)
+	out := make([]int, len(cmds))
+	for i, cmd := range cmds {
+		var p protocol.ClearBreakpointPayload
+		if err := protocol.DecodeCommandPayload(cmd, &p); err != nil {
+			hh.t.Fatal(err)
+		}
+		out[i] = p.ID
+	}
+	return out
+}
+
+func (hh *harness) countCommands(kind protocol.CommandKind) int {
+	hh.t.Helper()
+	n := 0
+	for _, k := range hh.cmds.kinds() {
+		if k == kind {
+			n++
+		}
+	}
+	return n
+}
+
+// lineState copies one line's transaction state for assertions.
+func (hh *harness) lineState(file string, line int) (bpLine, bool) {
+	hh.t.Helper()
+	hh.handler.mu.Lock()
+	defer hh.handler.mu.Unlock()
+	st := hh.handler.bpByFile[file][line]
+	if st == nil {
+		return bpLine{}, false
+	}
+	return *st, true
+}
+
+// waitForLine polls until pred holds, so a test can synchronise on a request
+// that issues no command of its own — a removal parked behind an in-flight set.
+func (hh *harness) waitForLine(file string, line int, pred func(bpLine) bool) {
+	hh.t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if st, ok := hh.lineState(file, line); ok && pred(st) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	hh.t.Fatalf("timed out waiting for %s:%d state", file, line)
+}
+
+func requireErrorResponse(t *testing.T, resp *godap.ErrorResponse, reqSeq int, contains string) {
+	t.Helper()
+	if resp.RequestSeq != reqSeq || resp.Success {
+		t.Fatalf("error response = %+v, want failure for request %d", resp.Response, reqSeq)
+	}
+	if !strings.Contains(resp.Message, contains) {
+		t.Fatalf("error message = %q, want it to mention %q", resp.Message, contains)
+	}
+}
+
+// A remove-all must not report success before its clear is confirmed, and a
+// rejected clear must fail the request while keeping the still-armed id.
+func TestRemoveAllFailedClearRetainsIDAndFailsRequest(t *testing.T) {
+	hh := suspendedHarness(t)
+	hh.installBreakpoint(bpSource, []int{10}, []int{101})
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	if ids := hh.clearIDs(1); ids[0] != 101 {
+		t.Fatalf("clear id = %d, want 101", ids[0])
+	}
+	hh.expectNoResponse()
+
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdClearBreakpoint,
+		Message: "breakpoint clear: restore bytes at 0x1000: boom",
+	})
+	requireErrorResponse(t, recvType[*godap.ErrorResponse](hh), removeSeq, "boom")
+
+	st, ok := hh.lineState(bpSource.Path, 10)
+	if !ok || st.installedID != 101 {
+		t.Fatalf("line state after failed clear = %+v (present=%v), want installedID 101 retained", st, ok)
+	}
+
+	// The retained mapping is what makes the removal retryable at all.
+	hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	if ids := hh.clearIDs(2); ids[1] != 101 {
+		t.Fatalf("retry clear id = %d, want 101", ids[1])
+	}
+}
+
+// One rejected clear among several fails the whole request, exactly once.
+func TestPartialClearFailureFailsRequestExactlyOnce(t *testing.T) {
+	hh := suspendedHarness(t)
+	hh.installBreakpoint(bpSource, []int{10, 20}, []int{101, 102})
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	if ids := hh.clearIDs(2); ids[0] != 101 || ids[1] != 102 {
+		t.Fatalf("clear ids = %v, want [101 102]", ids)
+	}
+
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
+	hh.expectNoResponse()
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdClearBreakpoint,
+		Message: "breakpoint 102 not found",
+	})
+
+	requireErrorResponse(t, recvType[*godap.ErrorResponse](hh), removeSeq, "breakpoint 102 not found")
+	hh.expectNoResponse()
+
+	if _, ok := hh.lineState(bpSource.Path, 10); ok {
+		t.Fatal("confirmed clear left line 10 in the cache")
+	}
+	st, ok := hh.lineState(bpSource.Path, 20)
+	if !ok || st.installedID != 102 {
+		t.Fatalf("line 20 state = %+v (present=%v), want installedID 102 retained", st, ok)
+	}
+}
+
+// A pending set superseded by a later empty request is cleared the moment its id
+// arrives, and neither request is answered before that removal completes.
+func TestSupersededPendingSetIsClearedOnConfirmation(t *testing.T) {
+	hh := suspendedHarness(t)
+
+	setSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 1)
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	hh.waitForLine(bpSource.Path, 10, func(st bpLine) bool { return !st.desired && len(st.clearOwners) == 1 })
+	hh.expectNoResponse()
+
+	hh.confirmSet(bpSource, 10, 101)
+	if ids := hh.clearIDs(1); ids[0] != 101 {
+		t.Fatalf("clear id = %d, want the id that just arrived (101)", ids[0])
+	}
+	hh.expectNoResponse()
+
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
+
+	// Request order: the superseded set answers first, the authoritative empty
+	// request last.
+	first := recvType[*godap.SetBreakpointsResponse](hh)
+	if first.RequestSeq != setSeq || len(first.Body.Breakpoints) != 1 || first.Body.Breakpoints[0].Verified {
+		t.Fatalf("superseded response = %+v (seq %d), want one unverified breakpoint for %d", first.Body, first.RequestSeq, setSeq)
+	}
+	second := recvType[*godap.SetBreakpointsResponse](hh)
+	if second.RequestSeq != removeSeq || len(second.Body.Breakpoints) != 0 {
+		t.Fatalf("remove response = %+v (seq %d), want empty for %d", second.Body, second.RequestSeq, removeSeq)
+	}
+
+	if _, ok := hh.lineState(bpSource.Path, 10); ok {
+		t.Fatal("superseded breakpoint survived in the cache")
+	}
+	if n := hh.countCommands(protocol.CmdSetBreakpoint); n != 1 {
+		t.Fatalf("SetBreakpoint commands = %d, want 1", n)
+	}
+	if n := hh.countCommands(protocol.CmdClearBreakpoint); n != 1 {
+		t.Fatalf("ClearBreakpoint commands = %d, want exactly 1", n)
+	}
+}
+
+// An overlapping request wanting an already-pending line attaches to that
+// operation instead of issuing a second SetBreakpoint for the same location.
+func TestOverlappingPendingSetIssuesOneCommand(t *testing.T) {
+	hh := suspendedHarness(t)
+
+	firstSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 1)
+
+	secondSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10, 20))
+	sets := hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 2)
+	var retried protocol.SetBreakpointPayload
+	if err := protocol.DecodeCommandPayload(sets[1], &retried); err != nil {
+		t.Fatal(err)
+	}
+	if retried.Line != 20 {
+		t.Fatalf("second SetBreakpoint = %+v, want the new line 20 only", retried)
+	}
+
+	hh.confirmSet(bpSource, 10, 101)
+	first := recvType[*godap.SetBreakpointsResponse](hh)
+	if first.RequestSeq != firstSeq {
+		t.Fatalf("first response seq = %d, want %d", first.RequestSeq, firstSeq)
+	}
+	requireBreakpointIDs(t, first, 101)
+
+	hh.confirmSet(bpSource, 20, 102)
+	second := recvType[*godap.SetBreakpointsResponse](hh)
+	if second.RequestSeq != secondSeq {
+		t.Fatalf("second response seq = %d, want %d", second.RequestSeq, secondSeq)
+	}
+	requireBreakpointIDs(t, second, 101, 102)
+
+	if n := hh.countCommands(protocol.CmdSetBreakpoint); n != 2 {
+		t.Fatalf("SetBreakpoint commands = %d, want 2 (no duplicate for line 10)", n)
+	}
+	if n := hh.countCommands(protocol.CmdClearBreakpoint); n != 0 {
+		t.Fatalf("ClearBreakpoint commands = %d, want 0", n)
+	}
+}
+
+// set → remove → re-add while the first set is still in flight: the latest
+// intent wins and leaves exactly one live breakpoint, with no wasted round trip.
+func TestSetRemoveReaddLeavesOneLiveBreakpoint(t *testing.T) {
+	hh := suspendedHarness(t)
+
+	setSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 1)
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	hh.waitForLine(bpSource.Path, 10, func(st bpLine) bool { return !st.desired })
+
+	readdSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.waitForLine(bpSource.Path, 10, func(st bpLine) bool { return st.desired })
+	hh.expectNoResponse()
+
+	hh.confirmSet(bpSource, 10, 101)
+
+	for _, want := range []int{setSeq, removeSeq, readdSeq} {
+		resp := recvType[*godap.SetBreakpointsResponse](hh)
+		if resp.RequestSeq != want {
+			t.Fatalf("response seq = %d, want %d (requests answer in order)", resp.RequestSeq, want)
+		}
+		switch want {
+		case removeSeq:
+			if len(resp.Body.Breakpoints) != 0 {
+				t.Fatalf("superseded removal response = %+v, want empty", resp.Body)
+			}
+		default:
+			requireBreakpointIDs(t, resp, 101)
+		}
+	}
+
+	st, ok := hh.lineState(bpSource.Path, 10)
+	if !ok || st.installedID != 101 || !st.desired {
+		t.Fatalf("final line state = %+v (present=%v), want one live breakpoint", st, ok)
+	}
+	if n := hh.countCommands(protocol.CmdSetBreakpoint); n != 1 {
+		t.Fatalf("SetBreakpoint commands = %d, want 1", n)
+	}
+	if n := hh.countCommands(protocol.CmdClearBreakpoint); n != 0 {
+		t.Fatalf("ClearBreakpoint commands = %d, want 0", n)
+	}
+}
+
+// A source blocked on its own removal must not hold up another source.
+func TestBreakpointSourcesSettleIndependently(t *testing.T) {
+	hh := suspendedHarness(t)
+	hh.installBreakpoint(bpSource, []int{10}, []int{101})
+
+	blockedSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	hh.clearIDs(1)
+
+	otherSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(otherSource, 20))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 2)
+	hh.confirmSet(otherSource, 20, 102)
+
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	if resp.RequestSeq != otherSeq {
+		t.Fatalf("response seq = %d, want the independent source %d", resp.RequestSeq, otherSeq)
+	}
+	requireBreakpointIDs(t, resp, 102)
+	hh.expectNoResponse()
+
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
+	blocked := recvType[*godap.SetBreakpointsResponse](hh)
+	if blocked.RequestSeq != blockedSeq || len(blocked.Body.Breakpoints) != 0 {
+		t.Fatalf("blocked response = %+v (seq %d), want empty for %d", blocked.Body, blocked.RequestSeq, blockedSeq)
+	}
+}
+
+// A restart re-identifies settled lines but must leave an in-flight operation —
+// and the FIFO slot correlating it — untouched.
+func TestRestartReconcilesAroundPendingOperation(t *testing.T) {
+	hh := suspendedHarness(t)
+	hh.installBreakpoint(bpSource, []int{10}, []int{41})
+
+	pendingSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10, 20))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 2)
+	hh.expectNoResponse()
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{
+		Breakpoints: []protocol.Breakpoint{
+			{ID: 101, Location: protocol.Location{File: bpSource.Path, Line: 10}},
+		},
+	})
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != restartSeq || !restarted.Success {
+		t.Fatalf("restart response = %+v, want success for %d", restarted.Response, restartSeq)
+	}
+
+	settled, ok := hh.lineState(bpSource.Path, 10)
+	if !ok || settled.installedID != 101 || settled.dapID != 41 {
+		t.Fatalf("settled line = %+v (present=%v), want installedID 101 with stable dapID 41", settled, ok)
+	}
+	pending, ok := hh.lineState(bpSource.Path, 20)
+	if !ok || pending.pending == nil || pending.installedID != 0 {
+		t.Fatalf("in-flight line = %+v (present=%v), want its operation preserved", pending, ok)
+	}
+
+	// The preserved FIFO slot still correlates the confirmation that arrives
+	// after the relaunch.
+	hh.confirmSet(bpSource, 20, 55)
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	if resp.RequestSeq != pendingSeq {
+		t.Fatalf("response seq = %d, want %d", resp.RequestSeq, pendingSeq)
+	}
+	requireBreakpointIDs(t, resp, 41, 55)
+}
+
+// A removal is complete as soon as its trap is gone: a re-add pipelined behind
+// it must not hold the removing request open until the new install lands.
+func TestRemovalCompletesBeforeReaddIsInstalled(t *testing.T) {
+	hh := suspendedHarness(t)
+	hh.installBreakpoint(bpSource, []int{10}, []int{101})
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	hh.clearIDs(1)
+
+	readdSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.waitForLine(bpSource.Path, 10, func(st bpLine) bool { return st.desired })
+	hh.expectNoResponse()
+
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
+
+	removed := recvType[*godap.SetBreakpointsResponse](hh)
+	if removed.RequestSeq != removeSeq || len(removed.Body.Breakpoints) != 0 {
+		t.Fatalf("remove response = %+v (seq %d), want empty for %d", removed.Body, removed.RequestSeq, removeSeq)
+	}
+
+	// Only now is the re-add issued, against a line the debugger has released.
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 2)
+	hh.confirmSet(bpSource, 10, 102)
+	readded := recvType[*godap.SetBreakpointsResponse](hh)
+	if readded.RequestSeq != readdSeq {
+		t.Fatalf("re-add response seq = %d, want %d", readded.RequestSeq, readdSeq)
+	}
+	requireBreakpointIDs(t, readded, 102)
+}
+
+// A rejected clear ends the line's only in-flight operation, so it must also
+// answer the earlier pipelined request whose Set it was cancelling — that
+// breakpoint really is armed, and nothing else will ever settle it.
+func TestFailedClearStillAnswersSupersededSet(t *testing.T) {
+	hh := suspendedHarness(t)
+
+	setSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 1)
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	hh.waitForLine(bpSource.Path, 10, func(st bpLine) bool { return !st.desired && len(st.clearOwners) == 1 })
+
+	hh.confirmSet(bpSource, 10, 101)
+	hh.clearIDs(1)
+	hh.expectNoResponse()
+
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdClearBreakpoint,
+		Message: "breakpoint clear: restore bytes at 0x1000: boom",
+	})
+
+	installed, ok := hh.recv().(*godap.SetBreakpointsResponse)
+	if !ok {
+		t.Fatal("superseded set was not answered before the failed removal")
+	}
+	if installed.RequestSeq != setSeq {
+		t.Fatalf("response seq = %d, want %d", installed.RequestSeq, setSeq)
+	}
+	// The clear failed, so the breakpoint this request asked for is genuinely
+	// armed — reporting it unverified would be a lie.
+	requireBreakpointIDs(t, installed, 101)
+	if !installed.Body.Breakpoints[0].Verified {
+		t.Fatalf("superseded breakpoint = %+v, want verified (its removal failed)", installed.Body.Breakpoints[0])
+	}
+
+	failed, ok := hh.recv().(*godap.ErrorResponse)
+	if !ok {
+		t.Fatal("failed removal was not reported as an error response")
+	}
+	requireErrorResponse(t, failed, removeSeq, "boom")
+	hh.expectNoResponse()
+
+	st, ok := hh.lineState(bpSource.Path, 10)
+	if !ok || st.installedID != 101 {
+		t.Fatalf("line state = %+v (present=%v), want the armed id retained", st, ok)
+	}
+}
+
+// Confirmations the adapter did not ask for must never produce a second
+// response for an already-answered request.
+func TestSetBreakpointsRespondsExactlyOnce(t *testing.T) {
+	hh := suspendedHarness(t)
+	hh.installBreakpoint(bpSource, []int{10}, []int{101})
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	hh.clearIDs(1)
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
+
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	if resp.RequestSeq != removeSeq || len(resp.Body.Breakpoints) != 0 {
+		t.Fatalf("remove response = %+v (seq %d), want empty for %d", resp.Body, resp.RequestSeq, removeSeq)
+	}
+
+	// Duplicate and out-of-band confirmations for the same work.
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
+	hh.inject(protocol.EventError, protocol.ErrorPayload{Command: protocol.CmdClearBreakpoint, Message: "already gone"})
+	hh.confirmSet(bpSource, 10, 102)
+	hh.expectNoResponse()
+}

--- a/internal/dap/breakpoints_test.go
+++ b/internal/dap/breakpoints_test.go
@@ -450,6 +450,138 @@ func TestFailedClearStillAnswersSupersededSet(t *testing.T) {
 	}
 }
 
+// A restart re-identifies EVERY line it retains, including one with an
+// operation still in flight: the in-flight clear was marshalled with the
+// pre-restart id and will fail against the relaunched process, and retain-on-
+// failure would otherwise reissue that dead id forever while the real new
+// breakpoint stayed armed.
+func TestRestartReidentifiesLineUnderPendingClear(t *testing.T) {
+	hh := suspendedHarness(t)
+	hh.installBreakpoint(bpSource, []int{10}, []int{101})
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	if ids := hh.clearIDs(1); ids[0] != 101 {
+		t.Fatalf("clear id = %d, want 101", ids[0])
+	}
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{
+		Breakpoints: []protocol.Breakpoint{
+			{ID: 1, Location: protocol.Location{File: bpSource.Path, Line: 10}},
+		},
+	})
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != restartSeq || !restarted.Success {
+		t.Fatalf("restart response = %+v, want success for %d", restarted.Response, restartSeq)
+	}
+
+	st, ok := hh.lineState(bpSource.Path, 10)
+	if !ok || st.installedID != 1 {
+		t.Fatalf("line state = %+v (present=%v), want the fresh debugger id 1", st, ok)
+	}
+	if st.dapID != 101 {
+		t.Fatalf("dapID = %d, want the stable client identity 101", st.dapID)
+	}
+	if st.pending == nil {
+		t.Fatal("restart cancelled the in-flight operation")
+	}
+	hh.handler.mu.Lock()
+	inFlight := len(hh.handler.clearQ)
+	hh.handler.mu.Unlock()
+	if inFlight != 1 {
+		t.Fatalf("clearQ length = %d, want the in-flight operation preserved", inFlight)
+	}
+
+	// The stale clear, carrying the pre-restart id, is rejected by the new
+	// engine — but the mapping has already self-healed.
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdClearBreakpoint,
+		Message: "breakpoint 101 not found",
+	})
+	requireErrorResponse(t, recvType[*godap.ErrorResponse](hh), removeSeq, "breakpoint 101 not found")
+
+	hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	ids := hh.clearIDs(2)
+	if ids[1] != 1 {
+		t.Fatalf("retry clear id = %d, want the fresh id 1 (not the dead %d)", ids[1], ids[0])
+	}
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 1})
+	_ = recvType[*godap.SetBreakpointsResponse](hh)
+
+	if _, ok := hh.lineState(bpSource.Path, 10); ok {
+		t.Fatal("confirmed clear left the line in the cache")
+	}
+}
+
+// A line whose Set is still in flight owns no identity yet, so a restart
+// payload naming it describes another driver's breakpoint and must not be
+// adopted — neither as a retained id nor as a discard.
+func TestRestartIgnoresLineWithNoInstalledIdentity(t *testing.T) {
+	hh := suspendedHarness(t)
+
+	hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 1)
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{
+		Breakpoints: []protocol.Breakpoint{
+			{ID: 7, Location: protocol.Location{File: bpSource.Path, Line: 10}},
+		},
+		Discarded: []protocol.DiscardedBreakpoint{
+			{Location: protocol.Location{File: bpSource.Path, Line: 10}, Reason: "no such line"},
+		},
+	})
+	restarted := recvType[*godap.RestartResponse](hh)
+	if restarted.RequestSeq != restartSeq {
+		t.Fatalf("restart response seq = %d, want %d", restarted.RequestSeq, restartSeq)
+	}
+
+	st, ok := hh.lineState(bpSource.Path, 10)
+	if !ok || st.installedID != 0 || st.pending == nil || !st.desired {
+		t.Fatalf("line state = %+v (present=%v), want the in-flight set untouched", st, ok)
+	}
+
+	// Our own confirmation still lands on it and settles the request normally.
+	hh.confirmSet(bpSource, 10, 55)
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	requireBreakpointIDs(t, resp, 55)
+}
+
+// The adapter must hand every breakpoint command to the hub, in the order their
+// FIFO slots were reserved, however large the burst — it blocks rather than
+// drops. This is one half of the delivery contract the transaction depends on:
+// a command that never reaches the debugger produces no confirmation, so its
+// line stays `pending` forever and its request is never answered. Hub-side
+// admission is the other half (#160 / #162).
+func TestLargeSetBreakpointsDeliversEveryCommandInOrder(t *testing.T) {
+	hh := suspendedHarness(t)
+
+	// Comfortably past the handler's own command buffer, so the staged outbox
+	// has to block on the hub read pump rather than discard.
+	count := 3 * cmdBufferSize
+	lines := make([]int, count)
+	for i := range lines {
+		lines[i] = 10 + i
+	}
+	hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, lines...))
+
+	cmds := hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, count)
+	if len(cmds) != count {
+		t.Fatalf("SetBreakpoint commands = %d, want %d", len(cmds), count)
+	}
+	for i, cmd := range cmds {
+		var p protocol.SetBreakpointPayload
+		if err := protocol.DecodeCommandPayload(cmd, &p); err != nil {
+			t.Fatal(err)
+		}
+		if p.Line != lines[i] {
+			t.Fatalf("command %d = line %d, want %d (wire order must match reservation order)", i, p.Line, lines[i])
+		}
+	}
+}
+
 // Confirmations the adapter did not ask for must never produce a second
 // response for an already-answered request.
 func TestSetBreakpointsRespondsExactlyOnce(t *testing.T) {

--- a/internal/dap/breakpoints_test.go
+++ b/internal/dap/breakpoints_test.go
@@ -632,6 +632,20 @@ func (hh *harness) staleClearIsStillQueued() bool {
 	return len(hh.handler.clearQ) == 1
 }
 
+// setQIsOnlyPendingFor reports whether the set FIFO holds exactly one operation
+// and it is the one the line is currently waiting on — the shape that proves an
+// abandoned operation's answer neither reissued a command nor left a phantom
+// slot the next confirmation would correlate to.
+func (hh *harness) setQIsOnlyPendingFor(file string, line int) bool {
+	hh.handler.mu.Lock()
+	defer hh.handler.mu.Unlock()
+	st := hh.handler.bpByFile[file][line]
+	if st == nil || st.pending == nil || len(hh.handler.setQ) != 1 {
+		return false
+	}
+	return hh.handler.setQ[0] == st.pending
+}
+
 // After a discard abandons its clear, a later request that wants the line back
 // must converge immediately, and the stale clear's rejection must not touch it.
 func TestDiscardedLineAcceptsLaterSetAndIgnoresStaleClearError(t *testing.T) {
@@ -652,6 +666,15 @@ func TestDiscardedLineAcceptsLaterSetAndIgnoresStaleClearError(t *testing.T) {
 	// The stale rejection belongs to nobody: it must not fail or resolve the
 	// request now waiting on this line.
 	hh.expectNoResponse()
+	// Nor may it act on the line it no longer speaks for. Reissuing here would
+	// arm a second trap for one requested breakpoint and put a second operation
+	// in the FIFO, so every later confirmation would correlate to the wrong one.
+	if n := hh.countCommands(protocol.CmdSetBreakpoint); n != 2 {
+		t.Fatalf("SetBreakpoint commands = %d, want 2 — the stale rejection must not reissue the line", n)
+	}
+	if !hh.setQIsOnlyPendingFor(bpSource.Path, 10) {
+		t.Fatal("set FIFO must hold exactly the live re-add operation")
+	}
 
 	hh.confirmSet(bpSource, 10, 7)
 	resp := recvType[*godap.SetBreakpointsResponse](hh)
@@ -761,19 +784,35 @@ func TestFailedClearWithNothingArmedCompletesAndResumes(t *testing.T) {
 	}
 }
 
-// Confirmations the adapter did not ask for must never produce a second
-// response for an already-answered request.
+// A request must be answered exactly once even when its own settlement is
+// re-offered. A line that is already installed and still wanted converges inside
+// onSetBreakpoints itself, so the request is settled by the line AND then
+// re-tested by the final readiness check that exists for requests which settle
+// on nobody's behalf: only the claim in ready() keeps that from being two
+// responses to one request. Confirmations the adapter did not ask for must not
+// produce a second response either.
 func TestSetBreakpointsRespondsExactlyOnce(t *testing.T) {
 	hh := suspendedHarness(t)
 	hh.installBreakpoint(bpSource, []int{10}, []int{101})
+
+	resetSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	if resp.RequestSeq != resetSeq {
+		t.Fatalf("re-set response seq = %d, want %d", resp.RequestSeq, resetSeq)
+	}
+	requireBreakpointIDs(t, resp, 101)
+	hh.expectNoResponse()
+	if n := hh.countCommands(protocol.CmdSetBreakpoint); n != 1 {
+		t.Fatalf("SetBreakpoint commands = %d, want the already-converged line left alone", n)
+	}
 
 	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
 	hh.clearIDs(1)
 	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
 
-	resp := recvType[*godap.SetBreakpointsResponse](hh)
-	if resp.RequestSeq != removeSeq || len(resp.Body.Breakpoints) != 0 {
-		t.Fatalf("remove response = %+v (seq %d), want empty for %d", resp.Body, resp.RequestSeq, removeSeq)
+	removed := recvType[*godap.SetBreakpointsResponse](hh)
+	if removed.RequestSeq != removeSeq || len(removed.Body.Breakpoints) != 0 {
+		t.Fatalf("remove response = %+v (seq %d), want empty for %d", removed.Body, removed.RequestSeq, removeSeq)
 	}
 
 	// Duplicate and out-of-band confirmations for the same work.

--- a/internal/dap/breakpoints_test.go
+++ b/internal/dap/breakpoints_test.go
@@ -582,6 +582,185 @@ func TestLargeSetBreakpointsDeliversEveryCommandInOrder(t *testing.T) {
 	}
 }
 
+// discardUnderPendingClear installs a breakpoint, starts removing it, then has a
+// restart discard the line while that clear is still in flight. The removal is
+// satisfied by the discard itself, so its request completes successfully and the
+// line is forgotten — leaving the clear abandoned, still queued, still owed an
+// answer by the debugger.
+func discardUnderPendingClear(t *testing.T, hh *harness) int {
+	t.Helper()
+	hh.installBreakpoint(bpSource, []int{10}, []int{101})
+
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	hh.clearIDs(1)
+
+	restartSeq := hh.sendReq("restart", &godap.RestartRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdRestart)
+	hh.inject(protocol.EventRestarted, protocol.RestartedPayload{
+		Discarded: []protocol.DiscardedBreakpoint{
+			{Location: protocol.Location{File: bpSource.Path, Line: 10}, Reason: "no such line"},
+		},
+	})
+
+	var removed *godap.SetBreakpointsResponse
+	var restarted *godap.RestartResponse
+	for range 3 {
+		switch msg := hh.recv().(type) {
+		case *godap.SetBreakpointsResponse:
+			removed = msg
+		case *godap.RestartResponse:
+			restarted = msg
+		case *godap.ErrorResponse:
+			t.Fatalf("removal failed although the discard already satisfied it: %+v", msg.Response)
+		}
+	}
+	if removed == nil || removed.RequestSeq != removeSeq || len(removed.Body.Breakpoints) != 0 {
+		t.Fatalf("removal response = %+v, want empty success for %d", removed, removeSeq)
+	}
+	if restarted == nil || restarted.RequestSeq != restartSeq {
+		t.Fatalf("restart response = %+v, want %d", restarted, restartSeq)
+	}
+	if st, ok := hh.lineState(bpSource.Path, 10); ok {
+		t.Fatalf("discarded line survived as %+v, want it forgotten", st)
+	}
+	return restartSeq
+}
+
+func (hh *harness) staleClearIsStillQueued() bool {
+	hh.handler.mu.Lock()
+	defer hh.handler.mu.Unlock()
+	return len(hh.handler.clearQ) == 1
+}
+
+// After a discard abandons its clear, a later request that wants the line back
+// must converge immediately, and the stale clear's rejection must not touch it.
+func TestDiscardedLineAcceptsLaterSetAndIgnoresStaleClearError(t *testing.T) {
+	hh := suspendedHarness(t)
+	discardUnderPendingClear(t, hh)
+	if !hh.staleClearIsStillQueued() {
+		t.Fatal("abandoned clear lost its FIFO slot")
+	}
+
+	// The abandoned operation must not latch the line: this has to issue a Set.
+	readdSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 2)
+
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdClearBreakpoint,
+		Message: "breakpoint 101 not found",
+	})
+	// The stale rejection belongs to nobody: it must not fail or resolve the
+	// request now waiting on this line.
+	hh.expectNoResponse()
+
+	hh.confirmSet(bpSource, 10, 7)
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	if resp.RequestSeq != readdSeq {
+		t.Fatalf("response seq = %d, want %d", resp.RequestSeq, readdSeq)
+	}
+	requireBreakpointIDs(t, resp, 7)
+	if !resp.Body.Breakpoints[0].Verified {
+		t.Fatalf("re-added breakpoint = %+v, want verified", resp.Body.Breakpoints[0])
+	}
+}
+
+// A removal the discard already satisfied must not be failed by the stale
+// rejection that arrives afterwards.
+func TestDiscardedLineDoesNotFailAlreadySatisfiedRemoval(t *testing.T) {
+	hh := suspendedHarness(t)
+	discardUnderPendingClear(t, hh)
+
+	// Nothing is armed, so this replace-all owns no removal and answers at once.
+	emptySeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	if resp.RequestSeq != emptySeq || len(resp.Body.Breakpoints) != 0 {
+		t.Fatalf("empty response = %+v (seq %d), want empty success for %d", resp.Body, resp.RequestSeq, emptySeq)
+	}
+
+	hh.inject(protocol.EventError, protocol.ErrorPayload{
+		Command: protocol.CmdClearBreakpoint,
+		Message: "breakpoint 101 not found",
+	})
+	hh.expectNoResponse()
+
+	if n := hh.countCommands(protocol.CmdClearBreakpoint); n != 1 {
+		t.Fatalf("ClearBreakpoint commands = %d, want no retry of the discarded line", n)
+	}
+}
+
+// A stale clear that succeeds late must also be a pure FIFO pop: it must not
+// disarm the line's new identity, and the next real removal must still
+// correlate to its own confirmation.
+func TestStaleClearSuccessDoesNotDisturbReidentifiedLine(t *testing.T) {
+	hh := suspendedHarness(t)
+	discardUnderPendingClear(t, hh)
+
+	hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource, 10))
+	hh.cmds.waitForCommands(t, protocol.CmdSetBreakpoint, 2)
+	hh.confirmSet(bpSource, 10, 7)
+	_ = recvType[*godap.SetBreakpointsResponse](hh)
+
+	// The abandoned clear finally succeeds against the old process.
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
+	hh.expectNoResponse()
+	st, ok := hh.lineState(bpSource.Path, 10)
+	if !ok || st.installedID != 7 {
+		t.Fatalf("line state = %+v (present=%v), want the new identity 7 intact", st, ok)
+	}
+
+	// The FIFO is still aligned: a real removal targets the new id and is
+	// answered by its own confirmation.
+	removeSeq := hh.sendReq("setBreakpoints", setBreakpointsFor(bpSource))
+	ids := hh.clearIDs(2)
+	if ids[1] != 7 {
+		t.Fatalf("clear id = %d, want the current identity 7", ids[1])
+	}
+	hh.expectNoResponse()
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 7})
+	resp := recvType[*godap.SetBreakpointsResponse](hh)
+	if resp.RequestSeq != removeSeq || len(resp.Body.Breakpoints) != 0 {
+		t.Fatalf("removal response = %+v (seq %d), want empty success for %d", resp.Body, resp.RequestSeq, removeSeq)
+	}
+	if _, ok := hh.lineState(bpSource.Path, 10); ok {
+		t.Fatal("confirmed clear left the line in the cache")
+	}
+}
+
+// A rejected clear is only un-retryable while its breakpoint is still armed.
+// With nothing armed there is nothing to retry and nothing to report: the
+// removal did happen, so its requests complete rather than fail, and the line
+// resumes converging on the newest intent instead of stalling.
+func TestFailedClearWithNothingArmedCompletesAndResumes(t *testing.T) {
+	h := NewHandler(nil, nil, nil)
+
+	removal := &bpRequest{reqSeq: 1, openClears: 1}
+	readd := &bpRequest{reqSeq: 2}
+	slot := &bpSlot{req: readd, line: 10, source: bpSource}
+	readd.slots = []*bpSlot{slot}
+	h.bpByFile[bpSource.Path] = map[int]*bpLine{10: {
+		desired:     true,
+		setWaiters:  []*bpSlot{slot},
+		clearOwners: []*bpRequest{removal},
+	}}
+
+	h.mu.Lock()
+	ready := h.failClearLocked(bpSource.Path, 10, "breakpoint 101 not found")
+	h.mu.Unlock()
+
+	if len(ready) != 1 || ready[0] != removal {
+		t.Fatalf("ready = %+v, want only the removal request", ready)
+	}
+	if removal.clearFailure != "" {
+		t.Fatalf("removal reported %q, want success — nothing was armed to fail on", removal.clearFailure)
+	}
+	if len(h.setQ) != 1 || len(h.outbox) != 1 {
+		t.Fatalf("setQ=%d outbox=%d, want the desired line to resume converging", len(h.setQ), len(h.outbox))
+	}
+	if slot.resolved {
+		t.Fatal("waiting slot was resolved before its breakpoint was installed")
+	}
+}
+
 // Confirmations the adapter did not ask for must never produce a second
 // response for an already-answered request.
 func TestSetBreakpointsRespondsExactlyOnce(t *testing.T) {

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -235,7 +235,7 @@ func (h *Handler) onBreakpointSet(evt protocol.Event) {
 	h.mu.Lock()
 	var ready []*bpRequest
 	if op := h.popSetLocked(); op != nil {
-		if st := h.bpByFile[op.file][op.line]; st != nil {
+		if st := h.liveLineLocked(op); st != nil {
 			st.pending = nil
 			st.installedID = p.Breakpoint.ID
 			st.loc = p.Breakpoint.Location
@@ -259,7 +259,7 @@ func (h *Handler) onBreakpointCleared() {
 	h.mu.Lock()
 	var ready []*bpRequest
 	if op := h.popClearLocked(); op != nil {
-		if st := h.bpByFile[op.file][op.line]; st != nil {
+		if st := h.liveLineLocked(op); st != nil {
 			st.pending = nil
 			st.installedID = 0
 			st.dapID = 0
@@ -297,6 +297,25 @@ func (h *Handler) popClearLocked() *bpOp {
 	op := h.clearQ[0]
 	h.clearQ = h.clearQ[1:]
 	return op
+}
+
+// liveLineLocked returns the line an operation still speaks for, or nil if the
+// operation has been abandoned — its line was discarded by a restart, forgotten,
+// or has since moved on to a different operation.
+//
+// An abandoned operation keeps its place in setQ/clearQ, because the debugger
+// will still answer it and that answer has to pop the queue head it reserved or
+// every later confirmation correlates to the wrong request. But it must not
+// settle waiters, fail owners, or write state: the removal it was performing was
+// already accounted for when it was abandoned, and the line's identity now
+// belongs to whatever replaced it. So its answer does exactly one thing — pop.
+// Caller MUST hold h.mu.
+func (h *Handler) liveLineLocked(op *bpOp) *bpLine {
+	st := h.bpByFile[op.file][op.line]
+	if st == nil || st.pending != op {
+		return nil
+	}
+	return st
 }
 
 func (h *Handler) onFrames(evt protocol.Event) {
@@ -474,10 +493,16 @@ func (h *Handler) reconcileRestartBreakpointsLocked(p protocol.RestartedPayload)
 		st.desired = false
 		st.loc = protocol.Location{}
 		st.failure = dropped.Reason
+		// Abandon any operation still in flight against the dropped line. Its
+		// command was addressed to a breakpoint the relaunched process no longer
+		// has, so its answer can only be stale — leaving it as the line's live
+		// operation would latch the line, blocking every later request behind a
+		// removal that has already happened. The op stays queued in
+		// setQ/clearQ purely so its answer pops the right head (see
+		// liveLineLocked).
+		st.pending = nil
 		// The breakpoint is gone, so anyone parked on the line — including a
-		// request still waiting for it to be removed — can be answered now. Any
-		// in-flight operation is left to run its course; its confirmation finds
-		// a line that no longer has anything to converge.
+		// request still waiting for it to be removed — can be answered now.
 		ready = append(ready, h.settleLineLocked(dropped.Location.File, dropped.Location.Line)...)
 		discarded = append(discarded, godap.Breakpoint{
 			Id:       dapID,
@@ -684,7 +709,7 @@ func (h *Handler) failBreakpointSet(msg string) {
 	h.mu.Lock()
 	var ready []*bpRequest
 	if op := h.popSetLocked(); op != nil {
-		if st := h.bpByFile[op.file][op.line]; st != nil {
+		if st := h.liveLineLocked(op); st != nil {
 			st.pending = nil
 			st.failure = msg
 			st.desired = false
@@ -704,12 +729,13 @@ func (h *Handler) failBreakpointClear(msg string) {
 	h.mu.Lock()
 	var ready []*bpRequest
 	if op := h.popClearLocked(); op != nil {
-		if st := h.bpByFile[op.file][op.line]; st != nil {
+		if st := h.liveLineLocked(op); st != nil {
 			st.pending = nil
 			ready = h.failClearLocked(op.file, op.line, msg)
 		}
 	}
 	h.mu.Unlock()
 
+	h.flushCommands()
 	h.respond(ready)
 }

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -221,6 +221,11 @@ func (h *Handler) onOutput(evt protocol.Event) {
 	h.send(&godap.OutputEvent{Event: h.event("output"), Body: godap.OutputEventBody{Category: category, Output: p.Content}})
 }
 
+// onBreakpointSet records a confirmed install against the operation at the head
+// of setQ. The id is an installed FACT and is recorded even when a later request
+// already dropped the line — the trap IS armed, and forgetting it is how it
+// becomes unremovable. Advancing the line then immediately clears it, so a
+// superseded Set is never committed as the line's desired state.
 func (h *Handler) onBreakpointSet(evt protocol.Event) {
 	var p protocol.BreakpointSetPayload
 	if err := protocol.DecodeEventPayload(evt, &p); err != nil {
@@ -228,40 +233,70 @@ func (h *Handler) onBreakpointSet(evt protocol.Event) {
 	}
 
 	h.mu.Lock()
-	var ready *bpRequest
-	if len(h.setQ) > 0 {
-		slot := h.setQ[0]
-		h.setQ = h.setQ[1:]
-		if lines := h.bpByFile[slot.file]; lines != nil {
-			lines[slot.line] = breakpointState{
-				dapID:      p.Breakpoint.ID,
-				debuggerID: p.Breakpoint.ID,
+	var ready []*bpRequest
+	if op := h.popSetLocked(); op != nil {
+		if st := h.bpByFile[op.file][op.line]; st != nil {
+			st.pending = nil
+			st.installedID = p.Breakpoint.ID
+			st.loc = p.Breakpoint.Location
+			st.failure = ""
+			if st.dapID == 0 {
+				st.dapID = p.Breakpoint.ID
 			}
-		}
-		slot.resolved = true
-		slot.bp = godap.Breakpoint{
-			Id:       p.Breakpoint.ID,
-			Verified: true,
-			Line:     p.Breakpoint.Location.Line,
-			Source:   dapSource(p.Breakpoint.Location),
-		}
-		if slot.req.done() {
-			ready = slot.req
+			ready = h.advanceLineLocked(op.file, op.line)
 		}
 	}
 	h.mu.Unlock()
 
-	if ready != nil {
-		h.sendSetBreakpointsResponse(ready)
-	}
+	h.flushCommands()
+	h.respond(ready)
 }
 
+// onBreakpointCleared retires the operation at the head of clearQ. A line's
+// debugger id is dropped ONLY here: a confirmed removal is the only proof the
+// trap is actually gone.
 func (h *Handler) onBreakpointCleared() {
 	h.mu.Lock()
-	if len(h.clearQ) > 0 {
-		h.clearQ = h.clearQ[1:]
+	var ready []*bpRequest
+	if op := h.popClearLocked(); op != nil {
+		if st := h.bpByFile[op.file][op.line]; st != nil {
+			st.pending = nil
+			st.installedID = 0
+			st.dapID = 0
+			st.loc = protocol.Location{}
+			// The removal is complete the moment the trap is gone — even if a
+			// later request has already re-desired the line and the next Set is
+			// about to be issued for it.
+			ready = st.dischargeOwners("")
+			ready = append(ready, h.advanceLineLocked(op.file, op.line)...)
+		}
 	}
 	h.mu.Unlock()
+
+	h.flushCommands()
+	h.respond(ready)
+}
+
+// popSetLocked takes the operation the next EventBreakpointSet belongs to. A nil
+// result means the confirmation was driven by another client — there is nothing
+// of ours to correlate it to. Caller MUST hold h.mu.
+func (h *Handler) popSetLocked() *bpOp {
+	if len(h.setQ) == 0 {
+		return nil
+	}
+	op := h.setQ[0]
+	h.setQ = h.setQ[1:]
+	return op
+}
+
+// popClearLocked is popSetLocked for EventBreakpointCleared. Caller MUST hold h.mu.
+func (h *Handler) popClearLocked() *bpOp {
+	if len(h.clearQ) == 0 {
+		return nil
+	}
+	op := h.clearQ[0]
+	h.clearQ = h.clearQ[1:]
+	return op
 }
 
 func (h *Handler) onFrames(evt protocol.Event) {
@@ -378,8 +413,9 @@ func (h *Handler) onRestarted(evt protocol.Event) {
 	// new process reports its own state through its entry stop.
 	h.restartWasSuspended = false
 	var discarded []godap.Breakpoint
+	var ready []*bpRequest
 	if decoded {
-		discarded = h.reconcileRestartBreakpointsLocked(p)
+		discarded, ready = h.reconcileRestartBreakpointsLocked(p)
 	}
 	h.mu.Unlock()
 
@@ -392,39 +428,53 @@ func (h *Handler) onRestarted(evt protocol.Event) {
 			},
 		})
 	}
+	h.respond(ready)
 	if seq != 0 {
 		h.send(&godap.RestartResponse{Response: h.response(seq, "restart")})
 	}
 }
 
-func (h *Handler) reconcileRestartBreakpointsLocked(p protocol.RestartedPayload) []godap.Breakpoint {
+// reconcileRestartBreakpointsLocked adopts the relaunched process's breakpoint
+// identities: retained lines keep their stable DAP id but take the fresh
+// debugger id, and discarded lines are dropped and reported unverified. A line
+// with an operation in flight is left alone — that operation still owns the
+// line's convergence and its confirmation is still queued in setQ/clearQ, so
+// rewriting its state here would desynchronise both. Caller MUST hold h.mu.
+func (h *Handler) reconcileRestartBreakpointsLocked(p protocol.RestartedPayload) ([]godap.Breakpoint, []*bpRequest) {
 	for _, bp := range p.Breakpoints {
-		lines := h.bpByFile[bp.Location.File]
-		state, ok := lines[bp.Location.Line]
-		if !ok || state.debuggerID == 0 {
+		st := h.bpByFile[bp.Location.File][bp.Location.Line]
+		if st == nil || st.installedID == 0 || st.pending != nil {
 			continue
 		}
-		state.debuggerID = bp.ID
-		lines[bp.Location.Line] = state
+		st.installedID = bp.ID
+		st.loc = bp.Location
 	}
 
 	discarded := make([]godap.Breakpoint, 0, len(p.Discarded))
+	var ready []*bpRequest
 	for _, dropped := range p.Discarded {
-		lines := h.bpByFile[dropped.Location.File]
-		state, ok := lines[dropped.Location.Line]
-		if !ok || state.debuggerID == 0 {
+		st := h.bpByFile[dropped.Location.File][dropped.Location.Line]
+		if st == nil || st.installedID == 0 || st.pending != nil {
 			continue
 		}
-		delete(lines, dropped.Location.Line)
+		dapID := st.dapID
+		st.installedID = 0
+		st.dapID = 0
+		st.desired = false
+		st.loc = protocol.Location{}
+		st.failure = dropped.Reason
+		// The breakpoint is gone, so anyone parked on the line — including a
+		// request still waiting for it to be removed — can be answered now.
+		ready = append(ready, h.settleLineLocked(dropped.Location.File, dropped.Location.Line)...)
 		discarded = append(discarded, godap.Breakpoint{
-			Id:       state.dapID,
+			Id:       dapID,
 			Verified: false,
 			Message:  dropped.Reason,
 			Source:   dapSource(dropped.Location),
 			Line:     dropped.Location.Line,
 		})
 	}
-	return discarded
+	return discarded, ready
 }
 
 // onError routes a bingo EventError to the DAP request it corresponds to,
@@ -439,7 +489,7 @@ func (h *Handler) onError(evt protocol.Event) {
 	case protocol.CmdSetBreakpoint:
 		h.failBreakpointSet(p.Message)
 	case protocol.CmdClearBreakpoint:
-		h.onBreakpointCleared()
+		h.failBreakpointClear(p.Message)
 	case protocol.CmdGoroutines:
 		h.mu.Lock()
 		seq, ok := 0, false
@@ -613,37 +663,40 @@ func (h *Handler) failStart(msg string) {
 	h.send(&godap.TerminatedEvent{Event: h.event("terminated")})
 }
 
-// failBreakpointSet resolves the head pending set slot as unverified, then
-// completes its request if that was the last outstanding slot.
+// failBreakpointSet reports a rejected SetBreakpoint against the operation at the
+// head of setQ: every slot parked on the line is answered unverified. The line's
+// intent is dropped so the convergence loop does not spin re-issuing a request
+// the debugger just refused — the client's next setBreakpoints drives any retry.
 func (h *Handler) failBreakpointSet(msg string) {
 	h.mu.Lock()
-	var ready *bpRequest
-	if len(h.setQ) > 0 {
-		slot := h.setQ[0]
-		h.setQ = h.setQ[1:]
-		if lines := h.bpByFile[slot.file]; lines != nil {
-			delete(lines, slot.line)
-		}
-		slot.resolved = true
-		slot.bp = godap.Breakpoint{Verified: false, Line: slot.line, Message: msg}
-		if slot.req.done() {
-			ready = slot.req
+	var ready []*bpRequest
+	if op := h.popSetLocked(); op != nil {
+		if st := h.bpByFile[op.file][op.line]; st != nil {
+			st.pending = nil
+			st.failure = msg
+			st.desired = false
+			ready = h.settleLineLocked(op.file, op.line)
 		}
 	}
 	h.mu.Unlock()
 
-	if ready != nil {
-		h.sendSetBreakpointsResponse(ready)
-	}
+	h.respond(ready)
 }
 
-func (h *Handler) sendSetBreakpointsResponse(r *bpRequest) {
-	bps := make([]godap.Breakpoint, len(r.slots))
-	for i, s := range r.slots {
-		bps[i] = s.bp
+// failBreakpointClear reports a rejected ClearBreakpoint. The line's mapping is
+// deliberately RETAINED: the trap is still armed in the debugger, so dropping
+// its id would leave a breakpoint the client could never remove. The requests
+// that asked for the removal are failed rather than answered success.
+func (h *Handler) failBreakpointClear(msg string) {
+	h.mu.Lock()
+	var ready []*bpRequest
+	if op := h.popClearLocked(); op != nil {
+		if st := h.bpByFile[op.file][op.line]; st != nil {
+			st.pending = nil
+			ready = h.failClearLocked(op.file, op.line, msg)
+		}
 	}
-	h.send(&godap.SetBreakpointsResponse{
-		Response: h.response(r.reqSeq, "setBreakpoints"),
-		Body:     godap.SetBreakpointsResponseBody{Breakpoints: bps},
-	})
+	h.mu.Unlock()
+
+	h.respond(ready)
 }

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -436,14 +436,25 @@ func (h *Handler) onRestarted(evt protocol.Event) {
 
 // reconcileRestartBreakpointsLocked adopts the relaunched process's breakpoint
 // identities: retained lines keep their stable DAP id but take the fresh
-// debugger id, and discarded lines are dropped and reported unverified. A line
-// with an operation in flight is left alone — that operation still owns the
-// line's convergence and its confirmation is still queued in setQ/clearQ, so
-// rewriting its state here would desynchronise both. Caller MUST hold h.mu.
+// debugger id, and discarded lines are dropped and reported unverified.
+//
+// A line whose operation is still in flight is re-identified too. FIFO
+// correlation rides the queued *bpOp, not installedID, so adopting the fresh id
+// cannot desynchronise setQ/clearQ — whereas keeping the pre-restart id would
+// strand the line on an identifier the new engine never issued: the in-flight
+// clear (already marshalled with the dead id) fails against the relaunched
+// process, and failClearLocked's deliberate retain-on-failure would then reissue
+// that dead id for every later attempt, leaving the real new breakpoint
+// unremovable. Re-identifying here is what lets the mapping self-heal.
+//
+// A line with nothing installed (installedID == 0) is still skipped: its
+// convergence has not produced an identity of ours yet, so a payload entry for
+// that line describes some other driver's breakpoint, not one we own.
+// Caller MUST hold h.mu.
 func (h *Handler) reconcileRestartBreakpointsLocked(p protocol.RestartedPayload) ([]godap.Breakpoint, []*bpRequest) {
 	for _, bp := range p.Breakpoints {
 		st := h.bpByFile[bp.Location.File][bp.Location.Line]
-		if st == nil || st.installedID == 0 || st.pending != nil {
+		if st == nil || st.installedID == 0 {
 			continue
 		}
 		st.installedID = bp.ID
@@ -454,7 +465,7 @@ func (h *Handler) reconcileRestartBreakpointsLocked(p protocol.RestartedPayload)
 	var ready []*bpRequest
 	for _, dropped := range p.Discarded {
 		st := h.bpByFile[dropped.Location.File][dropped.Location.Line]
-		if st == nil || st.installedID == 0 || st.pending != nil {
+		if st == nil || st.installedID == 0 {
 			continue
 		}
 		dapID := st.dapID
@@ -464,7 +475,9 @@ func (h *Handler) reconcileRestartBreakpointsLocked(p protocol.RestartedPayload)
 		st.loc = protocol.Location{}
 		st.failure = dropped.Reason
 		// The breakpoint is gone, so anyone parked on the line — including a
-		// request still waiting for it to be removed — can be answered now.
+		// request still waiting for it to be removed — can be answered now. Any
+		// in-flight operation is left to run its course; its confirmation finds
+		// a line that no longer has anything to converge.
 		ready = append(ready, h.settleLineLocked(dropped.Location.File, dropped.Location.Line)...)
 		discarded = append(discarded, godap.Breakpoint{
 			Id:       dapID,

--- a/internal/dap/handler.go
+++ b/internal/dap/handler.go
@@ -169,10 +169,13 @@ type bpSlot struct {
 	bp       godap.Breakpoint
 }
 
-// bpOp is one in-flight debugger command for a single file:line. At most one
-// exists per line at a time, which is what keeps the id-less FIFO correlation
-// unambiguous: the head of setQ/clearQ is the operation the next confirmation
-// belongs to — and which queue it sits in is what makes it a set or a clear.
+// bpOp is one in-flight debugger command for a single file:line. A line has at
+// most one LIVE operation at a time, which is what keeps the id-less FIFO
+// correlation unambiguous: the head of setQ/clearQ is the operation the next
+// confirmation belongs to — and which queue it sits in is what makes it a set or
+// a clear. An operation whose line was discarded by a restart is abandoned and
+// no longer speaks for that line, but stays queued so its answer still pops the
+// head it reserved (see liveLineLocked).
 type bpOp struct {
 	file string
 	line int
@@ -183,7 +186,7 @@ type bpOp struct {
 // legitimately disagree. installedID is a fact — set only by a confirmed
 // SetBreakpoint, dropped only by a confirmed ClearBreakpoint — while desired is
 // the latest-wins intent of the most recent request for the source. A line with
-// the two in agreement is converged; otherwise exactly one op is in flight and
+// the two in agreement is converged; otherwise exactly one operation is live and
 // every waiter parks here until it completes. dapID is the stable client-facing
 // identity, which deliberately outlives a debugger id change across restart.
 type bpLine struct {

--- a/internal/dap/handler.go
+++ b/internal/dap/handler.go
@@ -60,6 +60,10 @@ type Handler struct {
 	writeMu sync.Mutex
 	seq     int
 
+	// flushMu serialises outbox drains so staged commands are handed to the hub
+	// in staging order. Never taken while holding mu.
+	flushMu sync.Mutex
+
 	// mu guards all coordination state below. Never held across a socket
 	// write (release mu, then take writeMu) or a cmdOut enqueue.
 	mu sync.Mutex
@@ -116,15 +120,20 @@ type Handler struct {
 	// Suspend/resume (EventContinued).
 	pendingContinues int
 
-	// Breakpoint bookkeeping. bpByFile maps file -> requested line -> DAP and
-	// debugger identities. The two diverge after Restart: DAP identity remains
-	// stable while the fresh debugger assigns a new internal id.
-	// setQ/clearQ are FIFOs of in-flight confirmations, correlated to the hub's
-	// ordered event stream (valid while the DAP client is the sole breakpoint
-	// driver).
-	bpByFile map[string]map[int]breakpointState
-	setQ     []*bpSlot
-	clearQ   []int
+	// Breakpoint bookkeeping. bpByFile maps file -> line -> that line's
+	// transaction state (see bpLine). setQ/clearQ are FIFOs of in-flight
+	// operations, correlated to the hub's ordered event stream (valid while the
+	// DAP client is the sole breakpoint driver).
+	bpByFile map[string]map[int]*bpLine
+	setQ     []*bpOp
+	clearQ   []*bpOp
+
+	// outbox stages breakpoint commands so they reach the hub in the exact
+	// order their setQ/clearQ slot was reserved. Two goroutines produce them —
+	// the DAP read loop (a new setBreakpoints) and the hub write pump (a
+	// confirmation that advances a line) — and the FIFOs are only meaningful
+	// if the wire order matches the reservation order. See flushCommands.
+	outbox [][]byte
 
 	// Data-request correlation FIFOs, one per bingo confirmation event kind.
 	threadsQ []int
@@ -154,30 +163,67 @@ const varRefBase = 1 << 16
 // (or already holding) its resolved DAP breakpoint.
 type bpSlot struct {
 	req      *bpRequest
-	file     string
 	line     int
+	source   godap.Source
 	resolved bool
 	bp       godap.Breakpoint
 }
 
-type breakpointState struct {
-	dapID      int
-	debuggerID int
+// bpOp is one in-flight debugger command for a single file:line. At most one
+// exists per line at a time, which is what keeps the id-less FIFO correlation
+// unambiguous: the head of setQ/clearQ is the operation the next confirmation
+// belongs to — and which queue it sits in is what makes it a set or a clear.
+type bpOp struct {
+	file string
+	line int
 }
 
-// bpRequest collects the slots of a single setBreakpoints request; its response
-// is sent once every slot is resolved (in request order — see AGENTS.md).
+// bpLine keeps what is INSTALLED in the debugger separate from what the client
+// last asked for, because pipelined setBreakpoints requests make the two
+// legitimately disagree. installedID is a fact — set only by a confirmed
+// SetBreakpoint, dropped only by a confirmed ClearBreakpoint — while desired is
+// the latest-wins intent of the most recent request for the source. A line with
+// the two in agreement is converged; otherwise exactly one op is in flight and
+// every waiter parks here until it completes. dapID is the stable client-facing
+// identity, which deliberately outlives a debugger id change across restart.
+type bpLine struct {
+	dapID       int
+	installedID int
+	loc         protocol.Location
+	desired     bool
+	failure     string
+
+	pending     *bpOp
+	setWaiters  []*bpSlot
+	clearOwners []*bpRequest
+}
+
+// bpRequest collects one setBreakpoints request's outstanding work: a slot per
+// requested line plus openClears, the removals it owns. Its response is sent
+// once BOTH are settled, so a request can never report success while a clear it
+// caused is still in flight (or has failed).
 type bpRequest struct {
-	reqSeq int
-	slots  []*bpSlot
+	reqSeq       int
+	slots        []*bpSlot
+	openClears   int
+	clearFailure string
+	responded    bool
 }
 
-func (r *bpRequest) done() bool {
+// ready reports whether the request may be answered now, claiming the right to
+// answer it. Slots and clear obligations settle on different goroutines and can
+// complete in either order, so the claim is what guarantees exactly one
+// response per request. Caller MUST hold h.mu.
+func (r *bpRequest) ready() bool {
+	if r.responded || r.openClears > 0 {
+		return false
+	}
 	for _, s := range r.slots {
 		if !s.resolved {
 			return false
 		}
 	}
+	r.responded = true
 	return true
 }
 
@@ -218,7 +264,7 @@ func NewHandler(conn net.Conn, provider Provider, log *slog.Logger) *Handler {
 		log:      log,
 		cmdOut:   make(chan []byte, cmdBufferSize),
 		done:     make(chan struct{}),
-		bpByFile: make(map[string]map[int]breakpointState),
+		bpByFile: make(map[string]map[int]*bpLine),
 		varCache: make(map[int][]godap.Variable),
 	}
 }
@@ -391,6 +437,37 @@ func (h *Handler) enqueue(cmd []byte) {
 	select {
 	case h.cmdOut <- cmd:
 	case <-h.done:
+	}
+}
+
+// queueCommandLocked stages a breakpoint command for the hub. Staging (rather
+// than enqueuing directly) is what keeps the wire order equal to the setQ/clearQ
+// reservation order: the reservation happens under mu, but the enqueue cannot
+// (it may block), so two producers could otherwise interleave and correlate a
+// confirmation to the wrong operation. Caller MUST hold h.mu.
+func (h *Handler) queueCommandLocked(cmd []byte) {
+	if cmd == nil {
+		return
+	}
+	h.outbox = append(h.outbox, cmd)
+}
+
+// flushCommands drains staged commands to the hub in staging order. flushMu
+// serialises concurrent drains; mu is released around each enqueue so the rule
+// against holding mu across a cmdOut send still holds.
+func (h *Handler) flushCommands() {
+	h.flushMu.Lock()
+	defer h.flushMu.Unlock()
+	for {
+		h.mu.Lock()
+		if len(h.outbox) == 0 {
+			h.mu.Unlock()
+			return
+		}
+		cmd := h.outbox[0]
+		h.outbox = h.outbox[1:]
+		h.mu.Unlock()
+		h.enqueue(cmd)
 	}
 }
 

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -416,6 +416,19 @@ func (hh *harness) inject(kind protocol.EventKind, payload any) {
 	}
 }
 
+// expectNoResponse asserts the handler is not answering anything right now — a
+// setBreakpoints request must stay open while an operation it owns is in flight.
+func (hh *harness) expectNoResponse() {
+	hh.t.Helper()
+	_ = hh.client.SetReadDeadline(time.Now().Add(80 * time.Millisecond))
+	defer func() { _ = hh.client.SetReadDeadline(time.Time{}) }()
+	if _, err := hh.reader.Peek(1); err == nil {
+		hh.t.Fatal("handler responded while an owned breakpoint operation was still pending")
+	} else if nerr, ok := err.(net.Error); !ok || !nerr.Timeout() {
+		hh.t.Fatalf("peek while pending: %v", err)
+	}
+}
+
 func initArgs() *godap.InitializeRequest {
 	return &godap.InitializeRequest{Arguments: godap.InitializeRequestArguments{AdapterID: "bingo"}}
 }
@@ -718,13 +731,16 @@ func TestSetBreakpointsDiffAndFIFO(t *testing.T) {
 		Breakpoints: []godap.SourceBreakpoint{{Line: 20}},
 	}}
 	hh.sendReq("setBreakpoints", sb2)
-	// Line 20 unchanged → resolves immediately without a new SetBreakpoint.
+	// A ClearBreakpoint for the removed line 10 must have been enqueued, and the
+	// response must wait for it: the request owns that removal.
+	hh.cmds.waitForCommand(t, protocol.CmdClearBreakpoint)
+	hh.expectNoResponse()
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
+
 	resp2 := recvType[*godap.SetBreakpointsResponse](hh)
 	if len(resp2.Body.Breakpoints) != 1 || resp2.Body.Breakpoints[0].Line != 20 {
 		t.Fatalf("diff response = %+v", resp2.Body.Breakpoints)
 	}
-	// A ClearBreakpoint for the removed line 10 must have been enqueued.
-	hh.cmds.waitForCommand(t, protocol.CmdClearBreakpoint)
 }
 
 func seedRestartBreakpointCache(t *testing.T, hh *harness, source godap.Source) {
@@ -794,8 +810,8 @@ func requireRestartBreakpointCache(t *testing.T, hh *harness, source godap.Sourc
 	retained := hh.handler.bpByFile[source.Path][10]
 	_, droppedStillCached := hh.handler.bpByFile[source.Path][20]
 	hh.handler.mu.Unlock()
-	if retained.debuggerID != 101 || retained.dapID != 41 {
-		t.Fatalf("retained breakpoint state = %+v, want debuggerID=101 dapID=41", retained)
+	if retained == nil || retained.installedID != 101 || retained.dapID != 41 {
+		t.Fatalf("retained breakpoint state = %+v, want installedID=101 dapID=41", retained)
 	}
 	if droppedStillCached {
 		t.Fatal("discarded breakpoint remained in cache")
@@ -837,6 +853,7 @@ func clearReidentifiedBreakpoint(t *testing.T, hh *harness, source godap.Source)
 	if clear.ID != 101 {
 		t.Fatalf("clear breakpoint id = %d, want fresh debugger id 101", clear.ID)
 	}
+	hh.inject(protocol.EventBreakpointCleared, protocol.BreakpointClearedPayload{ID: 101})
 	_ = recvType[*godap.SetBreakpointsResponse](hh)
 }
 
@@ -955,17 +972,18 @@ func TestRestartErrorAllowsRetry(t *testing.T) {
 
 func TestRestartPreservesBreakpointCorrelationQueues(t *testing.T) {
 	h := NewHandler(nil, nil, nil)
-	setSlot := &bpSlot{}
-	h.setQ = []*bpSlot{setSlot}
-	h.clearQ = []int{73}
+	setOp := &bpOp{file: "/x/main.go", line: 10}
+	clearOp := &bpOp{file: "/x/main.go", line: 20}
+	h.setQ = []*bpOp{setOp}
+	h.clearQ = []*bpOp{clearOp}
 
 	h.onRestarted(protocol.MustEvent(protocol.EventRestarted, 1, protocol.RestartedPayload{}))
 
-	if len(h.setQ) != 1 || h.setQ[0] != setSlot {
+	if len(h.setQ) != 1 || h.setQ[0] != setOp {
 		t.Fatalf("setQ changed across restart: %+v", h.setQ)
 	}
-	if len(h.clearQ) != 1 || h.clearQ[0] != 73 {
-		t.Fatalf("clearQ changed across restart: %v", h.clearQ)
+	if len(h.clearQ) != 1 || h.clearQ[0] != clearOp {
+		t.Fatalf("clearQ changed across restart: %+v", h.clearQ)
 	}
 }
 

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -987,6 +987,25 @@ func TestRestartPreservesBreakpointCorrelationQueues(t *testing.T) {
 	}
 }
 
+func requireSequentialOpaqueBreakpoints(t *testing.T, got []godap.Breakpoint, count int) map[int]struct{} {
+	t.Helper()
+	if len(got) != count {
+		t.Fatalf("got %d breakpoints, want %d", len(got), count)
+	}
+	ids := make(map[int]struct{}, count+1)
+	for i, bp := range got {
+		wantLine := i + 1
+		if !bp.Verified || bp.Id <= 0 || bp.Line != wantLine {
+			t.Fatalf("breakpoint %d = %+v, want verified line %d with a positive id", i, bp, wantLine)
+		}
+		if _, duplicate := ids[bp.Id]; duplicate {
+			t.Fatalf("breakpoint %d reused id %d", i, bp.Id)
+		}
+		ids[bp.Id] = struct{}{}
+	}
+	return ids
+}
+
 func TestSetBreakpointsBurstThroughHubPreservesFIFO(t *testing.T) {
 	dbg := newGatedBreakpointDebugger()
 	defer dbg.release()
@@ -1044,20 +1063,7 @@ func TestSetBreakpointsBurstThroughHubPreservesFIFO(t *testing.T) {
 	if resp.RequestSeq != setSeq {
 		t.Fatalf("setBreakpoints request seq = %d, want %d", resp.RequestSeq, setSeq)
 	}
-	if len(resp.Body.Breakpoints) != breakpointCount {
-		t.Fatalf("got %d breakpoints, want %d", len(resp.Body.Breakpoints), breakpointCount)
-	}
-	ids := make(map[int]struct{}, breakpointCount+1)
-	for i, bp := range resp.Body.Breakpoints {
-		wantLine := i + 1
-		if !bp.Verified || bp.Id <= 0 || bp.Line != wantLine {
-			t.Fatalf("breakpoint %d = %+v, want verified line %d with a positive id", i, bp, wantLine)
-		}
-		if _, duplicate := ids[bp.Id]; duplicate {
-			t.Fatalf("breakpoint %d reused id %d", i, bp.Id)
-		}
-		ids[bp.Id] = struct{}{}
-	}
+	ids := requireSequentialOpaqueBreakpoints(t, resp.Body.Breakpoints, breakpointCount)
 	if got := dbg.setCount(); got != breakpointCount {
 		t.Fatalf("SetBreakpoint calls = %d, want %d", got, breakpointCount)
 	}

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -1047,11 +1047,16 @@ func TestSetBreakpointsBurstThroughHubPreservesFIFO(t *testing.T) {
 	if len(resp.Body.Breakpoints) != breakpointCount {
 		t.Fatalf("got %d breakpoints, want %d", len(resp.Body.Breakpoints), breakpointCount)
 	}
+	ids := make(map[int]struct{}, breakpointCount+1)
 	for i, bp := range resp.Body.Breakpoints {
 		wantLine := i + 1
-		if !bp.Verified || bp.Id != wantLine || bp.Line != wantLine {
-			t.Fatalf("breakpoint %d = %+v, want verified line/id %d", i, bp, wantLine)
+		if !bp.Verified || bp.Id <= 0 || bp.Line != wantLine {
+			t.Fatalf("breakpoint %d = %+v, want verified line %d with a positive id", i, bp, wantLine)
 		}
+		if _, duplicate := ids[bp.Id]; duplicate {
+			t.Fatalf("breakpoint %d reused id %d", i, bp.Id)
+		}
+		ids[bp.Id] = struct{}{}
 	}
 	if got := dbg.setCount(); got != breakpointCount {
 		t.Fatalf("SetBreakpoint calls = %d, want %d", got, breakpointCount)
@@ -1069,8 +1074,11 @@ func TestSetBreakpointsBurstThroughHubPreservesFIFO(t *testing.T) {
 		t.Fatalf("next setBreakpoints request seq = %d, want %d", next.RequestSeq, nextSeq)
 	}
 	last := next.Body.Breakpoints[len(next.Body.Breakpoints)-1]
-	if !last.Verified || last.Id != 1000 || last.Line != 1000 {
-		t.Fatalf("next breakpoint = %+v, want verified line/id 1000", last)
+	if !last.Verified || last.Id <= 0 || last.Line != 1000 {
+		t.Fatalf("next breakpoint = %+v, want verified line 1000 with a positive id", last)
+	}
+	if _, duplicate := ids[last.Id]; duplicate {
+		t.Fatalf("next breakpoint reused id %d", last.Id)
 	}
 
 	hh.handler.mu.Lock()

--- a/internal/dap/hublogicalbp_test.go
+++ b/internal/dap/hublogicalbp_test.go
@@ -1,0 +1,688 @@
+package dap
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	godap "github.com/google/go-dap"
+
+	"github.com/bingosuite/bingo/internal/debugger"
+	"github.com/bingosuite/bingo/internal/hub"
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+// This file pins the fix for issue #200 through the real stack: a real
+// hub.Hub, a real dap.Handler, and a gating hub.WSConn interposed at the exact
+// Handler.ReadMessage -> Client.readPump boundary where a marshalled command
+// has left the handler but has not yet been injected into the hub.
+//
+// The hazard: the handler decides to clear breakpoint A and hands the bytes to
+// the read pump. Before the pump injects them, another client completes a
+// Restart. The replacement engine allocates physical ids from 1 again, so A's
+// old physical id can name a *different* breakpoint in the new process. With
+// hub-owned logical ids the delayed clear still resolves to A.
+
+// raceDebugger is a debugger fake with a faithful per-instance breakpoint
+// table (ids from 1) plus an entry stop on Launch, mirroring the engine's
+// emitStoppedAtCurrentPC so the DAP handshake can complete.
+type raceDebugger struct {
+	mu     sync.Mutex
+	events chan protocol.Event
+	nextID int
+	armed  map[int]protocol.Location
+	closed bool
+}
+
+func newRaceDebugger() *raceDebugger {
+	return &raceDebugger{
+		events: make(chan protocol.Event, 64),
+		armed:  make(map[int]protocol.Location),
+	}
+}
+
+func (d *raceDebugger) Events() <-chan protocol.Event { return d.events }
+
+func (d *raceDebugger) emitEntryStop() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return
+	}
+	d.events <- protocol.MustEvent(protocol.EventStepped, 0, protocol.SteppedPayload{
+		Location: protocol.Location{File: "main.go", Line: 1},
+	})
+}
+
+func (d *raceDebugger) Launch(string, []string, []string) error {
+	go d.emitEntryStop()
+	return nil
+}
+
+func (d *raceDebugger) Attach(int, string) error { return nil }
+
+func (d *raceDebugger) Kill() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.closed = true
+	return nil
+}
+
+func (d *raceDebugger) Continue() error { return nil }
+func (d *raceDebugger) StepOver() error { return nil }
+func (d *raceDebugger) StepInto() error { return nil }
+func (d *raceDebugger) StepOut() error  { return nil }
+func (d *raceDebugger) Pause() error    { return nil }
+
+func (d *raceDebugger) SetBreakpoint(file string, line int) (protocol.Breakpoint, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.nextID++
+	loc := protocol.Location{File: file, Line: line}
+	d.armed[d.nextID] = loc
+	return protocol.Breakpoint{ID: d.nextID, Location: loc, Enabled: true}, nil
+}
+
+func (d *raceDebugger) ClearBreakpoint(id int) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, ok := d.armed[id]; !ok {
+		return fmt.Errorf("breakpoint %d not found", id)
+	}
+	delete(d.armed, id)
+	return nil
+}
+
+func (d *raceDebugger) Locals(int) ([]protocol.Variable, error) { return nil, nil }
+func (d *raceDebugger) Evaluate(int, string) (protocol.Variable, error) {
+	return protocol.Variable{}, nil
+}
+func (d *raceDebugger) StackFrames() ([]protocol.Frame, error)    { return nil, nil }
+func (d *raceDebugger) Goroutines() ([]protocol.Goroutine, error) { return nil, nil }
+func (d *raceDebugger) GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error) {
+	return protocol.GoroutineSnapshotPayload{}, nil
+}
+
+// armedLines returns the lines this engine still has armed, sorted.
+func (d *raceDebugger) armedLines() []int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	out := make([]int, 0, len(d.armed))
+	for _, loc := range d.armed {
+		out = append(out, loc.Line)
+	}
+	sort.Ints(out)
+	return out
+}
+
+func (d *raceDebugger) physicalIDFor(line int) int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for id, loc := range d.armed {
+		if loc.Line == line {
+			return id
+		}
+	}
+	return 0
+}
+
+// engineFleet hands the hub a fresh raceDebugger per Launch/Restart, retaining
+// each one so the test can assert against the engine that actually holds the
+// traps.
+type engineFleet struct {
+	mu      sync.Mutex
+	created []*raceDebugger
+}
+
+func (f *engineFleet) factory() func() debugger.Debugger {
+	return func() debugger.Debugger {
+		d := newRaceDebugger()
+		f.mu.Lock()
+		f.created = append(f.created, d)
+		f.mu.Unlock()
+		return d
+	}
+}
+
+func (f *engineFleet) at(t *testing.T, i int) *raceDebugger {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.created) <= i {
+		t.Fatalf("engine %d was never created (have %d)", i, len(f.created))
+	}
+	return f.created[i]
+}
+
+// gatingConn wraps the DAP handler as the hub sees it and can hold a
+// ClearBreakpoint command after ReadMessage has produced it but before the hub
+// read pump injects it — the exact window issue #200 describes.
+type gatingConn struct {
+	hub.WSConn
+
+	mu   sync.Mutex
+	hold chan struct{}
+	held chan struct{}
+}
+
+func (g *gatingConn) arm() {
+	g.mu.Lock()
+	g.hold = make(chan struct{})
+	g.held = make(chan struct{}, 1)
+	g.mu.Unlock()
+}
+
+func (g *gatingConn) waitHeld(t *testing.T) {
+	t.Helper()
+	g.mu.Lock()
+	held := g.held
+	g.mu.Unlock()
+	select {
+	case <-held:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the handler to produce a ClearBreakpoint")
+	}
+}
+
+func (g *gatingConn) release() {
+	g.mu.Lock()
+	hold := g.hold
+	g.hold = nil
+	g.mu.Unlock()
+	if hold != nil {
+		close(hold)
+	}
+}
+
+func (g *gatingConn) ReadMessage() (int, []byte, error) {
+	mt, data, err := g.WSConn.ReadMessage()
+	if err != nil {
+		return mt, data, err
+	}
+	cmd, cerr := protocol.UnmarshalCommand(data)
+	if cerr != nil || cmd.Kind != protocol.CmdClearBreakpoint {
+		return mt, data, err
+	}
+	g.mu.Lock()
+	hold, held := g.hold, g.held
+	g.mu.Unlock()
+	if hold == nil {
+		return mt, data, err
+	}
+	select {
+	case held <- struct{}{}:
+	default:
+	}
+	<-hold
+	return mt, data, err
+}
+
+// hubSession adapts a real *hub.Hub to the DAP Provider/Session interfaces,
+// interposing the gating connection so the test controls command delivery.
+type hubSession struct {
+	hb   *hub.Hub
+	gate *gatingConn
+}
+
+func (s *hubSession) SessionID() string { return "race-session" }
+
+func (s *hubSession) AddClient(conn hub.WSConn, log *slog.Logger) (*hub.Client, error) {
+	s.gate.WSConn = conn
+	return s.hb.AddClient(s.gate, log)
+}
+
+type hubProvider struct{ sess *hubSession }
+
+func (p *hubProvider) CreateSession() (Session, error)   { return p.sess, nil }
+func (p *hubProvider) GetSession(string) (Session, bool) { return p.sess, true }
+
+// observer is a plain WebSocket client on the same hub: it both drives Restart
+// and records the bingo events every client sees, so the test can assert that
+// WebSocket and DAP observe the same stable ids.
+type observer struct {
+	mu     sync.Mutex
+	out    chan []byte
+	events []protocol.Event
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newObserver() *observer {
+	return &observer{out: make(chan []byte, 64), closed: make(chan struct{})}
+}
+
+func (o *observer) ReadMessage() (int, []byte, error) {
+	select {
+	case data := <-o.out:
+		return hub.TextMessage, data, nil
+	case <-o.closed:
+		return 0, nil, net.ErrClosed
+	}
+}
+
+func (o *observer) WriteMessage(_ int, data []byte) error {
+	evt, err := protocol.UnmarshalEvent(data)
+	if err != nil {
+		return nil
+	}
+	o.mu.Lock()
+	o.events = append(o.events, evt)
+	o.mu.Unlock()
+	return nil
+}
+
+func (o *observer) Close() error {
+	o.once.Do(func() { close(o.closed) })
+	return nil
+}
+
+func (o *observer) SetReadLimit(int64)                {}
+func (o *observer) SetReadDeadline(time.Time) error   { return nil }
+func (o *observer) SetWriteDeadline(time.Time) error  { return nil }
+func (o *observer) SetPongHandler(func(string) error) {}
+
+func (o *observer) send(t *testing.T, kind protocol.CommandKind, payload any) {
+	t.Helper()
+	data, err := marshalCommand(kind, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case o.out <- data:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out sending %s", kind)
+	}
+}
+
+// waitEvent polls for the first event of kind, decoding it into out.
+func (o *observer) waitEvent(t *testing.T, kind protocol.EventKind, out any) protocol.Event {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		o.mu.Lock()
+		for _, e := range o.events {
+			if e.Kind == kind {
+				o.mu.Unlock()
+				if out != nil {
+					if err := protocol.DecodeEventPayload(e, out); err != nil {
+						t.Fatal(err)
+					}
+				}
+				return e
+			}
+		}
+		o.mu.Unlock()
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for event %s", kind)
+	return protocol.Event{}
+}
+
+// setIDs returns the breakpoint ids from every BreakpointSet event seen so far.
+func (o *observer) setIDs(t *testing.T) []int {
+	t.Helper()
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	var ids []int
+	for _, e := range o.events {
+		if e.Kind != protocol.EventBreakpointSet {
+			continue
+		}
+		var p protocol.BreakpointSetPayload
+		if err := protocol.DecodeEventPayload(e, &p); err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, p.Breakpoint.ID)
+	}
+	return ids
+}
+
+// raceRig is a real hub + real DAP handler + a WebSocket observer client.
+type raceRig struct {
+	t       *testing.T
+	hub     *hub.Hub
+	fleet   *engineFleet
+	gate    *gatingConn
+	handler *Handler
+	client  net.Conn
+	reader  *bufio.Reader
+	codec   *godap.Codec
+	obs     *observer
+	seq     int
+}
+
+func newRaceRig(t *testing.T) *raceRig {
+	t.Helper()
+	log := slog.New(slog.NewTextHandler(nopWriter{}, nil))
+
+	fleet := &engineFleet{}
+	hb := hub.NewSession("race-session", fleet.factory(), log)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		hb.Run(t.Context())
+	}()
+
+	gate := &gatingConn{}
+	prov := &hubProvider{sess: &hubSession{hb: hb, gate: gate}}
+
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, aerr := ln.Accept()
+		if aerr == nil {
+			accepted <- c
+		}
+	}()
+	client, err := net.Dial("tcp4", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverConn := <-accepted
+
+	handler := NewHandler(serverConn, prov, log)
+	go handler.Serve()
+
+	codec := godap.NewCodec()
+	if err := codec.RegisterEvent(sessionEventName, func() godap.Message { return new(sessionEvent) }); err != nil {
+		t.Fatal(err)
+	}
+
+	obs := newObserver()
+	if _, err := hb.AddClient(obs, log); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		gate.release()
+		_ = client.Close()
+		_ = handler.Close()
+		_ = obs.Close()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+		}
+	})
+
+	return &raceRig{
+		t: t, hub: hb, fleet: fleet, gate: gate, handler: handler,
+		client: client, reader: bufio.NewReader(client), codec: codec, obs: obs,
+	}
+}
+
+func (r *raceRig) sendReq(command string, m godap.RequestMessage) int {
+	r.t.Helper()
+	r.seq++
+	req := m.GetRequest()
+	req.Seq = r.seq
+	req.Type = "request"
+	req.Command = command
+	if err := godap.WriteProtocolMessage(r.client, m); err != nil {
+		r.t.Fatalf("write %s: %v", command, err)
+	}
+	return r.seq
+}
+
+func (r *raceRig) recvUntil(want string) godap.Message {
+	r.t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		_ = r.client.SetReadDeadline(time.Now().Add(3 * time.Second))
+		data, err := godap.ReadBaseMessage(r.reader)
+		if err != nil {
+			r.t.Fatalf("recv: %v", err)
+		}
+		m, err := r.codec.DecodeMessage(data)
+		if err != nil {
+			continue
+		}
+		switch typed := m.(type) {
+		case *godap.SetBreakpointsResponse:
+			if want == "setBreakpoints" {
+				return typed
+			}
+		case *godap.InitializeResponse:
+			if want == "initialize" {
+				return typed
+			}
+		case *godap.InitializedEvent:
+			if want == "initialized" {
+				return typed
+			}
+		case *godap.ConfigurationDoneResponse:
+			if want == "configurationDone" {
+				return typed
+			}
+		}
+	}
+	r.t.Fatalf("timed out waiting for %s", want)
+	return nil
+}
+
+// setBreakpoints issues a replace-all setBreakpoints for main.go and waits for
+// the response (the handler answers only once every operation it owns settled).
+func (r *raceRig) setBreakpoints(lines ...int) *godap.SetBreakpointsResponse {
+	r.t.Helper()
+	bps := make([]godap.SourceBreakpoint, 0, len(lines))
+	for _, l := range lines {
+		bps = append(bps, godap.SourceBreakpoint{Line: l})
+	}
+	r.sendReq("setBreakpoints", &godap.SetBreakpointsRequest{
+		Arguments: godap.SetBreakpointsArguments{
+			Source:      godap.Source{Path: "main.go"},
+			Breakpoints: bps,
+		},
+	})
+	return r.recvUntil("setBreakpoints").(*godap.SetBreakpointsResponse)
+}
+
+// handshake runs initialize -> launch(stopOnEntry) -> initialized ->
+// configurationDone against the real hub, leaving the session suspended at the
+// entry stop (where the hub still drains ordinary commands).
+func (r *raceRig) handshake() {
+	r.t.Helper()
+	r.sendReq("initialize", initArgs())
+	r.recvUntil("initialize")
+	r.sendReq("launch", &godap.LaunchRequest{
+		Arguments: json.RawMessage(`{"program":"/bin/x","stopOnEntry":true}`),
+	})
+	r.recvUntil("initialized")
+}
+
+// installedID returns the bingo breakpoint id the handler believes is armed at
+// main.go:line, or 0.
+func (r *raceRig) installedID(line int) int {
+	r.handler.mu.Lock()
+	defer r.handler.mu.Unlock()
+	for _, lines := range r.handler.bpByFile {
+		if st, ok := lines[line]; ok {
+			return st.installedID
+		}
+	}
+	return 0
+}
+
+// prepareGap installs A(main.go:10) and B(main.go:20) behind a throwaway
+// breakpoint so their physical ids are 2 and 3 — leaving the compaction gap a
+// relaunch needs for a stale physical id to alias the wrong breakpoint.
+func (r *raceRig) prepareGap() (logicalA, logicalB int) {
+	r.t.Helper()
+	r.setBreakpoints(5, 10, 20)
+	r.setBreakpoints(10, 20)
+
+	first := r.fleet.at(r.t, 0)
+	if got := first.physicalIDFor(10); got != 2 {
+		r.t.Fatalf("A should hold physical id 2 in the first engine, got %d", got)
+	}
+	if got := first.physicalIDFor(20); got != 3 {
+		r.t.Fatalf("B should hold physical id 3 in the first engine, got %d", got)
+	}
+	logicalA, logicalB = r.installedID(10), r.installedID(20)
+	if logicalA == 0 || logicalB == 0 {
+		r.t.Fatalf("handler lost track of the breakpoints (A=%d B=%d)", logicalA, logicalB)
+	}
+	return logicalA, logicalB
+}
+
+// TestStaleClearAcrossRestartHitsTheRightBreakpoint is the permanent
+// regression for issue #200: a clear generated before a restart, injected
+// after it, must still disarm the breakpoint it named.
+func TestStaleClearAcrossRestartHitsTheRightBreakpoint(t *testing.T) {
+	rig := newRaceRig(t)
+	rig.handshake()
+
+	logicalA, logicalB := rig.prepareGap()
+	if logicalA == logicalB {
+		t.Fatal("A and B must have distinct ids")
+	}
+
+	// Ask the handler to remove A. Its ClearBreakpoint is held at the
+	// ReadMessage -> readPump boundary, before the hub ever sees it.
+	rig.gate.arm()
+	go func() { _ = rig.setBreakpoints(20) }()
+	rig.gate.waitHeld(t)
+
+	// A second client restarts the session. The replacement engine allocates
+	// physical ids from 1, so A's old physical id (2) now names B.
+	rig.obs.send(t, protocol.CmdRestart, protocol.RestartPayload{})
+	var restarted protocol.RestartedPayload
+	rig.obs.waitEvent(t, protocol.EventRestarted, &restarted)
+
+	fresh := rig.fleet.at(t, 1)
+	if got := fresh.physicalIDFor(10); got != 1 {
+		t.Fatalf("fresh engine should have compacted A to physical id 1, got %d", got)
+	}
+	if got := fresh.physicalIDFor(20); got != 2 {
+		t.Fatalf("fresh engine should have compacted B to physical id 2, got %d", got)
+	}
+
+	// Logical identity survives the relaunch, so the client's ids stay valid.
+	gotIDs := make([]int, 0, len(restarted.Breakpoints))
+	for _, bp := range restarted.Breakpoints {
+		gotIDs = append(gotIDs, bp.ID)
+	}
+	sort.Ints(gotIDs)
+	want := []int{logicalA, logicalB}
+	sort.Ints(want)
+	if len(gotIDs) != 2 || gotIDs[0] != want[0] || gotIDs[1] != want[1] {
+		t.Fatalf("restart must preserve logical ids: want %v, got %v", want, gotIDs)
+	}
+
+	rig.gate.release()
+
+	// The delayed clear must land on A in the *new* process.
+	deadline := time.Now().Add(3 * time.Second)
+	var lines []int
+	for time.Now().Before(deadline) {
+		lines = fresh.armedLines()
+		if len(lines) == 1 && lines[0] == 20 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if len(lines) != 1 || lines[0] != 20 {
+		t.Fatalf("stale clear disarmed the wrong breakpoint: armed lines %v (want [20])", lines)
+	}
+
+	// The handler's view must agree with the physical effect.
+	if id := rig.installedID(10); id != 0 {
+		t.Fatalf("handler still believes A is installed (id %d)", id)
+	}
+	if id := rig.installedID(20); id != logicalB {
+		t.Fatalf("handler lost B's stable id: want %d, got %d", logicalB, id)
+	}
+}
+
+// TestClearBeforeRestartIsUnaffected is the in-order negative control: with no
+// gating, the same sequence must behave normally.
+func TestClearBeforeRestartIsUnaffected(t *testing.T) {
+	rig := newRaceRig(t)
+	rig.handshake()
+
+	_, logicalB := rig.prepareGap()
+
+	rig.setBreakpoints(20)
+
+	first := rig.fleet.at(t, 0)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if lines := first.armedLines(); len(lines) == 1 && lines[0] == 20 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if lines := first.armedLines(); len(lines) != 1 || lines[0] != 20 {
+		t.Fatalf("in-order clear should leave only B armed, got %v", lines)
+	}
+
+	rig.obs.send(t, protocol.CmdRestart, protocol.RestartPayload{})
+	var restarted protocol.RestartedPayload
+	rig.obs.waitEvent(t, protocol.EventRestarted, &restarted)
+
+	if len(restarted.Breakpoints) != 1 || restarted.Breakpoints[0].ID != logicalB {
+		t.Fatalf("restart should reinstall only B with its stable id %d, got %+v",
+			logicalB, restarted.Breakpoints)
+	}
+	fresh := rig.fleet.at(t, 1)
+	if lines := fresh.armedLines(); len(lines) != 1 || lines[0] != 20 {
+		t.Fatalf("fresh engine should hold only B, got %v", lines)
+	}
+}
+
+// TestWebSocketAndDAPSeeTheSameIDs pins that both client protocols on one
+// session are handed the same stable identities.
+func TestWebSocketAndDAPSeeTheSameIDs(t *testing.T) {
+	rig := newRaceRig(t)
+	rig.handshake()
+
+	logicalA, logicalB := rig.prepareGap()
+
+	// The WebSocket observer saw the same ids the DAP handler recorded.
+	ids := rig.obs.setIDs(t)
+	if len(ids) < 3 {
+		t.Fatalf("observer should have seen three BreakpointSet events, got %v", ids)
+	}
+	if ids[1] != logicalA || ids[2] != logicalB {
+		t.Fatalf("WebSocket ids %v disagree with DAP ids (A=%d B=%d)", ids, logicalA, logicalB)
+	}
+
+	// Restart so the fresh engine's physical ids no longer coincide with the
+	// logical ones — only then does a missing translation actually show.
+	rig.obs.send(t, protocol.CmdRestart, protocol.RestartPayload{})
+	rig.obs.waitEvent(t, protocol.EventRestarted, &protocol.RestartedPayload{})
+
+	fresh := rig.fleet.at(t, 1)
+	physicalA := fresh.physicalIDFor(10)
+	if physicalA == logicalA {
+		t.Fatalf("test is blind: physical and logical ids for A both %d", physicalA)
+	}
+
+	// A breakpoint hit reported by the engine with a physical id must reach
+	// every client as the logical id.
+	fresh.events <- protocol.MustEvent(protocol.EventBreakpointHit, 0, protocol.BreakpointHitPayload{
+		Breakpoint: protocol.Breakpoint{
+			ID:       physicalA,
+			Location: protocol.Location{File: "main.go", Line: 10},
+		},
+	})
+
+	var hit protocol.BreakpointHitPayload
+	rig.obs.waitEvent(t, protocol.EventBreakpointHit, &hit)
+	if hit.Breakpoint.ID != logicalA {
+		t.Fatalf("BreakpointHit must carry the logical id %d, got %d", logicalA, hit.Breakpoint.ID)
+	}
+	if hit.Breakpoint.Location.Line != 10 {
+		t.Fatalf("BreakpointHit location must survive re-encoding, got %+v", hit.Breakpoint.Location)
+	}
+}

--- a/internal/dap/hublogicalbp_test.go
+++ b/internal/dap/hublogicalbp_test.go
@@ -237,10 +237,10 @@ func (s *hubSession) AddClient(conn hub.WSConn, log *slog.Logger) (*hub.Client, 
 	return s.hb.AddClient(s.gate, log)
 }
 
-type hubProvider struct{ sess *hubSession }
+type raceHubProvider struct{ sess *hubSession }
 
-func (p *hubProvider) CreateSession() (Session, error)   { return p.sess, nil }
-func (p *hubProvider) GetSession(string) (Session, bool) { return p.sess, true }
+func (p *raceHubProvider) CreateSession() (Session, error)   { return p.sess, nil }
+func (p *raceHubProvider) GetSession(string) (Session, bool) { return p.sess, true }
 
 // observer is a plain WebSocket client on the same hub: it both drives Restart
 // and records the bingo events every client sees, so the test can assert that
@@ -370,7 +370,7 @@ func newRaceRig(t *testing.T) *raceRig {
 	}()
 
 	gate := &gatingConn{}
-	prov := &hubProvider{sess: &hubSession{hb: hb, gate: gate}}
+	prov := &raceHubProvider{sess: &hubSession{hb: hb, gate: gate}}
 
 	ln, err := net.Listen("tcp4", "127.0.0.1:0")
 	if err != nil {
@@ -487,6 +487,33 @@ func (r *raceRig) setBreakpoints(lines ...int) *godap.SetBreakpointsResponse {
 	return r.recvUntil("setBreakpoints").(*godap.SetBreakpointsResponse)
 }
 
+// setBreakpointsAsync issues a setBreakpoints from its own goroutine, which is
+// what lets a test hold that request's command at the gate while driving the
+// session from a second client.
+//
+// Joining the returned channel is not optional: setBreakpoints reports failures
+// through t, and doing that once the test has returned panics the whole package
+// run. The registered cleanup releases the gate before waiting so every exit
+// path joins — including a t.Fatalf on the test goroutine, which would
+// otherwise leave this one parked at the gate forever.
+func (r *raceRig) setBreakpointsAsync(lines ...int) <-chan struct{} {
+	r.t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = r.setBreakpoints(lines...)
+	}()
+	r.t.Cleanup(func() {
+		r.gate.release()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			r.t.Error("the held setBreakpoints goroutine never finished")
+		}
+	})
+	return done
+}
+
 // handshake runs initialize -> launch(stopOnEntry) -> initialized ->
 // configurationDone against the real hub, leaving the session suspended at the
 // entry stop (where the hub still drains ordinary commands).
@@ -550,7 +577,7 @@ func TestStaleClearAcrossRestartHitsTheRightBreakpoint(t *testing.T) {
 	// Ask the handler to remove A. Its ClearBreakpoint is held at the
 	// ReadMessage -> readPump boundary, before the hub ever sees it.
 	rig.gate.arm()
-	go func() { _ = rig.setBreakpoints(20) }()
+	held := rig.setBreakpointsAsync(20)
 	rig.gate.waitHeld(t)
 
 	// A second client restarts the session. The replacement engine allocates
@@ -580,6 +607,7 @@ func TestStaleClearAcrossRestartHitsTheRightBreakpoint(t *testing.T) {
 	}
 
 	rig.gate.release()
+	<-held
 
 	// The delayed clear must land on A in the *new* process.
 	deadline := time.Now().Add(3 * time.Second)

--- a/internal/hub/breakpoints.go
+++ b/internal/hub/breakpoints.go
@@ -51,19 +51,36 @@ type breakpointIDs struct {
 	byLogical  map[int]*breakpointMapping
 	byPhysical map[int]int
 
-	// retired remembers physical ids this engine's breakpoints were removed
-	// under, so an event the engine had already queued when the removal ran
-	// still reports the identity the client held. Engine ids are never reused
-	// within one engine, and reset() drops the whole record with the engine.
-	retired      map[int]int
-	retiredOrder []int
+	// The tombstone record for breakpoints this engine has removed, kept in
+	// BOTH directions:
+	//
+	//   - retiredLogical (physical→logical) lets an event the engine had
+	//     already queued when the removal ran still report the identity the
+	//     client held, rather than a number it was never told about.
+	//   - retiredPhysical (logical→physical) keeps that reported id CLEARABLE.
+	//     Clearing the breakpoint the process is currently parked on is undone
+	//     by the engine's step-off: resumeFromBreakpoint replays the entry
+	//     pointer it stashed at hit time, and reinstall re-adds it under the
+	//     SAME physical id. Without this direction the resurrected trap would
+	//     be reported under a logical id the hub had already forgotten, so no
+	//     client could ever remove it again — and the location could not be
+	//     re-set either, since the engine still has it armed.
+	//
+	// Physical ids are monotonic within one engine (breakpointTable.nextID
+	// only ever increments), and reset() drops the whole record whenever the
+	// engine is replaced, so a tombstone can only ever name the breakpoint it
+	// was created for — never a later one, and never one in another generation.
+	retiredLogical  map[int]int
+	retiredPhysical map[int]int
+	retiredOrder    []int
 }
 
 func newBreakpointIDs() *breakpointIDs {
 	return &breakpointIDs{
-		byLogical:  make(map[int]*breakpointMapping),
-		byPhysical: make(map[int]int),
-		retired:    make(map[int]int),
+		byLogical:       make(map[int]*breakpointMapping),
+		byPhysical:      make(map[int]int),
+		retiredLogical:  make(map[int]int),
+		retiredPhysical: make(map[int]int),
 	}
 }
 
@@ -113,17 +130,22 @@ func (b *breakpointIDs) untrack(logical int) {
 	b.retire(m.physicalID, logical)
 }
 
-// retire records a removed breakpoint's physical id, evicting the oldest entry
-// once the record is full.
+// retire records a removed breakpoint's physical id in both directions,
+// evicting the oldest entry once the record is full.
 func (b *breakpointIDs) retire(physicalID, logical int) {
-	if _, dup := b.retired[physicalID]; dup {
+	if _, dup := b.retiredLogical[physicalID]; dup {
 		return
 	}
 	if len(b.retiredOrder) >= retiredCap {
-		delete(b.retired, b.retiredOrder[0])
+		oldest := b.retiredOrder[0]
+		if staleLogical, ok := b.retiredLogical[oldest]; ok {
+			delete(b.retiredPhysical, staleLogical)
+		}
+		delete(b.retiredLogical, oldest)
 		b.retiredOrder = b.retiredOrder[1:]
 	}
-	b.retired[physicalID] = logical
+	b.retiredLogical[physicalID] = logical
+	b.retiredPhysical[logical] = physicalID
 	b.retiredOrder = append(b.retiredOrder, physicalID)
 }
 
@@ -148,10 +170,28 @@ func (b *breakpointIDs) logicalFor(physicalID int, loc protocol.Location) int {
 	if logical, ok := b.byPhysical[physicalID]; ok {
 		return logical
 	}
-	if logical, ok := b.retired[physicalID]; ok {
+	if logical, ok := b.retiredLogical[physicalID]; ok {
 		return logical
 	}
 	return b.adopt(physicalID, loc)
+}
+
+// physicalForClear resolves a logical id to the physical id the active engine
+// knows it by.
+//
+// A retired id still resolves, because a removal the hub confirmed can be undone
+// by the engine: stepping off the breakpoint the process is parked on reinstalls
+// it under the same physical id. Refusing the retired id would strand that
+// resurrected trap — unremovable (the hub forgot the mapping) and unsettable
+// (the engine still has the address armed). Resolving it instead is safe because
+// a physical id is never reused within an engine and the record dies with the
+// engine.
+func (b *breakpointIDs) physicalForClear(logical int) (int, bool) {
+	if m, ok := b.byLogical[logical]; ok {
+		return m.physicalID, true
+	}
+	physicalID, ok := b.retiredPhysical[logical]
+	return physicalID, ok
 }
 
 // installedLogical returns the logical ids the hub itself installed, ascending
@@ -171,12 +211,14 @@ func (b *breakpointIDs) installedLogical() []int {
 }
 
 // reset drops every mapping for a target that no longer exists, keeping next
-// where it is. Called on a fresh Launch/Attach, never on Restart — Restart's
-// whole point is that the logical identities survive.
+// where it is. Called on a fresh Launch/Attach and by Restart before it re-homes
+// the surviving identities: both replace the engine, and every physical id —
+// live or retired — becomes meaningless the moment that happens.
 func (b *breakpointIDs) reset() {
 	b.byLogical = make(map[int]*breakpointMapping)
 	b.byPhysical = make(map[int]int)
-	b.retired = make(map[int]int)
+	b.retiredLogical = make(map[int]int)
+	b.retiredPhysical = make(map[int]int)
 	b.retiredOrder = nil
 }
 
@@ -215,15 +257,18 @@ func (h *Hub) clearBreakpoint(dbg debugger.Debugger, cmd protocol.Command) (disp
 		return dispatchResult{}, err
 	}
 	logicalID := p.ID
-	m, ok := h.bps.lookup(logicalID)
+	physicalID, ok := h.bps.physicalForClear(logicalID)
 	if !ok {
 		return dispatchResult{}, fmt.Errorf("breakpoint %d not found", logicalID)
 	}
-	if err := dbg.ClearBreakpoint(m.physicalID); err != nil {
+	if err := dbg.ClearBreakpoint(physicalID); err != nil {
 		// Retain the mapping: a failed clear leaves the trap armed (see
 		// breakpointTable.clear), so the client must keep being able to name it.
 		return dispatchResult{}, err
 	}
+	// A no-op when the id was already retired, which is what makes clearing a
+	// step-off-resurrected breakpoint repeatable: the tombstone survives so the
+	// next resurrection is still reported — and removable — under the same id.
 	h.bps.untrack(logicalID)
 	evt, err := protocol.NewEvent(protocol.EventBreakpointCleared, 0, protocol.BreakpointClearedPayload{
 		ID: logicalID,

--- a/internal/hub/breakpoints.go
+++ b/internal/hub/breakpoints.go
@@ -214,18 +214,19 @@ func (h *Hub) clearBreakpoint(dbg debugger.Debugger, cmd protocol.Command) (disp
 	if err := protocol.DecodeCommandPayload(cmd, &p); err != nil {
 		return dispatchResult{}, err
 	}
-	m, ok := h.bps.lookup(p.ID)
+	logicalID := p.ID
+	m, ok := h.bps.lookup(logicalID)
 	if !ok {
-		return dispatchResult{}, fmt.Errorf("breakpoint %d not found", p.ID)
+		return dispatchResult{}, fmt.Errorf("breakpoint %d not found", logicalID)
 	}
 	if err := dbg.ClearBreakpoint(m.physicalID); err != nil {
 		// Retain the mapping: a failed clear leaves the trap armed (see
 		// breakpointTable.clear), so the client must keep being able to name it.
 		return dispatchResult{}, err
 	}
-	h.bps.untrack(p.ID)
+	h.bps.untrack(logicalID)
 	evt, err := protocol.NewEvent(protocol.EventBreakpointCleared, 0, protocol.BreakpointClearedPayload{
-		ID: p.ID,
+		ID: logicalID,
 	})
 	if err != nil {
 		return dispatchResult{}, err

--- a/internal/hub/breakpoints.go
+++ b/internal/hub/breakpoints.go
@@ -1,0 +1,257 @@
+package hub
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/bingosuite/bingo/internal/debugger"
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+// breakpointMapping is one logical breakpoint's record: the id the *currently
+// active* engine knows it by, plus the source location Restart reinstalls it
+// from.
+type breakpointMapping struct {
+	physicalID int
+	loc        protocol.Location
+
+	// installed marks a breakpoint the hub itself put in place, and is what
+	// makes it a Restart target. An adopted mapping (see logicalFor) only names
+	// something the hub observed; reinstalling it would arm a trap on the new
+	// process that no client ever asked for.
+	installed bool
+}
+
+// retiredCap bounds the per-engine record of removed breakpoints. Only a very
+// recent retirement can still be named by an in-flight event, so evicting the
+// oldest entries costs nothing while keeping a set/clear-churning session from
+// growing this without limit.
+const retiredCap = 1024
+
+// breakpointIDs owns the translation between the session-stable logical ids
+// clients hold and the per-engine physical ids a debugger allocates.
+//
+// Every engine restarts its allocation at 1 (internal/debugger/breakpoint.go),
+// so a physical id only means anything to the engine that issued it. A command
+// can still be *generated* against one engine and *injected* after that engine
+// has been replaced: the DAP adapter marshals a ClearBreakpoint while its hub
+// read pump is descheduled, another client completes a Restart in the meantime,
+// and the stale id then names a different breakpoint in the fresh process.
+// Passing raw engine ids through the protocol therefore lets a delayed clear
+// disarm the wrong trap (issue #200). Owning the identity here means such a
+// command either resolves to the same breakpoint in the replacement process or
+// is rejected outright.
+type breakpointIDs struct {
+	// next is monotonic for the whole hub lifetime and is deliberately NOT
+	// reset by a later Launch/Attach. Re-minting a logical id is what would let
+	// a delayed command from a previous target alias a breakpoint in the new
+	// one — exactly the aliasing this type exists to prevent.
+	next int
+
+	byLogical  map[int]*breakpointMapping
+	byPhysical map[int]int
+
+	// retired remembers physical ids this engine's breakpoints were removed
+	// under, so an event the engine had already queued when the removal ran
+	// still reports the identity the client held. Engine ids are never reused
+	// within one engine, and reset() drops the whole record with the engine.
+	retired      map[int]int
+	retiredOrder []int
+}
+
+func newBreakpointIDs() *breakpointIDs {
+	return &breakpointIDs{
+		byLogical:  make(map[int]*breakpointMapping),
+		byPhysical: make(map[int]int),
+		retired:    make(map[int]int),
+	}
+}
+
+// track mints a logical id for a freshly installed physical breakpoint.
+func (b *breakpointIDs) track(physicalID int, loc protocol.Location) int {
+	b.next++
+	logical := b.next
+	b.bind(logical, physicalID, loc)
+	return logical
+}
+
+// adopt mints a logical id for a physical breakpoint the hub did not install,
+// so it can be reported without leaking (or colliding with) an engine id. The
+// mapping is deliberately not a Restart target.
+func (b *breakpointIDs) adopt(physicalID int, loc protocol.Location) int {
+	logical := b.track(physicalID, loc)
+	b.byLogical[logical].installed = false
+	return logical
+}
+
+// bind points an existing logical id at the physical id the active engine gave
+// it. Restart uses this to re-home every surviving breakpoint onto the
+// replacement engine without changing the identity clients hold.
+func (b *breakpointIDs) bind(logical, physicalID int, loc protocol.Location) {
+	if prev, ok := b.byLogical[logical]; ok {
+		b.dropPhysical(prev.physicalID, logical)
+	}
+	b.byLogical[logical] = &breakpointMapping{physicalID: physicalID, loc: loc, installed: true}
+	b.byPhysical[physicalID] = logical
+}
+
+func (b *breakpointIDs) lookup(logical int) (*breakpointMapping, bool) {
+	m, ok := b.byLogical[logical]
+	return m, ok
+}
+
+// untrack forgets a logical breakpoint. Called only once a removal is
+// confirmed: a rejected clear leaves the trap armed, so dropping the mapping
+// optimistically would make that breakpoint permanently unremovable.
+func (b *breakpointIDs) untrack(logical int) {
+	m, ok := b.byLogical[logical]
+	if !ok {
+		return
+	}
+	delete(b.byLogical, logical)
+	b.dropPhysical(m.physicalID, logical)
+	b.retire(m.physicalID, logical)
+}
+
+// retire records a removed breakpoint's physical id, evicting the oldest entry
+// once the record is full.
+func (b *breakpointIDs) retire(physicalID, logical int) {
+	if _, dup := b.retired[physicalID]; dup {
+		return
+	}
+	if len(b.retiredOrder) >= retiredCap {
+		delete(b.retired, b.retiredOrder[0])
+		b.retiredOrder = b.retiredOrder[1:]
+	}
+	b.retired[physicalID] = logical
+	b.retiredOrder = append(b.retiredOrder, physicalID)
+}
+
+// dropPhysical removes a reverse entry only while it still points at logical,
+// so re-homing a mapping cannot delete another breakpoint's reverse lookup.
+func (b *breakpointIDs) dropPhysical(physicalID, logical int) {
+	if cur, ok := b.byPhysical[physicalID]; ok && cur == logical {
+		delete(b.byPhysical, physicalID)
+	}
+}
+
+// logicalFor resolves an engine-reported physical id to the client-visible
+// logical id.
+//
+// A hit the engine had already queued when the matching clear ran resolves
+// through the retirement record, so the client sees the id it actually held
+// rather than one it was never told about. Anything still unknown (a raw hub
+// whose debugger was driven directly) is adopted rather than passed through:
+// passing it through would let it collide with a logical id that names a
+// different breakpoint.
+func (b *breakpointIDs) logicalFor(physicalID int, loc protocol.Location) int {
+	if logical, ok := b.byPhysical[physicalID]; ok {
+		return logical
+	}
+	if logical, ok := b.retired[physicalID]; ok {
+		return logical
+	}
+	return b.adopt(physicalID, loc)
+}
+
+// installedLogical returns the logical ids the hub itself installed, ascending
+// so Restart reinstalls in a deterministic sequence across runs. Adopted
+// mappings are excluded — the hub never armed them, so it must not re-arm them
+// on the replacement process.
+func (b *breakpointIDs) installedLogical() []int {
+	ids := make([]int, 0, len(b.byLogical))
+	for id, m := range b.byLogical {
+		if !m.installed {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	sort.Ints(ids)
+	return ids
+}
+
+// reset drops every mapping for a target that no longer exists, keeping next
+// where it is. Called on a fresh Launch/Attach, never on Restart — Restart's
+// whole point is that the logical identities survive.
+func (b *breakpointIDs) reset() {
+	b.byLogical = make(map[int]*breakpointMapping)
+	b.byPhysical = make(map[int]int)
+	b.retired = make(map[int]int)
+	b.retiredOrder = nil
+}
+
+// setBreakpoint installs a breakpoint and reports it under a newly minted
+// logical id. The engine's physical id never leaves the hub.
+func (h *Hub) setBreakpoint(dbg debugger.Debugger, cmd protocol.Command) (dispatchResult, error) {
+	var p protocol.SetBreakpointPayload
+	if err := protocol.DecodeCommandPayload(cmd, &p); err != nil {
+		return dispatchResult{}, err
+	}
+	bp, err := dbg.SetBreakpoint(p.File, p.Line)
+	if err != nil {
+		return dispatchResult{}, err
+	}
+	bp.ID = h.bps.track(bp.ID, bp.Location)
+	evt, err := protocol.NewEvent(protocol.EventBreakpointSet, 0, protocol.BreakpointSetPayload{
+		Breakpoint: bp,
+	})
+	if err != nil {
+		return dispatchResult{}, err
+	}
+	return dispatchResult{event: &evt}, nil
+}
+
+// clearBreakpoint translates a logical id to the active engine's physical id
+// and removes it.
+//
+// An id the hub does not currently know is rejected without touching the
+// debugger. That is the load-bearing half of the fix: a clear generated against
+// a replaced or relaunched target names a breakpoint that no longer exists, and
+// forwarding it would remove whichever breakpoint the fresh engine happened to
+// give that number.
+func (h *Hub) clearBreakpoint(dbg debugger.Debugger, cmd protocol.Command) (dispatchResult, error) {
+	var p protocol.ClearBreakpointPayload
+	if err := protocol.DecodeCommandPayload(cmd, &p); err != nil {
+		return dispatchResult{}, err
+	}
+	m, ok := h.bps.lookup(p.ID)
+	if !ok {
+		return dispatchResult{}, fmt.Errorf("breakpoint %d not found", p.ID)
+	}
+	if err := dbg.ClearBreakpoint(m.physicalID); err != nil {
+		// Retain the mapping: a failed clear leaves the trap armed (see
+		// breakpointTable.clear), so the client must keep being able to name it.
+		return dispatchResult{}, err
+	}
+	h.bps.untrack(p.ID)
+	evt, err := protocol.NewEvent(protocol.EventBreakpointCleared, 0, protocol.BreakpointClearedPayload{
+		ID: p.ID,
+	})
+	if err != nil {
+		return dispatchResult{}, err
+	}
+	return dispatchResult{event: &evt}, nil
+}
+
+// localizeBreakpointIDs rewrites engine-owned physical breakpoint ids in a
+// debugger event to the hub's logical ids before it reaches clients.
+// EventBreakpointHit is the only engine-generated event carrying one; the
+// internal step-over/step-out sentinels report EventStepped and never surface a
+// breakpoint id at all.
+func (h *Hub) localizeBreakpointIDs(evt protocol.Event) protocol.Event {
+	if evt.Kind != protocol.EventBreakpointHit {
+		return evt
+	}
+	var p protocol.BreakpointHitPayload
+	if err := protocol.DecodeEventPayload(evt, &p); err != nil {
+		h.log.Warn("undecodable BreakpointHit payload — forwarding unchanged", "err", err)
+		return evt
+	}
+	p.Breakpoint.ID = h.bps.logicalFor(p.Breakpoint.ID, p.Breakpoint.Location)
+	localized, err := protocol.NewEvent(evt.Kind, evt.Seq, p)
+	if err != nil {
+		h.log.Error("failed to re-encode BreakpointHit — forwarding unchanged", "err", err)
+		return evt
+	}
+	return localized
+}

--- a/internal/hub/breakpoints_test.go
+++ b/internal/hub/breakpoints_test.go
@@ -1,0 +1,451 @@
+package hub_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/bingosuite/bingo/internal/debugger"
+	"github.com/bingosuite/bingo/internal/hub"
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+// tableDebugger is a debugger fake with a faithful breakpoint table: every
+// instance allocates ids from its own counter, so a replacement instance hands
+// out the same numbers its predecessor did — the reuse that makes a stale
+// physical id dangerous (issue #200).
+type tableDebugger struct {
+	mu     sync.Mutex
+	events chan protocol.Event
+	calls  []string
+
+	nextID int
+	armed  map[int]protocol.Location
+
+	// setErrFor fails SetBreakpoint for a specific line (0 disables).
+	setErrFor int
+	clearErr  error
+}
+
+func newTableDebugger() *tableDebugger {
+	return &tableDebugger{
+		events: make(chan protocol.Event, 32),
+		armed:  make(map[int]protocol.Location),
+	}
+}
+
+func (d *tableDebugger) record(call string) {
+	d.mu.Lock()
+	d.calls = append(d.calls, call)
+	d.mu.Unlock()
+}
+
+func (d *tableDebugger) recordedCalls() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	cp := make([]string, len(d.calls))
+	copy(cp, d.calls)
+	return cp
+}
+
+// armedLines returns the source lines of every armed breakpoint, sorted, so a
+// test can assert exactly which traps survive an operation.
+func (d *tableDebugger) armedLines() []int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	lines := make([]int, 0, len(d.armed))
+	for _, loc := range d.armed {
+		lines = append(lines, loc.Line)
+	}
+	sort.Ints(lines)
+	return lines
+}
+
+// physicalIDFor returns the id this engine gave the breakpoint at line, or 0.
+func (d *tableDebugger) physicalIDFor(line int) int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for id, loc := range d.armed {
+		if loc.Line == line {
+			return id
+		}
+	}
+	return 0
+}
+
+func (d *tableDebugger) setNextID(n int) {
+	d.mu.Lock()
+	d.nextID = n
+	d.mu.Unlock()
+}
+
+func (d *tableDebugger) setClearErr(err error) {
+	d.mu.Lock()
+	d.clearErr = err
+	d.mu.Unlock()
+}
+
+func (d *tableDebugger) Events() <-chan protocol.Event { return d.events }
+func (d *tableDebugger) closeEvents()                  { close(d.events) }
+
+func (d *tableDebugger) Launch(string, []string, []string) error { d.record("Launch"); return nil }
+func (d *tableDebugger) Attach(int, string) error                { d.record("Attach"); return nil }
+func (d *tableDebugger) Kill() error                             { d.record("Kill"); return nil }
+func (d *tableDebugger) Continue() error                         { d.record("Continue"); return nil }
+func (d *tableDebugger) StepOver() error                         { d.record("StepOver"); return nil }
+func (d *tableDebugger) StepInto() error                         { d.record("StepInto"); return nil }
+func (d *tableDebugger) StepOut() error                          { d.record("StepOut"); return nil }
+func (d *tableDebugger) Pause() error                            { d.record("Pause"); return nil }
+
+func (d *tableDebugger) SetBreakpoint(file string, line int) (protocol.Breakpoint, error) {
+	d.record(fmt.Sprintf("SetBreakpoint(%s:%d)", file, line))
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.setErrFor != 0 && d.setErrFor == line {
+		return protocol.Breakpoint{}, fmt.Errorf("no such line %d", line)
+	}
+	d.nextID++
+	loc := protocol.Location{File: file, Line: line}
+	d.armed[d.nextID] = loc
+	return protocol.Breakpoint{ID: d.nextID, Location: loc, Enabled: true}, nil
+}
+
+func (d *tableDebugger) ClearBreakpoint(id int) error {
+	d.record(fmt.Sprintf("ClearBreakpoint(%d)", id))
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.clearErr != nil {
+		return d.clearErr
+	}
+	if _, ok := d.armed[id]; !ok {
+		return fmt.Errorf("breakpoint %d not found", id)
+	}
+	delete(d.armed, id)
+	return nil
+}
+
+func (d *tableDebugger) Locals(int) ([]protocol.Variable, error) { return nil, nil }
+func (d *tableDebugger) Evaluate(int, string) (protocol.Variable, error) {
+	return protocol.Variable{}, nil
+}
+func (d *tableDebugger) StackFrames() ([]protocol.Frame, error)    { return nil, nil }
+func (d *tableDebugger) Goroutines() ([]protocol.Goroutine, error) { return nil, nil }
+func (d *tableDebugger) GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error) {
+	return protocol.GoroutineSnapshotPayload{}, nil
+}
+
+// debuggerFleet hands the hub a fresh tableDebugger per Launch/Restart and
+// keeps every instance so a test can inspect the physical state of the engine
+// that actually holds the traps.
+type debuggerFleet struct {
+	mu        sync.Mutex
+	created   []*tableDebugger
+	configure func(index int, d *tableDebugger)
+}
+
+func (f *debuggerFleet) factory() func() debugger.Debugger {
+	return func() debugger.Debugger {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		d := newTableDebugger()
+		if f.configure != nil {
+			f.configure(len(f.created), d)
+		}
+		f.created = append(f.created, d)
+		return d
+	}
+}
+
+func (f *debuggerFleet) at(i int) *tableDebugger {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ExpectWithOffset(1, len(f.created)).To(BeNumerically(">", i), "engine %d was never created", i)
+	return f.created[i]
+}
+
+func (f *debuggerFleet) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.created)
+}
+
+// setBP installs a breakpoint through the hub and returns the logical id the
+// hub broadcast for it.
+func setBP(conn *fakeWSConn, file string, line int) int {
+	GinkgoHelper()
+	conn.inject(mustCommand(protocol.CmdSetBreakpoint,
+		protocol.SetBreakpointPayload{File: file, Line: line}))
+	var p protocol.BreakpointSetPayload
+	waitForEventKind(conn, protocol.EventBreakpointSet, &p)
+	return p.Breakpoint.ID
+}
+
+// Logical breakpoint identity (issue #200). Physical ids belong to one engine
+// and are reused by its replacement, so the hub owns a session-stable logical
+// id per breakpoint and translates in both directions.
+var _ = Describe("logical breakpoint ids", func() {
+	var (
+		fleet  *debuggerFleet
+		h      *hub.Hub
+		conn   *fakeWSConn
+		cancel context.CancelFunc
+	)
+
+	// startManaged brings up a managed session whose first engine allocates
+	// physical ids from 101, so any logical id that leaked a physical one is
+	// immediately visible.
+	startManaged := func(configure func(int, *tableDebugger)) {
+		fleet = &debuggerFleet{configure: func(i int, d *tableDebugger) {
+			if i == 0 {
+				d.setNextID(100)
+			}
+			if configure != nil {
+				configure(i, d)
+			}
+		}}
+		h = hub.NewSession("session", fleet.factory(), nil)
+		cancel = runHub(h)
+		conn = newFakeWSConn()
+		_, err := h.AddClient(conn, nil)
+		Expect(err).NotTo(HaveOccurred())
+		_, _ = recvEvent(conn) // welcome
+		conn.inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "myapp"}))
+		waitForEventKind(conn, protocol.EventSessionState, nil)
+	}
+
+	AfterEach(func() {
+		if cancel != nil {
+			cancel()
+		}
+	})
+
+	It("broadcasts a logical id, never the engine's physical id", func() {
+		startManaged(nil)
+
+		logical := setBP(conn, "main.go", 10)
+		Expect(fleet.at(0).physicalIDFor(10)).To(Equal(101),
+			"engine should have allocated its own physical id")
+		Expect(logical).NotTo(Equal(101), "clients must not see raw engine ids")
+		Expect(logical).To(Equal(1), "logical ids start at 1 for the session")
+	})
+
+	It("translates a clear to the active engine's physical id", func() {
+		startManaged(nil)
+
+		logical := setBP(conn, "main.go", 10)
+		conn.inject(mustCommand(protocol.CmdClearBreakpoint,
+			protocol.ClearBreakpointPayload{ID: logical}))
+
+		var cleared protocol.BreakpointClearedPayload
+		waitForEventKind(conn, protocol.EventBreakpointCleared, &cleared)
+		Expect(cleared.ID).To(Equal(logical), "confirmation reports the logical id")
+		Expect(fleet.at(0).recordedCalls()).To(ContainElement("ClearBreakpoint(101)"))
+		Expect(fleet.at(0).armedLines()).To(BeEmpty())
+	})
+
+	It("rejects an unknown logical id without touching the debugger", func() {
+		startManaged(nil)
+
+		logical := setBP(conn, "main.go", 10)
+		Expect(logical).To(Equal(1))
+
+		// 101 is the *physical* id of the live breakpoint. A client that
+		// somehow held it must not be able to disarm anything with it.
+		conn.inject(mustCommand(protocol.CmdClearBreakpoint,
+			protocol.ClearBreakpointPayload{ID: 101}))
+
+		var errPayload protocol.ErrorPayload
+		waitForEventKind(conn, protocol.EventError, &errPayload)
+		Expect(errPayload.Command).To(Equal(protocol.CmdClearBreakpoint))
+		Expect(fleet.at(0).armedLines()).To(Equal([]int{10}), "breakpoint must stay armed")
+		for _, call := range fleet.at(0).recordedCalls() {
+			Expect(call).NotTo(HavePrefix("ClearBreakpoint"),
+				"an unknown logical id must never reach the debugger")
+		}
+	})
+
+	It("retains the mapping when the debugger rejects a clear", func() {
+		startManaged(nil)
+
+		logical := setBP(conn, "main.go", 10)
+		fleet.at(0).setClearErr(fmt.Errorf("restore bytes failed"))
+
+		conn.inject(mustCommand(protocol.CmdClearBreakpoint,
+			protocol.ClearBreakpointPayload{ID: logical}))
+		waitForEventKind(conn, protocol.EventError, nil)
+
+		// The trap is still armed, so the client must still be able to name it.
+		fleet.at(0).setClearErr(nil)
+		conn.inject(mustCommand(protocol.CmdClearBreakpoint,
+			protocol.ClearBreakpointPayload{ID: logical}))
+		var cleared protocol.BreakpointClearedPayload
+		waitForEventKind(conn, protocol.EventBreakpointCleared, &cleared)
+		Expect(cleared.ID).To(Equal(logical))
+		Expect(fleet.at(0).armedLines()).To(BeEmpty())
+	})
+
+	It("translates a BreakpointHit's physical id to the logical id", func() {
+		startManaged(nil)
+
+		logical := setBP(conn, "main.go", 10)
+		physical := fleet.at(0).physicalIDFor(10)
+
+		fleet.at(0).events <- protocol.MustEvent(protocol.EventBreakpointHit, 1,
+			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{
+				ID:       physical,
+				Location: protocol.Location{File: "main.go", Line: 10},
+			}})
+
+		var hit protocol.BreakpointHitPayload
+		waitForEventKind(conn, protocol.EventBreakpointHit, &hit)
+		Expect(hit.Breakpoint.ID).To(Equal(logical))
+		Expect(hit.Breakpoint.Location.Line).To(Equal(10), "location must survive re-encoding")
+	})
+
+	It("preserves logical ids across Restart while physical ids compact", func() {
+		startManaged(nil)
+
+		logicalA := setBP(conn, "main.go", 10)
+		logicalB := setBP(conn, "main.go", 20)
+		Expect(fleet.at(0).physicalIDFor(10)).To(Equal(101))
+		Expect(fleet.at(0).physicalIDFor(20)).To(Equal(102))
+
+		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		var restarted protocol.RestartedPayload
+		waitForEventKind(conn, protocol.EventRestarted, &restarted)
+
+		Expect(fleet.count()).To(Equal(2))
+		fresh := fleet.at(1)
+		Expect(fresh.physicalIDFor(10)).To(Equal(1), "fresh engine reuses low ids")
+		Expect(fresh.physicalIDFor(20)).To(Equal(2))
+
+		ids := make([]int, 0, len(restarted.Breakpoints))
+		for _, bp := range restarted.Breakpoints {
+			ids = append(ids, bp.ID)
+		}
+		Expect(ids).To(Equal([]int{logicalA, logicalB}),
+			"restart must report the identities clients already hold")
+
+		// A clear for logical A must reach the *new* engine's A, not whatever
+		// breakpoint inherited A's old number.
+		conn.inject(mustCommand(protocol.CmdClearBreakpoint,
+			protocol.ClearBreakpointPayload{ID: logicalA}))
+		waitForEventKind(conn, protocol.EventBreakpointCleared, nil)
+		Expect(fresh.armedLines()).To(Equal([]int{20}))
+		Expect(fresh.recordedCalls()).To(ContainElement("ClearBreakpoint(1)"))
+	})
+
+	It("rejects a later clear for a breakpoint the restart discarded", func() {
+		startManaged(func(i int, d *tableDebugger) {
+			if i == 1 {
+				d.setErrFor = 10 // line 10 no longer resolves after the relaunch
+			}
+		})
+
+		logicalA := setBP(conn, "main.go", 10)
+		setBP(conn, "main.go", 20)
+
+		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		var restarted protocol.RestartedPayload
+		waitForEventKind(conn, protocol.EventRestarted, &restarted)
+		Expect(restarted.Discarded).To(HaveLen(1))
+		Expect(restarted.Discarded[0].Location.Line).To(Equal(10))
+		Expect(restarted.Breakpoints).To(HaveLen(1))
+
+		fresh := fleet.at(1)
+		Expect(fresh.armedLines()).To(Equal([]int{20}))
+
+		conn.inject(mustCommand(protocol.CmdClearBreakpoint,
+			protocol.ClearBreakpointPayload{ID: logicalA}))
+		waitForEventKind(conn, protocol.EventError, nil)
+		Expect(fresh.armedLines()).To(Equal([]int{20}),
+			"a discarded logical id must not disarm the surviving breakpoint")
+	})
+
+	// The engine emits a hit into a buffered channel and ClearBreakpoint has no
+	// suspend guard, so Run's select can execute a queued clear before draining
+	// a hit that was generated first. The hit must still report the id the
+	// client held, and must not resurrect the breakpoint it just removed.
+	It("reports a hit that raced its own clear under the id the client held", func() {
+		startManaged(nil)
+
+		logical := setBP(conn, "main.go", 10)
+		physical := fleet.at(0).physicalIDFor(10)
+
+		conn.inject(mustCommand(protocol.CmdClearBreakpoint,
+			protocol.ClearBreakpointPayload{ID: logical}))
+		waitForEventKind(conn, protocol.EventBreakpointCleared, nil)
+
+		fleet.at(0).events <- protocol.MustEvent(protocol.EventBreakpointHit, 1,
+			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{
+				ID:       physical,
+				Location: protocol.Location{File: "main.go", Line: 10},
+			}})
+
+		var hit protocol.BreakpointHitPayload
+		waitForEventKind(conn, protocol.EventBreakpointHit, &hit)
+		Expect(hit.Breakpoint.ID).To(Equal(logical),
+			"a late hit must name the breakpoint the client knew, not a new id")
+
+		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		var restarted protocol.RestartedPayload
+		waitForEventKind(conn, protocol.EventRestarted, &restarted)
+		Expect(restarted.Breakpoints).To(BeEmpty())
+		Expect(fleet.at(1).armedLines()).To(BeEmpty(),
+			"restart must not re-arm a breakpoint the client removed")
+	})
+
+	It("never re-arms a breakpoint the hub did not install", func() {
+		startManaged(nil)
+
+		// A physical id the hub never minted — a raw debugger driven directly.
+		fleet.at(0).events <- protocol.MustEvent(protocol.EventBreakpointHit, 1,
+			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{
+				ID:       999,
+				Location: protocol.Location{File: "other.go", Line: 42},
+			}})
+
+		var hit protocol.BreakpointHitPayload
+		waitForEventKind(conn, protocol.EventBreakpointHit, &hit)
+		Expect(hit.Breakpoint.ID).NotTo(Equal(999), "engine ids must not reach clients")
+
+		installed := setBP(conn, "main.go", 10)
+		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		var restarted protocol.RestartedPayload
+		waitForEventKind(conn, protocol.EventRestarted, &restarted)
+
+		Expect(restarted.Breakpoints).To(HaveLen(1))
+		Expect(restarted.Breakpoints[0].ID).To(Equal(installed))
+		Expect(fleet.at(1).armedLines()).To(Equal([]int{10}),
+			"only hub-installed breakpoints are restart targets")
+	})
+
+	It("does not re-mint logical ids after a fresh Launch", func() {
+		startManaged(nil)
+
+		staleLogical := setBP(conn, "main.go", 10)
+
+		// The target exits; the session goes idle and is launched again.
+		fleet.at(0).closeEvents()
+		Eventually(h.State, "1s", "10ms").Should(Equal(protocol.StateIdle))
+
+		conn.inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "myapp"}))
+		Eventually(h.State, "1s", "10ms").Should(Equal(protocol.StateRunning))
+		Expect(fleet.count()).To(Equal(2))
+
+		fresh := setBP(conn, "main.go", 20)
+		Expect(fresh).To(BeNumerically(">", staleLogical),
+			"logical ids stay monotonic across a fresh Launch")
+
+		// A clear generated against the previous target can still arrive. It
+		// must be rejected, not aliased onto the new target's breakpoint.
+		conn.inject(mustCommand(protocol.CmdClearBreakpoint,
+			protocol.ClearBreakpointPayload{ID: staleLogical}))
+		waitForEventKind(conn, protocol.EventError, nil)
+		Expect(fleet.at(1).armedLines()).To(Equal([]int{20}))
+	})
+})

--- a/internal/hub/breakpoints_test.go
+++ b/internal/hub/breakpoints_test.go
@@ -83,6 +83,17 @@ func (d *tableDebugger) setNextID(n int) {
 	d.mu.Unlock()
 }
 
+// rearm models the engine's step-off resurrection: resuming from the breakpoint
+// the process is parked on replays the entry pointer stashed at hit time and
+// reinstalls it under the SAME physical id, even though the client's clear had
+// already removed it (internal/debugger: resumeFromBreakpoint →
+// breakpointTable.reinstall → addToTable).
+func (d *tableDebugger) rearm(physicalID int, loc protocol.Location) {
+	d.mu.Lock()
+	d.armed[physicalID] = loc
+	d.mu.Unlock()
+}
+
 func (d *tableDebugger) setClearErr(err error) {
 	d.mu.Lock()
 	d.clearErr = err
@@ -391,12 +402,89 @@ var _ = Describe("logical breakpoint ids", func() {
 		Expect(hit.Breakpoint.ID).To(Equal(logical),
 			"a late hit must name the breakpoint the client knew, not a new id")
 
+		// Having reported that id, the hub must still accept it: a client that
+		// reacts to the hit by clearing it again has to reach the debugger
+		// rather than be told the id does not exist.
+		conn.inject(mustCommand(protocol.CmdClearBreakpoint,
+			protocol.ClearBreakpointPayload{ID: logical}))
+		Eventually(func() []string { return fleet.at(0).recordedCalls() }).
+			Should(ContainElement(fmt.Sprintf("ClearBreakpoint(%d)", physical)),
+				"a reported id must stay resolvable to this engine's breakpoint")
+
 		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
 		var restarted protocol.RestartedPayload
 		waitForEventKind(conn, protocol.EventRestarted, &restarted)
 		Expect(restarted.Breakpoints).To(BeEmpty())
 		Expect(fleet.at(1).armedLines()).To(BeEmpty(),
 			"restart must not re-arm a breakpoint the client removed")
+	})
+
+	// The engine undoes a clear issued while the process is parked on that very
+	// breakpoint: stepping off replays the entry stashed at hit time and
+	// reinstalls it under the same physical id. The hub had already retired the
+	// mapping, so without a tombstone the resurrected trap is reported under an
+	// id the hub no longer accepts — permanently unremovable, and unsettable too
+	// because the engine still has the address armed.
+	It("keeps a step-off-resurrected breakpoint clearable", func() {
+		startManaged(nil)
+
+		logical := setBP(conn, "main.go", 10)
+		physical := fleet.at(0).physicalIDFor(10)
+
+		conn.inject(mustCommand(protocol.CmdClearBreakpoint,
+			protocol.ClearBreakpointPayload{ID: logical}))
+		waitForEventKind(conn, protocol.EventBreakpointCleared, nil)
+		Expect(fleet.at(0).armedLines()).To(BeEmpty())
+
+		fleet.at(0).rearm(physical, protocol.Location{File: "main.go", Line: 10})
+		fleet.at(0).events <- protocol.MustEvent(protocol.EventBreakpointHit, 1,
+			protocol.BreakpointHitPayload{Breakpoint: protocol.Breakpoint{
+				ID:       physical,
+				Location: protocol.Location{File: "main.go", Line: 10},
+			}})
+
+		var hit protocol.BreakpointHitPayload
+		waitForEventKind(conn, protocol.EventBreakpointHit, &hit)
+		Expect(hit.Breakpoint.ID).To(Equal(logical))
+
+		conn.inject(mustCommand(protocol.CmdClearBreakpoint,
+			protocol.ClearBreakpointPayload{ID: logical}))
+		var cleared protocol.BreakpointClearedPayload
+		waitForEventKind(conn, protocol.EventBreakpointCleared, &cleared)
+		Expect(cleared.ID).To(Equal(logical))
+		Expect(fleet.at(0).armedLines()).To(BeEmpty(),
+			"the resurrected trap must actually be removed from the engine")
+	})
+
+	// The tombstone that keeps a resurrected id clearable must not outlive its
+	// engine, or it would reintroduce the aliasing this whole layer prevents.
+	It("does not let a retired id survive into a replacement engine", func() {
+		startManaged(nil)
+
+		logical := setBP(conn, "main.go", 10)
+		conn.inject(mustCommand(protocol.CmdClearBreakpoint,
+			protocol.ClearBreakpointPayload{ID: logical}))
+		waitForEventKind(conn, protocol.EventBreakpointCleared, nil)
+
+		// A breakpoint the restart DOES carry over, so the fresh engine hands
+		// out the physical id the retired one used to hold.
+		survivor := setBP(conn, "main.go", 20)
+		conn.inject(mustCommand(protocol.CmdRestart, protocol.RestartPayload{}))
+		waitForEventKind(conn, protocol.EventRestarted, nil)
+
+		fresh := fleet.at(1)
+		Expect(fresh.armedLines()).To(Equal([]int{20}))
+
+		conn.inject(mustCommand(protocol.CmdClearBreakpoint,
+			protocol.ClearBreakpointPayload{ID: logical}))
+		var errPayload protocol.ErrorPayload
+		waitForEventKind(conn, protocol.EventError, &errPayload)
+		Expect(fresh.armedLines()).To(Equal([]int{20}),
+			"a retired id from the previous engine must not disarm anything")
+		Expect(fresh.recordedCalls()).NotTo(ContainElement(
+			ContainSubstring("ClearBreakpoint")),
+			"the replacement engine must never see a retired id")
+		Expect(survivor).NotTo(Equal(logical))
 	})
 
 	It("never re-arms a breakpoint the hub did not install", func() {

--- a/internal/hub/dispatcher.go
+++ b/internal/hub/dispatcher.go
@@ -17,6 +17,12 @@ type dispatchResult struct {
 // dispatch translates cmd into a debugger call and returns the immediate
 // confirmation event (if any) plus any error.
 //
+// Breakpoint commands are deliberately absent: their ids cross the hub's
+// logical/physical translation boundary, so Hub.dispatchCommand handles them
+// (see breakpoints.go). Reaching them here would mean that routing was
+// bypassed, so the default case reports an error rather than handing a
+// client-supplied id straight to the engine.
+//
 //nolint:gocognit,gocyclo // Protocol command routing is intentionally centralized here.
 func dispatch(dbg debugger.Debugger, cmd protocol.Command) (dispatchResult, error) {
 	switch cmd.Kind {
@@ -37,37 +43,6 @@ func dispatch(dbg debugger.Debugger, cmd protocol.Command) (dispatchResult, erro
 
 	case protocol.CmdKill:
 		return dispatchResult{}, dbg.Kill()
-
-	case protocol.CmdSetBreakpoint:
-		var p protocol.SetBreakpointPayload
-		if err := protocol.DecodeCommandPayload(cmd, &p); err != nil {
-			return dispatchResult{}, err
-		}
-		bp, err := dbg.SetBreakpoint(p.File, p.Line)
-		if err != nil {
-			return dispatchResult{}, err
-		}
-		evt, err := protocol.NewEvent(protocol.EventBreakpointSet, 0, protocol.BreakpointSetPayload{
-			Breakpoint: bp,
-		})
-		if err != nil {
-			return dispatchResult{}, err
-		}
-		return dispatchResult{event: &evt}, nil
-
-	case protocol.CmdClearBreakpoint:
-		var p protocol.ClearBreakpointPayload
-		if err := protocol.DecodeCommandPayload(cmd, &p); err != nil {
-			return dispatchResult{}, err
-		}
-		if err := dbg.ClearBreakpoint(p.ID); err != nil {
-			return dispatchResult{}, err
-		}
-		evt, err := protocol.NewEvent(protocol.EventBreakpointCleared, 0, protocol.BreakpointClearedPayload(p))
-		if err != nil {
-			return dispatchResult{}, err
-		}
-		return dispatchResult{event: &evt}, nil
 
 	// Execution control: no immediate event. The debugger emits Stepped /
 	// Continued asynchronously.

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -107,12 +106,13 @@ type Hub struct {
 	// sense for a process bingo itself started).
 	lastLaunch *protocol.LaunchPayload
 
-	// restartBreakpoints mirrors the breakpoints installed on the current
-	// debugger (id -> location), purely so Restart can reinstall them on the
-	// relaunched process. The engine's breakpointTable remains the sole
-	// source of truth for the live process; this is bookkeeping the hub
-	// needs across a Kill+relaunch, when the old breakpointTable is gone.
-	restartBreakpoints map[int]protocol.Location
+	// bps owns the session-stable logical breakpoint ids clients see and their
+	// mapping onto the active engine's physical ids, plus each breakpoint's
+	// location so Restart can reinstall it on the relaunched process. The
+	// engine's breakpointTable remains the sole source of truth for the live
+	// process; this is the identity layer above it (see breakpoints.go).
+	// Touched only on the Run goroutine.
+	bps *breakpointIDs
 }
 
 type clientCommand struct {
@@ -132,7 +132,7 @@ func newHub(log *slog.Logger) *Hub {
 		shutdownCh:              make(chan struct{}),
 		done:                    make(chan struct{}),
 		log:                     log,
-		restartBreakpoints:      make(map[int]protocol.Location),
+		bps:                     newBreakpointIDs(),
 	}
 }
 
@@ -300,6 +300,7 @@ func (h *Hub) removeClient(c *Client) {
 // also synthesises errors/confirmations.
 func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 	suspending := suspendingEvents[evt.Kind]
+	evt = h.localizeBreakpointIDs(evt)
 
 	// Discard any resuming command buffered while the process was still running
 	// BEFORE broadcasting the suspending event. Such a command is necessarily
@@ -356,6 +357,7 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 				}
 				return
 			}
+			nextEvt = h.localizeBreakpointIDs(nextEvt)
 			nextEvt.Seq = h.seq.Add(1)
 			h.broadcast(nextEvt)
 			if nextEvt.Kind == protocol.EventProcessExited {
@@ -505,7 +507,7 @@ func (h *Hub) executeCommand(cmd protocol.Command) {
 		return
 	}
 
-	result, err := dispatch(dbg, cmd)
+	result, err := h.dispatchCommand(dbg, cmd)
 	if callerOwned && !h.transferStartedDebugger(dbg, cmd, err) {
 		return
 	}
@@ -524,7 +526,7 @@ func (h *Hub) executeCommand(cmd protocol.Command) {
 			return
 		}
 		h.rememberLaunch(cmd)
-		h.restartBreakpoints = make(map[int]protocol.Location)
+		h.bps.reset()
 	case protocol.CmdAttach:
 		if !h.transitionState(protocol.StateRunning) {
 			return
@@ -532,20 +534,32 @@ func (h *Hub) executeCommand(cmd protocol.Command) {
 		// Restart only makes sense for a process bingo itself launched —
 		// mirrors Delve's canRestart check.
 		h.lastLaunch = nil
-		h.restartBreakpoints = make(map[int]protocol.Location)
+		h.bps.reset()
 	case protocol.CmdContinue, protocol.CmdStepOver, protocol.CmdStepInto, protocol.CmdStepOut:
 		if !h.transitionState(protocol.StateRunning) {
 			return
 		}
-	case protocol.CmdSetBreakpoint:
-		h.rememberBreakpoint(result)
-	case protocol.CmdClearBreakpoint:
-		h.forgetBreakpoint(cmd)
 	}
 
 	if result.event != nil {
 		result.event.Seq = h.seq.Add(1)
 		h.broadcast(*result.event)
+	}
+}
+
+// dispatchCommand routes cmd to the debugger. Breakpoint commands are handled
+// by the hub itself because they cross the logical/physical id boundary
+// (breakpoints.go) — everything else goes through the hub-agnostic dispatch
+// table. Both shapes return the same (dispatchResult, error) so error wrapping
+// and the single confirmation broadcast stay centralized in executeCommand.
+func (h *Hub) dispatchCommand(dbg debugger.Debugger, cmd protocol.Command) (dispatchResult, error) {
+	switch cmd.Kind {
+	case protocol.CmdSetBreakpoint:
+		return h.setBreakpoint(dbg, cmd)
+	case protocol.CmdClearBreakpoint:
+		return h.clearBreakpoint(dbg, cmd)
+	default:
+		return dispatch(dbg, cmd)
 	}
 }
 
@@ -561,42 +575,27 @@ func (h *Hub) rememberLaunch(cmd protocol.Command) {
 	h.lastLaunch = &p
 }
 
-// rememberBreakpoint records a successfully-set breakpoint's id -> location
-// so Restart can reinstall it later.
-func (h *Hub) rememberBreakpoint(result dispatchResult) {
-	if result.event == nil {
-		return
-	}
-	var p protocol.BreakpointSetPayload
-	if err := protocol.DecodeEventPayload(*result.event, &p); err != nil {
-		return
-	}
-	h.restartBreakpoints[p.Breakpoint.ID] = p.Breakpoint.Location
-}
-
-// forgetBreakpoint removes a cleared breakpoint from the Restart bookkeeping.
-func (h *Hub) forgetBreakpoint(cmd protocol.Command) {
-	var p protocol.ClearBreakpointPayload
-	if err := protocol.DecodeCommandPayload(cmd, &p); err != nil {
-		return
-	}
-	delete(h.restartBreakpoints, p.ID)
-}
-
-// sortedRestartLocations returns the tracked breakpoint locations in
-// ascending ID order, so Restart reinstalls them in a deterministic sequence
-// (and thus assigns deterministic new IDs) across runs.
-func (h *Hub) sortedRestartLocations() []protocol.Location {
-	ids := make([]int, 0, len(h.restartBreakpoints))
-	for id := range h.restartBreakpoints {
-		ids = append(ids, id)
-	}
-	sort.Ints(ids)
-	locs := make([]protocol.Location, 0, len(ids))
+// sortedRestartTargets returns the live logical breakpoints in ascending
+// logical-ID order, so Restart reinstalls them in a deterministic sequence
+// across runs.
+func (h *Hub) sortedRestartTargets() []restartTarget {
+	ids := h.bps.installedLogical()
+	targets := make([]restartTarget, 0, len(ids))
 	for _, id := range ids {
-		locs = append(locs, h.restartBreakpoints[id])
+		m, ok := h.bps.lookup(id)
+		if !ok {
+			continue
+		}
+		targets = append(targets, restartTarget{logicalID: id, loc: m.loc})
 	}
-	return locs
+	return targets
+}
+
+// restartTarget is one breakpoint Restart must re-establish on the relaunched
+// process, carrying the logical identity clients already hold.
+type restartTarget struct {
+	logicalID int
+	loc       protocol.Location
 }
 
 // handleRestart kills the current process (if any), relaunches the last
@@ -641,7 +640,7 @@ func (h *Hub) handleRestart(cmd protocol.Command) {
 		env = override.Env
 	}
 
-	saved := h.sortedRestartLocations()
+	saved := h.sortedRestartTargets()
 
 	oldDbg, open := h.detachDebugger()
 	if !open {
@@ -674,19 +673,25 @@ func (h *Hub) handleRestart(cmd protocol.Command) {
 		return
 	}
 
+	// Reinstalling re-homes each surviving logical id onto the replacement
+	// engine's own (compacted, reused) physical id. The identities clients hold
+	// are unchanged, so a clear generated before the restart still names the
+	// same breakpoint afterwards; one that cannot be reinstalled loses its
+	// mapping and any later clear for it is rejected rather than aliasing a
+	// different breakpoint — see breakpoints.go and AGENTS.md.
 	installed := make([]protocol.Breakpoint, 0, len(saved))
 	discarded := make([]protocol.DiscardedBreakpoint, 0)
-	newBreakpoints := make(map[int]protocol.Location, len(saved))
-	for _, loc := range saved {
-		bp, err := newDbg.SetBreakpoint(loc.File, loc.Line)
+	h.bps.reset()
+	for _, target := range saved {
+		bp, err := newDbg.SetBreakpoint(target.loc.File, target.loc.Line)
 		if err != nil {
-			discarded = append(discarded, protocol.DiscardedBreakpoint{Location: loc, Reason: err.Error()})
+			discarded = append(discarded, protocol.DiscardedBreakpoint{Location: target.loc, Reason: err.Error()})
 			continue
 		}
+		h.bps.bind(target.logicalID, bp.ID, bp.Location)
+		bp.ID = target.logicalID
 		installed = append(installed, bp)
-		newBreakpoints[bp.ID] = bp.Location
 	}
-	h.restartBreakpoints = newBreakpoints
 
 	evt, err := protocol.NewEvent(protocol.EventRestarted, h.seq.Add(1), protocol.RestartedPayload{
 		Program:     program,

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -976,17 +976,22 @@ var _ = Describe("Hub", func() {
 		It("broadcasts BreakpointCleared with the removed ID", func() {
 			conn := newFakeWSConn()
 			mustAddClient(h, conn)
+			fd.setBPResult = protocol.Breakpoint{
+				ID:       7,
+				Location: protocol.Location{File: "main.go", Line: 42},
+			}
+
+			conn.inject(mustCommand(protocol.CmdSetBreakpoint,
+				protocol.SetBreakpointPayload{File: "main.go", Line: 42}))
+			var set protocol.BreakpointSetPayload
+			waitForEventKind(conn, protocol.EventBreakpointSet, &set)
 
 			conn.inject(mustCommand(protocol.CmdClearBreakpoint,
-				protocol.ClearBreakpointPayload{ID: 5}))
+				protocol.ClearBreakpointPayload{ID: set.Breakpoint.ID}))
 
-			Eventually(func() protocol.EventKind {
-				e, ok := recvEvent(conn)
-				if !ok {
-					return ""
-				}
-				return e.Kind
-			}, "500ms", "10ms").Should(Equal(protocol.EventBreakpointCleared))
+			var cleared protocol.BreakpointClearedPayload
+			waitForEventKind(conn, protocol.EventBreakpointCleared, &cleared)
+			Expect(cleared.ID).To(Equal(set.Breakpoint.ID))
 		})
 	})
 


### PR DESCRIPTION
Fixes #200

## Stack

`#138` → `#182` → **this PR**

Based on `xsachax-fix-dap-breakpoint-transactions` (#182). Review that first — this PR builds on its breakpoint transaction rather than replacing it.

Rebased onto the frozen #182 head `7a30a7148d8b617810c6f73d77af659e9d11314a`. The restack was a pure replay — each of this PR's three commits kept an identical `git patch-id`, so the only tree change relative to the previous head is #182's own test commit.

## The defect

`breakpointTable.nextID` (`internal/debugger/breakpoint.go`) restarts at 1 in every engine, so a **physical** breakpoint id only means anything to the engine that issued it — and `handleRestart` replaces that engine.

A command can be *generated* against one engine and *injected* after it has been replaced. The DAP adapter marshals a `ClearBreakpoint{ID: oldPhysicalID}` into `Handler.cmdOut`; the hub read pump can be descheduled between `Handler.ReadMessage` returning those bytes and `Client.readPump` calling `injectCommand` (`internal/hub/client.go`). Another client completes a Restart in that window. The stale id then names a **different** breakpoint in the fresh process, and releasing it disarms the wrong trap.

Reproduced deterministically under `-race` with a real `Hub` + real DAP `Handler` and a gating `WSConn`: installed A=phys2 / B=phys3, held `clear(2)`, restarted to A=phys1 / B=phys2, released the clear, and observed **A armed / B deleted** while the Handler believed A was cleared.

## Why an epoch does not fix it

An epoch stamped at `Hub.injectCommand` is *provably insufficient*: provenance is bound when the Handler **generates** the bytes, but injection happens after the Restart and would read the **new** epoch. The command is indistinguishable from a fresh one at the point it is stamped.

## The fix

The hub owns breakpoint identity. Client-visible ids are session-stable **logical** ids, translated to per-engine physical ids at every boundary. New `internal/hub/breakpoints.go`:

- **Monotonic for the whole hub lifetime.** `reset()` (a fresh `Launch`/`Attach`) drops the mappings but deliberately does **not** rewind the high-water mark — re-minting is exactly what would let a delayed command from a previous target alias a breakpoint in the new one.
- **`Set`** installs, mints a logical id, and broadcasts `EventBreakpointSet` with it. The engine's id never leaves the hub.
- **`Clear`** rejects an unknown logical id **without touching the debugger** (the load-bearing half), translates a known one to the active physical id, and only `untrack`s after the debugger confirms. **No optimistic deletion** — a rejected clear leaves the trap armed (`breakpointTable.clear` keeps its entry when the memory write fails), so the client must keep being able to name it.
- **`Restart`** iterates logical ids deterministically, reinstalls each location, re-homes the mapping onto the new physical id, and reports `RestartedPayload.Breakpoints` under the **same** logical ids. Entries that fail to resolve are removed and reported as `Discarded`; a later clear naming one is rejected safely.
- **`BreakpointHit`** physical ids are rewritten to logical before broadcast, on both broadcast paths in `handleEvent`.
- **A hit can race its own clear.** The engine emits into a buffered channel and `engine.ClearBreakpoint` has no suspend guard, so `Run`'s `select` may execute a queued clear before draining a hit generated earlier. Removals are therefore *retired* per engine (bounded, dropped by `reset()`) so the late hit still reports the id the client held.
- **Adopted ≠ installed.** A physical id that is neither live nor retired is adopted for reporting rather than passed through (pass-through could collide with a logical id naming a different breakpoint — this keeps raw `hub.New` hubs coherent), but it is **not** a restart target: the hub never armed it and must not arm it on the replacement process.

All five protocol surfaces carrying a breakpoint id are covered: `BreakpointSetPayload.Breakpoint.ID`, `BreakpointClearedPayload.ID`, `BreakpointHitPayload.Breakpoint.ID`, `RestartedPayload.Breakpoints[].ID`, and the inbound `ClearBreakpointPayload.ID`.

`CmdSetBreakpoint`/`CmdClearBreakpoint` are removed from the generic `dispatch` switch and routed to hub-aware handlers, preserving centralized error wrapping and exactly one confirmation per command. No changes to `internal/debugger`. No correlation ids, no epochs, no DAP-only hacks.

### Follow-up: a cleared breakpoint the engine resurrects

Semantic review found a second, independent way a logical id could be stranded — not an aliasing bug, but its mirror image.

Clearing the breakpoint the tracee is **parked on** is undone by the engine. `resumeFromBreakpoint` replays the `e.lastBP` entry pointer it stashed at hit time rather than re-reading the table, and `breakpointTable.reinstall` re-adds that entry under its **original physical id**. The hub had already retired the mapping on the confirmed clear, so the resurrected trap was reported under a logical id that `CmdClearBreakpoint` then rejected — and the location could not be re-set either, because the engine still had the address armed (`errBreakpointExists`). The result was a phantom breakpoint that was permanently neither removable nor settable.

The retirement record is now **bidirectional**:

- `retiredLogical` (physical → logical) reports a late or resurrected hit under the id the client holds.
- `retiredPhysical` (logical → physical) keeps that reported id **clearable**.

A tombstone-clear is deliberately **not** consumed: the tracee may still be parked there and resurrect it again, so the id has to stay reportable and removable. This cannot weaken the #200 fix, because `breakpointTable.set` never reuses a physical id within one engine, and `reset()` purges the record on every `Launch`/`Attach`/**and Restart** — a tombstone can only ever name the breakpoint it was created for, never one in another generation. A dedicated spec pins that by restarting into an engine which reuses the retired physical id and asserting the replacement engine never sees a `ClearBreakpoint`.

### Out-of-band Launch (documented, not a regression)

A *second* client issuing a fresh `CmdLaunch`/`CmdAttach` on a shared session invalidates every logical id: mappings reset while the high-water mark advances. A client still holding old ids gets a clean `EventError` rather than silently disarming a stranger's breakpoint — which is exactly what the pre-fix raw physical ids did, so this is a strict improvement. It is **not** transparent, though: a DAP adapter whose `bpLine`s still record pre-Launch ids believes lines are armed that the new process lacks, and only finds out when a removal fails. `CmdRestart` — what the DAP `restart` request maps to — is the supported way to relaunch *while preserving* ids. An explicit invalidation event would be a new protocol surface and is deliberately out of scope for #200, which is about not corrupting the ids that do survive. Recorded in `AGENTS.md`.

## Tests

- **Permanent regression** (`internal/dap/hublogicalbp_test.go`): real `Hub` + real DAP `Handler` + a gating `WSConn` at the exact `Handler.ReadMessage` → `Client.readPump` boundary. Holds a generated clear, completes a Restart via a second client, releases the clear, and asserts the **physical** new-engine A is cleared, B remains armed, and the Handler's logical state agrees.
- **Negative control**: the same clear injected *before* the Restart behaves normally, so the fix does not change the in-order path. It stays green under the bug-restoring mutation, which is what a control should do — but that is a sanity check on the mutation's blast radius, not evidence about what the headline test isolates. (An earlier revision of this description claimed the latter; that inference was invalid.)
- **Multi-client**: WebSocket and DAP observers see the same stable ids. Restarts first so logical and physical genuinely diverge, and asserts `physicalA != logicalA` before checking translation, so the test cannot pass vacuously.
- **Hub unit specs** (12, `internal/hub/breakpoints_test.go`): logical id broadcast, clear translation, unknown-id rejection, failed-clear retention, hit translation, restart preservation while physical ids compact, discarded-mapping rejection, monotonicity across a fresh Launch, hit-racing-its-own-clear (extended: the reported id must still be clearable), never re-arming a breakpoint the hub did not install, keeping a step-off-resurrected breakpoint clearable, and refusing to let a retired id survive into a replacement engine. The fake engine allocates from 101 so any leaked physical id is immediately visible.

### Mutation checks

| Mutation | Caught by |
|---|---|
| Expose physical ids (old behavior) | `TestStaleClearAcrossRestartHitsTheRightBreakpoint` — `armed lines [10] (want [20])`, i.e. the literal #200 defect — plus 6 hub specs |
| `reset()` also rewinds the high-water mark | `does not re-mint logical ids after a fresh Launch` |
| Skip `BreakpointHit` translation | 3 hub specs + `TestWebSocketAndDAPSeeTheSameIDs` |
| Drop the retirement lookup | `reports a hit that raced its own clear under the id the client held` |
| Adopted mappings become restart targets | `never re-arms a breakpoint the hub did not install` |
| Drop the `retiredPhysical` clear fallback | `keeps a step-off-resurrected breakpoint clearable` |
| `reset()` forgets to purge the tombstone | `does not let a retired id survive into a replacement engine` |

## Validation

- `gofmt` / `goimports` clean; `go vet -tags bingonative ./...` clean; `golangci-lint run --build-tags bingonative ./...` — **0 issues**
- `go test -tags bingonative -race ./internal/hub ./internal/dap` — 5× repeated, all green
- `go test -tags bingonative -race ./...` — all packages green
- **Native darwin/arm64 E2E** (`restart || fullstack || dap || breakpoints`) — 8/8 through the whole stack
- Diff contains only this layer relative to #182 head

## Compatibility

- **Wire version unchanged (1.2).** Breakpoint ids were already opaque `int`s; only their ownership and lifetime changed. No field shape or payload change.
- **The one observable behavior change:** a `ClearBreakpoint` naming an id the hub does not know now returns `EventError` instead of forwarding to the debugger. That is the fix — previously such a command could silently disarm an unrelated breakpoint.
- Ids are now stable across Restart (they previously changed silently), which is strictly more useful to clients.
- The DAP transaction from #182 is unmodified. Its positional `setQ`/`clearQ` FIFOs now receive logical confirmations that are consistent with the actual physical effect, and `reconcileRestartBreakpointsLocked`'s id adoption becomes a no-op since logical ids survive a restart.
- Raw `hub.New` behavior is preserved via adoption; no e2e or hub test depends on raw id pass-through.

