### PR TITLE
fix(wsmon): truncate one-line output on code-point boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,23 @@ automatic — is delivered exactly once on `Events()`, where a client treats the
 uniformly as telemetry. It must stay out of the correlated set: never route it
 through `sendAndWait`. See issue #187.
 
+Two consequences a caller must handle, both inherent to an id-less broadcast
+protocol rather than to this change:
+
+- **Delivery is best-effort.** The answer rides the shared `Events()` buffer,
+  which `readPump` drops from when the consumer stops draining, and a rejected
+  request answers with `EventError`(`CmdGoroutineSnapshot`) instead of a
+  snapshot. Anything that blocks waiting for a snapshot must handle both — see
+  `cmd/wsmon`'s `-once`, which fails fast on a rejection or a closed stream
+  rather than waiting forever.
+- **The answer is broadcast.** A query is fanned out to every client on the
+  session like any other event, and it carries empty `Created`/`Exited`. An
+  observer that renders "the latest snapshot's deltas" (as `cmd/wsmon`'s
+  lifecycle panel does) therefore blanks that panel until the next automatic
+  stop; an append-only timeline (the VS Code view) is unaffected. Making a query
+  addressable to its requester needs wire-level correlation and is deliberately
+  out of scope here — a candidate for a telemetry 1.3.
+
 `syncMu` serializes synchronous commands, but a timeout does **not** cancel the
 command already sent to the server. The pending queue therefore retains a
 timed-out request as retired reply debt until its matching confirmation or
@@ -706,6 +723,16 @@ consumed the pending deltas — the following automatic snapshot diffed against
 the query, so goroutines created and exited in between appeared in neither
 (issue #187). Do not add a delta-bearing query path back: the wire payload is
 unchanged, and a client that wants deltas must read the automatic stream.
+
+The regression gate is the `concurrency`-labelled `declareBaselineOwnershipSpec`
+E2E, and it is deliberately shaped: a query at an ordinary breakpoint stop sees
+exactly the live set that stop's automatic snapshot already adopted, so adopting
+again would be a no-op and prove nothing. The spec instead **steps over a `go`
+statement** — steps are the one suspend that carries no automatic snapshot — so
+the query observes a goroutine the baseline has never seen, then asserts the
+NEXT automatic snapshot still reports it as created. It fails if the query is
+made lifecycle-tracking or the automatic path non-tracking; the unit tests
+around `snapshotFrom` pin the seam's semantics but cannot catch a rewiring.
 
 **Graceful fallback.** Every read is best-effort. `resolveGoLayout` marks the
 layout invalid if any required `g`/`gobuf`/`stack`/`m` offset is missing, and any

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,12 +219,31 @@ In [pkg/client](pkg/client/), the `Client` interface splits methods by what
 they wait for:
 
 - **Synchronous** (`Restart`, `SetBreakpoint`, `ClearBreakpoint`, `Locals`,
-  `Evaluate`, `StackFrames`, `Goroutines`, `GoroutineSnapshot`): block until
-  the matching confirmation event (or `EventError` for the same command kind)
-  arrives. Implemented via `sendAndWait` in [pkg/client/ws.go](pkg/client/ws.go).
-- **Fire-and-forget** (`Launch`, `Attach`, `Kill`, `Continue`, `Step*`, `Pause`):
-  return as soon as the command is on the wire. Results arrive asynchronously
-  on the `Events()` channel.
+  `Evaluate`, `StackFrames`, `Goroutines`): block until the matching
+  confirmation event (or `EventError` for the same command kind) arrives.
+  Implemented via `sendAndWait` in [pkg/client/ws.go](pkg/client/ws.go).
+- **Fire-and-forget** (`Launch`, `Attach`, `Kill`, `Continue`, `Step*`, `Pause`,
+  `RequestGoroutineSnapshot`): return as soon as the command is on the wire.
+  Results arrive asynchronously on the `Events()` channel.
+
+`RequestGoroutineSnapshot` is fire-and-forget **for a correctness reason, not
+convenience**: `EventGoroutineSnapshot` is the only dual-purpose frame in the
+protocol — the server also pushes it unsolicited on every entry/breakpoint/pause
+stop — so it can never be correlated to a request by kind. A synchronous
+`GoroutineSnapshot()` has no sound placement in the reply-debt model below, in
+either direction. *Retiring* a timed-out snapshot request as debt lets that debt
+silently swallow the next automatic push, permanently losing that stop's
+lifecycle deltas. *Discarding* it instead re-opens #144 for this kind: a stale
+reply — or any automatic push — then satisfies a later same-kind call. Even
+before any timeout, a plain in-flight call is satisfied by whichever snapshot
+lands first, which is usually a stop's automatic push. All three follow from one
+root: a frame that can exist with **no request** cannot be matched to one.
+
+So the fix is to remove the waiter, not to place it better. The request registers
+**no pending entry and no reply debt**, and every snapshot — requested or
+automatic — is delivered exactly once on `Events()`, where a client treats them
+uniformly as telemetry. It must stay out of the correlated set: never route it
+through `sendAndWait`. See issue #187.
 
 `syncMu` serializes synchronous commands, but a timeout does **not** cancel the
 command already sent to the server. The pending queue therefore retains a
@@ -240,16 +259,15 @@ continue timing out while that reply stream remains one response short. Keep the
 WebSocket open: disconnecting the last client tears down the hub/debuggee, while
 unrelated async events remain valid.
 
-`GoroutineSnapshot` is a temporary exception to timeout debt because
-`EventGoroutineSnapshot` is dual-purpose: it confirms `CmdGoroutineSnapshot`
-and is also pushed automatically after breakpoint, pause, and entry stops. A
-timed-out snapshot request is removed from the pending queue so it cannot consume
-the next unrelated telemetry snapshot. This preserves the stream, not
-correlation: while the legacy synchronous API exists, a genuinely late query
-reply or an unrelated automatic push can still satisfy a later in-flight
-`GoroutineSnapshot` waiter; without a waiter, either falls through to `Events()`.
-Issue #187 and stacked PR #192 remove the synchronous query surface and that
-ambiguity rather than expanding the exception here.
+Every command `sendAndWait` serves is a **genuine confirmation** — one that
+cannot exist without a request — so the timeout path above is uniform, with no
+per-kind exemption. Do not add one. `EventGoroutineSnapshot` is the only frame
+that breaks that property, and while a synchronous snapshot query existed it
+forced exactly such a carve-out (discard instead of retire). That carve-out
+preserved the telemetry stream but could not create correlation: with a waiter
+present, a genuinely late query reply or an unrelated automatic push could still
+satisfy a later in-flight call. Removing the waiter removed the ambiguity — the
+snapshot is now event-driven end to end and out of this model entirely.
 
 This is deliberately bounded by the id-less broadcast protocol. The queue
 preserves this client's ordered command stream; it cannot distinguish an
@@ -647,7 +665,9 @@ auto-emitted on exactly the suspends that can change the concurrency picture —
 single-step/step-over path from extra per-step memory reads. `emitBreakpointHit`
 / `emitPaused` build the snapshot **once**, embed its current goroutine in the
 stop event, then stream the same snapshot — one build, no double scan, no double
-delta pass.
+delta pass. Because the event is dual-purpose (push *and* query answer), the
+SDK's request is fire-and-forget — `Client.RequestGoroutineSnapshot`, never a
+`sendAndWait` — and only the automatic ones carry lifecycle deltas.
 
 **Not a suspending event.** It follows a suspending event (or answers a query)
 and never gates the hub. DAP `translateEvent` **deliberately ignores** it:
@@ -672,6 +692,20 @@ created/exited and adopts the new set. First snapshot returns nil deltas (a fres
 session must not report every goroutine as "created"). A **degraded** snapshot
 (runtime unreadable — e.g. the pre-init entry stop) does **not** touch
 `prevGoids`: an empty read must not look like every goroutine exited.
