### PR TITLE
fix(dap): drain queued terminate before disconnect EOF

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2051,9 +2051,12 @@ slow-client eviction. There is deliberately no DAP-awareness anywhere in
   DAP socket as a failed writer — the socket lifecycle is owned by `Serve`/`Close`.
 - `ReadMessage()` (called on the hub read-pump goroutine): blocks on an internal
   `cmdOut chan []byte` of marshalled bingo `Command`s produced by the DAP read
-  loop; returns `io.EOF` on Close. **cmdOut-priority:** a non-blocking check of
-  `cmdOut` precedes the `{cmdOut | done}` select, so a `Kill` enqueued right
-  before `Close` (disconnect-terminate) is still handed off before EOF. The hub
+  loop; returns `io.EOF` on Close. **cmdOut-priority:** it probes `cmdOut` before
+  the `{cmdOut | done}` select and, if `done` wins, probes `cmdOut` once more
+  before returning EOF. The final drain is load-bearing: disconnect enqueues
+  `Kill` before `Close`, but both channels can become ready between the first
+  probe and the blocking select; without the re-probe, random select choice can
+  drop the queued kill while another observer keeps the session alive. The hub
   may backpressure this read pump while its ordinary-command queue is full;
   `cmdOut` stays bounded, and Handler `Close` unblocks both `ReadMessage` and a
   DAP producer waiting to enqueue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2054,12 +2054,13 @@ slow-client eviction. There is deliberately no DAP-awareness anywhere in
   loop; returns `io.EOF` on Close. **cmdOut-priority:** it probes `cmdOut` before
   the `{cmdOut | done}` select and, if `done` wins, probes `cmdOut` once more
   before returning EOF. The final drain is load-bearing: disconnect enqueues
-  `Kill` before `Close`, but both channels can become ready between the first
-  probe and the blocking select; without the re-probe, random select choice can
-  drop the queued kill while another observer keeps the session alive. The hub
-  may backpressure this read pump while its ordinary-command queue is full;
-  `cmdOut` stays bounded, and Handler `Close` unblocks both `ReadMessage` and a
-  DAP producer waiting to enqueue.
+  `Kill` before writing its response (which can call `Close` on failure) and
+  before its explicit `Close`, but both channels can become ready between the
+  first probe and the blocking select. Without the re-probe, random select
+  choice can drop the queued kill while another observer keeps the session
+  alive. The hub may backpressure this read pump while its ordinary-command
+  queue is full; `cmdOut` stays bounded, and Handler `Close` unblocks both
+  `ReadMessage` and a DAP producer waiting to enqueue.
 - `Serve()` (its own goroutine, one per connection): the DAP read loop —
   `godap.ReadProtocolMessage` → `dispatchRequest`. Runs the handshake state
   machine, enqueues bingo commands, and answers non-hub requests directly.

--- a/internal/dap/handler.go
+++ b/internal/dap/handler.go
@@ -46,9 +46,9 @@ type Handler struct {
 	log      *slog.Logger
 
 	// cmdOut carries marshalled bingo Commands from the DAP read loop to the
-	// hub's read pump (via ReadMessage). ReadMessage drains it with priority
-	// over done so a command enqueued immediately before Close (e.g. Kill on
-	// disconnect) is still delivered.
+	// hub's read pump (via ReadMessage). ReadMessage checks it before waiting
+	// and once more when done wins so a command enqueued before Close (e.g.
+	// Kill on disconnect) is still delivered.
 	cmdOut chan []byte
 
 	done      chan struct{}
@@ -294,9 +294,9 @@ func isClosedConn(err error) bool {
 
 // --- hub.WSConn implementation -------------------------------------------------
 
-// ReadMessage delivers the next bingo command to the hub's read pump. It
-// prefers a buffered command over done so a command enqueued right before Close
-// (Kill on disconnect) is still handed off.
+// ReadMessage delivers the next bingo command to the hub's read pump. It checks
+// for a buffered command before waiting and again when done wins so a command
+// enqueued before Close (Kill on disconnect) is handed off before EOF.
 func (h *Handler) ReadMessage() (int, []byte, error) {
 	select {
 	case b := <-h.cmdOut:
@@ -307,7 +307,12 @@ func (h *Handler) ReadMessage() (int, []byte, error) {
 	case b := <-h.cmdOut:
 		return hub.TextMessage, b, nil
 	case <-h.done:
-		return 0, nil, io.EOF
+		select {
+		case b := <-h.cmdOut:
+			return hub.TextMessage, b, nil
+		default:
+			return 0, nil, io.EOF
+		}
 	}
 }
 

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -2,11 +2,14 @@ package dap
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -358,6 +361,17 @@ func newHarnessProvider(t *testing.T, prov Provider, rec *cmdRecorder) *harness 
 type nopWriter struct{}
 
 func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+type nopConn struct{}
+
+func (nopConn) Read([]byte) (int, error)         { return 0, io.EOF }
+func (nopConn) Write(p []byte) (int, error)      { return len(p), nil }
+func (nopConn) Close() error                     { return nil }
+func (nopConn) LocalAddr() net.Addr              { return nil }
+func (nopConn) RemoteAddr() net.Addr             { return nil }
+func (nopConn) SetDeadline(time.Time) error      { return nil }
+func (nopConn) SetReadDeadline(time.Time) error  { return nil }
+func (nopConn) SetWriteDeadline(time.Time) error { return nil }
 
 // sendReq writes a DAP request with an auto-incrementing seq, returning that seq.
 func (hh *harness) sendReq(command string, m godap.RequestMessage) int {
@@ -1291,6 +1305,50 @@ func TestStepEmitsStoppedStep(t *testing.T) {
 	stopped := recvType[*godap.StoppedEvent](hh)
 	if stopped.Body.Reason != "step" {
 		t.Errorf("reason = %q, want step", stopped.Body.Reason)
+	}
+}
+
+func TestReadMessageDrainsQueuedCommandAcrossClose(t *testing.T) {
+	kill, err := marshalCommand(protocol.CmdKill, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type readResult struct {
+		messageType int
+		data        []byte
+		err         error
+	}
+
+	// The unfixed method lost roughly one command per 10,000 iterations on this
+	// schedule; enough trials make a silent pass vanishingly unlikely.
+	const trials = 500_000
+	for i := 0; i < trials; i++ {
+		h := &Handler{
+			conn:   nopConn{},
+			cmdOut: make(chan []byte, cmdBufferSize),
+			done:   make(chan struct{}),
+		}
+		result := make(chan readResult, 1)
+		go func() {
+			messageType, data, err := h.ReadMessage()
+			result <- readResult{messageType: messageType, data: data, err: err}
+		}()
+
+		runtime.Gosched()
+		h.enqueue(kill)
+		_ = h.Close()
+
+		got := <-result
+		if got.err != nil {
+			t.Fatalf("trial %d: ReadMessage returned before delivering the queued command: %v", i, got.err)
+		}
+		if got.messageType != hub.TextMessage || !bytes.Equal(got.data, kill) {
+			t.Fatalf("trial %d: ReadMessage returned (%d, %q), want (%d, %q)", i, got.messageType, got.data, hub.TextMessage, kill)
+		}
+		if _, _, err := h.ReadMessage(); !errors.Is(err, io.EOF) {
+			t.Fatalf("trial %d: ReadMessage after draining command returned %v, want EOF", i, err)
+		}
 	}
 }
 

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -373,6 +373,22 @@ func (nopConn) SetDeadline(time.Time) error      { return nil }
 func (nopConn) SetReadDeadline(time.Time) error  { return nil }
 func (nopConn) SetWriteDeadline(time.Time) error { return nil }
 
+type failWriteConn struct {
+	nopConn
+	beforeWrite func()
+	closed      chan struct{}
+}
+
+func (c *failWriteConn) Write([]byte) (int, error) {
+	c.beforeWrite()
+	return 0, errors.New("forced write failure")
+}
+
+func (c *failWriteConn) Close() error {
+	close(c.closed)
+	return nil
+}
+
 // sendReq writes a DAP request with an auto-incrementing seq, returning that seq.
 func (hh *harness) sendReq(command string, m godap.RequestMessage) int {
 	hh.t.Helper()
@@ -1349,6 +1365,42 @@ func TestReadMessageDrainsQueuedCommandAcrossClose(t *testing.T) {
 		if _, _, err := h.ReadMessage(); !errors.Is(err, io.EOF) {
 			t.Fatalf("trial %d: ReadMessage after draining command returned %v, want EOF", i, err)
 		}
+	}
+}
+
+func TestDisconnectQueuesKillBeforeFailedResponse(t *testing.T) {
+	filler, err := marshalCommand(protocol.CmdContinue, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn := &failWriteConn{closed: make(chan struct{})}
+	h := NewHandler(conn, nil, slog.New(slog.NewTextHandler(nopWriter{}, nil)))
+	h.session = &fakeSession{id: "sess-test"}
+	conn.beforeWrite = func() {
+		// Filling the queue during the response write makes the ordering
+		// deterministic: a later Kill cannot race done after send closes it.
+		for len(h.cmdOut) < cap(h.cmdOut) {
+			h.cmdOut <- filler
+		}
+	}
+
+	h.onDisconnect(&godap.DisconnectRequest{})
+
+	select {
+	case <-conn.closed:
+	default:
+		t.Fatal("DisconnectResponse write failure did not close the connection")
+	}
+
+	_, data, err := h.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage after failed DisconnectResponse: %v", err)
+	}
+	rec := &cmdRecorder{}
+	rec.add(data)
+	if kinds := rec.kinds(); len(kinds) != 1 || kinds[0] != protocol.CmdKill {
+		t.Fatalf("first command after failed DisconnectResponse = %v, want [%s]", kinds, protocol.CmdKill)
 	}
 }
 

--- a/internal/dap/requests.go
+++ b/internal/dap/requests.go
@@ -482,13 +482,12 @@ func (h *Handler) onDisconnect(req *godap.DisconnectRequest) {
 		terminate = true
 	}
 
-	h.send(&godap.DisconnectResponse{Response: h.response(req.Seq, "disconnect")})
-
 	if terminate && hasSession {
 		if cmd, err := marshalCommand(protocol.CmdKill, nil); err == nil {
 			h.enqueue(cmd) // drained by ReadMessage's priority path before EOF
 		}
 	}
+	h.send(&godap.DisconnectResponse{Response: h.response(req.Seq, "disconnect")})
 	_ = h.Close()
 }
 


### PR DESCRIPTION
## Summary

- drain commands queued before `Handler.Close` before returning EOF, including when `done` wins the blocking select
- enqueue disconnect `CmdKill` before writing `DisconnectResponse`, so a failed response write cannot close the handler before terminate ownership is buffered
- preserve the landed hub backpressure/FIFO behavior and the no-lock-across-enqueue/socket-write invariant
- add the 500,000-iteration inter-select regression and a deterministic failed-response regression

## Restack

- rebuilt the accepted two-commit series on exact `origin/main` `7248d2a8bc3044399e259dd4e95f91fb6865ef7d`
- range-diff retains both accepted commits in order
- normalized changed lines under `internal/dap` are identical to the accepted PR series; documentation conflict resolution only retains the backpressure text already landed on `main`
- independent concurrency review found no blockers and reproduced both regressions by reverting each fix in isolation

## Testing

- `gofmt -w internal/dap/handler.go internal/dap/handler_test.go internal/dap/requests.go`
- `go tool goimports -w internal/dap/handler.go internal/dap/handler_test.go internal/dap/requests.go`
- `go test -tags bingonative -race ./internal/dap ./internal/hub -count=1`
- `go test -tags bingonative ./... -count=1`
- `go vet -tags bingonative ./...`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 golangci-lint run ./...`
- `just build linux amd64`
- `just build darwin arm64`
- `just e2e-darwin` — 22/22 passed

Fixes #211