+
+**Automatic snapshots alone own the baseline.** `prevGoids` is the *only*
+lifecycle memory, so whoever advances it decides what the next automatic
+snapshot can report. The on-demand `CmdGoroutineSnapshot` path is therefore a
+pure observation: `engine.GoroutineSnapshot` calls `goroutineSnapshotQuery`
+(`buildSnapshot(false)`), which reports the same live picture with **empty
+Created/Exited** and leaves `prevGoids` untouched; only `goroutineSnapshot`
+(`buildSnapshot(true)`, used by `emitBreakpointHit` / `emitPaused` /
+`emitGoroutineSnapshot` at the entry stop) diffs and adopts. `snapshotFrom` is
+the single seam where the two differ. Before this split a manual refresh
+consumed the pending deltas — the following automatic snapshot diffed against
+the query, so goroutines created and exited in between appeared in neither
+(issue #187). Do not add a delta-bearing query path back: the wire payload is
+unchanged, and a client that wants deltas must read the automatic stream.
 
 **Graceful fallback.** Every read is best-effort. `resolveGoLayout` marks the
 layout invalid if any required `g`/`gobuf`/`stack`/`m` offset is missing, and any
@@ -1537,8 +1571,10 @@ through the justfile.
   it to `goLayout`/`resolveGoLayout`; a missing *required* offset invalidates the
   layout and falls back to the synthetic goroutine — keep new fields optional
   unless they're truly required. Preserve the streaming-cadence invariant
-  (snapshot on breakpoint/pause/entry, never per-step) and the degraded-snapshot
-  rule (don't touch `prevGoids` on an unreadable read).
+  (snapshot on breakpoint/pause/entry, never per-step), the degraded-snapshot
+  rule (don't touch `prevGoids` on an unreadable read), and the
+  automatic-snapshots-own-the-baseline rule (a `CmdGoroutineSnapshot` query
+  reports no deltas and never advances `prevGoids`).
 - **Suspend/resume sets**: update both `suspendingEvents` and
   `resumingCommands` in [hub.go](internal/hub/hub.go), and the matching
   hub_test cases.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,10 +244,12 @@ unrelated async events remain valid.
 `EventGoroutineSnapshot` is dual-purpose: it confirms `CmdGoroutineSnapshot`
 and is also pushed automatically after breakpoint, pause, and entry stops. A
 timed-out snapshot request is removed from the pending queue so it cannot consume
-the next unrelated telemetry snapshot. A genuinely late query reply therefore
-falls through to `Events()` too; the client cannot distinguish the two without
-wire correlation. The dependent snapshot/API cleanup removes this synchronous
-query surface rather than expanding the exception here.
+the next unrelated telemetry snapshot. This preserves the stream, not
+correlation: while the legacy synchronous API exists, a genuinely late query
+reply or an unrelated automatic push can still satisfy a later in-flight
+`GoroutineSnapshot` waiter; without a waiter, either falls through to `Events()`.
+Issue #187 and stacked PR #192 remove the synchronous query surface and that
+ambiguity rather than expanding the exception here.
 
 This is deliberately bounded by the id-less broadcast protocol. The queue
 preserves this client's ordered command stream; it cannot distinguish an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,9 +251,13 @@ protocol rather than to this change:
 - **Delivery is best-effort.** The answer rides the shared `Events()` buffer,
   which `readPump` drops from when the consumer stops draining, and a rejected
   request answers with `EventError`(`CmdGoroutineSnapshot`) instead of a
-  snapshot. Anything that blocks waiting for a snapshot must handle both — see
-  `cmd/wsmon`'s `-once`, which fails fast on a rejection or a closed stream
-  rather than waiting forever.
+  snapshot. Anything that waits for a snapshot must handle both — and must not
+  treat that error as *its* answer: `EventError` is broadcast and carries no
+  requester, so it may be another client's rejection with a valid snapshot still
+  to come. Correlating it by kind is the same mistake as correlating the
+  snapshot itself. `cmd/wsmon`'s `-once` shows the intended shape: the rejection
+  is advisory, a later snapshot wins, and a `-timeout` deadline (not the error)
+  is what bounds the wait.
 - **The answer is broadcast.** A query is fanned out to every client on the
   session like any other event, and it carries empty `Created`/`Exited`. An
   observer that renders "the latest snapshot's deltas" (as `cmd/wsmon`'s

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,13 +218,33 @@ created via `hub.New(dbg, log)` (tests / single-session) do not.
 In [pkg/client](pkg/client/), the `Client` interface splits methods by what
 they wait for:
 
-- **Synchronous** (`SetBreakpoint`, `ClearBreakpoint`, `Locals`, `StackFrames`,
-  `Goroutines`): block until the matching confirmation event (or `EventError`
-  for the same command kind) arrives. Implemented via `sendAndWait` in
-  [pkg/client/ws.go](pkg/client/ws.go).
-- **Fire-and-forget** (`Launch`, `Attach`, `Kill`, `Continue`, `Step*`):
+- **Synchronous** (`Restart`, `SetBreakpoint`, `ClearBreakpoint`, `Locals`,
+  `Evaluate`, `StackFrames`, `Goroutines`, `GoroutineSnapshot`): block until
+  the matching confirmation event (or `EventError` for the same command kind)
+  arrives. Implemented via `sendAndWait` in [pkg/client/ws.go](pkg/client/ws.go).
+- **Fire-and-forget** (`Launch`, `Attach`, `Kill`, `Continue`, `Step*`, `Pause`):
   return as soon as the command is on the wire. Results arrive asynchronously
   on the `Events()` channel.
+
+`syncMu` serializes synchronous commands, but a timeout does **not** cancel the
+command already sent to the server. The pending queue therefore retains a
+timed-out request as retired reply debt until its matching confirmation or
+matching `EventError` arrives. `routeToPending` always claims and removes the
+oldest matching entry under `pendingMu` before notifying a live waiter; retired
+matches are consumed without notification. This prevents a late response from
+one of this client's timed-out commands from satisfying a newer same-kind call,
+and prevents back-to-back matching frames from blocking the read pump on a
+waiter's one-element channel. If a debt never resolves, a newer same-kind call
+must time out rather than accept an ambiguous reply; subsequent same-kind calls
+continue timing out while that reply stream remains one response short. Keep the
+WebSocket open: disconnecting the last client tears down the hub/debuggee, while
+unrelated async events remain valid.
+
+This is deliberately bounded by the id-less broadcast protocol. The queue
+preserves this client's ordered command stream; it cannot distinguish an
+unsolicited same-kind event or confirmation caused by another driving client.
+The single-driver caveat still applies until the wire protocol gains correlation
+IDs.
 
 ## Engine concurrency model — non-obvious invariants
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,15 @@ continue timing out while that reply stream remains one response short. Keep the
 WebSocket open: disconnecting the last client tears down the hub/debuggee, while
 unrelated async events remain valid.
 
+`GoroutineSnapshot` is a temporary exception to timeout debt because
+`EventGoroutineSnapshot` is dual-purpose: it confirms `CmdGoroutineSnapshot`
+and is also pushed automatically after breakpoint, pause, and entry stops. A
+timed-out snapshot request is removed from the pending queue so it cannot consume
+the next unrelated telemetry snapshot. A genuinely late query reply therefore
+falls through to `Events()` too; the client cannot distinguish the two without
+wire correlation. The dependent snapshot/API cleanup removes this synchronous
+query surface rather than expanding the exception here.
+
 This is deliberately bounded by the id-less broadcast protocol. The queue
 preserves this client's ordered command stream; it cannot distinguish an
 unsolicited same-kind event or confirmation caused by another driving client.

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -19,7 +19,9 @@ import (
 
 // fullSnapshotNext renders the next EventGoroutineSnapshot in full rather than
 // as the usual one-line summary, so a user-typed `snapshot` gets the detailed
-// view. Shared between the REPL goroutine and the event printer.
+// view. It is a display preference, not correlation: the arm is consumed by
+// whichever snapshot arrives first and is cleared by any broadcast snapshot
+// error. Shared between the REPL goroutine and the event printer.
 var fullSnapshotNext atomic.Bool
 
 //nolint:gocognit,gocyclo // The CLI keeps command routing in one switch while commands are still small.
@@ -249,10 +251,14 @@ func main() {
 
 		case "snapshot", "snap":
 			// Fire-and-forget: the snapshot answers on the event stream, where
-			// automatic stop snapshots also arrive. fullSnapshotNext only
-			// changes how the next one is *rendered* (full instead of the
-			// one-line summary) — every snapshot is printed either way, so
-			// nothing is correlated or discarded.
+			// automatic stop snapshots also arrive. fullSnapshotNext is a
+			// display arm only — it selects the renderer for the NEXT snapshot,
+			// whichever that turns out to be. An automatic push (or another
+			// client's requested one) can consume the arm, and any broadcast
+			// snapshot error can disarm it, so the detailed view may land on a
+			// different snapshot than the one this command asked for. No
+			// snapshot data is lost either way: every one is printed, in order,
+			// in one form or the other.
 			fullSnapshotNext.Store(true)
 			if err := c.RequestGoroutineSnapshot(); err != nil {
 				fullSnapshotNext.Store(false)
@@ -344,8 +350,9 @@ func printAuxEvent(evt protocol.Event) {
 		var p protocol.ErrorPayload
 		if protocol.DecodeEventPayload(evt, &p) == nil {
 			if p.Command == protocol.CmdGoroutineSnapshot {
-				// A rejected request has no snapshot to render in full; leaving
-				// the flag armed would expand the next automatic push instead.
+				// Disarm on any broadcast snapshot rejection, including one
+				// caused by another client: EventError carries no requester, so
+				// leaving the arm set would expand an unrelated automatic push.
 				fullSnapshotNext.Store(false)
 			}
 			fmt.Printf("\n  [error] %s: %s\nbingo> ", p.Command, p.Message)

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -10,11 +10,17 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/bingosuite/bingo/pkg/client"
 	"github.com/bingosuite/bingo/pkg/protocol"
 	"github.com/chzyer/readline"
 )
+
+// fullSnapshotNext renders the next EventGoroutineSnapshot in full rather than
+// as the usual one-line summary, so a user-typed `snapshot` gets the detailed
+// view. Shared between the REPL goroutine and the event printer.
+var fullSnapshotNext atomic.Bool
 
 //nolint:gocognit,gocyclo // The CLI keeps command routing in one switch while commands are still small.
 func main() {
@@ -242,12 +248,17 @@ func main() {
 			}
 
 		case "snapshot", "snap":
-			snap, err := c.GoroutineSnapshot()
-			if err != nil {
+			// Fire-and-forget: the snapshot answers on the event stream, where
+			// automatic stop snapshots also arrive. fullSnapshotNext only
+			// changes how the next one is *rendered* (full instead of the
+			// one-line summary) — every snapshot is printed either way, so
+			// nothing is correlated or discarded.
+			fullSnapshotNext.Store(true)
+			if err := c.RequestGoroutineSnapshot(); err != nil {
+				fullSnapshotNext.Store(false)
 				printErr(err)
 				continue
 			}
-			printSnapshot(snap)
 
 		case "help", "h", "?":
 			printHelp()
@@ -332,6 +343,11 @@ func printAuxEvent(evt protocol.Event) {
 	case protocol.EventError:
 		var p protocol.ErrorPayload
 		if protocol.DecodeEventPayload(evt, &p) == nil {
+			if p.Command == protocol.CmdGoroutineSnapshot {
+				// A rejected request has no snapshot to render in full; leaving
+				// the flag armed would expand the next automatic push instead.
+				fullSnapshotNext.Store(false)
+			}
 			fmt.Printf("\n  [error] %s: %s\nbingo> ", p.Command, p.Message)
 		}
 
@@ -345,6 +361,12 @@ func printAuxEvent(evt protocol.Event) {
 	case protocol.EventGoroutineSnapshot:
 		var p protocol.GoroutineSnapshotPayload
 		if protocol.DecodeEventPayload(evt, &p) == nil {
+			if fullSnapshotNext.CompareAndSwap(true, false) {
+				fmt.Println()
+				printSnapshot(p)
+				fmt.Print("bingo> ")
+				return
+			}
 			msg := fmt.Sprintf("\n  [goroutines] %d live, %d threads, current G%d",
 				len(p.Goroutines), len(p.Threads), p.Current)
 			if len(p.Created) > 0 {
@@ -447,7 +469,7 @@ func printHelp() {
   locals [frame]             show local variables (default frame 0)
   bt / backtrace             show call stack
   goroutines / grs           list goroutines (with parent/start)
-  snapshot / snap            full concurrency snapshot (goroutines + threads + deltas)
+  snapshot / snap            request a full concurrency snapshot (printed when it arrives)
 
   help / h / ?               show this help
   quit / q / exit            disconnect and exit`)

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+// captureStdout runs fn with os.Stdout redirected and returns what it printed.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	original := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = original }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("close pipe writer: %v", err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	return string(out)
+}
+
+func testSnapshotEvent(t *testing.T, seq uint64) protocol.Event {
+	t.Helper()
+
+	return protocol.MustEvent(protocol.EventGoroutineSnapshot, seq, protocol.GoroutineSnapshotPayload{
+		Goroutines: []protocol.Goroutine{
+			{ID: 1, Status: "running", Current: true},
+			{ID: 18, Status: "waiting", ParentID: 1},
+		},
+		Threads: []protocol.Thread{{ID: 4242, MID: 3, GoID: 1, Current: true}},
+		Current: 1,
+		Created: []int{18},
+	})
+}
+
+// The `snapshot` command arms a one-shot full render; every other snapshot —
+// including the automatic pushes — stays a one-line summary. Both are printed:
+// the flag only picks the renderer, it never consumes or correlates an event.
+func TestFullSnapshotNextRendersOnceThenSummarises(t *testing.T) {
+	t.Cleanup(func() { fullSnapshotNext.Store(false) })
+
+	fullSnapshotNext.Store(true)
+	full := captureStdout(t, func() { printEvent(testSnapshotEvent(t, 2)) })
+	if !strings.Contains(full, "goroutines: 2  threads: 1  current: G1") {
+		t.Fatalf("requested snapshot render = %q, want the full view", full)
+	}
+	if !strings.Contains(full, "created: [18]") {
+		t.Fatalf("requested snapshot render = %q, want the lifecycle deltas", full)
+	}
+	if fullSnapshotNext.Load() {
+		t.Fatal("fullSnapshotNext still armed after one snapshot")
+	}
+
+	summary := captureStdout(t, func() { printEvent(testSnapshotEvent(t, 3)) })
+	if !strings.Contains(summary, "[goroutines] 2 live, 1 threads, current G1") {
+		t.Fatalf("automatic snapshot render = %q, want the summary line", summary)
+	}
+	if strings.Contains(summary, "goroutines: 2  threads: 1") {
+		t.Fatalf("automatic snapshot render = %q, want no full view", summary)
+	}
+}
+
+// A rejected request (e.g. the process isn't suspended) must disarm the full
+// render, or the next automatic push would be expanded in its place.
+func TestSnapshotErrorDisarmsFullRender(t *testing.T) {
+	t.Cleanup(func() { fullSnapshotNext.Store(false) })
+
+	fullSnapshotNext.Store(true)
+	rejected := protocol.MustEvent(protocol.EventError, 2, protocol.ErrorPayload{
+		Command: protocol.CmdGoroutineSnapshot,
+		Message: "process not suspended",
+	})
+	if out := captureStdout(t, func() { printEvent(rejected) }); !strings.Contains(out, "process not suspended") {
+		t.Fatalf("error render = %q, want the server message", out)
+	}
+	if fullSnapshotNext.Load() {
+		t.Fatal("fullSnapshotNext still armed after a rejected request")
+	}
+
+	summary := captureStdout(t, func() { printEvent(testSnapshotEvent(t, 3)) })
+	if !strings.Contains(summary, "[goroutines] 2 live") {
+		t.Fatalf("automatic snapshot render = %q, want the summary line", summary)
+	}
+}

--- a/cmd/wsmon/main.go
+++ b/cmd/wsmon/main.go
@@ -69,13 +69,23 @@ func (c *config) validate() error {
 	return nil
 }
 
+// usageError reports a validation failure the same way the flag package reports
+// a parse failure: the message, then the flag SET's usage. It must be fs.Usage,
+// not the package-level flag.Usage — those are different functions, and
+// bindFlags installs the custom header on the set, so calling flag.Usage() here
+// would print the stock "Usage of <binary>:" instead and diverge from what a
+// parse error prints.
+func usageError(fs *flag.FlagSet, err error) {
+	_, _ = fmt.Fprintf(fs.Output(), "error: %v\n", err)
+	fs.Usage()
+}
+
 func main() {
 	cfg := bindFlags(flag.CommandLine)
 	flag.Parse()
 
 	if err := cfg.validate(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		flag.Usage()
+		usageError(flag.CommandLine, err)
 		os.Exit(2)
 	}
 

--- a/cmd/wsmon/main.go
+++ b/cmd/wsmon/main.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"unicode/utf8"
 
 	"github.com/bingosuite/bingo/pkg/client"
 	"github.com/bingosuite/bingo/pkg/protocol"
@@ -521,13 +522,43 @@ func unvisitedIDs(nodes map[int]protocol.Goroutine, visited map[int]bool) []int 
 	return ids
 }
 
+// oneLine's budget counts complete code points, never bytes. It renders
+// arbitrary tracee output, panic text, and rejection messages, so a byte-sliced
+// cut can land inside a multi-byte rune and emit invalid UTF-8 that terminals
+// show as a replacement glyph (issue #209). Runes are the closest proxy to
+// on-screen length that needs no display-width dependency; a grapheme cluster
+// (a base plus its combining marks) can still be split, and an East Asian or
+// emoji run can still exceed the budget in columns, both of which would take a
+// segmentation/width table to avoid.
+const (
+	oneLineMaxRunes  = 120
+	oneLineKeepRunes = oneLineMaxRunes - len("...")
+)
+
 func oneLine(s string) string {
 	s = strings.TrimSpace(strings.ReplaceAll(s, "\n", `\n`))
-	if len(s) > 120 {
-		return s[:117] + "..."
-	}
 	if s == "" {
 		return "-"
+	}
+	if utf8.RuneCountInString(s) > oneLineMaxRunes {
+		return truncateRunes(s, oneLineKeepRunes) + "..."
+	}
+	return s
+}
+
+// truncateRunes keeps the first n runes of s. Ranging over a string yields the
+// start offset of every rune, so the cut is always on a code-point boundary.
+// Bytes that are already invalid UTF-8 in s are each one rune here — matching
+// utf8.RuneCountInString and Go's own range semantics — and are passed through
+// untouched rather than rewritten, so truncation never introduces a broken
+// sequence that the input did not already contain.
+func truncateRunes(s string, n int) string {
+	count := 0
+	for i := range s {
+		if count == n {
+			return s[:i]
+		}
+		count++
 	}
 	return s
 }

--- a/cmd/wsmon/main.go
+++ b/cmd/wsmon/main.go
@@ -72,13 +72,13 @@ func main() {
 		_ = c.Close()
 	}()
 
-	if snap, err := c.GoroutineSnapshot(); err == nil {
-		m.applySnapshot(snap)
-		m.render()
-		if *once {
-			return
-		}
-	} else if !*once {
+	// The snapshot answers on the event stream like every automatic push, so
+	// this is fire-and-forget; the render loop below applies whichever arrives
+	// first. -once therefore waits for the first snapshot event either way.
+	if err := c.RequestGoroutineSnapshot(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: request goroutine snapshot: %v\n", err)
+	}
+	if !*once {
 		m.render()
 	}
 

--- a/cmd/wsmon/main.go
+++ b/cmd/wsmon/main.go
@@ -1,11 +1,10 @@
 // Command wsmon joins an existing bingo WebSocket session and renders the
 // streaming goroutine/thread telemetry in a terminal.
 //
-//	wsmon -session id [-addr host:port] [-once]
+//	wsmon -session id [-addr host:port] [-once] [-timeout d]
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -36,8 +35,10 @@ func main() {
 	addr := flag.String("addr", "localhost:6060", "server address (host:port)")
 	sessionID := flag.String("session", "", "session ID to join")
 	once := flag.Bool("once", false, "print one snapshot then exit")
+	timeout := flag.Duration("timeout", 30*time.Second,
+		"with -once, how long to wait for a snapshot (0 waits forever)")
 	flag.Usage = func() {
-		_, _ = fmt.Fprintf(flag.CommandLine.Output(), "usage: wsmon -session <id> [-addr host:port] [-once]\n\n")
+		_, _ = fmt.Fprintf(flag.CommandLine.Output(), "usage: wsmon -session <id> [-addr host:port] [-once] [-timeout d]\n\n")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
@@ -84,7 +85,7 @@ func main() {
 		m.render()
 	}
 
-	if err := m.run(c.Events(), *once, m.render); err != nil {
+	if err := m.run(c.Events(), *once, *timeout, m.render); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
@@ -94,42 +95,63 @@ func main() {
 }
 
 // run drains events until the stream closes, -once has rendered its snapshot,
-// or the server rejects the snapshot request. render is injected so tests can
-// count redraws without terminal output.
+// or (under -once) the deadline expires. render is injected so tests can count
+// redraws without terminal output.
 //
-// A rejection is only fatal under -once: that mode blocks until a snapshot
-// arrives, and after a rejection none is coming, so the old code waited
-// forever. In live mode the monitor keeps observing — the next stop pushes a
-// snapshot on its own — and surfaces the rejection on the status line.
-func (m *monitor) run(events <-chan protocol.Event, once bool, render func()) error {
-	for evt := range events {
-		if msg, ok := snapshotRejection(evt); ok && once {
-			return fmt.Errorf("server rejected the snapshot request: %s", msg)
-		}
-
-		renderedSnapshot, redraw := m.applyEvent(evt)
-		if !redraw {
-			continue
-		}
-		if once && !renderedSnapshot {
-			continue
-		}
-		render()
-		if once && renderedSnapshot {
-			return nil
-		}
+// A snapshot rejection is ADVISORY, never fatal on its own: EventError is
+// broadcast, so an error naming CmdGoroutineSnapshot may belong to another
+// client entirely, and a valid snapshot can still arrive right after it (the
+// target reaching a stop pushes one unprompted). Attributing it to our request
+// would reintroduce exactly the correlate-by-kind mistake this command was
+// changed to avoid. So a later snapshot always wins; the last rejection seen is
+// only reported as context if the wait ends without one. The deadline is what
+// keeps -once bounded when our own request really was rejected.
+func (m *monitor) run(events <-chan protocol.Event, once bool, timeout time.Duration, render func()) error {
+	var deadline <-chan time.Time
+	if once && timeout > 0 {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		deadline = timer.C
 	}
 
-	if once {
-		return errors.New("connection closed before a snapshot arrived")
+	var lastRejection string
+	for {
+		select {
+		case evt, ok := <-events:
+			if !ok {
+				if once {
+					return fmt.Errorf("connection closed before a snapshot arrived%s",
+						rejectionContext(lastRejection))
+				}
+				return nil
+			}
+
+			if msg, rejected := snapshotRejection(evt); rejected {
+				lastRejection = msg
+			}
+
+			renderedSnapshot, redraw := m.applyEvent(evt)
+			if !redraw {
+				continue
+			}
+			if once && !renderedSnapshot {
+				continue
+			}
+			render()
+			if once && renderedSnapshot {
+				return nil
+			}
+
+		case <-deadline:
+			return fmt.Errorf("no snapshot within %s%s", timeout, rejectionContext(lastRejection))
+		}
 	}
-	return nil
 }
 
-// snapshotRejection reports a failed CmdGoroutineSnapshot. EventError is
-// broadcast to every client, so this cannot tell our own rejection from another
-// client's; under -once either means no snapshot is coming, which is why the
-// caller treats both the same rather than waiting for a reply it can't identify.
+// snapshotRejection reports a failed CmdGoroutineSnapshot seen on the stream.
+// EventError carries no requester, so this says only "some snapshot request was
+// rejected" — it can never be attributed to this client's request. Callers must
+// treat it as advisory context, not as an answer.
 func snapshotRejection(evt protocol.Event) (string, bool) {
 	if evt.Kind != protocol.EventError {
 		return "", false
@@ -139,6 +161,13 @@ func snapshotRejection(evt protocol.Event) (string, bool) {
 		return "", false
 	}
 	return p.Message, true
+}
+
+func rejectionContext(msg string) string {
+	if msg == "" {
+		return ""
+	}
+	return fmt.Sprintf(" (a snapshot request was rejected meanwhile: %s)", msg)
 }
 
 func (m *monitor) applyEvent(evt protocol.Event) (bool, bool) {

--- a/cmd/wsmon/main.go
+++ b/cmd/wsmon/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -76,27 +77,68 @@ func main() {
 	// this is fire-and-forget; the render loop below applies whichever arrives
 	// first. -once therefore waits for the first snapshot event either way.
 	if err := c.RequestGoroutineSnapshot(); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: request goroutine snapshot: %v\n", err)
+		fmt.Fprintf(os.Stderr, "error: request goroutine snapshot: %v\n", err)
+		os.Exit(1)
 	}
 	if !*once {
 		m.render()
 	}
 
-	for evt := range c.Events() {
+	if err := m.run(c.Events(), *once, m.render); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	if !*once {
+		fmt.Println("\nconnection closed; monitor stopped")
+	}
+}
+
+// run drains events until the stream closes, -once has rendered its snapshot,
+// or the server rejects the snapshot request. render is injected so tests can
+// count redraws without terminal output.
+//
+// A rejection is only fatal under -once: that mode blocks until a snapshot
+// arrives, and after a rejection none is coming, so the old code waited
+// forever. In live mode the monitor keeps observing — the next stop pushes a
+// snapshot on its own — and surfaces the rejection on the status line.
+func (m *monitor) run(events <-chan protocol.Event, once bool, render func()) error {
+	for evt := range events {
+		if msg, ok := snapshotRejection(evt); ok && once {
+			return fmt.Errorf("server rejected the snapshot request: %s", msg)
+		}
+
 		renderedSnapshot, redraw := m.applyEvent(evt)
 		if !redraw {
 			continue
 		}
-		if *once && !renderedSnapshot {
+		if once && !renderedSnapshot {
 			continue
 		}
-		m.render()
-		if *once && renderedSnapshot {
-			return
+		render()
+		if once && renderedSnapshot {
+			return nil
 		}
 	}
 
-	fmt.Println("\nconnection closed; monitor stopped")
+	if once {
+		return errors.New("connection closed before a snapshot arrived")
+	}
+	return nil
+}
+
+// snapshotRejection reports a failed CmdGoroutineSnapshot. EventError is
+// broadcast to every client, so this cannot tell our own rejection from another
+// client's; under -once either means no snapshot is coming, which is why the
+// caller treats both the same rather than waiting for a reply it can't identify.
+func snapshotRejection(evt protocol.Event) (string, bool) {
+	if evt.Kind != protocol.EventError {
+		return "", false
+	}
+	var p protocol.ErrorPayload
+	if protocol.DecodeEventPayload(evt, &p) != nil || p.Command != protocol.CmdGoroutineSnapshot {
+		return "", false
+	}
+	return p.Message, true
 }
 
 func (m *monitor) applyEvent(evt protocol.Event) (bool, bool) {
@@ -186,6 +228,16 @@ func describeEvent(evt protocol.Event) (string, bool) {
 			return "", false
 		}
 		return fmt.Sprintf("Output %s: %s", p.Stream, oneLine(p.Content)), true
+
+	case protocol.EventError:
+		var p protocol.ErrorPayload
+		if protocol.DecodeEventPayload(evt, &p) != nil {
+			return "", false
+		}
+		if p.Command == protocol.CmdNone {
+			return fmt.Sprintf("Error: %s", oneLine(p.Message)), true
+		}
+		return fmt.Sprintf("Error %s: %s", p.Command, oneLine(p.Message)), true
 
 	default:
 		return "", false

--- a/cmd/wsmon/main.go
+++ b/cmd/wsmon/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -31,28 +32,57 @@ type monitor struct {
 	hasSnapshot bool
 }
 
-func main() {
-	addr := flag.String("addr", "localhost:6060", "server address (host:port)")
-	sessionID := flag.String("session", "", "session ID to join")
-	once := flag.Bool("once", false, "print one snapshot then exit")
-	timeout := flag.Duration("timeout", 30*time.Second,
+// config holds wsmon's parsed flags. bindFlags is shared with the tests so
+// validation runs against the real flag definitions rather than a copy.
+type config struct {
+	addr      string
+	sessionID string
+	once      bool
+	timeout   time.Duration
+}
+
+func bindFlags(fs *flag.FlagSet) *config {
+	cfg := &config{}
+	fs.StringVar(&cfg.addr, "addr", "localhost:6060", "server address (host:port)")
+	fs.StringVar(&cfg.sessionID, "session", "", "session ID to join")
+	fs.BoolVar(&cfg.once, "once", false, "print one snapshot then exit")
+	fs.DurationVar(&cfg.timeout, "timeout", 30*time.Second,
 		"with -once, how long to wait for a snapshot (0 waits forever)")
-	flag.Usage = func() {
-		_, _ = fmt.Fprintf(flag.CommandLine.Output(), "usage: wsmon -session <id> [-addr host:port] [-once] [-timeout d]\n\n")
-		flag.PrintDefaults()
+	fs.Usage = func() {
+		_, _ = fmt.Fprintf(fs.Output(), "usage: wsmon -session <id> [-addr host:port] [-once] [-timeout d]\n\n")
+		fs.PrintDefaults()
 	}
+	return cfg
+}
+
+// validate rejects usage errors that the flag package itself accepts.
+func (c *config) validate() error {
+	if strings.TrimSpace(c.sessionID) == "" {
+		return errors.New("-session is required")
+	}
+	if c.timeout < 0 {
+		// Only 0 means "wait forever". A negative duration would reach run's
+		// `timeout > 0` guard and silently do the same, so `-timeout -30s`
+		// would produce an unbounded wait while the flag documents otherwise.
+		return fmt.Errorf("-timeout must be >= 0 (0 waits forever), got %s", c.timeout)
+	}
+	return nil
+}
+
+func main() {
+	cfg := bindFlags(flag.CommandLine)
 	flag.Parse()
 
-	if strings.TrimSpace(*sessionID) == "" {
-		fmt.Fprintln(os.Stderr, "error: -session is required")
+	if err := cfg.validate(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		flag.Usage()
 		os.Exit(2)
 	}
 
-	fmt.Printf("joining session %s on %s...\n", *sessionID, *addr)
-	c, err := client.Join(*addr, *sessionID)
+	fmt.Printf("joining session %s on %s...\n", cfg.sessionID, cfg.addr)
+	c, err := client.Join(cfg.addr, cfg.sessionID)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: join session %s on %s: %v\n", *sessionID, *addr, err)
+		fmt.Fprintf(os.Stderr, "error: join session %s on %s: %v\n", cfg.sessionID, cfg.addr, err)
 		os.Exit(1)
 	}
 	defer func() { _ = c.Close() }()
@@ -81,15 +111,15 @@ func main() {
 		fmt.Fprintf(os.Stderr, "error: request goroutine snapshot: %v\n", err)
 		os.Exit(1)
 	}
-	if !*once {
+	if !cfg.once {
 		m.render()
 	}
 
-	if err := m.run(c.Events(), *once, *timeout, m.render); err != nil {
+	if err := m.run(c.Events(), cfg.once, cfg.timeout, m.render); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
-	if !*once {
+	if !cfg.once {
 		fmt.Println("\nconnection closed; monitor stopped")
 	}
 }

--- a/cmd/wsmon/main_test.go
+++ b/cmd/wsmon/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
@@ -63,5 +64,102 @@ func TestApplyEventOnlySnapshotsCountAsRendered(t *testing.T) {
 	}
 	if m.hasSnapshot {
 		t.Fatal("monitor recorded a snapshot it never received")
+	}
+}
+
+func snapshotErrorEvent(t *testing.T, seq uint64) protocol.Event {
+	t.Helper()
+
+	return protocol.MustEvent(protocol.EventError, seq, protocol.ErrorPayload{
+		Command: protocol.CmdGoroutineSnapshot,
+		Message: "process not suspended",
+	})
+}
+
+// -once used to wait forever when the server rejected the request: the reply it
+// was blocked on never came and EventError was ignored. It must now fail fast
+// with the server's reason so the caller can exit nonzero.
+func TestRunOnceFailsOnRejectedSnapshotRequest(t *testing.T) {
+	events := make(chan protocol.Event, 2)
+	events <- snapshotErrorEvent(t, 2)
+	close(events)
+
+	m := &monitor{clients: -1}
+	renders := 0
+	err := m.run(events, true, func() { renders++ })
+	if err == nil {
+		t.Fatal("run(-once) returned nil for a rejected snapshot request")
+	}
+	if !strings.Contains(err.Error(), "process not suspended") {
+		t.Fatalf("run error = %v, want the server's reason", err)
+	}
+	if renders != 0 {
+		t.Fatalf("renders = %d, want 0 (nothing to draw)", renders)
+	}
+}
+
+// A closed stream under -once is also a failure: the promised snapshot never
+// arrived, so exiting 0 would report success for empty output.
+func TestRunOnceFailsWhenStreamClosesWithoutSnapshot(t *testing.T) {
+	events := make(chan protocol.Event)
+	close(events)
+
+	m := &monitor{clients: -1}
+	err := m.run(events, true, func() {})
+	if err == nil || !strings.Contains(err.Error(), "connection closed") {
+		t.Fatalf("run error = %v, want a closed-stream failure", err)
+	}
+}
+
+// -once still succeeds on the happy path, rendering exactly the snapshot.
+func TestRunOnceRendersFirstSnapshotThenStops(t *testing.T) {
+	events := make(chan protocol.Event, 3)
+	events <- protocol.MustEvent(protocol.EventSessionState, 2, protocol.SessionStatePayload{
+		SessionID: "s1",
+		State:     protocol.StateSuspended,
+	})
+	events <- protocol.MustEvent(protocol.EventGoroutineSnapshot, 3, protocol.GoroutineSnapshotPayload{
+		Goroutines: []protocol.Goroutine{{ID: 1, Current: true}},
+		Current:    1,
+	})
+	close(events)
+
+	m := &monitor{clients: -1}
+	renders := 0
+	if err := m.run(events, true, func() { renders++ }); err != nil {
+		t.Fatalf("run(-once): %v", err)
+	}
+	if renders != 1 {
+		t.Fatalf("renders = %d, want exactly 1 (the snapshot)", renders)
+	}
+	if !m.hasSnapshot || m.snapshot.Current != 1 {
+		t.Fatalf("monitor snapshot = %+v, want the delivered one", m.snapshot)
+	}
+}
+
+// Live mode must not die on a rejection — the next stop pushes a snapshot on its
+// own — but it must surface the reason instead of swallowing it.
+func TestRunLiveSurvivesRejectionAndShowsReason(t *testing.T) {
+	events := make(chan protocol.Event, 2)
+	events <- snapshotErrorEvent(t, 2)
+	events <- protocol.MustEvent(protocol.EventGoroutineSnapshot, 3, protocol.GoroutineSnapshotPayload{
+		Goroutines: []protocol.Goroutine{{ID: 1, Current: true}},
+		Current:    1,
+	})
+	close(events)
+
+	m := &monitor{clients: -1}
+	renders := 0
+	if err := m.run(events, false, func() { renders++ }); err != nil {
+		t.Fatalf("run(live): %v", err)
+	}
+	if renders != 2 {
+		t.Fatalf("renders = %d, want 2 (the error line and the snapshot)", renders)
+	}
+	if !strings.Contains(m.lastEvent, "process not suspended") {
+		t.Fatalf("lastEvent = %q, want the rejection reason", m.lastEvent)
+	}
+	if !m.hasSnapshot {
+		t.Fatal("live mode dropped the snapshot that followed the rejection")
 	}
 }

--- a/cmd/wsmon/main_test.go
+++ b/cmd/wsmon/main_test.go
@@ -280,3 +280,67 @@ func TestRunTreatsOnlyZeroAsUnbounded(t *testing.T) {
 		t.Fatal("validate() accepted a negative -timeout, which run would treat as unbounded")
 	}
 }
+
+// -timeout 0 documents "wait forever", so run must arm no timer at all. A naive
+// implementation that always created one would call time.NewTimer(0), which
+// fires immediately and would fail this test with "no snapshot within 0s". The
+// snapshot is delivered only after a delay far longer than the deadlines the
+// other tests use, and the whole thing is bounded so a regression reports a
+// failure instead of hanging the suite.
+func TestRunOnceZeroTimeoutArmsNoDeadline(t *testing.T) {
+	events := make(chan protocol.Event)
+	renders := make(chan struct{}, 1)
+	result := make(chan error, 1)
+
+	go func() {
+		result <- m0().run(events, true, 0, func() { renders <- struct{}{} })
+	}()
+
+	select {
+	case err := <-result:
+		t.Fatalf("run returned early with %v; -timeout 0 must not arm a deadline", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	events <- snapshotPushEvent(t, 2, 3)
+
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("run(-once, timeout 0): %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not return after the snapshot arrived")
+	}
+	if len(renders) != 1 {
+		t.Fatalf("renders = %d, want exactly 1", len(renders))
+	}
+}
+
+// Live mode never arms a deadline either, whatever -timeout says.
+func TestRunLiveIgnoresTimeout(t *testing.T) {
+	events := make(chan protocol.Event)
+	result := make(chan error, 1)
+
+	go func() {
+		result <- m0().run(events, false, time.Nanosecond, func() {})
+	}()
+
+	select {
+	case err := <-result:
+		t.Fatalf("live run returned early with %v; -timeout must not apply without -once", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(events)
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("live run after stream close: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("live run did not return after the stream closed")
+	}
+}
+
+func m0() *monitor { return &monitor{clients: -1} }

--- a/cmd/wsmon/main_test.go
+++ b/cmd/wsmon/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
@@ -76,38 +77,88 @@ func snapshotErrorEvent(t *testing.T, seq uint64) protocol.Event {
 	})
 }
 
-// -once used to wait forever when the server rejected the request: the reply it
-// was blocked on never came and EventError was ignored. It must now fail fast
-// with the server's reason so the caller can exit nonzero.
-func TestRunOnceFailsOnRejectedSnapshotRequest(t *testing.T) {
-	events := make(chan protocol.Event, 2)
+func snapshotPushEvent(t *testing.T, seq uint64, current int) protocol.Event {
+	t.Helper()
+
+	return protocol.MustEvent(protocol.EventGoroutineSnapshot, seq, protocol.GoroutineSnapshotPayload{
+		Goroutines: []protocol.Goroutine{{ID: current, Current: true}},
+		Current:    current,
+	})
+}
+
+// The adversarial ordering: another client's snapshot request is rejected while
+// the target runs, then the target reaches a stop and pushes a snapshot to
+// everyone. EventError carries no requester, so treating it as OUR answer would
+// be correlation by kind — the very thing this command stopped doing. A later
+// snapshot must win.
+func TestRunOnceSucceedsWhenSnapshotFollowsBroadcastRejection(t *testing.T) {
+	events := make(chan protocol.Event, 3)
 	events <- snapshotErrorEvent(t, 2)
+	events <- snapshotPushEvent(t, 3, 7)
 	close(events)
 
 	m := &monitor{clients: -1}
 	renders := 0
-	err := m.run(events, true, func() { renders++ })
-	if err == nil {
-		t.Fatal("run(-once) returned nil for a rejected snapshot request")
+	if err := m.run(events, true, time.Minute, func() { renders++ }); err != nil {
+		t.Fatalf("run(-once) failed on an unrelated broadcast rejection: %v", err)
 	}
-	if !strings.Contains(err.Error(), "process not suspended") {
-		t.Fatalf("run error = %v, want the server's reason", err)
+	if renders != 1 {
+		t.Fatalf("renders = %d, want exactly 1 (the snapshot)", renders)
 	}
-	if renders != 0 {
-		t.Fatalf("renders = %d, want 0 (nothing to draw)", renders)
+	if !m.hasSnapshot || m.snapshot.Current != 7 {
+		t.Fatalf("monitor snapshot = %+v, want the pushed one", m.snapshot)
 	}
 }
 
-// A closed stream under -once is also a failure: the promised snapshot never
+// When no snapshot follows, -once must still terminate — bounded by the
+// deadline, not by guessing that the broadcast error was ours — and report the
+// rejection as context.
+func TestRunOnceDeadlineReportsObservedRejection(t *testing.T) {
+	events := make(chan protocol.Event, 1)
+	events <- snapshotErrorEvent(t, 2)
+	// Left open: the stream stays alive, so only the deadline can end the wait.
+
+	m := &monitor{clients: -1}
+	err := m.run(events, true, 50*time.Millisecond, func() {})
+	if err == nil {
+		t.Fatal("run(-once) returned nil despite never receiving a snapshot")
+	}
+	if !strings.Contains(err.Error(), "no snapshot within") {
+		t.Fatalf("run error = %v, want a deadline failure", err)
+	}
+	if !strings.Contains(err.Error(), "process not suspended") {
+		t.Fatalf("run error = %v, want the observed rejection as context", err)
+	}
+}
+
+// The deadline also bounds a silent server, with no rejection to report.
+func TestRunOnceDeadlineWithoutRejection(t *testing.T) {
+	events := make(chan protocol.Event)
+
+	m := &monitor{clients: -1}
+	err := m.run(events, true, 50*time.Millisecond, func() {})
+	if err == nil || !strings.Contains(err.Error(), "no snapshot within") {
+		t.Fatalf("run error = %v, want a deadline failure", err)
+	}
+	if strings.Contains(err.Error(), "rejected") {
+		t.Fatalf("run error = %v, want no rejection context when none was seen", err)
+	}
+}
+
+// A closed stream under -once is a failure too: the promised snapshot never
 // arrived, so exiting 0 would report success for empty output.
 func TestRunOnceFailsWhenStreamClosesWithoutSnapshot(t *testing.T) {
-	events := make(chan protocol.Event)
+	events := make(chan protocol.Event, 1)
+	events <- snapshotErrorEvent(t, 2)
 	close(events)
 
 	m := &monitor{clients: -1}
-	err := m.run(events, true, func() {})
+	err := m.run(events, true, time.Minute, func() {})
 	if err == nil || !strings.Contains(err.Error(), "connection closed") {
 		t.Fatalf("run error = %v, want a closed-stream failure", err)
+	}
+	if !strings.Contains(err.Error(), "process not suspended") {
+		t.Fatalf("run error = %v, want the observed rejection as context", err)
 	}
 }
 
@@ -118,15 +169,12 @@ func TestRunOnceRendersFirstSnapshotThenStops(t *testing.T) {
 		SessionID: "s1",
 		State:     protocol.StateSuspended,
 	})
-	events <- protocol.MustEvent(protocol.EventGoroutineSnapshot, 3, protocol.GoroutineSnapshotPayload{
-		Goroutines: []protocol.Goroutine{{ID: 1, Current: true}},
-		Current:    1,
-	})
+	events <- snapshotPushEvent(t, 3, 1)
 	close(events)
 
 	m := &monitor{clients: -1}
 	renders := 0
-	if err := m.run(events, true, func() { renders++ }); err != nil {
+	if err := m.run(events, true, time.Minute, func() { renders++ }); err != nil {
 		t.Fatalf("run(-once): %v", err)
 	}
 	if renders != 1 {
@@ -137,20 +185,17 @@ func TestRunOnceRendersFirstSnapshotThenStops(t *testing.T) {
 	}
 }
 
-// Live mode must not die on a rejection — the next stop pushes a snapshot on its
-// own — but it must surface the reason instead of swallowing it.
+// Live mode never applies a deadline and never dies on a rejection: it displays
+// the reason and keeps observing, because the next stop pushes a snapshot.
 func TestRunLiveSurvivesRejectionAndShowsReason(t *testing.T) {
 	events := make(chan protocol.Event, 2)
 	events <- snapshotErrorEvent(t, 2)
-	events <- protocol.MustEvent(protocol.EventGoroutineSnapshot, 3, protocol.GoroutineSnapshotPayload{
-		Goroutines: []protocol.Goroutine{{ID: 1, Current: true}},
-		Current:    1,
-	})
+	events <- snapshotPushEvent(t, 3, 1)
 	close(events)
 
 	m := &monitor{clients: -1}
 	renders := 0
-	if err := m.run(events, false, func() { renders++ }); err != nil {
+	if err := m.run(events, false, time.Millisecond, func() { renders++ }); err != nil {
 		t.Fatalf("run(live): %v", err)
 	}
 	if renders != 2 {

--- a/cmd/wsmon/main_test.go
+++ b/cmd/wsmon/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"io"
 	"strings"
@@ -344,3 +345,53 @@ func TestRunLiveIgnoresTimeout(t *testing.T) {
 }
 
 func m0() *monitor { return &monitor{clients: -1} }
+
+const usageHeader = "usage: wsmon -session <id> [-addr host:port] [-once] [-timeout d]"
+
+// bindFlags installs the custom usage on the FlagSet it is given, so anything
+// reporting a usage error must go through that set — see usageError.
+func TestBindFlagsInstallsCustomUsage(t *testing.T) {
+	var out bytes.Buffer
+	fs := flag.NewFlagSet("wsmon", flag.ContinueOnError)
+	fs.SetOutput(&out)
+	bindFlags(fs)
+
+	fs.Usage()
+
+	if got := out.String(); !strings.Contains(got, usageHeader) {
+		t.Fatalf("usage output = %q, want the custom header", got)
+	}
+	if got := out.String(); !strings.Contains(got, "-timeout") {
+		t.Fatalf("usage output = %q, want the flag defaults", got)
+	}
+}
+
+// A validation failure must print the same usage a parse failure does. Calling
+// the package-level flag.Usage() here instead of the set's own would silently
+// print the stock "Usage of <binary>:" header — the regression this pins.
+func TestUsageErrorUsesTheFlagSetUsage(t *testing.T) {
+	var out bytes.Buffer
+	fs := flag.NewFlagSet("wsmon", flag.ContinueOnError)
+	fs.SetOutput(&out)
+	cfg := bindFlags(fs)
+	if err := fs.Parse([]string{"-session", "s1", "-timeout", "-5s"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	err := cfg.validate()
+	if err == nil {
+		t.Fatal("validate() accepted a negative -timeout")
+	}
+	usageError(fs, err)
+
+	got := out.String()
+	if !strings.Contains(got, "error: -timeout must be >= 0") {
+		t.Fatalf("output = %q, want the validation message", got)
+	}
+	if !strings.Contains(got, usageHeader) {
+		t.Fatalf("output = %q, want the custom usage header, not the stock one", got)
+	}
+	if strings.Contains(got, "Usage of ") {
+		t.Fatalf("output = %q, want no stock flag-package header", got)
+	}
+}

--- a/cmd/wsmon/main_test.go
+++ b/cmd/wsmon/main_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
@@ -393,5 +394,158 @@ func TestUsageErrorUsesTheFlagSetUsage(t *testing.T) {
 	}
 	if strings.Contains(got, "Usage of ") {
 		t.Fatalf("output = %q, want no stock flag-package header", got)
+	}
+}
+
+// oneLine renders arbitrary tracee stdout/stderr, panic text, and rejection
+// messages, so its budget has to cut on code-point boundaries: a byte cut lands
+// inside a multi-byte rune and emits invalid UTF-8 that terminals show as a
+// replacement glyph (issue #209). The table pins the short/exact/over budget
+// boundaries across ASCII, Japanese, astral emoji, combining sequences, embedded
+// CR/LF, and input that is already invalid UTF-8.
+func TestOneLine(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: "-"},
+		{name: "whitespace only", in: "   \t ", want: "-"},
+		{name: "short ascii", in: "hello", want: "hello"},
+		{name: "surrounding space trimmed", in: "  hello  ", want: "hello"},
+
+		// Newline normalization is unchanged by the UTF-8 fix: LF becomes the
+		// two-character escape, and a CR is left alone because collapsing it
+		// would be a separate rendering change.
+		{name: "embedded lf", in: "line one\nline two", want: `line one\nline two`},
+		{name: "embedded crlf", in: "line one\r\nline two", want: "line one\r" + `\n` + "line two"},
+		{name: "trailing lf", in: "hello\n", want: `hello\n`},
+
+		{name: "ascii at budget", in: strings.Repeat("a", 120), want: strings.Repeat("a", 120)},
+		{
+			name: "ascii one over budget",
+			in:   strings.Repeat("a", 121),
+			want: strings.Repeat("a", 117) + "...",
+		},
+
+		// The issue's exact repro: byte 117 falls inside the first Japanese
+		// rune, so s[:117] would end on its leading byte.
+		{
+			name: "cut lands inside a japanese rune",
+			in:   strings.Repeat("a", 116) + strings.Repeat("日", 10),
+			want: strings.Repeat("a", 116) + "日" + "...",
+		},
+		// 360 bytes but only 120 runes: a byte budget truncated this to 39
+		// characters, a rune budget leaves it whole.
+		{name: "japanese at budget", in: strings.Repeat("日", 120), want: strings.Repeat("日", 120)},
+		{
+			name: "japanese one over budget",
+			in:   strings.Repeat("日", 121),
+			want: strings.Repeat("日", 117) + "...",
+		},
+
+		// Astral planes are 4 bytes per rune, so 40 of them blow the old byte
+		// budget while sitting well inside the rune budget.
+		{name: "emoji under budget", in: strings.Repeat("🙂", 40), want: strings.Repeat("🙂", 40)},
+		{
+			name: "emoji one over budget",
+			in:   strings.Repeat("🙂", 121),
+			want: strings.Repeat("🙂", 117) + "...",
+		},
+		// A ZWJ sequence is several code points; cutting between them is
+		// allowed here — avoiding it needs grapheme segmentation.
+		{
+			name: "zwj sequence at the cut",
+			in:   strings.Repeat("a", 116) + "👨\u200d👩\u200d👧",
+			want: strings.Repeat("a", 116) + "👨" + "...",
+		},
+
+		// 61 base+mark pairs is 122 runes, so the cut separates the 59th base
+		// from its accent. Still valid UTF-8, still no split code point.
+		{
+			name: "combining mark separated from its base",
+			in:   strings.Repeat("e\u0301", 61),
+			want: strings.Repeat("e\u0301", 58) + "e" + "...",
+		},
+
+		// The LF escape is two ASCII runes, so the budget can land between
+		// them. Cosmetic, valid UTF-8, and unchanged from the byte version.
+		{
+			name: "cut inside the newline escape",
+			in:   strings.Repeat("a", 116) + "\n" + strings.Repeat("b", 10),
+			want: strings.Repeat("a", 116) + `\` + "...",
+		},
+
+		// Bytes that are already invalid pass through untouched rather than
+		// being rewritten to U+FFFD: oneLine truncates, it does not sanitize.
+		{name: "short invalid utf8", in: "bad \xff byte", want: "bad \xff byte"},
+		// Each invalid byte counts as one rune (utf8.RuneCountInString and
+		// range agree), so the cut sits after \xff and before the 17th 日.
+		{
+			name: "invalid byte before the cut",
+			in:   strings.Repeat("a", 100) + "\xff" + strings.Repeat("日", 30),
+			want: strings.Repeat("a", 100) + "\xff" + strings.Repeat("日", 16) + "...",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := oneLine(tc.in)
+			if got != tc.want {
+				t.Fatalf("oneLine(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if n := utf8.RuneCountInString(got); n > oneLineMaxRunes {
+				t.Fatalf("oneLine(%q) has %d runes, want at most %d", tc.in, n, oneLineMaxRunes)
+			}
+			if utf8.ValidString(tc.in) && !utf8.ValidString(got) {
+				t.Fatalf("oneLine(%q) = %q, which is not valid UTF-8", tc.in, got)
+			}
+		})
+	}
+}
+
+// A byte cut is unsafe only at some offsets, so sweep every prefix of a mixed
+// 1/2/3/4-byte string past the budget and assert the result is always valid
+// UTF-8 and within the budget. This is the property byte slicing cannot hold.
+func TestOneLineNeverSplitsACodePoint(t *testing.T) {
+	mixed := strings.Repeat("aé日🙂", 80)
+
+	for i := 0; i <= len(mixed); i++ {
+		in := mixed[:i]
+		if !utf8.ValidString(in) {
+			continue
+		}
+		got := oneLine(in)
+		if !utf8.ValidString(got) {
+			t.Fatalf("oneLine(prefix of %d bytes) = %q, want valid UTF-8", i, got)
+		}
+		if n := utf8.RuneCountInString(got); n > oneLineMaxRunes {
+			t.Fatalf("oneLine(prefix of %d bytes) has %d runes, want at most %d", i, n, oneLineMaxRunes)
+		}
+	}
+}
+
+// truncateRunes is the seam the fix turns on, so pin it directly: it keeps whole
+// code points and returns the input untouched when it is already short enough.
+func TestTruncateRunes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		n    int
+		want string
+	}{
+		{name: "zero keeps nothing", in: "日本語", n: 0, want: ""},
+		{name: "shorter than n", in: "日本", n: 5, want: "日本"},
+		{name: "exactly n", in: "日本語", n: 3, want: "日本語"},
+		{name: "cuts on a rune boundary", in: "日本語", n: 2, want: "日本"},
+		{name: "invalid byte is one rune", in: "a\xffb", n: 2, want: "a\xff"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := truncateRunes(tc.in, tc.n); got != tc.want {
+				t.Fatalf("truncateRunes(%q, %d) = %q, want %q", tc.in, tc.n, got, tc.want)
+			}
+		})
 	}
 }

--- a/cmd/wsmon/main_test.go
+++ b/cmd/wsmon/main_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+// wsmon no longer blocks on a snapshot reply: its request is fire-and-forget and
+// every snapshot — requested or automatic — arrives on the event stream. This
+// pins the stream path that both the live redraw and -once now depend on.
+func TestApplyEventRendersSnapshotsFromTheEventStream(t *testing.T) {
+	m := &monitor{clients: -1, lastEvent: "joined"}
+
+	evt := protocol.MustEvent(protocol.EventGoroutineSnapshot, 2, protocol.GoroutineSnapshotPayload{
+		Goroutines: []protocol.Goroutine{{ID: 1, Current: true}, {ID: 9, ParentID: 1}},
+		Threads:    []protocol.Thread{{ID: 7, GoID: 1, Current: true}},
+		Current:    1,
+		Created:    []int{9},
+	})
+
+	renderedSnapshot, redraw := m.applyEvent(evt)
+	if !renderedSnapshot || !redraw {
+		t.Fatalf("applyEvent(snapshot) = (%v, %v), want (true, true)", renderedSnapshot, redraw)
+	}
+	if !m.hasSnapshot || m.snapshot.Current != 1 || len(m.snapshot.Goroutines) != 2 {
+		t.Fatalf("monitor snapshot = %+v, want the streamed payload", m.snapshot)
+	}
+
+	// A later automatic snapshot replaces it; nothing is consumed as a reply.
+	next := protocol.MustEvent(protocol.EventGoroutineSnapshot, 3, protocol.GoroutineSnapshotPayload{
+		Goroutines: []protocol.Goroutine{{ID: 1, Current: true}},
+		Current:    1,
+		Exited:     []int{9},
+	})
+	if renderedSnapshot, redraw = m.applyEvent(next); !renderedSnapshot || !redraw {
+		t.Fatalf("applyEvent(second snapshot) = (%v, %v), want (true, true)", renderedSnapshot, redraw)
+	}
+	if len(m.snapshot.Exited) != 1 || m.snapshot.Exited[0] != 9 {
+		t.Fatalf("monitor exited delta = %v, want [9]", m.snapshot.Exited)
+	}
+}
+
+// Only snapshots satisfy -once; other traffic redraws at most.
+func TestApplyEventOnlySnapshotsCountAsRendered(t *testing.T) {
+	m := &monitor{clients: -1}
+
+	state := protocol.MustEvent(protocol.EventSessionState, 2, protocol.SessionStatePayload{
+		SessionID: "s1",
+		State:     protocol.StateSuspended,
+		Clients:   2,
+	})
+	if renderedSnapshot, redraw := m.applyEvent(state); renderedSnapshot || !redraw {
+		t.Fatalf("applyEvent(sessionState) = (%v, %v), want (false, true)", renderedSnapshot, redraw)
+	}
+	if m.state != protocol.StateSuspended || m.clients != 2 {
+		t.Fatalf("monitor state = %s clients = %d, want suspended/2", m.state, m.clients)
+	}
+
+	continued := protocol.MustEvent(protocol.EventContinued, 3, protocol.ContinuedPayload{})
+	if renderedSnapshot, redraw := m.applyEvent(continued); renderedSnapshot || redraw {
+		t.Fatalf("applyEvent(continued) = (%v, %v), want (false, false)", renderedSnapshot, redraw)
+	}
+	if m.hasSnapshot {
+		t.Fatal("monitor recorded a snapshot it never received")
+	}
+}

--- a/cmd/wsmon/main_test.go
+++ b/cmd/wsmon/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -206,5 +208,75 @@ func TestRunLiveSurvivesRejectionAndShowsReason(t *testing.T) {
 	}
 	if !m.hasSnapshot {
 		t.Fatal("live mode dropped the snapshot that followed the rejection")
+	}
+}
+
+// The flag package accepts a negative duration, and run's `timeout > 0` guard
+// would then treat it exactly like 0 — an unbounded wait, which is the opposite
+// of what -timeout documents and what -once needs. Parse through the real flag
+// definitions so this cannot drift from main.
+func TestConfigValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "defaults with a session", args: []string{"-session", "s1"}},
+		{name: "zero waits forever", args: []string{"-session", "s1", "-timeout", "0"}},
+		{name: "positive timeout", args: []string{"-session", "s1", "-timeout", "5s"}},
+		{
+			name:    "negative timeout",
+			args:    []string{"-session", "s1", "-timeout", "-30s"},
+			wantErr: "-timeout must be >= 0",
+		},
+		{
+			name:    "negative nanosecond",
+			args:    []string{"-session", "s1", "-timeout", "-1ns"},
+			wantErr: "-timeout must be >= 0",
+		},
+		{
+			name:    "missing session",
+			args:    []string{"-once"},
+			wantErr: "-session is required",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := flag.NewFlagSet("wsmon", flag.ContinueOnError)
+			fs.SetOutput(io.Discard)
+			cfg := bindFlags(fs)
+			if err := fs.Parse(tc.args); err != nil {
+				t.Fatalf("parse %v: %v", tc.args, err)
+			}
+
+			err := cfg.validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validate() = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("validate() = %v, want an error containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// A negative duration must never reach run: it would disarm the deadline and
+// hang -once forever. This pins the guard the validation protects.
+func TestRunTreatsOnlyZeroAsUnbounded(t *testing.T) {
+	fs := flag.NewFlagSet("wsmon", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	cfg := bindFlags(fs)
+	if err := fs.Parse([]string{"-session", "s1", "-once", "-timeout", "-30s"}); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.timeout >= 0 {
+		t.Fatalf("timeout = %s, want the negative value the flag package accepts", cfg.timeout)
+	}
+	if err := cfg.validate(); err == nil {
+		t.Fatal("validate() accepted a negative -timeout, which run would treat as unbounded")
 	}
 }

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -132,6 +132,7 @@ In another terminal, join the **same session id** read-only and watch it update:
 go run ./cmd/wsmon -addr localhost:6060 -session <session-id>
 # one-shot (print a single snapshot and exit): add -once
 # bound the one-shot wait (default 30s, 0 = wait forever): -timeout 5s
+# a negative -timeout is rejected, so a typo can't silently mean "forever"
 ```
 
 `wsmon` sends one on-demand snapshot request on join and then renders whatever
@@ -157,11 +158,12 @@ repaints with the new round's workers — the plumbing, end to end.
 - `wsmon` is a pure observer: it never sends run-control commands, so it cannot
   disturb the DAP driver. Many `wsmon` + DAP clients can share one session.
   `-once` waits for the first snapshot and is bounded by `-timeout` (default
-  30s, `0` waits forever), so a rejected request can't hang it. A broadcast
-  `EventError` naming `GoroutineSnapshot` is advisory only — it may be another
-  client's rejection, and a snapshot can still follow — so a later snapshot
-  always wins and the rejection is reported only as context if the wait times
-  out or the connection closes first.
+  30s, `0` waits forever; negatives are rejected rather than silently meaning
+  forever), so a rejected request can't hang it. A broadcast `EventError` naming
+  `GoroutineSnapshot` is advisory only — it may be another client's rejection,
+  and a snapshot can still follow — so a later snapshot always wins and the
+  rejection is reported only as context if the wait times out or the connection
+  closes first.
 - The graphical observer is also read-only. It sends exactly one on-demand
   snapshot request after joining and on explicit Refresh only. On-demand
   requests are never correlated to their answer: every snapshot — requested or

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -133,12 +133,18 @@ go run ./cmd/wsmon -addr localhost:6060 -session <session-id>
 # one-shot (print a single snapshot and exit): add -once
 ```
 
+`wsmon` sends one on-demand snapshot request on join and then renders whatever
+arrives on the event stream — the request is fire-and-forget, so with `-once` it
+prints the first snapshot that lands (the requested one, or an automatic stop
+snapshot if the tracee is running and stops first).
+
 `wsmon` redraws in place on every `EventGoroutineSnapshot`, showing:
 
 - the **goroutine spawn tree** built from `ParentID` (the `go` statement that
   spawned each goroutine), with the current goroutine marked;
 - the **OS thread set** (runtime M's) and which goroutine each is running;
-- the **created / exited** goid deltas since the previous snapshot;
+- the **created / exited** goid deltas since the previous automatic snapshot
+  (an on-demand request answers with the live picture and no deltas);
 - the **last stop event** (breakpoint / pause / step / exit) and session state.
 
 Each time you Continue in the driver and hit the breakpoint again, `wsmon`
@@ -149,7 +155,10 @@ repaints with the new round's workers — the plumbing, end to end.
 - `wsmon` is a pure observer: it never sends run-control commands, so it cannot
   disturb the DAP driver. Many `wsmon` + DAP clients can share one session.
 - The graphical observer is also read-only. It sends exactly one on-demand
-  snapshot request after joining and on explicit Refresh only.
+  snapshot request after joining and on explicit Refresh only. On-demand
+  requests are never correlated to their answer: every snapshot — requested or
+  automatic — arrives as a push on the event stream, and only automatic ones
+  carry lifecycle deltas (a refresh cannot consume the next stop's).
 - Snapshots stream on **breakpoint / pause / entry**, not per single-step (steps
   stay cheap). Use the driver's breakpoints/continue to advance between frames.
 - If the tracee is a stripped binary or stopped before runtime init, the snapshot

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -131,12 +131,14 @@ In another terminal, join the **same session id** read-only and watch it update:
 ```sh
 go run ./cmd/wsmon -addr localhost:6060 -session <session-id>
 # one-shot (print a single snapshot and exit): add -once
+# bound the one-shot wait (default 30s, 0 = wait forever): -timeout 5s
 ```
 
 `wsmon` sends one on-demand snapshot request on join and then renders whatever
 arrives on the event stream — the request is fire-and-forget, so with `-once` it
 prints the first snapshot that lands (the requested one, or an automatic stop
-snapshot if the tracee is running and stops first).
+snapshot if the tracee is running and stops first) and gives up after
+`-timeout`.
 
 `wsmon` redraws in place on every `EventGoroutineSnapshot`, showing:
 
@@ -154,8 +156,12 @@ repaints with the new round's workers — the plumbing, end to end.
 
 - `wsmon` is a pure observer: it never sends run-control commands, so it cannot
   disturb the DAP driver. Many `wsmon` + DAP clients can share one session.
-  `-once` fails fast (nonzero) if the server rejects the snapshot request or the
-  connection closes first, rather than waiting for a snapshot that is not coming.
+  `-once` waits for the first snapshot and is bounded by `-timeout` (default
+  30s, `0` waits forever), so a rejected request can't hang it. A broadcast
+  `EventError` naming `GoroutineSnapshot` is advisory only — it may be another
+  client's rejection, and a snapshot can still follow — so a later snapshot
+  always wins and the rejection is reported only as context if the wait times
+  out or the connection closes first.
 - The graphical observer is also read-only. It sends exactly one on-demand
   snapshot request after joining and on explicit Refresh only. On-demand
   requests are never correlated to their answer: every snapshot — requested or

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -154,11 +154,18 @@ repaints with the new round's workers — the plumbing, end to end.
 
 - `wsmon` is a pure observer: it never sends run-control commands, so it cannot
   disturb the DAP driver. Many `wsmon` + DAP clients can share one session.
+  `-once` fails fast (nonzero) if the server rejects the snapshot request or the
+  connection closes first, rather than waiting for a snapshot that is not coming.
 - The graphical observer is also read-only. It sends exactly one on-demand
   snapshot request after joining and on explicit Refresh only. On-demand
   requests are never correlated to their answer: every snapshot — requested or
   automatic — arrives as a push on the event stream, and only automatic ones
   carry lifecycle deltas (a refresh cannot consume the next stop's).
+- A requested snapshot is **broadcast to every client** on the session, deltas
+  empty. `wsmon`'s lifecycle panel shows the latest snapshot's deltas, so another
+  client's refresh blanks it until the next stop; the VS Code timeline appends,
+  so it is unaffected. Addressing a query to its requester needs wire-level
+  correlation — out of scope for the current protocol.
 - Snapshots stream on **breakpoint / pause / entry**, not per single-step (steps
   stay cheap). Use the driver's breakpoints/continue to advance between frames.
 - If the tracee is a stripped binary or stopped before runtime init, the snapshot

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -213,11 +213,11 @@ dropped.
 ### Synchronous vs. fire-and-forget at the client boundary
 
 `pkg/client` splits methods by what they wait for. Synchronous methods
-(`SetBreakpoint`, `Locals`, `StackFrames`, `Goroutines`, `ClearBreakpoint`)
-block on their confirmation event **or** an `EventError` for the same command
-kind — see [`sendAndWait` / `routeToPending`](../pkg/client/ws.go). An
-`EventError` whose `Command` matches is turned back into a Go `error` for the
-caller:
+(`Restart`, `SetBreakpoint`, `ClearBreakpoint`, `Locals`, `Evaluate`,
+`StackFrames`, `Goroutines`, `GoroutineSnapshot`) block on their confirmation
+event **or** an `EventError` for the same command kind — see
+[`sendAndWait` / `routeToPending`](../pkg/client/ws.go). An `EventError` whose
+`Command` matches is turned back into a Go `error` for the caller:
 
 ```go
 case evt := <-ch:
@@ -228,10 +228,27 @@ case evt := <-ch:
     }
 ```
 
-Fire-and-forget methods (`Launch`, `Attach`, `Kill`, `Continue`, `Step*`) return
-once the command is on the wire; their results — including asynchronous
-`EventError`s with `Command == CmdNone` — arrive on `Events()` and are printed
-by the CLI's event loop.
+A synchronous timeout does not cancel the command on the server. Its pending
+entry becomes retired reply debt and stays ordered ahead of newer same-kind
+requests until a matching confirmation or matching `EventError` consumes it.
+The read pump claims and removes a match under `pendingMu` before sending to a
+live waiter's one-element channel; a retired match is consumed without a send.
+If the old reply never arrives, the same-kind reply stream stays one response
+behind and subsequent calls time out safely instead of accepting ambiguous
+events. The client must not close the whole connection as timeout recovery
+because a last-client disconnect tears down the session and debuggee, while
+unrelated asynchronous events remain valid.
+
+This fence covers only the serialized command stream sent by that client.
+Confirmation events carry no request ID and are broadcast to every client, so
+an unsolicited same-kind event or another driver's confirmation remains
+indistinguishable. That multi-driver limitation requires wire-level correlation
+IDs rather than more client-side guessing.
+
+Fire-and-forget methods (`Launch`, `Attach`, `Kill`, `Continue`, `Step*`,
+`Pause`) return once the command is on the wire; their results — including
+asynchronous `EventError`s with `Command == CmdNone` — arrive on `Events()` and
+are printed by the CLI's event loop.
 
 ## 8. Propagating errors to clients: typed `EventError`
 
@@ -287,3 +304,4 @@ server-side `slog` output and map to short client-facing messages there. The
 | Goroutine → owner error propagation              | Emit a typed `protocol.Event` (`EventError` / `EventProcessExited`) on `Debugger.Events()`    |
 | Methods not on the `Debugger` interface          | Keep unexported on `engine`; return errors up the synchronous chain to the loop               |
 | Server → WebSocket client error                  | Broadcast a typed `EventError`; message text is intentionally surfaced (local tool)           |
+| Timed-out synchronous client command             | Retain ordered reply debt; consume its late reply/error before notifying a newer waiter       |

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -239,6 +239,15 @@ events. The client must not close the whole connection as timeout recovery
 because a last-client disconnect tears down the session and debuggee, while
 unrelated asynchronous events remain valid.
 
+`GoroutineSnapshot` is the temporary exception. Its confirmation event is also
+unsolicited telemetry emitted after breakpoint, pause, and entry stops, so a
+timed-out snapshot request is discarded instead of retired as debt. Otherwise
+the next auto-pushed snapshot would disappear into the retired query. A
+genuinely late query reply consequently reaches `Events()`; the id-less protocol
+cannot distinguish it from an automatic snapshot. The dependent snapshot/API
+cleanup removes this synchronous query rather than redesigning its semantics
+here.
+
 This fence covers only the serialized command stream sent by that client.
 Confirmation events carry no request ID and are broadcast to every client, so
 an unsolicited same-kind event or another driver's confirmation remains
@@ -304,4 +313,4 @@ server-side `slog` output and map to short client-facing messages there. The
 | Goroutine → owner error propagation              | Emit a typed `protocol.Event` (`EventError` / `EventProcessExited`) on `Debugger.Events()`    |
 | Methods not on the `Debugger` interface          | Keep unexported on `engine`; return errors up the synchronous chain to the loop               |
 | Server → WebSocket client error                  | Broadcast a typed `EventError`; message text is intentionally surfaced (local tool)           |
-| Timed-out synchronous client command             | Retain ordered reply debt; consume its late reply/error before notifying a newer waiter       |
+| Timed-out synchronous client command             | Retain ordered reply debt, except discard the dual-purpose snapshot query to preserve telemetry |

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -242,11 +242,12 @@ unrelated asynchronous events remain valid.
 `GoroutineSnapshot` is the temporary exception. Its confirmation event is also
 unsolicited telemetry emitted after breakpoint, pause, and entry stops, so a
 timed-out snapshot request is discarded instead of retired as debt. Otherwise
-the next auto-pushed snapshot would disappear into the retired query. A
-genuinely late query reply consequently reaches `Events()`; the id-less protocol
-cannot distinguish it from an automatic snapshot. The dependent snapshot/API
-cleanup removes this synchronous query rather than redesigning its semantics
-here.
+the next auto-pushed snapshot would disappear into the retired query. This
+preserves telemetry but cannot create correlation: while the legacy synchronous
+API exists, either a genuinely late query reply or an automatic push can satisfy
+a later in-flight snapshot waiter; with no waiter, either reaches `Events()`.
+Issue #187 and stacked PR #192 remove the synchronous query and that ambiguity
+rather than redesigning its semantics here.
 
 This fence covers only the serialized command stream sent by that client.
 Confirmation events carry no request ID and are broadcast to every client, so

--- a/docs/ErrorHandling.md
+++ b/docs/ErrorHandling.md
@@ -214,7 +214,7 @@ dropped.
 
 `pkg/client` splits methods by what they wait for. Synchronous methods
 (`Restart`, `SetBreakpoint`, `ClearBreakpoint`, `Locals`, `Evaluate`,
-`StackFrames`, `Goroutines`, `GoroutineSnapshot`) block on their confirmation
+`StackFrames`, `Goroutines`) block on their confirmation
 event **or** an `EventError` for the same command kind — see
 [`sendAndWait` / `routeToPending`](../pkg/client/ws.go). An `EventError` whose
 `Command` matches is turned back into a Go `error` for the caller:
@@ -239,15 +239,16 @@ events. The client must not close the whole connection as timeout recovery
 because a last-client disconnect tears down the session and debuggee, while
 unrelated asynchronous events remain valid.
 
-`GoroutineSnapshot` is the temporary exception. Its confirmation event is also
-unsolicited telemetry emitted after breakpoint, pause, and entry stops, so a
-timed-out snapshot request is discarded instead of retired as debt. Otherwise
-the next auto-pushed snapshot would disappear into the retired query. This
-preserves telemetry but cannot create correlation: while the legacy synchronous
-API exists, either a genuinely late query reply or an automatic push can satisfy
-a later in-flight snapshot waiter; with no waiter, either reaches `Events()`.
-Issue #187 and stacked PR #192 remove the synchronous query and that ambiguity
-rather than redesigning its semantics here.
+This model covers genuine confirmations only — events that cannot exist without
+a request. `EventGoroutineSnapshot` is not one: the server also pushes it after
+every breakpoint, pause, and entry stop. While a synchronous snapshot query
+existed it needed a per-kind carve-out in the timeout path, and neither side of
+that carve-out is sound — retiring the request as debt swallows the next
+auto-pushed snapshot, while discarding it preserves the stream but restores the
+#144 ambiguity, letting a late reply or an automatic push satisfy a later
+in-flight call. Removing the waiter removed the dilemma: the request is
+fire-and-forget and its answer is ordinary telemetry on `Events()`. Do not
+reintroduce an exemption here.
 
 This fence covers only the serialized command stream sent by that client.
 Confirmation events carry no request ID and are broadcast to every client, so
@@ -256,9 +257,13 @@ indistinguishable. That multi-driver limitation requires wire-level correlation
 IDs rather than more client-side guessing.
 
 Fire-and-forget methods (`Launch`, `Attach`, `Kill`, `Continue`, `Step*`,
-`Pause`) return once the command is on the wire; their results — including
-asynchronous `EventError`s with `Command == CmdNone` — arrive on `Events()` and
-are printed by the CLI's event loop.
+`Pause`, `RequestGoroutineSnapshot`) return once the command is on the wire;
+their results — including asynchronous `EventError`s with `Command == CmdNone` —
+arrive on `Events()` and are printed by the CLI's event loop.
+`RequestGoroutineSnapshot` belongs here because `EventGoroutineSnapshot` is also
+pushed unsolicited on every stop: correlating it by kind would let an automatic
+push answer the request, or let a timed-out request's reply debt swallow an
+automatic push (issue #187). It registers no pending entry at all.
 
 ## 8. Propagating errors to clients: typed `EventError`
 
@@ -314,4 +319,4 @@ server-side `slog` output and map to short client-facing messages there. The
 | Goroutine → owner error propagation              | Emit a typed `protocol.Event` (`EventError` / `EventProcessExited`) on `Debugger.Events()`    |
 | Methods not on the `Debugger` interface          | Keep unexported on `engine`; return errors up the synchronous chain to the loop               |
 | Server → WebSocket client error                  | Broadcast a typed `EventError`; message text is intentionally surfaced (local tool)           |
-| Timed-out synchronous client command             | Retain ordered reply debt, except discard the dual-purpose snapshot query to preserve telemetry |
+| Timed-out synchronous client command             | Retain ordered reply debt; consume its late reply/error before notifying a newer waiter       |

--- a/internal/debugger/debugger.go
+++ b/internal/debugger/debugger.go
@@ -57,10 +57,12 @@ type Debugger interface {
 	StackFrames() ([]protocol.Frame, error)
 	Goroutines() ([]protocol.Goroutine, error)
 
-	// GoroutineSnapshot returns the full concurrency picture — every goroutine
-	// (with parent linkage), every OS thread, the current goroutine, and the
-	// created/exited lifecycle deltas since the previous snapshot. Requires the
-	// process to be suspended.
+	// GoroutineSnapshot returns the full concurrency picture on demand — every
+	// goroutine (with parent linkage), every OS thread, and the current
+	// goroutine. Requires the process to be suspended. It is a pure
+	// observation: it reports no created/exited deltas and does not advance the
+	// lifecycle baseline, which the automatic entry/breakpoint/pause snapshots
+	// alone own.
 	GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error)
 
 	// Events delivers async notifications. Closed on shutdown; caller must drain.

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -488,19 +488,20 @@ func (e *engine) Goroutines() ([]protocol.Goroutine, error) {
 	return goroutines, err
 }
 
-// GoroutineSnapshot returns the full concurrency picture on demand: every
-// goroutine (with parent linkage for a spawn tree), every OS thread, the
-// current goroutine, and the created/exited lifecycle deltas since the previous
-// snapshot. Only valid while suspended (the tracee must be stopped for the
-// memory reads to be race-free). Like the auto-streamed snapshots it advances
-// the lifecycle-delta baseline.
+// GoroutineSnapshot answers an on-demand snapshot request: every goroutine
+// (with parent linkage for a spawn tree), every OS thread, and the current
+// goroutine. Only valid while suspended (the tracee must be stopped for the
+// memory reads to be race-free). Unlike the auto-streamed stop snapshots it is
+// a pure observation — it reports no created/exited deltas and does not advance
+// the lifecycle baseline, so a refresh can't consume the deltas the next
+// automatic snapshot must report.
 func (e *engine) GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error) {
 	var snap protocol.GoroutineSnapshotPayload
 	err := e.dispatch(func() error {
 		if err := e.requireSuspended(); err != nil {
 			return err
 		}
-		snap = e.goroutineSnapshot()
+		snap = e.goroutineSnapshotQuery()
 		return nil
 	})
 	return snap, err
@@ -1174,9 +1175,10 @@ func (e *engine) emitBreakpointHit(bp *breakpointEntry, stop StopEvent) {
 	e.emit(protocol.EventGoroutineSnapshot, snap)
 }
 
-// emitGoroutineSnapshot builds and streams a standalone concurrency snapshot.
-// Used at the entry stop and on the CmdGoroutineSnapshot on-demand path. It is
-// a non-suspending event, so the hub forwards it without gating.
+// emitGoroutineSnapshot builds and streams a standalone concurrency snapshot at
+// the launch/attach entry stop, which has no stop event of its own to piggyback
+// on. It is an automatic snapshot, so it seeds the lifecycle baseline. It is a
+// non-suspending event, so the hub forwards it without gating.
 func (e *engine) emitGoroutineSnapshot() {
 	e.emit(protocol.EventGoroutineSnapshot, e.goroutineSnapshot())
 }

--- a/internal/debugger/export_test.go
+++ b/internal/debugger/export_test.go
@@ -1,7 +1,12 @@
 // Exposes internal symbols to debugger_test. Compiled only during `go test`.
 package debugger
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
 
 func ExportedTrapInstruction() []byte {
 	return archTrapInstruction()
@@ -95,4 +100,38 @@ func ExportedSetBreakpointAtErr(d Debugger, addr uint64) error {
 		_, err := e.bps.set(e.backend, "<direct-addr>", 0, addr)
 		return err
 	})
+}
+
+// ExportedSnapshotFrom assembles a snapshot payload around a pre-built
+// goroutine list, bypassing the runtime memory scan, so tests can pin the
+// lifecycle split: trackLifecycle=true is the automatic stop path (diffs and
+// adopts the baseline), false is the on-demand query path. Runs on the engine
+// loop thread, like the real callers.
+func ExportedSnapshotFrom(d Debugger, gs []protocol.Goroutine, trackLifecycle bool) protocol.GoroutineSnapshotPayload {
+	e := d.(*engine)
+	var snap protocol.GoroutineSnapshotPayload
+	if err := e.dispatch(func() error {
+		snap = e.snapshotFrom(gs, 0, trackLifecycle)
+		return nil
+	}); err != nil {
+		panic("ExportedSnapshotFrom: " + err.Error())
+	}
+	return snap
+}
+
+// ExportedPrevGoids returns the remembered live goid set (the lifecycle-delta
+// baseline), sorted. Nil before the first automatic snapshot.
+func ExportedPrevGoids(d Debugger) []int {
+	e := d.(*engine)
+	var ids []int
+	if err := e.dispatch(func() error {
+		for id := range e.prevGoids {
+			ids = append(ids, id)
+		}
+		sort.Ints(ids)
+		return nil
+	}); err != nil {
+		panic("ExportedPrevGoids: " + err.Error())
+	}
+	return ids
 }

--- a/internal/debugger/goroutines.go
+++ b/internal/debugger/goroutines.go
@@ -418,11 +418,25 @@ func (e *engine) readGoroutines() ([]protocol.Goroutine, error) {
 	return []protocol.Goroutine{e.syntheticGoroutine(pc)}, nil
 }
 
-// goroutineSnapshot builds the full concurrency picture and computes the
-// created/exited deltas against the previous snapshot. It updates the engine's
-// remembered live set, so successive snapshots report only what changed. Runs
-// on the engine loop thread; prevGoids needs no synchronization.
+// goroutineSnapshot builds the automatic stop snapshot: the full concurrency
+// picture plus the created/exited deltas against the previous automatic
+// snapshot, adopting the new live set as the next baseline. Only the automatic
+// stops (entry, breakpoint hit, pause) own that baseline. Runs on the engine
+// loop thread; prevGoids needs no synchronization.
 func (e *engine) goroutineSnapshot() protocol.GoroutineSnapshotPayload {
+	return e.buildSnapshot(true)
+}
+
+// goroutineSnapshotQuery answers an on-demand CmdGoroutineSnapshot. It reports
+// the same live picture but is a pure observation: Created/Exited stay empty and
+// prevGoids is untouched, so a refresh between two stops cannot consume the
+// deltas the next automatic snapshot must report (they are only remembered
+// once, in prevGoids, and would otherwise be lost).
+func (e *engine) goroutineSnapshotQuery() protocol.GoroutineSnapshotPayload {
+	return e.buildSnapshot(false)
+}
+
+func (e *engine) buildSnapshot(trackLifecycle bool) protocol.GoroutineSnapshotPayload {
 	sp, pc := e.liveRegisters()
 
 	gs, ok := e.buildGoroutineList(sp, pc)
@@ -434,7 +448,13 @@ func (e *engine) goroutineSnapshot() protocol.GoroutineSnapshotPayload {
 			Goroutines: []protocol.Goroutine{e.syntheticGoroutine(pc)},
 		}
 	}
+	return e.snapshotFrom(gs, pc, trackLifecycle)
+}
 
+// snapshotFrom assembles the payload around an already-built goroutine list.
+// trackLifecycle is the single point where an automatic snapshot's ownership of
+// the lifecycle baseline differs from a query's read-only view.
+func (e *engine) snapshotFrom(gs []protocol.Goroutine, livePC uint64, trackLifecycle bool) protocol.GoroutineSnapshotPayload {
 	var current int
 	live := make(map[int]struct{}, len(gs))
 	for _, g := range gs {
@@ -444,21 +464,22 @@ func (e *engine) goroutineSnapshot() protocol.GoroutineSnapshotPayload {
 		}
 	}
 
-	created, exited := e.diffGoids(live)
-
-	return protocol.GoroutineSnapshotPayload{
+	snap := protocol.GoroutineSnapshotPayload{
 		Goroutines: gs,
-		Threads:    e.readThreads(current, pc),
+		Threads:    e.readThreads(current, livePC),
 		Current:    current,
-		Created:    created,
-		Exited:     exited,
 	}
+	if trackLifecycle {
+		snap.Created, snap.Exited = e.diffGoids(live)
+	}
+	return snap
 }
 
-// diffGoids compares the current live goid set against the previous snapshot's
-// and returns the created (new) and exited (gone) goids, then adopts the new
-// set. Returns nil slices on the first snapshot so a fresh session doesn't
-// report every existing goroutine as "created".
+// diffGoids compares the current live goid set against the previous automatic
+// snapshot's and returns the created (new) and exited (gone) goids, then adopts
+// the new set. Returns nil slices on the first snapshot so a fresh session
+// doesn't report every existing goroutine as "created". Only reached from the
+// automatic stop path — see goroutineSnapshotQuery.
 func (e *engine) diffGoids(live map[int]struct{}) (created, exited []int) {
 	if e.prevGoids != nil {
 		for id := range live {

--- a/internal/debugger/goroutines_lifecycle_test.go
+++ b/internal/debugger/goroutines_lifecycle_test.go
@@ -27,6 +27,10 @@ func newLifecycleEngine(t *testing.T) debugger.Debugger {
 // A query between two automatic snapshots must neither consume the pending
 // deltas nor fabricate its own: the second automatic snapshot has to report
 // everything that changed since the first one.
+// The wiring — that engine.GoroutineSnapshot actually reaches the query path —
+// is pinned by the concurrency E2E (declareBaselineOwnershipSpec), which is the
+// only place a query can observe a live set the automatic baseline has not
+// adopted. These tests pin the seam's semantics; they cannot catch a rewiring.
 func TestQuerySnapshotDoesNotConsumeLifecycleDeltas(t *testing.T) {
 	d := newLifecycleEngine(t)
 

--- a/internal/debugger/goroutines_lifecycle_test.go
+++ b/internal/debugger/goroutines_lifecycle_test.go
@@ -1,0 +1,118 @@
+package debugger_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/bingosuite/bingo/internal/debugger"
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+func goroutineSet(ids ...int) []protocol.Goroutine {
+	gs := make([]protocol.Goroutine, 0, len(ids))
+	for _, id := range ids {
+		gs = append(gs, protocol.Goroutine{ID: id, Status: "running"})
+	}
+	return gs
+}
+
+func newLifecycleEngine(t *testing.T) debugger.Debugger {
+	t.Helper()
+
+	d := debugger.NewWithBackend(newFakeBackend(), nil)
+	t.Cleanup(func() { _ = d.Kill() })
+	return d
+}
+
+// A query between two automatic snapshots must neither consume the pending
+// deltas nor fabricate its own: the second automatic snapshot has to report
+// everything that changed since the first one.
+func TestQuerySnapshotDoesNotConsumeLifecycleDeltas(t *testing.T) {
+	d := newLifecycleEngine(t)
+
+	first := debugger.ExportedSnapshotFrom(d, goroutineSet(1, 2), true)
+	if len(first.Created) != 0 || len(first.Exited) != 0 {
+		t.Fatalf("first automatic snapshot deltas = %v/%v, want empty baseline",
+			first.Created, first.Exited)
+	}
+	if got := debugger.ExportedPrevGoids(d); !reflect.DeepEqual(got, []int{1, 2}) {
+		t.Fatalf("baseline after first automatic snapshot = %v, want [1 2]", got)
+	}
+
+	// On-demand query taken at a moment when 2 is gone and 3 exists.
+	query := debugger.ExportedSnapshotFrom(d, goroutineSet(1, 3), false)
+	if len(query.Created) != 0 || len(query.Exited) != 0 {
+		t.Fatalf("query snapshot deltas = %v/%v, want none", query.Created, query.Exited)
+	}
+	if !reflect.DeepEqual(query.Goroutines, goroutineSet(1, 3)) {
+		t.Fatalf("query snapshot goroutines = %+v, want the live set", query.Goroutines)
+	}
+	if got := debugger.ExportedPrevGoids(d); !reflect.DeepEqual(got, []int{1, 2}) {
+		t.Fatalf("baseline after query = %v, want it untouched at [1 2]", got)
+	}
+
+	// The next automatic snapshot still reports everything since the first one.
+	second := debugger.ExportedSnapshotFrom(d, goroutineSet(1, 3), true)
+	if !reflect.DeepEqual(second.Created, []int{3}) {
+		t.Fatalf("second automatic snapshot created = %v, want [3]", second.Created)
+	}
+	if !reflect.DeepEqual(second.Exited, []int{2}) {
+		t.Fatalf("second automatic snapshot exited = %v, want [2]", second.Exited)
+	}
+	if got := debugger.ExportedPrevGoids(d); !reflect.DeepEqual(got, []int{1, 3}) {
+		t.Fatalf("baseline after second automatic snapshot = %v, want [1 3]", got)
+	}
+}
+
+// Repeated queries stay read-only: no query may seed the baseline either, or
+// the first automatic snapshot after a fresh session would lose its deltas.
+func TestQuerySnapshotNeverSeedsLifecycleBaseline(t *testing.T) {
+	d := newLifecycleEngine(t)
+
+	for i := 0; i < 3; i++ {
+		if snap := debugger.ExportedSnapshotFrom(d, goroutineSet(1, 2), false); len(snap.Created)+len(snap.Exited) != 0 {
+			t.Fatalf("query %d deltas = %v/%v, want none", i, snap.Created, snap.Exited)
+		}
+	}
+	if got := debugger.ExportedPrevGoids(d); got != nil {
+		t.Fatalf("baseline after queries = %v, want nil (unseeded)", got)
+	}
+
+	// The first automatic snapshot is still a baseline, not a delta report.
+	first := debugger.ExportedSnapshotFrom(d, goroutineSet(1, 2), true)
+	if len(first.Created)+len(first.Exited) != 0 {
+		t.Fatalf("first automatic snapshot deltas = %v/%v, want empty baseline",
+			first.Created, first.Exited)
+	}
+	next := debugger.ExportedSnapshotFrom(d, goroutineSet(1, 2, 5), true)
+	if !reflect.DeepEqual(next.Created, []int{5}) {
+		t.Fatalf("automatic snapshot created = %v, want [5]", next.Created)
+	}
+}
+
+// The on-demand command must still be answerable and must still refuse to read
+// a process that isn't suspended.
+func TestGoroutineSnapshotCommandRequiresSuspended(t *testing.T) {
+	d := newLifecycleEngine(t)
+
+	if _, err := d.GoroutineSnapshot(); err == nil {
+		t.Fatal("GoroutineSnapshot while not suspended: want error")
+	}
+
+	debugger.ExportedForceSuspended(d)
+	snap, err := d.GoroutineSnapshot()
+	if err != nil {
+		t.Fatalf("GoroutineSnapshot while suspended: %v", err)
+	}
+	// Without DWARF the runtime is unreadable, so the query degrades to the
+	// synthetic goroutine — and a degraded read must not touch the baseline.
+	if len(snap.Goroutines) != 1 {
+		t.Fatalf("degraded query goroutines = %+v, want the synthetic one", snap.Goroutines)
+	}
+	if len(snap.Created)+len(snap.Exited) != 0 {
+		t.Fatalf("degraded query deltas = %v/%v, want none", snap.Created, snap.Exited)
+	}
+	if got := debugger.ExportedPrevGoids(d); got != nil {
+		t.Fatalf("baseline after degraded query = %v, want nil", got)
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -65,6 +65,13 @@ type Client interface {
 	// correlated to a request by kind. Every snapshot, requested or automatic,
 	// is delivered on Events(). Requested snapshots carry no created/exited
 	// deltas; only the automatic ones do.
+	//
+	// Delivery is best-effort: like every event it goes through the shared
+	// Events() buffer, which drops when a caller stops draining, and a rejected
+	// request answers with EventError (Command == CmdGoroutineSnapshot) rather
+	// than a snapshot. A caller that blocks waiting for one must handle both.
+	// The answer is also broadcast to every client on the session, so other
+	// observers see this refresh — with empty deltas — as an ordinary snapshot.
 	RequestGoroutineSnapshot() error
 
 	Close() error

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -58,10 +58,14 @@ type Client interface {
 	StackFrames() ([]protocol.Frame, error)
 	Goroutines() ([]protocol.Goroutine, error)
 
-	// GoroutineSnapshot blocks until the server returns the full concurrency
-	// snapshot: every goroutine (with parent linkage), every OS thread, the
-	// current goroutine, and the created/exited lifecycle deltas.
-	GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error)
+	// RequestGoroutineSnapshot asks the server for a full concurrency snapshot.
+	// Fire-and-forget like Pause: it returns as soon as the command is sent.
+	// EventGoroutineSnapshot is dual-purpose — the server also pushes it
+	// automatically on every entry/breakpoint/pause stop — so it can never be
+	// correlated to a request by kind. Every snapshot, requested or automatic,
+	// is delivered on Events(). Requested snapshots carry no created/exited
+	// deltas; only the automatic ones do.
+	RequestGoroutineSnapshot() error
 
 	Close() error
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -69,7 +69,10 @@ type Client interface {
 	// Delivery is best-effort: like every event it goes through the shared
 	// Events() buffer, which drops when a caller stops draining, and a rejected
 	// request answers with EventError (Command == CmdGoroutineSnapshot) rather
-	// than a snapshot. A caller that blocks waiting for one must handle both.
+	// than a snapshot. A caller that waits for one must handle both — and must
+	// not read that error as its own answer: it is broadcast and carries no
+	// requester, so it may be another client's rejection with a valid snapshot
+	// still coming. Bound such a wait with a deadline, not with the error.
 	// The answer is also broadcast to every client on the session, so other
 	// observers see this refresh — with empty deltas — as an ordinary snapshot.
 	RequestGoroutineSnapshot() error

--- a/pkg/client/ws.go
+++ b/pkg/client/ws.go
@@ -15,13 +15,14 @@ import (
 var _ Client = (*wsClient)(nil)
 
 const (
-	syncTimeout     = 10 * time.Second
 	dialTimeout     = 5 * time.Second
 	eventBufferSize = 64
 )
 
-// pendingReq is a synchronous method blocked on its confirmation event (or an
-// EventError for the same command kind).
+var syncTimeout = 10 * time.Second
+
+// pendingReq keeps its place after a timeout because the server command is not
+// cancelled. A nil ch marks reply debt whose eventual response must be consumed.
 type pendingReq struct {
 	wantKind protocol.EventKind
 	cmdKind  protocol.CommandKind
@@ -41,10 +42,10 @@ type wsClient struct {
 	// syncMu serialises sendAndWait so one in-flight pending request at a time.
 	syncMu sync.Mutex
 
-	// pending: read-pump checks this on every event and routes matching
-	// confirmations / errors to pending.ch instead of the public events chan.
+	// pending preserves request order across timeouts so a late reply cannot be
+	// mistaken for a newer same-kind request.
 	pendingMu sync.Mutex
-	pending   *pendingReq
+	pending   []*pendingReq
 
 	// writeMu: gorilla allows one concurrent reader and one concurrent writer.
 	writeMu sync.Mutex
@@ -134,28 +135,67 @@ func (c *wsClient) readPump() {
 }
 
 func (c *wsClient) routeToPending(evt protocol.Event) bool {
-	c.pendingMu.Lock()
-	p := c.pending
-	c.pendingMu.Unlock()
-
-	if p == nil {
-		return false
-	}
-
-	if evt.Kind == p.wantKind {
-		p.ch <- evt
-		return true
-	}
-
+	var errorCommand protocol.CommandKind
 	if evt.Kind == protocol.EventError {
 		var ep protocol.ErrorPayload
-		if protocol.DecodeEventPayload(evt, &ep) == nil && ep.Command == p.cmdKind {
-			p.ch <- evt
-			return true
+		if protocol.DecodeEventPayload(evt, &ep) != nil {
+			return false
 		}
+		errorCommand = ep.Command
 	}
 
+	c.pendingMu.Lock()
+	for i, p := range c.pending {
+		matches := evt.Kind == p.wantKind
+		if evt.Kind == protocol.EventError {
+			matches = errorCommand == p.cmdKind
+		}
+		if !matches {
+			continue
+		}
+
+		ch := p.ch
+		c.removePendingAt(i)
+		c.pendingMu.Unlock()
+
+		if ch != nil {
+			ch <- evt
+		}
+		return true
+	}
+	c.pendingMu.Unlock()
+
 	return false
+}
+
+func (c *wsClient) removePendingAt(i int) {
+	copy(c.pending[i:], c.pending[i+1:])
+	c.pending[len(c.pending)-1] = nil
+	c.pending = c.pending[:len(c.pending)-1]
+}
+
+func (c *wsClient) discardPending(req *pendingReq) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+
+	for i, p := range c.pending {
+		if p == req {
+			c.removePendingAt(i)
+			return
+		}
+	}
+}
+
+func (c *wsClient) retirePending(req *pendingReq) {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+
+	for _, p := range c.pending {
+		if p == req {
+			p.ch = nil
+			return
+		}
+	}
 }
 
 func (c *wsClient) send(cmd protocol.Command) error {
@@ -178,16 +218,11 @@ func (c *wsClient) sendAndWait(cmd protocol.Command, wantKind protocol.EventKind
 	req := &pendingReq{wantKind: wantKind, cmdKind: cmd.Kind, ch: ch}
 
 	c.pendingMu.Lock()
-	c.pending = req
+	c.pending = append(c.pending, req)
 	c.pendingMu.Unlock()
 
-	defer func() {
-		c.pendingMu.Lock()
-		c.pending = nil
-		c.pendingMu.Unlock()
-	}()
-
 	if err := c.send(cmd); err != nil {
+		c.discardPending(req)
 		return protocol.Event{}, err
 	}
 
@@ -200,8 +235,10 @@ func (c *wsClient) sendAndWait(cmd protocol.Command, wantKind protocol.EventKind
 		}
 		return evt, nil
 	case <-time.After(syncTimeout):
+		c.retirePending(req)
 		return protocol.Event{}, fmt.Errorf("timeout waiting for %s response", wantKind)
 	case <-c.done:
+		c.discardPending(req)
 		return protocol.Event{}, fmt.Errorf("client closed")
 	}
 }

--- a/pkg/client/ws.go
+++ b/pkg/client/ws.go
@@ -235,13 +235,7 @@ func (c *wsClient) sendAndWait(cmd protocol.Command, wantKind protocol.EventKind
 		}
 		return evt, nil
 	case <-time.After(syncTimeout):
-		if cmd.Kind == protocol.CmdGoroutineSnapshot && wantKind == protocol.EventGoroutineSnapshot {
-			// Snapshot events are also unsolicited telemetry; debt would consume
-			// the next auto-pushed snapshot instead of delivering it to Events.
-			c.discardPending(req)
-		} else {
-			c.retirePending(req)
-		}
+		c.retirePending(req)
 		return protocol.Event{}, fmt.Errorf("timeout waiting for %s response", wantKind)
 	case <-c.done:
 		c.discardPending(req)
@@ -451,20 +445,18 @@ func (c *wsClient) Goroutines() ([]protocol.Goroutine, error) {
 	return p.Goroutines, nil
 }
 
-func (c *wsClient) GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error) {
+// RequestGoroutineSnapshot sends CmdGoroutineSnapshot and returns once it is on
+// the wire. It deliberately does not use sendAndWait: EventGoroutineSnapshot is
+// also pushed unsolicited on every entry/breakpoint/pause stop, so a kind-keyed
+// pending entry would let an automatic push satisfy this call (and, after a
+// timeout, let this call's reply debt swallow an automatic push). The snapshot
+// arrives on Events() like every other one.
+func (c *wsClient) RequestGoroutineSnapshot() error {
 	cmd, err := newCommand(protocol.CmdGoroutineSnapshot, struct{}{})
 	if err != nil {
-		return protocol.GoroutineSnapshotPayload{}, err
+		return err
 	}
-	evt, err := c.sendAndWait(cmd, protocol.EventGoroutineSnapshot)
-	if err != nil {
-		return protocol.GoroutineSnapshotPayload{}, err
-	}
-	var p protocol.GoroutineSnapshotPayload
-	if err := protocol.DecodeEventPayload(evt, &p); err != nil {
-		return protocol.GoroutineSnapshotPayload{}, fmt.Errorf("decode GoroutineSnapshot: %w", err)
-	}
-	return p, nil
+	return c.send(cmd)
 }
 
 // Close disconnects from the server. Safe to call multiple times.

--- a/pkg/client/ws.go
+++ b/pkg/client/ws.go
@@ -235,7 +235,13 @@ func (c *wsClient) sendAndWait(cmd protocol.Command, wantKind protocol.EventKind
 		}
 		return evt, nil
 	case <-time.After(syncTimeout):
-		c.retirePending(req)
+		if cmd.Kind == protocol.CmdGoroutineSnapshot && wantKind == protocol.EventGoroutineSnapshot {
+			// Snapshot events are also unsolicited telemetry; debt would consume
+			// the next auto-pushed snapshot instead of delivering it to Events.
+			c.discardPending(req)
+		} else {
+			c.retirePending(req)
+		}
 		return protocol.Event{}, fmt.Errorf("timeout waiting for %s response", wantKind)
 	case <-c.done:
 		c.discardPending(req)

--- a/pkg/client/ws_pending_test.go
+++ b/pkg/client/ws_pending_test.go
@@ -381,25 +381,30 @@ func TestUnresolvedReplyDebtMakesLaterRequestTimeout(t *testing.T) {
 	}
 }
 
-func TestTimedOutGoroutineSnapshotDoesNotConsumeAutoSnapshot(t *testing.T) {
+// The synchronous snapshot query this test was written against is gone; the
+// telemetry guarantee it protected is not. A snapshot request that is never
+// answered leaves no pending entry and no reply debt behind, so a later stop's
+// breakpoint event and its auto-pushed snapshot both reach Events() intact and
+// in order — there is nothing left that could absorb either of them.
+func TestUnansweredGoroutineSnapshotRequestDoesNotConsumeAutoSnapshot(t *testing.T) {
 	useSyncTimeout(t, 100*time.Millisecond)
 	h := newLoopbackClient(t)
 
-	result := make(chan error, 1)
-	go func() {
-		_, err := h.client.GoroutineSnapshot()
-		result <- err
-	}()
+	if err := h.client.RequestGoroutineSnapshot(); err != nil {
+		t.Fatalf("RequestGoroutineSnapshot: %v", err)
+	}
 	assertCommandKind(t, h.readCommand(t), protocol.CmdGoroutineSnapshot)
 
-	select {
-	case err := <-result:
-		if err == nil || !strings.Contains(err.Error(), "timeout") {
-			t.Fatalf("GoroutineSnapshot error = %v, want timeout", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("GoroutineSnapshot did not return")
+	h.client.pendingMu.Lock()
+	pending := len(h.client.pending)
+	h.client.pendingMu.Unlock()
+	if pending != 0 {
+		t.Fatalf("pending entries after snapshot request = %d, want 0", pending)
 	}
+
+	// Well past the old synchronous deadline, so a debt-based implementation
+	// would have had its retired entry armed by now.
+	time.Sleep(2 * syncTimeout)
 
 	h.writeEvent(t, protocol.MustEvent(
 		protocol.EventBreakpointHit,

--- a/pkg/client/ws_pending_test.go
+++ b/pkg/client/ws_pending_test.go
@@ -1,0 +1,425 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+
+	"github.com/gorilla/websocket"
+)
+
+type acceptedWebSocket struct {
+	conn *websocket.Conn
+	err  error
+}
+
+type loopbackClient struct {
+	client    *wsClient
+	conn      *websocket.Conn
+	server    *httptest.Server
+	release   chan struct{}
+	closeOnce sync.Once
+}
+
+func newLoopbackClient(t *testing.T) *loopbackClient {
+	t.Helper()
+
+	accepted := make(chan acceptedWebSocket, 1)
+	release := make(chan struct{})
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			accepted <- acceptedWebSocket{err: err}
+			return
+		}
+
+		welcome, err := protocol.MarshalEvent(protocol.MustEvent(
+			protocol.EventSessionState,
+			1,
+			protocol.SessionStatePayload{
+				SessionID: "test-session",
+				State:     protocol.StateIdle,
+				Clients:   1,
+			},
+		))
+		if err != nil {
+			accepted <- acceptedWebSocket{err: err}
+			_ = conn.Close()
+			return
+		}
+		if err := conn.WriteMessage(websocket.TextMessage, welcome); err != nil {
+			accepted <- acceptedWebSocket{err: err}
+			_ = conn.Close()
+			return
+		}
+
+		accepted <- acceptedWebSocket{conn: conn}
+		<-release
+		_ = conn.Close()
+	}))
+
+	rawClient, err := Create(strings.TrimPrefix(server.URL, "http://"))
+	if err != nil {
+		close(release)
+		server.Close()
+		t.Fatalf("Create: %v", err)
+	}
+
+	result := <-accepted
+	if result.err != nil {
+		_ = rawClient.Close()
+		close(release)
+		server.Close()
+		t.Fatalf("accept WebSocket: %v", result.err)
+	}
+
+	client, ok := rawClient.(*wsClient)
+	if !ok {
+		_ = rawClient.Close()
+		close(release)
+		server.Close()
+		t.Fatalf("client type = %T, want *wsClient", rawClient)
+	}
+
+	h := &loopbackClient{
+		client:  client,
+		conn:    result.conn,
+		server:  server,
+		release: release,
+	}
+	t.Cleanup(h.close)
+	return h
+}
+
+func (h *loopbackClient) close() {
+	h.closeOnce.Do(func() {
+		_ = h.client.Close()
+		close(h.release)
+		h.server.Close()
+	})
+}
+
+func (h *loopbackClient) readCommand(t *testing.T) protocol.Command {
+	t.Helper()
+
+	if err := h.conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set command read deadline: %v", err)
+	}
+	_, data, err := h.conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read command: %v", err)
+	}
+	if err := h.conn.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatalf("clear command read deadline: %v", err)
+	}
+
+	cmd, err := protocol.UnmarshalCommand(data)
+	if err != nil {
+		t.Fatalf("unmarshal command: %v", err)
+	}
+	return cmd
+}
+
+func (h *loopbackClient) writeEvent(t *testing.T, evt protocol.Event) {
+	t.Helper()
+
+	data, err := protocol.MarshalEvent(evt)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	if err := h.conn.SetWriteDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set event write deadline: %v", err)
+	}
+	if err := h.conn.WriteMessage(websocket.TextMessage, data); err != nil {
+		t.Fatalf("write event: %v", err)
+	}
+	if err := h.conn.SetWriteDeadline(time.Time{}); err != nil {
+		t.Fatalf("clear event write deadline: %v", err)
+	}
+}
+
+func useSyncTimeout(t *testing.T, timeout time.Duration) {
+	t.Helper()
+
+	previous := syncTimeout
+	syncTimeout = timeout
+	t.Cleanup(func() {
+		syncTimeout = previous
+	})
+}
+
+type breakpointResult struct {
+	breakpoint protocol.Breakpoint
+	err        error
+}
+
+func callSetBreakpoint(c *wsClient, file string, line int) <-chan breakpointResult {
+	result := make(chan breakpointResult, 1)
+	go func() {
+		breakpoint, err := c.SetBreakpoint(file, line)
+		result <- breakpointResult{breakpoint: breakpoint, err: err}
+	}()
+	return result
+}
+
+func awaitBreakpoint(t *testing.T, result <-chan breakpointResult) breakpointResult {
+	t.Helper()
+
+	select {
+	case got := <-result:
+		return got
+	case <-time.After(2 * time.Second):
+		t.Fatal("SetBreakpoint did not return")
+		return breakpointResult{}
+	}
+}
+
+func awaitEvent(t *testing.T, events <-chan protocol.Event) protocol.Event {
+	t.Helper()
+
+	select {
+	case evt, ok := <-events:
+		if !ok {
+			t.Fatal("events channel closed")
+		}
+		return evt
+	case <-time.After(2 * time.Second):
+		t.Fatal("event did not arrive")
+		return protocol.Event{}
+	}
+}
+
+func assertCommandKind(t *testing.T, cmd protocol.Command, want protocol.CommandKind) {
+	t.Helper()
+
+	if cmd.Kind != want {
+		t.Fatalf("command kind = %s, want %s", cmd.Kind, want)
+	}
+}
+
+func TestTimedOutReplyDebtDoesNotSatisfyLaterRequest(t *testing.T) {
+	useSyncTimeout(t, 100*time.Millisecond)
+	h := newLoopbackClient(t)
+
+	first := callSetBreakpoint(h.client, "first.go", 10)
+	assertCommandKind(t, h.readCommand(t), protocol.CmdSetBreakpoint)
+	if result := awaitBreakpoint(t, first); result.err == nil || !strings.Contains(result.err.Error(), "timeout") {
+		t.Fatalf("first SetBreakpoint error = %v, want timeout", result.err)
+	}
+
+	localsResult := make(chan struct {
+		variables []protocol.Variable
+		err       error
+	}, 1)
+	go func() {
+		variables, err := h.client.Locals(0)
+		localsResult <- struct {
+			variables []protocol.Variable
+			err       error
+		}{variables: variables, err: err}
+	}()
+	assertCommandKind(t, h.readCommand(t), protocol.CmdLocals)
+	h.writeEvent(t, protocol.MustEvent(protocol.EventOutput, 2, protocol.OutputPayload{
+		Stream:  "stdout",
+		Content: "other-kind event",
+	}))
+	h.writeEvent(t, protocol.MustEvent(protocol.EventLocals, 3, protocol.LocalsPayload{
+		FrameIndex: 0,
+		Variables:  []protocol.Variable{{Name: "answer", Value: "42", Type: "int"}},
+	}))
+
+	select {
+	case result := <-localsResult:
+		if result.err != nil {
+			t.Fatalf("Locals: %v", result.err)
+		}
+		if len(result.variables) != 1 || result.variables[0].Value != "42" {
+			t.Fatalf("Locals variables = %+v", result.variables)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Locals did not return")
+	}
+	if evt := awaitEvent(t, h.client.Events()); evt.Kind != protocol.EventOutput {
+		t.Fatalf("async event kind = %s, want %s", evt.Kind, protocol.EventOutput)
+	}
+
+	second := callSetBreakpoint(h.client, "second.go", 20)
+	assertCommandKind(t, h.readCommand(t), protocol.CmdSetBreakpoint)
+	h.writeEvent(t, protocol.MustEvent(protocol.EventBreakpointSet, 4, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{
+			ID:       1,
+			Location: protocol.Location{File: "first.go", Line: 10},
+		},
+	}))
+	h.writeEvent(t, protocol.MustEvent(protocol.EventBreakpointSet, 5, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{
+			ID:       2,
+			Location: protocol.Location{File: "second.go", Line: 20},
+		},
+	}))
+	h.writeEvent(t, protocol.MustEvent(protocol.EventOutput, 6, protocol.OutputPayload{
+		Stream:  "stdout",
+		Content: "read pump active",
+	}))
+
+	result := awaitBreakpoint(t, second)
+	if result.err != nil {
+		t.Fatalf("second SetBreakpoint: %v", result.err)
+	}
+	if result.breakpoint.ID != 2 || result.breakpoint.Location.File != "second.go" {
+		t.Fatalf("second SetBreakpoint = %+v, want its own confirmation", result.breakpoint)
+	}
+	if evt := awaitEvent(t, h.client.Events()); evt.Kind != protocol.EventOutput {
+		t.Fatalf("post-reply event kind = %s, want %s", evt.Kind, protocol.EventOutput)
+	}
+
+	goroutinesResult := make(chan struct {
+		goroutines []protocol.Goroutine
+		err        error
+	}, 1)
+	go func() {
+		goroutines, err := h.client.Goroutines()
+		goroutinesResult <- struct {
+			goroutines []protocol.Goroutine
+			err        error
+		}{goroutines: goroutines, err: err}
+	}()
+	assertCommandKind(t, h.readCommand(t), protocol.CmdGoroutines)
+	h.writeEvent(t, protocol.MustEvent(protocol.EventGoroutines, 7, protocol.GoroutinesPayload{
+		Goroutines: []protocol.Goroutine{{ID: 9, Status: "waiting"}},
+	}))
+
+	select {
+	case result := <-goroutinesResult:
+		if result.err != nil {
+			t.Fatalf("Goroutines: %v", result.err)
+		}
+		if len(result.goroutines) != 1 || result.goroutines[0].ID != 9 {
+			t.Fatalf("Goroutines = %+v", result.goroutines)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Goroutines did not return")
+	}
+}
+
+func TestMatchingErrorConsumesReplyDebt(t *testing.T) {
+	useSyncTimeout(t, 100*time.Millisecond)
+	h := newLoopbackClient(t)
+
+	first := callSetBreakpoint(h.client, "first.go", 10)
+	assertCommandKind(t, h.readCommand(t), protocol.CmdSetBreakpoint)
+	if result := awaitBreakpoint(t, first); result.err == nil || !strings.Contains(result.err.Error(), "timeout") {
+		t.Fatalf("first SetBreakpoint error = %v, want timeout", result.err)
+	}
+
+	second := callSetBreakpoint(h.client, "second.go", 20)
+	assertCommandKind(t, h.readCommand(t), protocol.CmdSetBreakpoint)
+	h.writeEvent(t, protocol.MustEvent(protocol.EventError, 2, protocol.ErrorPayload{
+		Command: protocol.CmdSetBreakpoint,
+		Message: "first request failed late",
+	}))
+	h.writeEvent(t, protocol.MustEvent(protocol.EventBreakpointSet, 3, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{
+			ID:       2,
+			Location: protocol.Location{File: "second.go", Line: 20},
+		},
+	}))
+
+	result := awaitBreakpoint(t, second)
+	if result.err != nil {
+		t.Fatalf("second SetBreakpoint: %v", result.err)
+	}
+	if result.breakpoint.ID != 2 {
+		t.Fatalf("second SetBreakpoint = %+v, want ID 2", result.breakpoint)
+	}
+}
+
+func TestUnresolvedReplyDebtMakesLaterRequestTimeout(t *testing.T) {
+	useSyncTimeout(t, 100*time.Millisecond)
+	h := newLoopbackClient(t)
+
+	first := callSetBreakpoint(h.client, "first.go", 10)
+	assertCommandKind(t, h.readCommand(t), protocol.CmdSetBreakpoint)
+	if result := awaitBreakpoint(t, first); result.err == nil || !strings.Contains(result.err.Error(), "timeout") {
+		t.Fatalf("first SetBreakpoint error = %v, want timeout", result.err)
+	}
+
+	second := callSetBreakpoint(h.client, "second.go", 20)
+	assertCommandKind(t, h.readCommand(t), protocol.CmdSetBreakpoint)
+	h.writeEvent(t, protocol.MustEvent(protocol.EventBreakpointSet, 2, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{
+			ID:       2,
+			Location: protocol.Location{File: "second.go", Line: 20},
+		},
+	}))
+
+	result := awaitBreakpoint(t, second)
+	if result.err == nil || !strings.Contains(result.err.Error(), "timeout") {
+		t.Fatalf("second SetBreakpoint error = %v, want safe timeout", result.err)
+	}
+
+	localsResult := make(chan error, 1)
+	go func() {
+		_, err := h.client.Locals(0)
+		localsResult <- err
+	}()
+	assertCommandKind(t, h.readCommand(t), protocol.CmdLocals)
+	h.writeEvent(t, protocol.MustEvent(protocol.EventLocals, 3, protocol.LocalsPayload{FrameIndex: 0}))
+	select {
+	case err := <-localsResult:
+		if err != nil {
+			t.Fatalf("Locals after unresolved debt: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Locals after unresolved debt did not return")
+	}
+}
+
+func TestRouteToPendingClaimsBeforeDelivery(t *testing.T) {
+	ch := make(chan protocol.Event, 1)
+	client := &wsClient{
+		pending: []*pendingReq{{
+			wantKind: protocol.EventBreakpointSet,
+			cmdKind:  protocol.CmdSetBreakpoint,
+			ch:       ch,
+		}},
+	}
+	first := protocol.MustEvent(protocol.EventBreakpointSet, 1, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{ID: 1},
+	})
+	second := protocol.MustEvent(protocol.EventBreakpointSet, 2, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{ID: 2},
+	})
+
+	result := make(chan [2]bool, 1)
+	go func() {
+		result <- [2]bool{
+			client.routeToPending(first),
+			client.routeToPending(second),
+		}
+	}()
+
+	select {
+	case routed := <-result:
+		if !routed[0] || routed[1] {
+			t.Fatalf("route results = %v, want [true false]", routed)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("back-to-back matching events blocked pending delivery")
+	}
+
+	select {
+	case evt := <-ch:
+		if evt.Seq != first.Seq {
+			t.Fatalf("delivered seq = %d, want %d", evt.Seq, first.Seq)
+		}
+	default:
+		t.Fatal("first matching event was not delivered")
+	}
+}

--- a/pkg/client/ws_pending_test.go
+++ b/pkg/client/ws_pending_test.go
@@ -381,6 +381,53 @@ func TestUnresolvedReplyDebtMakesLaterRequestTimeout(t *testing.T) {
 	}
 }
 
+func TestTimedOutGoroutineSnapshotDoesNotConsumeAutoSnapshot(t *testing.T) {
+	useSyncTimeout(t, 100*time.Millisecond)
+	h := newLoopbackClient(t)
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := h.client.GoroutineSnapshot()
+		result <- err
+	}()
+	assertCommandKind(t, h.readCommand(t), protocol.CmdGoroutineSnapshot)
+
+	select {
+	case err := <-result:
+		if err == nil || !strings.Contains(err.Error(), "timeout") {
+			t.Fatalf("GoroutineSnapshot error = %v, want timeout", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("GoroutineSnapshot did not return")
+	}
+
+	h.writeEvent(t, protocol.MustEvent(
+		protocol.EventBreakpointHit,
+		2,
+		protocol.BreakpointHitPayload{},
+	))
+	h.writeEvent(t, protocol.MustEvent(
+		protocol.EventGoroutineSnapshot,
+		3,
+		protocol.GoroutineSnapshotPayload{Current: 42},
+	))
+
+	if evt := awaitEvent(t, h.client.Events()); evt.Kind != protocol.EventBreakpointHit {
+		t.Fatalf("first async event kind = %s, want %s", evt.Kind, protocol.EventBreakpointHit)
+	}
+	evt := awaitEvent(t, h.client.Events())
+	if evt.Kind != protocol.EventGoroutineSnapshot {
+		t.Fatalf("second async event kind = %s, want %s", evt.Kind, protocol.EventGoroutineSnapshot)
+	}
+	var snapshot protocol.GoroutineSnapshotPayload
+	if err := protocol.DecodeEventPayload(evt, &snapshot); err != nil {
+		t.Fatalf("decode auto snapshot: %v", err)
+	}
+	if snapshot.Current != 42 {
+		t.Fatalf("auto snapshot current = %d, want 42", snapshot.Current)
+	}
+}
+
 func TestRouteToPendingClaimsBeforeDelivery(t *testing.T) {
 	ch := make(chan protocol.Event, 1)
 	client := &wsClient{

--- a/pkg/client/ws_snapshot_test.go
+++ b/pkg/client/ws_snapshot_test.go
@@ -1,0 +1,160 @@
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+func snapshotEvent(t *testing.T, seq uint64, current int, created []int) protocol.Event {
+	t.Helper()
+
+	return protocol.MustEvent(protocol.EventGoroutineSnapshot, seq, protocol.GoroutineSnapshotPayload{
+		Goroutines: []protocol.Goroutine{{ID: current, Current: true}},
+		Current:    current,
+		Created:    created,
+	})
+}
+
+func awaitSnapshot(t *testing.T, events <-chan protocol.Event) protocol.GoroutineSnapshotPayload {
+	t.Helper()
+
+	evt := awaitEvent(t, events)
+	if evt.Kind != protocol.EventGoroutineSnapshot {
+		t.Fatalf("event kind = %s, want %s", evt.Kind, protocol.EventGoroutineSnapshot)
+	}
+	var p protocol.GoroutineSnapshotPayload
+	if err := protocol.DecodeEventPayload(evt, &p); err != nil {
+		t.Fatalf("decode snapshot: %v", err)
+	}
+	return p
+}
+
+func pendingCount(c *wsClient) int {
+	c.pendingMu.Lock()
+	defer c.pendingMu.Unlock()
+	return len(c.pending)
+}
+
+// The request must return as soon as the command is on the wire — before any
+// reply — and register nothing that a later event could be matched against.
+func TestRequestGoroutineSnapshotReturnsAfterWireWrite(t *testing.T) {
+	useSyncTimeout(t, 100*time.Millisecond)
+	h := newLoopbackClient(t)
+
+	done := make(chan error, 1)
+	go func() { done <- h.client.RequestGoroutineSnapshot() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("RequestGoroutineSnapshot: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RequestGoroutineSnapshot did not return before its reply")
+	}
+	assertCommandKind(t, h.readCommand(t), protocol.CmdGoroutineSnapshot)
+	if got := pendingCount(h.client); got != 0 {
+		t.Fatalf("pending entries after request = %d, want 0", got)
+	}
+
+	// Long past any synchronous timeout, the reply still arrives as an event.
+	time.Sleep(2 * syncTimeout)
+	h.writeEvent(t, snapshotEvent(t, 2, 7, nil))
+	if snap := awaitSnapshot(t, h.client.Events()); snap.Current != 7 {
+		t.Fatalf("snapshot current = %d, want 7", snap.Current)
+	}
+	if got := pendingCount(h.client); got != 0 {
+		t.Fatalf("pending entries after reply = %d, want 0", got)
+	}
+}
+
+// Automatic pushes around a requested snapshot must all be delivered, in order,
+// with none consumed as a reply and none duplicated.
+func TestAutomaticSnapshotsAroundRequestAllReachEvents(t *testing.T) {
+	h := newLoopbackClient(t)
+
+	h.writeEvent(t, snapshotEvent(t, 2, 1, nil)) // automatic: entry stop
+	if err := h.client.RequestGoroutineSnapshot(); err != nil {
+		t.Fatalf("RequestGoroutineSnapshot: %v", err)
+	}
+	assertCommandKind(t, h.readCommand(t), protocol.CmdGoroutineSnapshot)
+	h.writeEvent(t, snapshotEvent(t, 3, 2, nil))      // the query's reply
+	h.writeEvent(t, snapshotEvent(t, 4, 3, []int{3})) // automatic: breakpoint hit
+
+	for _, want := range []int{1, 2, 3} {
+		if snap := awaitSnapshot(t, h.client.Events()); snap.Current != want {
+			t.Fatalf("snapshot current = %d, want %d", snap.Current, want)
+		}
+	}
+	if got := pendingCount(h.client); got != 0 {
+		t.Fatalf("pending entries = %d, want 0", got)
+	}
+}
+
+// Reply debt from an unrelated timed-out synchronous call must never claim a
+// snapshot: snapshots are not correlated confirmations.
+func TestReplyDebtDoesNotSwallowAutomaticSnapshot(t *testing.T) {
+	useSyncTimeout(t, 100*time.Millisecond)
+	h := newLoopbackClient(t)
+
+	first := callSetBreakpoint(h.client, "first.go", 10)
+	assertCommandKind(t, h.readCommand(t), protocol.CmdSetBreakpoint)
+	if result := awaitBreakpoint(t, first); result.err == nil {
+		t.Fatal("first SetBreakpoint: want timeout")
+	}
+	if got := pendingCount(h.client); got != 1 {
+		t.Fatalf("retired reply debt = %d entries, want 1", got)
+	}
+
+	h.writeEvent(t, snapshotEvent(t, 2, 5, []int{5}))
+	snap := awaitSnapshot(t, h.client.Events())
+	if snap.Current != 5 || len(snap.Created) != 1 {
+		t.Fatalf("snapshot = %+v, want the automatic push intact", snap)
+	}
+
+	// The debt is still outstanding and still owned by SetBreakpoint alone.
+	if got := pendingCount(h.client); got != 1 {
+		t.Fatalf("reply debt after snapshot = %d entries, want it untouched at 1", got)
+	}
+	h.writeEvent(t, protocol.MustEvent(protocol.EventBreakpointSet, 3, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{ID: 1, Location: protocol.Location{File: "first.go", Line: 10}},
+	}))
+	deadline := time.Now().Add(2 * time.Second)
+	for pendingCount(h.client) != 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("stale SetBreakpoint confirmation never consumed its reply debt")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// A snapshot request must not disturb an in-flight synchronous call of another
+// kind, and an automatic push landing in between must not satisfy it.
+func TestSnapshotTrafficDoesNotDisturbSynchronousCall(t *testing.T) {
+	h := newLoopbackClient(t)
+
+	result := callSetBreakpoint(h.client, "main.go", 42)
+	assertCommandKind(t, h.readCommand(t), protocol.CmdSetBreakpoint)
+
+	if err := h.client.RequestGoroutineSnapshot(); err != nil {
+		t.Fatalf("RequestGoroutineSnapshot: %v", err)
+	}
+	assertCommandKind(t, h.readCommand(t), protocol.CmdGoroutineSnapshot)
+	h.writeEvent(t, snapshotEvent(t, 2, 9, nil))
+	h.writeEvent(t, protocol.MustEvent(protocol.EventBreakpointSet, 3, protocol.BreakpointSetPayload{
+		Breakpoint: protocol.Breakpoint{ID: 4, Location: protocol.Location{File: "main.go", Line: 42}},
+	}))
+
+	got := awaitBreakpoint(t, result)
+	if got.err != nil {
+		t.Fatalf("SetBreakpoint: %v", got.err)
+	}
+	if got.breakpoint.ID != 4 {
+		t.Fatalf("breakpoint = %+v, want its own confirmation", got.breakpoint)
+	}
+	if snap := awaitSnapshot(t, h.client.Events()); snap.Current != 9 {
+		t.Fatalf("snapshot current = %d, want 9", snap.Current)
+	}
+}

--- a/pkg/protocol/payload.go
+++ b/pkg/protocol/payload.go
@@ -152,13 +152,16 @@ type GoroutinesPayload struct {
 // picture (breakpoint hit, pause, launch/attach entry) and on demand via
 // CmdGoroutineSnapshot. Unlike EventGoroutines — which answers a single DAP
 // `threads` request and carries goroutines only — this event is not tied to a
-// request, so it also carries the thread list and the lifecycle deltas.
+// request, so it also carries the thread list and the lifecycle deltas. Created
+// and Exited are populated on the automatic snapshots only; an on-demand query
+// answers with the live picture and empty deltas so it cannot consume what the
+// next automatic snapshot must report.
 type GoroutineSnapshotPayload struct {
 	Goroutines []Goroutine `json:"goroutines"`
 	Threads    []Thread    `json:"threads"`
 	Current    int         `json:"current,omitempty"` // goid of the current goroutine, 0 if unknown
-	Created    []int       `json:"created,omitempty"` // goids new since the previous snapshot
-	Exited     []int       `json:"exited,omitempty"`  // goids gone since the previous snapshot
+	Created    []int       `json:"created,omitempty"` // goids new since the previous automatic snapshot
+	Exited     []int       `json:"exited,omitempty"`  // goids gone since the previous automatic snapshot
 }
 
 type SessionStatePayload struct {

--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -59,9 +59,12 @@ const (
 	// with parent linkage, OS threads, current goroutine, and created/exited
 	// lifecycle deltas). It is emitted automatically on every suspend that can
 	// change that picture — breakpoint hit, pause, and launch/attach entry —
-	// and on demand in response to CmdGoroutineSnapshot. It is NOT a suspending
-	// event: it follows a suspending event (or answers a query) and never gates
-	// the hub. See AGENTS.md → goroutine snapshot streaming.
+	// and on demand in response to CmdGoroutineSnapshot. Being dual-purpose it
+	// cannot be correlated to a request: clients must treat every one of them
+	// as an unsolicited push. Only the automatic ones carry lifecycle deltas.
+	// It is NOT a suspending event: it follows a suspending event (or answers a
+	// query) and never gates the hub. See AGENTS.md → goroutine snapshot
+	// streaming.
 	EventGoroutineSnapshot EventKind = "GoroutineSnapshot"
 
 	EventSessionState EventKind = "SessionState"
@@ -114,6 +117,8 @@ const (
 	// (answered with EventGoroutineSnapshot). The same snapshot is also pushed
 	// automatically on each suspend, so a UI only needs this to refresh out of
 	// band (e.g. right after connecting). Requires the process to be suspended.
+	// It is a pure observation: the answer carries no created/exited deltas and
+	// does not advance the lifecycle baseline that the automatic snapshots own.
 	CmdGoroutineSnapshot CommandKind = "GoroutineSnapshot"
 
 	// CmdRestart kills the current process (if any) and relaunches the last

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -917,9 +917,10 @@ func declareConcurrencySpec() {
 		Expect(err).NotTo(HaveOccurred(), "SetBreakpoint on tick")
 
 		// The auto-streamed EventGoroutineSnapshot that follows each breakpoint
-		// hit is the delta-bearing one (its Created/Exited are computed relative
-		// to the previous auto snapshot). We must NOT call GoroutineSnapshot()
-		// on-demand between hits, as that would advance the delta baseline.
+		// hit is the delta-bearing one: its Created/Exited are computed relative
+		// to the previous AUTOMATIC snapshot, and only those snapshots advance
+		// that baseline. An on-demand GoroutineSnapshot() between hits is a pure
+		// observation and cannot disturb it (asserted below).
 		nextSnapshot := func(stop string) protocol.GoroutineSnapshotPayload {
 			GinkgoHelper()
 			Expect(h.d.Continue()).To(Succeed(), "Continue to %s", stop)
@@ -984,6 +985,19 @@ func declareConcurrencySpec() {
 
 		workerID, leafID := worker.ID, leaf.ID
 
+		// An on-demand query taken BETWEEN two automatic snapshots returns a
+		// coherent live picture but owns no lifecycle state: it reports no
+		// deltas of its own and must leave the next automatic snapshot's deltas
+		// (asserted at stop #3 below) measured against stop #2.
+		onDemand, err := h.d.GoroutineSnapshot()
+		Expect(err).NotTo(HaveOccurred(), "GoroutineSnapshot on demand")
+		Expect(onDemand.Goroutines).NotTo(BeEmpty(), "on-demand snapshot has goroutines")
+		Expect(onDemand.Current).To(BeNumerically(">", 0), "on-demand current goid resolved")
+		Expect(findByStart(onDemand.Goroutines, "main.worker")).NotTo(BeNil(),
+			"on-demand snapshot sees the live worker")
+		Expect(onDemand.Created).To(BeEmpty(), "a query reports no created delta")
+		Expect(onDemand.Exited).To(BeEmpty(), "a query reports no exited delta")
+
 		// --- stop #3: children released and reaped ---
 		exited := nextSnapshot("exited")
 		Expect(exited.Exited).To(ContainElement(workerID), "worker in exited delta")
@@ -992,12 +1006,6 @@ func declareConcurrencySpec() {
 			"worker gone from the live set")
 		Expect(findByStart(exited.Goroutines, "main.leaf")).To(BeNil(),
 			"leaf gone from the live set")
-
-		// The on-demand snapshot command returns a coherent live picture too.
-		onDemand, err := h.d.GoroutineSnapshot()
-		Expect(err).NotTo(HaveOccurred(), "GoroutineSnapshot on demand")
-		Expect(onDemand.Goroutines).NotTo(BeEmpty(), "on-demand snapshot has goroutines")
-		Expect(onDemand.Current).To(BeNumerically(">", 0), "on-demand current goid resolved")
 	})
 }
 

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -371,6 +371,112 @@ func main() {
 }
 `
 
+// snapshotBaselineTargetSrc isolates the ONE window in which an on-demand
+// snapshot can differ from the last automatic one: a suspend that carries no
+// automatic snapshot. Steps are exactly that (emitStepped never scans allgs), so
+// stepping over a `go` statement creates a goroutine the automatic baseline has
+// never seen.
+//
+//	go parked() <- BP_SPAWN, stop #1: automatic snapshot adopts a baseline
+//	               WITHOUT parked, then one StepOver executes the statement
+//	tick()      <- BP_SNAPTICK, stop #2: parked MUST appear in the Created delta
+//
+// parked blocks forever on an unclosed channel so it is unambiguously alive at
+// both the on-demand query and the next automatic snapshot.
+const snapshotBaselineTargetSrc = `package main
+
+import "time"
+
+var hold = make(chan struct{})
+
+func parked() {
+	<-hold
+}
+
+func tick() {
+	time.Sleep(time.Millisecond) // BP_SNAPTICK
+}
+
+func main() {
+	go parked() // BP_SPAWN
+	for i := 0; i < 100000; i++ {
+		tick() // keep the process alive for teardown
+	}
+}
+`
+
+// declareBaselineOwnershipSpec is the mutation gate for "automatic snapshots
+// alone own the lifecycle baseline" (issue #187). Asserting it needs a query
+// whose live set DIFFERS from the last automatic snapshot's, which only happens
+// at a suspend that carried no automatic snapshot — i.e. after a step. So the
+// sequence is: automatic baseline at a breakpoint on the `go` statement, one
+// StepOver to execute it (creating a goroutine off the automatic stream), an
+// on-demand query, then continue to the next automatic snapshot.
+//
+// It fails on either ablation of the split:
+//   - engine.GoroutineSnapshot reverted to the tracking path: the query returns
+//     the new goid in Created AND adopts it, so the next automatic snapshot no
+//     longer reports it.
+//   - the automatic path made non-tracking: no baseline is ever adopted, so the
+//     automatic snapshot's Created is empty.
+func declareBaselineOwnershipSpec() {
+	It("keeps lifecycle deltas with automatic snapshots across an on-demand query", Label("concurrency"), func() {
+		src := snapshotBaselineTargetSrc
+		bin := buildTarget("snapshot_baseline_target", src)
+
+		h := newE2EHarness(bin)
+		h.waitFor(15*time.Second, protocol.EventStepped) // initial launch stop
+
+		_, err := h.d.SetBreakpoint("snapshot_baseline_target.go", markerLine(src, "// BP_SPAWN"))
+		Expect(err).NotTo(HaveOccurred(), "SetBreakpoint on the spawn line")
+
+		Expect(h.d.Continue()).To(Succeed(), "Continue to the spawn line")
+		hit := h.waitFor(15*time.Second,
+			protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+		Expect(hit.Kind).To(Equal(protocol.EventBreakpointHit), "spawn-line breakpoint hit")
+
+		baselineEvt := h.waitFor(15*time.Second, protocol.EventGoroutineSnapshot)
+		var baseline protocol.GoroutineSnapshotPayload
+		Expect(json.Unmarshal(baselineEvt.Payload, &baseline)).To(Succeed(), "decode baseline snapshot")
+		Expect(findByStart(baseline.Goroutines, "main.parked")).To(BeNil(),
+			"parked must not exist yet at the baseline stop")
+
+		// The `go` statement runs during a StepOver, which emits Stepped with no
+		// snapshot — so parked is born entirely off the automatic stream. This
+		// is the only state an automatic baseline can be missing.
+		Expect(h.d.StepOver()).To(Succeed(), "StepOver the spawn statement")
+		stepped := h.waitFor(15*time.Second,
+			protocol.EventStepped, protocol.EventProcessExited, protocol.EventError)
+		Expect(stepped.Kind).To(Equal(protocol.EventStepped), "the spawn statement executed via a step")
+
+		onDemand, err := h.d.GoroutineSnapshot()
+		Expect(err).NotTo(HaveOccurred(), "GoroutineSnapshot on demand")
+		parked := findByStart(onDemand.Goroutines, "main.parked")
+		Expect(parked).NotTo(BeNil(),
+			"the on-demand query must observe the goroutine created since the baseline")
+		Expect(onDemand.Created).To(BeEmpty(),
+			"a query reports no created delta (it does not own the baseline)")
+		Expect(onDemand.Exited).To(BeEmpty(), "a query reports no exited delta")
+		parkedID := parked.ID
+
+		_, err = h.d.SetBreakpoint("snapshot_baseline_target.go", markerLine(src, "// BP_SNAPTICK"))
+		Expect(err).NotTo(HaveOccurred(), "SetBreakpoint on the tick line")
+
+		Expect(h.d.Continue()).To(Succeed(), "Continue to the next automatic stop")
+		hit = h.waitFor(15*time.Second,
+			protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+		Expect(hit.Kind).To(Equal(protocol.EventBreakpointHit), "tick breakpoint hit")
+
+		nextEvt := h.waitFor(15*time.Second, protocol.EventGoroutineSnapshot)
+		var next protocol.GoroutineSnapshotPayload
+		Expect(json.Unmarshal(nextEvt.Payload, &next)).To(Succeed(), "decode next automatic snapshot")
+		Expect(findByStart(next.Goroutines, "main.parked")).NotTo(BeNil(),
+			"parked is still alive at the next stop")
+		Expect(next.Created).To(ContainElement(parkedID),
+			"the automatic snapshot still owns the delta the query observed but must not consume")
+	})
+}
+
 // declareBasicStepOverSpec adds the continue+step-over acceptance spec to the
 // enclosing Ginkgo container. It is the correctness gate: set a breakpoint on a
 // line that calls a function, repeatedly Continue to it and StepOver the call,
@@ -919,8 +1025,7 @@ func declareConcurrencySpec() {
 		// The auto-streamed EventGoroutineSnapshot that follows each breakpoint
 		// hit is the delta-bearing one: its Created/Exited are computed relative
 		// to the previous AUTOMATIC snapshot, and only those snapshots advance
-		// that baseline. An on-demand GoroutineSnapshot() between hits is a pure
-		// observation and cannot disturb it (asserted below).
+		// that baseline (declareBaselineOwnershipSpec pins that ownership).
 		nextSnapshot := func(stop string) protocol.GoroutineSnapshotPayload {
 			GinkgoHelper()
 			Expect(h.d.Continue()).To(Succeed(), "Continue to %s", stop)
@@ -986,9 +1091,12 @@ func declareConcurrencySpec() {
 		workerID, leafID := worker.ID, leaf.ID
 
 		// An on-demand query taken BETWEEN two automatic snapshots returns a
-		// coherent live picture but owns no lifecycle state: it reports no
-		// deltas of its own and must leave the next automatic snapshot's deltas
-		// (asserted at stop #3 below) measured against stop #2.
+		// coherent live picture and reports no deltas of its own. NOTE: at this
+		// stop the live set equals the last automatic snapshot's, so adopting it
+		// would be a no-op — this asserts the query's shape, not baseline
+		// ownership. declareBaselineOwnershipSpec is the discriminating test:
+		// it steps past a `go` statement first, so the query sees a set the
+		// baseline has never seen.
 		onDemand, err := h.d.GoroutineSnapshot()
 		Expect(err).NotTo(HaveOccurred(), "GoroutineSnapshot on demand")
 		Expect(onDemand.Goroutines).NotTo(BeEmpty(), "on-demand snapshot has goroutines")

--- a/test/integration/debugger_e2e_darwin_arm64_test.go
+++ b/test/integration/debugger_e2e_darwin_arm64_test.go
@@ -57,6 +57,7 @@ var _ = Describe("Darwin arm64 debugger backend (Mach exceptions) E2E", Label("d
 	declareExitCodeSpec()
 	declareAttachSpec()
 	declareConcurrencySpec()
+	declareBaselineOwnershipSpec()
 	declareFullStackSpec()
 	declareRestartSpec()
 	declareDAPSpec()

--- a/test/integration/debugger_e2e_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_linux_amd64_test.go
@@ -20,6 +20,7 @@ var _ = Describe("Linux amd64 debugger backend (ptrace) E2E", Label("linux"), fu
 	declareExitCodeSpec()
 	declareAttachSpec()
 	declareConcurrencySpec()
+	declareBaselineOwnershipSpec()
 	declareFullStackSpec()
 	declareRestartSpec()
 	declareDAPSpec()


### PR DESCRIPTION
## Summary

`cmd/wsmon`'s `oneLine` measured its budget in bytes and cut with `s[:117]`. The helper renders arbitrary tracee stdout/stderr, panic text, and snapshot rejection messages, so when byte 117 landed inside a multi-byte rune wsmon emitted **invalid UTF-8** before the ellipsis and terminals drew a replacement glyph. The same byte budget also truncated CJK and emoji at a third to a quarter of the intended length (40 emoji = 160 bytes was cut mid-rune despite being far inside a sane one-line budget).

The budget now counts **complete code points**.

Fixes #209

## Stack

`#148 → #192 → this PR`

This PR targets `xsachax-fix-snapshot-request-semantics` (#192), not `main`. #192 rewrote the surrounding `cmd/wsmon` code (fire-and-forget snapshot requests, `-once` bounding, `-timeout` validation, custom usage), so #209 has to land as a dependent layer rather than against stale `main` — the issue says as much. Review only the top commit; merge after #192.

## Design decisions

Two were deliberate and are worth confirming:

**1. Rune budget, not a byte budget with boundary back-off.** The issue sanctions either. Runes were chosen because they give a uniform character budget across scripts, are the closest proxy to on-screen length that needs *no* display-width dependency, and are byte-for-byte identical to the old behaviour for pure ASCII (the common case: `RuneCountInString(ascii) == len(ascii)`, and the rune cut walks one byte per iteration, so it returns exactly `s[:117]`).

The accepted trade-off, documented in the code: 120 wide runes can exceed 120 terminal *columns*. Measuring columns needs an East Asian width table, which is explicitly out of scope. Output stays bounded (≤ 120 runes, ≤ ~471 bytes).

**2. Input that is already invalid UTF-8 passes through untouched.** Each invalid byte counts as exactly one rune, matching `utf8.RuneCountInString` and Go's `range` semantics — the stdlib's `RuneCountInString` *is* `for range s { n++ }`, so the count and the cut use the identical iterator and cannot disagree, including for truncated sequences, overlongs, and surrogates. `oneLine` truncates; it does not sanitize. Rewriting bytes to U+FFFD would change output on the *non*-truncating path too, which is unrelated to #209. The precise invariant held is therefore: **truncation never introduces invalidity the input did not already contain**, and it is asserted directly in the tests.

Consequence of not adding segmentation: a grapheme cluster (base + combining mark, ZWJ emoji sequence) can still be split at the cut. Valid UTF-8 either way, documented, and pinned by tests.

## Scope

Surgical and deliberately narrow:

- Newline normalization is **byte-for-byte unchanged** (`\n` → the two-character escape; a bare `\r` still survives, which is pre-existing and out of scope — the `embedded crlf` case characterizes it so a future CR fix has to update it consciously).
- No display-width, grapheme-segmentation, or any other new dependency.
- No other rendering changes; no other call site depends on `oneLine`'s byte length.
- `AGENTS.md` needs no update — no documented invariant changes.

## Validation

- `go test -tags bingonative -race -count=1 ./cmd/wsmon/...` — pass
- `go test -tags bingonative -race -count=1 ./pkg/client/... ./pkg/protocol/... ./cmd/...` — pass (parent #192's wsmon and client suites included, no regressions)
- `go vet -tags bingonative ./...` — clean
- `go build -tags bingonative ./...` — clean
- `gofmt -l .` / `goimports` — clean (lefthook pre-commit ran)

**Test coverage.** A table over short / exact / over-budget boundaries: empty and whitespace-only input, short ASCII, surrounding-space trim, embedded LF, embedded CRLF, trailing LF, ASCII at 120 and at 121, the issue's exact repro (116 ASCII + Japanese, where byte 117 lands on a leading byte), Japanese at and over budget, astral emoji under and over budget, a ZWJ sequence at the cut, combining marks separated from their base, a cut landing inside the newline escape, short invalid UTF-8, and an invalid byte before the cut. Every case additionally asserts the output is within budget and that valid input never produces invalid output. A sweep test runs every byte prefix of a mixed 1/2/3/4-byte string through `oneLine` and asserts validity throughout, and `truncateRunes` is pinned directly (`n == 0`, shorter than `n`, exactly `n`, boundary cut, invalid byte).

**Mutation-checked.** Reverting the cut to `s[:oneLineKeepRunes]` fails 6 table cases plus the sweep. Independently, reverting only the *budget* to `len(s)` while keeping the rune-safe cut fails `japanese at budget` and `emoji under budget` — so the tests pin the design decision, not merely UTF-8 validity, and would also catch the issue's alternative "byte budget with back-off" implementation.

Independently reviewed; no issues found. Reviewer separately re-derived the four tricky test expectations (newline escape, combining marks, invalid byte, ZWJ) and confirmed the off-by-one behaviour of `truncateRunes`.

Draft until #192 merges.