### PR TITLE
fix(debugger): degrade incomplete runtime snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1691,10 +1691,12 @@ around `snapshotFrom` pin the seam's semantics but cannot catch a rewiring.
 
 **Graceful fallback.** Every read is best-effort. `resolveGoLayout` marks the
 layout invalid if any required `g`/`gobuf`/`stack`/`m` offset is missing, and an
-unreadable `allgs` header/slot, required `g` status/goid, or `allm` head/link
-degrades the whole snapshot to the legacy single synthetic goroutine (`ID:1,
-Status:"waiting"`, current PC) rather than returning a partial live set or
-erroring the stop. Intentional nil/dead/freelist entries remain filters, and
+unreadable `allgs` header/slot, required `g` status/goid/stack bound, or `allm`
+head/link degrades the whole snapshot to the legacy single synthetic goroutine
+(`ID:1, Status:"waiting"`, current PC) rather than returning a partial live set
+or erroring the stop. Both stack bounds are required for every included live
+goroutine: without them SP containment cannot rule that goroutine in or out as
+the stopped one. Intentional nil/dead/freelist entries remain filters, and
 optional metadata remains best-effort. This distinction is load-bearing on
 Linux: ptrace stops only the reporting thread, so sibling runtime mutations can
 race the walk; only backends that stop the world make the reads race-free. This
@@ -1705,10 +1707,12 @@ the `fakeBackend` engine unit tests green.
 thread's SP within `[g.stack.lo, g.stack.hi)`. The current *thread* is the M
 whose `curg` goid equals the current goid. A non-current goroutine's
 `CurrentLoc` uses `gobuf.pc` (where it resumes); the current one uses the live
-PC. Status strings are hardcoded (stable across Go versions); wait-reason
-strings are read dynamically from `runtime.waitReasonStrings`. Goroutines with
-goid<=0 or status `_Gdead` (scan bit stripped) are filtered out — their exit
-surfaces in the next Exited delta.
+PC. If a complete but clipped scan has not found the current goroutine, stop
+events report unknown rather than substituting the first unrelated entry.
+Status strings are hardcoded (stable across Go versions); wait-reason strings
+are read dynamically from `runtime.waitReasonStrings`. Goroutines with goid<=0
+or status `_Gdead` (scan bit stripped) are filtered out — their exit surfaces
+in the next Exited delta.
 
 **Note on `go f(args)` wrappers.** A goroutine started with arguments gets a
 compiler-generated `<caller>.gowrapN` closure as its startpc, so `StartLoc`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1690,10 +1690,15 @@ made lifecycle-tracking or the automatic path non-tracking; the unit tests
 around `snapshotFrom` pin the seam's semantics but cannot catch a rewiring.
 
 **Graceful fallback.** Every read is best-effort. `resolveGoLayout` marks the
-layout invalid if any required `g`/`gobuf`/`stack`/`m` offset is missing, and any
-unreadable address degrades the whole snapshot to the legacy single synthetic
-goroutine (`ID:1, Status:"waiting"`, current PC) rather than erroring the stop.
-This preserves behavior for stripped binaries / attach-without-DWARF and keeps
+layout invalid if any required `g`/`gobuf`/`stack`/`m` offset is missing, and an
+unreadable `allgs` header/slot, required `g` status/goid, or `allm` head/link
+degrades the whole snapshot to the legacy single synthetic goroutine (`ID:1,
+Status:"waiting"`, current PC) rather than returning a partial live set or
+erroring the stop. Intentional nil/dead/freelist entries remain filters, and
+optional metadata remains best-effort. This distinction is load-bearing on
+Linux: ptrace stops only the reporting thread, so sibling runtime mutations can
+race the walk; only backends that stop the world make the reads race-free. This
+also preserves behavior for stripped binaries / attach-without-DWARF and keeps
 the `fakeBackend` engine unit tests green.
 
 **Current goroutine = SP-containment** (platform-independent): the stopped

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1663,7 +1663,9 @@ target — is in [docs/ConcurrencyTelemetry.md](docs/ConcurrencyTelemetry.md).
 created/exited and adopts the new set. First snapshot returns nil deltas (a fresh
 session must not report every goroutine as "created"). A **degraded** snapshot
 (runtime unreadable — e.g. the pre-init entry stop) does **not** touch
-`prevGoids`: an empty read must not look like every goroutine exited.
+`prevGoids`: an empty read must not look like every goroutine exited. This holds
+for both automatic and on-demand snapshots: neither kind may clear or adopt a
+baseline from an incomplete walk.
 
 **Automatic snapshots alone own the baseline.** `prevGoids` is the *only*
 lifecycle memory, so whoever advances it decides what the next automatic

--- a/internal/debugger/engine_test.go
+++ b/internal/debugger/engine_test.go
@@ -24,10 +24,11 @@ func TestDebugger(t *testing.T) {
 // fakeBackend is an in-process Backend. Tests seed mem/regs, push StopEvents
 // to drive the state machine, and inspect recorded calls afterward.
 type fakeBackend struct {
-	memMu sync.RWMutex
-	mem   map[uint64]byte
-	regs  map[int]debugger.Registers
-	tids  []int
+	memMu        sync.RWMutex
+	mem          map[uint64]byte
+	readFailures map[uint64]int
+	regs         map[int]debugger.Registers
+	tids         []int
 
 	stopCh  chan debugger.StopEvent
 	waitErr chan error
@@ -67,16 +68,17 @@ type setRegistersCall struct {
 
 func newFakeBackend() *fakeBackend {
 	return &fakeBackend{
-		mem:        make(map[uint64]byte),
-		regs:       map[int]debugger.Registers{1: {}},
-		tids:       []int{1},
-		stopCh:     make(chan debugger.StopEvent, 8),
-		waitErr:    make(chan error, 1),
-		writtenAt:  make(map[uint64][]byte),
-		continueCh: make(chan struct{}, 16),
-		writeCount: make(map[uint64]int),
-		writeErrAt: make(map[uint64]error),
-		readErrAt:  make(map[uint64]error),
+		mem:          make(map[uint64]byte),
+		readFailures: make(map[uint64]int),
+		regs:         map[int]debugger.Registers{1: {}},
+		tids:         []int{1},
+		stopCh:       make(chan debugger.StopEvent, 8),
+		waitErr:      make(chan error, 1),
+		writtenAt:    make(map[uint64][]byte),
+		continueCh:   make(chan struct{}, 16),
+		writeCount:   make(map[uint64]int),
+		writeErrAt:   make(map[uint64]error),
+		readErrAt:    make(map[uint64]error),
 	}
 }
 
@@ -157,6 +159,12 @@ func (f *fakeBackend) seedRegs(r debugger.Registers) { f.regs[1] = r }
 
 func (f *fakeBackend) pushStop(evt debugger.StopEvent) { f.stopCh <- evt }
 
+func (f *fakeBackend) failNextReadAt(addr uint64) {
+	f.faultMu.Lock()
+	defer f.faultMu.Unlock()
+	f.readFailures[addr]++
+}
+
 // closeStop simulates process exit by closing stopCh, making Wait return
 // ErrProcessExited.
 func (f *fakeBackend) closeStop() {
@@ -221,6 +229,13 @@ func (f *fakeBackend) ReadMemory(addr uint64, dst []byte) error {
 	if err := f.faultFor("read", addr); err != nil {
 		return err
 	}
+	f.faultMu.Lock()
+	if f.readFailures[addr] > 0 {
+		f.readFailures[addr]--
+		f.faultMu.Unlock()
+		return errors.New("injected read failure")
+	}
+	f.faultMu.Unlock()
 	f.readCalls = append(f.readCalls, addr)
 	f.memMu.RLock()
 	defer f.memMu.RUnlock()

--- a/internal/debugger/export_test.go
+++ b/internal/debugger/export_test.go
@@ -26,6 +26,12 @@ type ExportedGoRuntimeLayout struct {
 	MAlllink uint64
 }
 
+type ExportedWalkResult struct {
+	Count    int
+	Complete bool
+	Clipped  bool
+}
+
 func ExportedTrapInstruction() []byte {
 	return archTrapInstruction()
 }
@@ -110,6 +116,54 @@ func ExportedGoroutineSnapshot(d Debugger) protocol.GoroutineSnapshotPayload {
 		panic("ExportedGoroutineSnapshot: " + err.Error())
 	}
 	return snap
+}
+
+func ExportedCurrentGoroutineFrom(snap protocol.GoroutineSnapshotPayload) protocol.Goroutine {
+	return currentGoroutineFrom(snap)
+}
+
+func ExportedThreadWalkResult(d Debugger) ExportedWalkResult {
+	e := d.(*engine)
+	var out ExportedWalkResult
+	if err := e.dispatch(func() error {
+		_, pc := e.liveRegisters()
+		result := e.readThreads(0, pc)
+		out = ExportedWalkResult{
+			Count:    len(result.Items),
+			Complete: result.Complete,
+			Clipped:  result.Clipped,
+		}
+		return nil
+	}); err != nil {
+		panic("ExportedThreadWalkResult: " + err.Error())
+	}
+	return out
+}
+
+func ExportedGoroutineWalkResult(d Debugger) ExportedWalkResult {
+	e := d.(*engine)
+	var out ExportedWalkResult
+	if err := e.dispatch(func() error {
+		sp, pc := e.liveRegisters()
+		result := e.buildGoroutineList(sp, pc)
+		out = ExportedWalkResult{
+			Count:    len(result.Items),
+			Complete: result.Complete,
+			Clipped:  result.Clipped,
+		}
+		return nil
+	}); err != nil {
+		panic("ExportedGoroutineWalkResult: " + err.Error())
+	}
+	return out
+}
+
+func ExportedMaxGoroutineScan() int {
+	return maxGoroutineScan
+}
+
+func ExportedMaxThreadScan() int {
+	return maxThreadScan
 }
 
 func ExportedFileMatches(candidate, target string) bool {

--- a/internal/debugger/export_test.go
+++ b/internal/debugger/export_test.go
@@ -118,6 +118,18 @@ func ExportedGoroutineSnapshot(d Debugger) protocol.GoroutineSnapshotPayload {
 	return snap
 }
 
+func ExportedGoroutineSnapshotQuery(d Debugger) protocol.GoroutineSnapshotPayload {
+	e := d.(*engine)
+	var snap protocol.GoroutineSnapshotPayload
+	if err := e.dispatch(func() error {
+		snap = e.goroutineSnapshotQuery()
+		return nil
+	}); err != nil {
+		panic("ExportedGoroutineSnapshotQuery: " + err.Error())
+	}
+	return snap
+}
+
 func ExportedCurrentGoroutineFrom(snap protocol.GoroutineSnapshotPayload) protocol.Goroutine {
 	return currentGoroutineFrom(snap)
 }
@@ -428,8 +440,8 @@ func (b *ExportedGateBackend) completeStepThreadExit() error {
 	return nil
 }
 
-// ExportedSnapshotFrom assembles a snapshot payload around a pre-built
-// goroutine list, bypassing the runtime memory scan, so tests can pin the
+// ExportedSnapshotFrom assembles a snapshot payload around pre-built complete
+// walk results, bypassing runtime memory, so tests can pin the
 // lifecycle split: trackLifecycle=true is the automatic stop path (diffs and
 // adopts the baseline), false is the on-demand query path. Runs on the engine
 // loop thread, like the real callers.
@@ -437,7 +449,8 @@ func ExportedSnapshotFrom(d Debugger, gs []protocol.Goroutine, trackLifecycle bo
 	e := d.(*engine)
 	var snap protocol.GoroutineSnapshotPayload
 	if err := e.dispatch(func() error {
-		snap = e.snapshotFrom(gs, 0, trackLifecycle)
+		current, live := snapshotGoroutineState(gs)
+		snap = e.snapshotFrom(gs, nil, current, live, trackLifecycle)
 		return nil
 	}); err != nil {
 		panic("ExportedSnapshotFrom: " + err.Error())

--- a/internal/debugger/export_test.go
+++ b/internal/debugger/export_test.go
@@ -9,6 +9,23 @@ import (
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
 
+type ExportedGoRuntimeLayout struct {
+	Allgs uint64
+	Allm  uint64
+
+	GStack        uint64
+	GAtomicstatus uint64
+	GGoid         uint64
+	GParentGoid   uint64
+
+	StackLo uint64
+	StackHi uint64
+
+	MProcid  uint64
+	MCurg    uint64
+	MAlllink uint64
+}
+
 func ExportedTrapInstruction() []byte {
 	return archTrapInstruction()
 }
@@ -42,6 +59,57 @@ func ExportedPCForFileLine(d Debugger, file string, line int) (uint64, error) {
 		return lookupErr
 	})
 	return pc, err
+}
+
+func ExportedGoRuntimeLayoutFor(d Debugger) ExportedGoRuntimeLayout {
+	e := d.(*engine)
+	var out ExportedGoRuntimeLayout
+	if err := e.dispatch(func() error {
+		l, ok := e.getGoLayout()
+		if !ok {
+			return fmt.Errorf("no Go runtime layout")
+		}
+		allgs, ok := e.dw.runtimeVarAddr("runtime.allgs")
+		if !ok {
+			return fmt.Errorf("no runtime.allgs")
+		}
+		allm, ok := e.dw.runtimeVarAddr("runtime.allm")
+		if !ok {
+			return fmt.Errorf("no runtime.allm")
+		}
+		out = ExportedGoRuntimeLayout{
+			Allgs: allgs,
+			Allm:  allm,
+
+			GStack:        uint64(l.gStack),
+			GAtomicstatus: uint64(l.gAtomicstatus),
+			GGoid:         uint64(l.gGoid),
+			GParentGoid:   uint64(l.gParentGoid),
+
+			StackLo: uint64(l.stackLo),
+			StackHi: uint64(l.stackHi),
+
+			MProcid:  uint64(l.mProcid),
+			MCurg:    uint64(l.mCurg),
+			MAlllink: uint64(l.mAlllink),
+		}
+		return nil
+	}); err != nil {
+		panic("ExportedGoRuntimeLayoutFor: " + err.Error())
+	}
+	return out
+}
+
+func ExportedGoroutineSnapshot(d Debugger) protocol.GoroutineSnapshotPayload {
+	e := d.(*engine)
+	var snap protocol.GoroutineSnapshotPayload
+	if err := e.dispatch(func() error {
+		snap = e.goroutineSnapshot()
+		return nil
+	}); err != nil {
+		panic("ExportedGoroutineSnapshot: " + err.Error())
+	}
+	return snap
 }
 
 func ExportedFileMatches(candidate, target string) bool {

--- a/internal/debugger/goroutines.go
+++ b/internal/debugger/goroutines.go
@@ -15,11 +15,11 @@ import (
 // linkage for a spawn tree, the thread set, the current goroutine, and the
 // created/exited lifecycle deltas. See AGENTS.md → goroutine snapshot reading.
 //
-// Everything here runs on the serialized engine loop while the tracee is
-// suspended, so memory reads are race-free. Every read is best-effort: any
-// failure (no DWARF, an unexpected layout, an unreadable address, or a runtime
-// not yet initialized at the entry stop) degrades gracefully to the legacy
-// single-synthetic goroutine rather than erroring the stop.
+// The engine serializes the walk while the reporting thread is suspended.
+// Darwin also stops sibling threads, but Linux ptrace stops are per-thread, so
+// runtime mutations can race the walk there. Any incomplete required read
+// therefore degrades gracefully to the legacy single-synthetic goroutine rather
+// than being mistaken for a lifecycle change or erroring the stop.
 
 const (
 	// maxGoroutineScan bounds the runtime.allgs walk so a corrupt slice header
@@ -225,25 +225,28 @@ func (e *engine) locForPC(pc uint64) protocol.Location {
 	return e.dw.locationForPC(pc)
 }
 
-// readGoroutine reads one runtime.g at gptr into a protocol.Goroutine. It
-// returns ok=false when the goroutine should be skipped (freelist slot, dead,
-// or unreadable). liveSP/livePC identify the currently-stopped thread so the
-// goroutine running there is marked Current and gets its live PC as CurrentLoc.
-func (e *engine) readGoroutine(l *goLayout, gptr, liveSP, livePC uint64) (protocol.Goroutine, bool) {
+// readGoroutine reads one runtime.g at gptr into a protocol.Goroutine. include
+// is false for intentional freelist/dead entries; complete is false only when a
+// required field is unreadable. liveSP/livePC identify the currently-stopped
+// thread so the goroutine running there is marked Current and gets its live PC.
+func (e *engine) readGoroutine(l *goLayout, gptr, liveSP, livePC uint64) (g protocol.Goroutine, include, complete bool) {
 	rawStatus, ok := e.readU32(gptr + uint64(l.gAtomicstatus))
 	if !ok {
-		return protocol.Goroutine{}, false
+		return protocol.Goroutine{}, false, false
 	}
 	status := rawStatus &^ gScanBit
 
 	goid, ok := e.readI64(gptr + uint64(l.gGoid))
-	if !ok || goid <= 0 || status == gStatusDead {
+	if !ok {
+		return protocol.Goroutine{}, false, false
+	}
+	if goid <= 0 || status == gStatusDead {
 		// Freelist / dead slots carry goid 0 or a stale id; a UI wants only the
 		// live set. Their departure is reported via the exited delta.
-		return protocol.Goroutine{}, false
+		return protocol.Goroutine{}, false, true
 	}
 
-	g := protocol.Goroutine{
+	g = protocol.Goroutine{
 		ID:     int(goid),
 		Status: goStatusString(status),
 	}
@@ -281,7 +284,7 @@ func (e *engine) readGoroutine(l *goLayout, gptr, liveSP, livePC uint64) (protoc
 		g.CurrentLoc = e.locForPC(schedPC)
 	}
 
-	return g, true
+	return g, true, true
 }
 
 func (e *engine) readI64(addr uint64) (int64, bool) {
@@ -316,10 +319,17 @@ func (e *engine) buildGoroutineList(liveSP, livePC uint64) ([]protocol.Goroutine
 	out := make([]protocol.Goroutine, 0, length)
 	for i := uint64(0); i < length; i++ {
 		gptr, ok := e.readU64(ptr + i*8)
-		if !ok || gptr == 0 {
+		if !ok {
+			return nil, false
+		}
+		if gptr == 0 {
 			continue
 		}
-		if g, ok := e.readGoroutine(l, gptr, liveSP, livePC); ok {
+		g, include, complete := e.readGoroutine(l, gptr, liveSP, livePC)
+		if !complete {
+			return nil, false
+		}
+		if include {
 			out = append(out, g)
 		}
 	}
@@ -331,19 +341,20 @@ func (e *engine) buildGoroutineList(liveSP, livePC uint64) ([]protocol.Goroutine
 
 // readThreads walks runtime.allm and reports every OS thread (M). currentGoid
 // (from the goroutine list) marks the thread whose goroutine is under
-// inspection as Current and gives it the live PC. Best-effort: nil on failure.
-func (e *engine) readThreads(currentGoid int, livePC uint64) []protocol.Thread {
+// inspection as Current and gives it the live PC. complete is false only when
+// the list itself can't be traversed; individual thread metadata is optional.
+func (e *engine) readThreads(currentGoid int, livePC uint64) ([]protocol.Thread, bool) {
 	l, ok := e.getGoLayout()
 	if !ok {
-		return nil
+		return nil, false
 	}
 	base, ok := e.dw.runtimeVarAddr("runtime.allm")
 	if !ok {
-		return nil
+		return nil, false
 	}
 	mptr, ok := e.readU64(base) // runtime.allm is a *m; read the head pointer
 	if !ok {
-		return nil
+		return nil, false
 	}
 
 	var out []protocol.Thread
@@ -373,11 +384,11 @@ func (e *engine) readThreads(currentGoid int, livePC uint64) []protocol.Thread {
 
 		next, ok := e.readU64(mptr + uint64(l.mAlllink))
 		if !ok {
-			break
+			return nil, false
 		}
 		mptr = next
 	}
-	return out
+	return out, true
 }
 
 // liveRegisters reads the currently-stopped thread's SP and PC (used to locate
@@ -464,9 +475,16 @@ func (e *engine) snapshotFrom(gs []protocol.Goroutine, livePC uint64, trackLifec
 		}
 	}
 
+	threads, ok := e.readThreads(current, livePC)
+	if !ok {
+		return protocol.GoroutineSnapshotPayload{
+			Goroutines: []protocol.Goroutine{e.syntheticGoroutine(livePC)},
+		}
+	}
+
 	snap := protocol.GoroutineSnapshotPayload{
 		Goroutines: gs,
-		Threads:    e.readThreads(current, livePC),
+		Threads:    threads,
 		Current:    current,
 	}
 	if trackLifecycle {

--- a/internal/debugger/goroutines.go
+++ b/internal/debugger/goroutines.go
@@ -509,13 +509,37 @@ func (e *engine) buildSnapshot(trackLifecycle bool) protocol.GoroutineSnapshotPa
 		// runtime init) must not look like every goroutine exited.
 		return e.degradedSnapshot(pc)
 	}
-	return e.snapshotFrom(goroutines.Items, pc, trackLifecycle)
+
+	current, live := snapshotGoroutineState(goroutines.Items)
+	threads := e.readThreads(current, pc)
+	if !threads.Complete {
+		return e.degradedSnapshot(pc)
+	}
+	return e.snapshotFrom(goroutines.Items, threads.Items, current, live, trackLifecycle)
 }
 
-// snapshotFrom assembles the payload around an already-built goroutine list.
+// snapshotFrom assembles a payload after both runtime walks have completed.
 // trackLifecycle is the single point where an automatic snapshot's ownership of
 // the lifecycle baseline differs from a query's read-only view.
-func (e *engine) snapshotFrom(gs []protocol.Goroutine, livePC uint64, trackLifecycle bool) protocol.GoroutineSnapshotPayload {
+func (e *engine) snapshotFrom(
+	gs []protocol.Goroutine,
+	threads []protocol.Thread,
+	current int,
+	live map[int]struct{},
+	trackLifecycle bool,
+) protocol.GoroutineSnapshotPayload {
+	snap := protocol.GoroutineSnapshotPayload{
+		Goroutines: gs,
+		Threads:    threads,
+		Current:    current,
+	}
+	if trackLifecycle {
+		snap.Created, snap.Exited = e.diffGoids(live)
+	}
+	return snap
+}
+
+func snapshotGoroutineState(gs []protocol.Goroutine) (int, map[int]struct{}) {
 	var current int
 	live := make(map[int]struct{}, len(gs))
 	for _, g := range gs {
@@ -524,21 +548,7 @@ func (e *engine) snapshotFrom(gs []protocol.Goroutine, livePC uint64, trackLifec
 			current = g.ID
 		}
 	}
-
-	threads := e.readThreads(current, livePC)
-	if !threads.Complete {
-		return e.degradedSnapshot(livePC)
-	}
-
-	snap := protocol.GoroutineSnapshotPayload{
-		Goroutines: gs,
-		Threads:    threads.Items,
-		Current:    current,
-	}
-	if trackLifecycle {
-		snap.Created, snap.Exited = e.diffGoids(live)
-	}
-	return snap
+	return current, live
 }
 
 // diffGoids compares the current live goid set against the previous automatic

--- a/internal/debugger/goroutines.go
+++ b/internal/debugger/goroutines.go
@@ -225,28 +225,55 @@ func (e *engine) locForPC(pc uint64) protocol.Location {
 	return e.dw.locationForPC(pc)
 }
 
-// readGoroutine reads one runtime.g at gptr into a protocol.Goroutine. include
-// is false for intentional freelist/dead entries; complete is false only when a
-// required field is unreadable. liveSP/livePC identify the currently-stopped
+type goroutineReadResult struct {
+	Item     protocol.Goroutine
+	Include  bool
+	Complete bool
+}
+
+type goroutineWalkResult struct {
+	Items    []protocol.Goroutine
+	Complete bool
+	Clipped  bool
+}
+
+type threadWalkResult struct {
+	Items    []protocol.Thread
+	Complete bool
+	Clipped  bool
+}
+
+// readGoroutine reads one runtime.g at gptr. Include is false for intentional
+// freelist/dead entries; Complete is false only when membership or current-
+// identity data is unreadable. liveSP/livePC identify the currently-stopped
 // thread so the goroutine running there is marked Current and gets its live PC.
-func (e *engine) readGoroutine(l *goLayout, gptr, liveSP, livePC uint64) (g protocol.Goroutine, include, complete bool) {
+func (e *engine) readGoroutine(l *goLayout, gptr, liveSP, livePC uint64) goroutineReadResult {
 	rawStatus, ok := e.readU32(gptr + uint64(l.gAtomicstatus))
 	if !ok {
-		return protocol.Goroutine{}, false, false
+		return goroutineReadResult{}
 	}
 	status := rawStatus &^ gScanBit
 
 	goid, ok := e.readI64(gptr + uint64(l.gGoid))
 	if !ok {
-		return protocol.Goroutine{}, false, false
+		return goroutineReadResult{}
 	}
 	if goid <= 0 || status == gStatusDead {
 		// Freelist / dead slots carry goid 0 or a stale id; a UI wants only the
 		// live set. Their departure is reported via the exited delta.
-		return protocol.Goroutine{}, false, true
+		return goroutineReadResult{Complete: true}
 	}
 
-	g = protocol.Goroutine{
+	lo, ok := e.readU64(gptr + uint64(l.gStack) + uint64(l.stackLo))
+	if !ok {
+		return goroutineReadResult{}
+	}
+	hi, ok := e.readU64(gptr + uint64(l.gStack) + uint64(l.stackHi))
+	if !ok {
+		return goroutineReadResult{}
+	}
+
+	g := protocol.Goroutine{
 		ID:     int(goid),
 		Status: goStatusString(status),
 	}
@@ -265,9 +292,7 @@ func (e *engine) readGoroutine(l *goLayout, gptr, liveSP, livePC uint64) (g prot
 		}
 	}
 
-	lo, okLo := e.readU64(gptr + uint64(l.gStack) + uint64(l.stackLo))
-	hi, okHi := e.readU64(gptr + uint64(l.gStack) + uint64(l.stackHi))
-	current := okLo && okHi && liveSP != 0 && liveSP >= lo && liveSP < hi
+	current := liveSP != 0 && liveSP >= lo && liveSP < hi
 	g.Current = current
 
 	if mptr, ok := e.readU64(gptr + uint64(l.gM)); ok && mptr != 0 {
@@ -284,7 +309,11 @@ func (e *engine) readGoroutine(l *goLayout, gptr, liveSP, livePC uint64) (g prot
 		g.CurrentLoc = e.locForPC(schedPC)
 	}
 
-	return g, true, true
+	return goroutineReadResult{
+		Item:     g,
+		Include:  true,
+		Complete: true,
+	}
 }
 
 func (e *engine) readI64(addr uint64) (int64, bool) {
@@ -292,26 +321,28 @@ func (e *engine) readI64(addr uint64) (int64, bool) {
 	return int64(v), ok
 }
 
-// buildGoroutineList enumerates runtime.allgs. ok is false when the runtime
-// can't be read (no DWARF, bad layout, unreadable slice, or no live goroutines
-// yet), so callers fall back to the synthetic goroutine.
-func (e *engine) buildGoroutineList(liveSP, livePC uint64) ([]protocol.Goroutine, bool) {
+// buildGoroutineList enumerates runtime.allgs. Complete is false when the
+// runtime can't be read (no DWARF, bad layout, unreadable membership data, or
+// no live goroutines yet). Clipped is independent: the walk reached its safety
+// ceiling but every visited entry was readable.
+func (e *engine) buildGoroutineList(liveSP, livePC uint64) goroutineWalkResult {
 	l, ok := e.getGoLayout()
 	if !ok {
-		return nil, false
+		return goroutineWalkResult{}
 	}
 	base, ok := e.dw.runtimeVarAddr("runtime.allgs")
 	if !ok {
-		return nil, false
+		return goroutineWalkResult{}
 	}
 	ptr, ok := e.readU64(base) // slice header: array pointer @ +0
 	if !ok || ptr == 0 {
-		return nil, false
+		return goroutineWalkResult{}
 	}
 	length, ok := e.readU64(base + 8) // slice header: len @ +8
 	if !ok || length == 0 {
-		return nil, false
+		return goroutineWalkResult{}
 	}
+	clipped := length > maxGoroutineScan
 	if length > maxGoroutineScan {
 		length = maxGoroutineScan
 	}
@@ -320,45 +351,52 @@ func (e *engine) buildGoroutineList(liveSP, livePC uint64) ([]protocol.Goroutine
 	for i := uint64(0); i < length; i++ {
 		gptr, ok := e.readU64(ptr + i*8)
 		if !ok {
-			return nil, false
+			return goroutineWalkResult{}
 		}
 		if gptr == 0 {
 			continue
 		}
-		g, include, complete := e.readGoroutine(l, gptr, liveSP, livePC)
-		if !complete {
-			return nil, false
+		result := e.readGoroutine(l, gptr, liveSP, livePC)
+		if !result.Complete {
+			return goroutineWalkResult{}
 		}
-		if include {
-			out = append(out, g)
+		if result.Include {
+			out = append(out, result.Item)
 		}
 	}
 	if len(out) == 0 {
-		return nil, false
+		return goroutineWalkResult{}
 	}
-	return out, true
+	return goroutineWalkResult{
+		Items:    out,
+		Complete: true,
+		Clipped:  clipped,
+	}
 }
 
 // readThreads walks runtime.allm and reports every OS thread (M). currentGoid
 // (from the goroutine list) marks the thread whose goroutine is under
-// inspection as Current and gives it the live PC. complete is false only when
+// inspection as Current and gives it the live PC. Complete is false only when
 // the list itself can't be traversed; individual thread metadata is optional.
-func (e *engine) readThreads(currentGoid int, livePC uint64) ([]protocol.Thread, bool) {
+// Clipped records the independent allm safety ceiling without conflating it
+// with an incomplete memory read.
+func (e *engine) readThreads(currentGoid int, livePC uint64) threadWalkResult {
 	l, ok := e.getGoLayout()
 	if !ok {
-		return nil, false
+		return threadWalkResult{}
 	}
 	base, ok := e.dw.runtimeVarAddr("runtime.allm")
 	if !ok {
-		return nil, false
+		return threadWalkResult{}
 	}
 	mptr, ok := e.readU64(base) // runtime.allm is a *m; read the head pointer
 	if !ok {
-		return nil, false
+		return threadWalkResult{}
 	}
 
 	var out []protocol.Thread
-	for i := 0; i < maxThreadScan && mptr != 0; i++ {
+	i := 0
+	for ; i < maxThreadScan && mptr != 0; i++ {
 		t := protocol.Thread{}
 		if procid, ok := e.readU64(mptr + uint64(l.mProcid)); ok {
 			t.ID = int(procid)
@@ -384,11 +422,15 @@ func (e *engine) readThreads(currentGoid int, livePC uint64) ([]protocol.Thread,
 
 		next, ok := e.readU64(mptr + uint64(l.mAlllink))
 		if !ok {
-			return nil, false
+			return threadWalkResult{}
 		}
 		mptr = next
 	}
-	return out, true
+	return threadWalkResult{
+		Items:    out,
+		Complete: true,
+		Clipped:  i == maxThreadScan && mptr != 0,
+	}
 }
 
 // liveRegisters reads the currently-stopped thread's SP and PC (used to locate
@@ -423,8 +465,9 @@ func (e *engine) syntheticGoroutine(livePC uint64) protocol.Goroutine {
 // Goroutines() query and the DAP threads list.
 func (e *engine) readGoroutines() ([]protocol.Goroutine, error) {
 	sp, pc := e.liveRegisters()
-	if gs, ok := e.buildGoroutineList(sp, pc); ok {
-		return gs, nil
+	result := e.buildGoroutineList(sp, pc)
+	if result.Complete {
+		return result.Items, nil
 	}
 	return []protocol.Goroutine{e.syntheticGoroutine(pc)}, nil
 }
@@ -450,8 +493,8 @@ func (e *engine) goroutineSnapshotQuery() protocol.GoroutineSnapshotPayload {
 func (e *engine) buildSnapshot(trackLifecycle bool) protocol.GoroutineSnapshotPayload {
 	sp, pc := e.liveRegisters()
 
-	gs, ok := e.buildGoroutineList(sp, pc)
-	if !ok {
+	goroutines := e.buildGoroutineList(sp, pc)
+	if !goroutines.Complete {
 		// Degraded snapshot: still report where we're stopped, but don't touch
 		// the remembered live set — an empty read (e.g. at the entry stop before
 		// runtime init) must not look like every goroutine exited.
@@ -459,7 +502,7 @@ func (e *engine) buildSnapshot(trackLifecycle bool) protocol.GoroutineSnapshotPa
 			Goroutines: []protocol.Goroutine{e.syntheticGoroutine(pc)},
 		}
 	}
-	return e.snapshotFrom(gs, pc, trackLifecycle)
+	return e.snapshotFrom(goroutines.Items, pc, trackLifecycle)
 }
 
 // snapshotFrom assembles the payload around an already-built goroutine list.
@@ -475,8 +518,8 @@ func (e *engine) snapshotFrom(gs []protocol.Goroutine, livePC uint64, trackLifec
 		}
 	}
 
-	threads, ok := e.readThreads(current, livePC)
-	if !ok {
+	threads := e.readThreads(current, livePC)
+	if !threads.Complete {
 		return protocol.GoroutineSnapshotPayload{
 			Goroutines: []protocol.Goroutine{e.syntheticGoroutine(livePC)},
 		}
@@ -484,7 +527,7 @@ func (e *engine) snapshotFrom(gs []protocol.Goroutine, livePC uint64, trackLifec
 
 	snap := protocol.GoroutineSnapshotPayload{
 		Goroutines: gs,
-		Threads:    threads,
+		Threads:    threads.Items,
 		Current:    current,
 	}
 	if trackLifecycle {
@@ -518,16 +561,14 @@ func (e *engine) diffGoids(live map[int]struct{}) (created, exited []int) {
 }
 
 // currentGoroutineFrom returns the goroutine marked Current in a snapshot, used
-// as the single Goroutine embedded in a stop event. Falls back to the first
-// entry (snapshots always carry at least the synthetic goroutine).
+// as the single Goroutine embedded in a stop event. Unknown is safer than
+// attributing the stop to the first unrelated goroutine when a capped scan has
+// not yet found the stopped goroutine.
 func currentGoroutineFrom(snap protocol.GoroutineSnapshotPayload) protocol.Goroutine {
 	for _, g := range snap.Goroutines {
 		if g.Current {
 			return g
 		}
-	}
-	if len(snap.Goroutines) > 0 {
-		return snap.Goroutines[0]
 	}
 	return protocol.Goroutine{}
 }

--- a/internal/debugger/goroutines.go
+++ b/internal/debugger/goroutines.go
@@ -460,6 +460,15 @@ func (e *engine) syntheticGoroutine(livePC uint64) protocol.Goroutine {
 	}
 }
 
+// degradedSnapshot is the single construction point for an incomplete runtime
+// walk. Downstream reporting must describe every such snapshot as degraded,
+// regardless of whether goroutine or thread traversal failed.
+func (e *engine) degradedSnapshot(livePC uint64) protocol.GoroutineSnapshotPayload {
+	return protocol.GoroutineSnapshotPayload{
+		Goroutines: []protocol.Goroutine{e.syntheticGoroutine(livePC)},
+	}
+}
+
 // readGoroutines returns the live goroutine set, falling back to a single
 // synthetic goroutine when the runtime can't be read. This backs the on-demand
 // Goroutines() query and the DAP threads list.
@@ -498,9 +507,7 @@ func (e *engine) buildSnapshot(trackLifecycle bool) protocol.GoroutineSnapshotPa
 		// Degraded snapshot: still report where we're stopped, but don't touch
 		// the remembered live set — an empty read (e.g. at the entry stop before
 		// runtime init) must not look like every goroutine exited.
-		return protocol.GoroutineSnapshotPayload{
-			Goroutines: []protocol.Goroutine{e.syntheticGoroutine(pc)},
-		}
+		return e.degradedSnapshot(pc)
 	}
 	return e.snapshotFrom(goroutines.Items, pc, trackLifecycle)
 }
@@ -520,9 +527,7 @@ func (e *engine) snapshotFrom(gs []protocol.Goroutine, livePC uint64, trackLifec
 
 	threads := e.readThreads(current, livePC)
 	if !threads.Complete {
-		return protocol.GoroutineSnapshotPayload{
-			Goroutines: []protocol.Goroutine{e.syntheticGoroutine(livePC)},
-		}
+		return e.degradedSnapshot(livePC)
 	}
 
 	snap := protocol.GoroutineSnapshotPayload{

--- a/internal/debugger/goroutines_test.go
+++ b/internal/debugger/goroutines_test.go
@@ -188,6 +188,9 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 		Entry("when the current g stack upper bound is unreadable", func() uint64 {
 			return fixture.g[1] + fixture.layout.GStack + fixture.layout.StackHi
 		}),
+		Entry("when the allm head pointer is unreadable", func() uint64 {
+			return fixture.layout.Allm
+		}),
 		Entry("when an allm link is unreadable", func() uint64 {
 			return fixture.m[0] + fixture.layout.MAlllink
 		}),

--- a/internal/debugger/goroutines_test.go
+++ b/internal/debugger/goroutines_test.go
@@ -196,6 +196,36 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 		}),
 	)
 
+	DescribeTable("keeps degraded on-demand snapshots read-only",
+		func(faultAddr func() uint64) {
+			seedU32(fb, fixture.g[2]+fixture.layout.GAtomicstatus, 6)
+			fb.failNextReadAt(faultAddr())
+
+			degraded := debugger.ExportedGoroutineSnapshotQuery(d)
+			recovered := debugger.ExportedGoroutineSnapshot(d)
+
+			Expect([]snapshotObservation{
+				observeSnapshot(degraded),
+				observeSnapshot(recovered),
+			}).To(Equal([]snapshotObservation{
+				{Goroutines: []int{1}, Selected: 1},
+				{
+					Goroutines: []int{101, 102},
+					Threads:    2,
+					Current:    102,
+					Selected:   102,
+					Exited:     []int{103},
+				},
+			}))
+		},
+		Entry("when allgs is incomplete", func() uint64 {
+			return allgsArrayAddr + 8
+		}),
+		Entry("when allm is incomplete", func() uint64 {
+			return fixture.m[0] + fixture.layout.MAlllink
+		}),
+	)
+
 	It("keeps nil, dead, and zero-goid entries as intentional filters", func() {
 		seedU32(fb, fixture.g[2]+fixture.layout.GAtomicstatus, 6)
 		dead := debugger.ExportedGoroutineSnapshot(d)

--- a/internal/debugger/goroutines_test.go
+++ b/internal/debugger/goroutines_test.go
@@ -84,7 +84,7 @@ func seedGoroutineMemory(fb *fakeBackend, d debugger.Debugger) goroutineMemoryFi
 	seedU64(fb, fixture.m[1]+layout.MProcid, 22)
 	seedU64(fb, fixture.m[1]+layout.MCurg, fixture.g[1])
 	seedU64(fb, fixture.m[1]+layout.MAlllink, 0)
-	fb.seedRegs(debugger.Registers{SP: 0x7800})
+	fb.seedRegs(debugger.Registers{SP: 0x8800})
 
 	return fixture
 }
@@ -101,6 +101,7 @@ type snapshotObservation struct {
 	Goroutines []int
 	Threads    int
 	Current    int
+	Selected   int
 	Created    []int
 	Exited     []int
 }
@@ -110,6 +111,7 @@ func observeSnapshot(snap protocol.GoroutineSnapshotPayload) snapshotObservation
 		Goroutines: goroutineIDs(snap.Goroutines),
 		Threads:    len(snap.Threads),
 		Current:    snap.Current,
+		Selected:   debugger.ExportedCurrentGoroutineFrom(snap).ID,
 		Created:    snap.Created,
 		Exited:     snap.Exited,
 	}
@@ -136,7 +138,8 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 		Expect(observeSnapshot(baseline)).To(Equal(snapshotObservation{
 			Goroutines: []int{101, 102, 103},
 			Threads:    2,
-			Current:    101,
+			Current:    102,
+			Selected:   102,
 		}))
 	})
 
@@ -150,6 +153,7 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 
 	DescribeTable("degrades the whole snapshot and preserves its lifecycle baseline",
 		func(faultAddr func() uint64) {
+			seedU32(fb, fixture.g[2]+fixture.layout.GAtomicstatus, 6)
 			fb.failNextReadAt(faultAddr())
 
 			degraded := debugger.ExportedGoroutineSnapshot(d)
@@ -159,8 +163,14 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 				observeSnapshot(degraded),
 				observeSnapshot(recovered),
 			}).To(Equal([]snapshotObservation{
-				{Goroutines: []int{1}},
-				{Goroutines: []int{101, 102, 103}, Threads: 2, Current: 101},
+				{Goroutines: []int{1}, Selected: 1},
+				{
+					Goroutines: []int{101, 102},
+					Threads:    2,
+					Current:    102,
+					Selected:   102,
+					Exited:     []int{103},
+				},
 			}))
 		},
 		Entry("when an allgs slot pointer is unreadable", func() uint64 {
@@ -171,6 +181,12 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 		}),
 		Entry("when a required g goid is unreadable", func() uint64 {
 			return fixture.g[1] + fixture.layout.GGoid
+		}),
+		Entry("when a non-current g stack lower bound is unreadable", func() uint64 {
+			return fixture.g[0] + fixture.layout.GStack + fixture.layout.StackLo
+		}),
+		Entry("when the current g stack upper bound is unreadable", func() uint64 {
+			return fixture.g[1] + fixture.layout.GStack + fixture.layout.StackHi
 		}),
 		Entry("when an allm link is unreadable", func() uint64 {
 			return fixture.m[0] + fixture.layout.MAlllink
@@ -188,8 +204,20 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 			observeSnapshot(dead),
 			observeSnapshot(liveAgain),
 		}).To(Equal([]snapshotObservation{
-			{Goroutines: []int{101, 102}, Threads: 2, Current: 101, Exited: []int{103}},
-			{Goroutines: []int{101, 102, 103}, Threads: 2, Current: 101, Created: []int{103}},
+			{
+				Goroutines: []int{101, 102},
+				Threads:    2,
+				Current:    102,
+				Selected:   102,
+				Exited:     []int{103},
+			},
+			{
+				Goroutines: []int{101, 102, 103},
+				Threads:    2,
+				Current:    102,
+				Selected:   102,
+				Created:    []int{103},
+			},
 		}))
 	})
 
@@ -202,7 +230,8 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 			Expect(observeSnapshot(snap)).To(Equal(snapshotObservation{
 				Goroutines: []int{101, 102, 103},
 				Threads:    2,
-				Current:    101,
+				Current:    102,
+				Selected:   102,
 			}))
 		},
 		Entry("for a goroutine parent", func() uint64 {
@@ -213,11 +242,82 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 		}),
 	)
 
-	It("degrades an on-demand Goroutines read instead of returning a partial set", func() {
-		fb.failNextReadAt(allgsArrayAddr + 8)
+	DescribeTable("degrades an on-demand Goroutines read instead of returning a partial set",
+		func(faultAddr func() uint64) {
+			fb.failNextReadAt(faultAddr())
 
-		gs, err := d.Goroutines()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(goroutineIDs(gs)).To(Equal([]int{1}))
+			gs, err := d.Goroutines()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(goroutineIDs(gs)).To(Equal([]int{1}))
+			Expect(gs[0].Current).To(BeTrue())
+		},
+		Entry("for an unreadable allgs slot", func() uint64 {
+			return allgsArrayAddr + 8
+		}),
+		Entry("for an unreadable stack lower bound", func() uint64 {
+			return fixture.g[0] + fixture.layout.GStack + fixture.layout.StackLo
+		}),
+		Entry("for an unreadable stack upper bound", func() uint64 {
+			return fixture.g[1] + fixture.layout.GStack + fixture.layout.StackHi
+		}),
+	)
+
+	It("keeps a clipped allm walk distinct from an incomplete one", func() {
+		fb.failNextReadAt(fixture.m[0] + fixture.layout.MAlllink)
+		incomplete := debugger.ExportedThreadWalkResult(d)
+		Expect(incomplete).To(Equal(debugger.ExportedWalkResult{}))
+
+		next := mBaseAddr
+		for i := 0; i < debugger.ExportedMaxThreadScan()+1; i++ {
+			current := next
+			next += runtimeStride
+			seedU64(fb, current+fixture.layout.MAlllink, next)
+		}
+
+		clipped := debugger.ExportedThreadWalkResult(d)
+
+		Expect(clipped).To(Equal(debugger.ExportedWalkResult{
+			Count:    debugger.ExportedMaxThreadScan(),
+			Complete: true,
+			Clipped:  true,
+		}))
+	})
+
+	It("keeps a clipped allgs walk distinct from an incomplete one", func() {
+		fb.failNextReadAt(allgsArrayAddr)
+		incomplete := debugger.ExportedGoroutineWalkResult(d)
+		Expect(incomplete).To(Equal(debugger.ExportedWalkResult{}))
+
+		seedU64(fb, fixture.layout.Allgs+8, uint64(debugger.ExportedMaxGoroutineScan()+1))
+		for i := 0; i < debugger.ExportedMaxGoroutineScan()+1; i++ {
+			seedU64(fb, allgsArrayAddr+uint64(i)*8, fixture.g[0])
+		}
+
+		clipped := debugger.ExportedGoroutineWalkResult(d)
+
+		Expect(clipped).To(Equal(debugger.ExportedWalkResult{
+			Count:    debugger.ExportedMaxGoroutineScan(),
+			Complete: true,
+			Clipped:  true,
+		}))
+	})
+
+	It("retains a complete goroutine set when current identity is unknown", func() {
+		fb.seedRegs(debugger.Registers{SP: 0xdeadbeef})
+
+		snap := debugger.ExportedGoroutineSnapshot(d)
+
+		Expect(observeSnapshot(snap)).To(Equal(snapshotObservation{
+			Goroutines: []int{101, 102, 103},
+			Threads:    2,
+		}))
+	})
+
+	It("does not substitute the first goroutine when current identity is unknown", func() {
+		current := debugger.ExportedCurrentGoroutineFrom(protocol.GoroutineSnapshotPayload{
+			Goroutines: []protocol.Goroutine{{ID: 101}, {ID: 102}},
+		})
+
+		Expect(current).To(Equal(protocol.Goroutine{}))
 	})
 })

--- a/internal/debugger/goroutines_test.go
+++ b/internal/debugger/goroutines_test.go
@@ -117,6 +117,22 @@ func observeSnapshot(snap protocol.GoroutineSnapshotPayload) snapshotObservation
 	}
 }
 
+func expectDegradedSnapshotPreservesBaseline(degraded, recovered protocol.GoroutineSnapshotPayload) {
+	Expect([]snapshotObservation{
+		observeSnapshot(degraded),
+		observeSnapshot(recovered),
+	}).To(Equal([]snapshotObservation{
+		{Goroutines: []int{1}, Selected: 1},
+		{
+			Goroutines: []int{101, 102},
+			Threads:    2,
+			Current:    102,
+			Selected:   102,
+			Exited:     []int{103},
+		},
+	}))
+}
+
 var _ = Describe("goroutine snapshot partial reads", func() {
 	var (
 		fb      *fakeBackend
@@ -159,19 +175,7 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 			degraded := debugger.ExportedGoroutineSnapshot(d)
 			recovered := debugger.ExportedGoroutineSnapshot(d)
 
-			Expect([]snapshotObservation{
-				observeSnapshot(degraded),
-				observeSnapshot(recovered),
-			}).To(Equal([]snapshotObservation{
-				{Goroutines: []int{1}, Selected: 1},
-				{
-					Goroutines: []int{101, 102},
-					Threads:    2,
-					Current:    102,
-					Selected:   102,
-					Exited:     []int{103},
-				},
-			}))
+			expectDegradedSnapshotPreservesBaseline(degraded, recovered)
 		},
 		Entry("when an allgs slot pointer is unreadable", func() uint64 {
 			return allgsArrayAddr + 8
@@ -204,19 +208,7 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 			degraded := debugger.ExportedGoroutineSnapshotQuery(d)
 			recovered := debugger.ExportedGoroutineSnapshot(d)
 
-			Expect([]snapshotObservation{
-				observeSnapshot(degraded),
-				observeSnapshot(recovered),
-			}).To(Equal([]snapshotObservation{
-				{Goroutines: []int{1}, Selected: 1},
-				{
-					Goroutines: []int{101, 102},
-					Threads:    2,
-					Current:    102,
-					Selected:   102,
-					Exited:     []int{103},
-				},
-			}))
+			expectDegradedSnapshotPreservesBaseline(degraded, recovered)
 		},
 		Entry("when allgs is incomplete", func() uint64 {
 			return allgsArrayAddr + 8

--- a/internal/debugger/goroutines_test.go
+++ b/internal/debugger/goroutines_test.go
@@ -1,0 +1,223 @@
+package debugger_test
+
+import (
+	"encoding/binary"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/bingosuite/bingo/internal/debugger"
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+const (
+	allgsArrayAddr = uint64(0x900000)
+	gBaseAddr      = uint64(0x910000)
+	mBaseAddr      = uint64(0xa10000)
+	runtimeStride  = uint64(0x1000)
+)
+
+type goroutineMemoryFixture struct {
+	layout debugger.ExportedGoRuntimeLayout
+	g      []uint64
+	m      []uint64
+}
+
+func seedU32(fb *fakeBackend, addr uint64, value uint32) {
+	var buf [4]byte
+	binary.LittleEndian.PutUint32(buf[:], value)
+	fb.seedMem(addr, buf[:])
+}
+
+func seedU64(fb *fakeBackend, addr, value uint64) {
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], value)
+	fb.seedMem(addr, buf[:])
+}
+
+func seedGoroutineMemory(fb *fakeBackend, d debugger.Debugger) goroutineMemoryFixture {
+	layout := debugger.ExportedGoRuntimeLayoutFor(d)
+	fixture := goroutineMemoryFixture{
+		layout: layout,
+		g: []uint64{
+			gBaseAddr,
+			gBaseAddr + runtimeStride,
+			gBaseAddr + 2*runtimeStride,
+			gBaseAddr + 3*runtimeStride,
+			gBaseAddr + 4*runtimeStride,
+		},
+		m: []uint64{
+			mBaseAddr,
+			mBaseAddr + runtimeStride,
+		},
+	}
+
+	slots := []uint64{
+		fixture.g[0],
+		fixture.g[1],
+		fixture.g[2],
+		0,
+		fixture.g[3],
+		fixture.g[4],
+	}
+	seedU64(fb, layout.Allgs, allgsArrayAddr)
+	seedU64(fb, layout.Allgs+8, uint64(len(slots)))
+	for i, gptr := range slots {
+		seedU64(fb, allgsArrayAddr+uint64(i)*8, gptr)
+	}
+
+	for i := 0; i < 3; i++ {
+		seedU32(fb, fixture.g[i]+layout.GAtomicstatus, 4)
+		seedU64(fb, fixture.g[i]+layout.GGoid, uint64(101+i))
+		seedU64(fb, fixture.g[i]+layout.GStack+layout.StackLo, 0x7000+uint64(i)*0x1000)
+		seedU64(fb, fixture.g[i]+layout.GStack+layout.StackHi, 0x8000+uint64(i)*0x1000)
+	}
+	seedU32(fb, fixture.g[3]+layout.GAtomicstatus, 6)
+	seedU64(fb, fixture.g[3]+layout.GGoid, 104)
+	seedU32(fb, fixture.g[4]+layout.GAtomicstatus, 4)
+	seedU64(fb, fixture.g[4]+layout.GGoid, 0)
+
+	seedU64(fb, layout.Allm, fixture.m[0])
+	seedU64(fb, fixture.m[0]+layout.MProcid, 11)
+	seedU64(fb, fixture.m[0]+layout.MCurg, fixture.g[0])
+	seedU64(fb, fixture.m[0]+layout.MAlllink, fixture.m[1])
+	seedU64(fb, fixture.m[1]+layout.MProcid, 22)
+	seedU64(fb, fixture.m[1]+layout.MCurg, fixture.g[1])
+	seedU64(fb, fixture.m[1]+layout.MAlllink, 0)
+	fb.seedRegs(debugger.Registers{SP: 0x7800})
+
+	return fixture
+}
+
+func goroutineIDs(gs []protocol.Goroutine) []int {
+	ids := make([]int, len(gs))
+	for i, g := range gs {
+		ids[i] = g.ID
+	}
+	return ids
+}
+
+type snapshotObservation struct {
+	Goroutines []int
+	Threads    int
+	Current    int
+	Created    []int
+	Exited     []int
+}
+
+func observeSnapshot(snap protocol.GoroutineSnapshotPayload) snapshotObservation {
+	return snapshotObservation{
+		Goroutines: goroutineIDs(snap.Goroutines),
+		Threads:    len(snap.Threads),
+		Current:    snap.Current,
+		Created:    snap.Created,
+		Exited:     snap.Exited,
+	}
+}
+
+var _ = Describe("goroutine snapshot partial reads", func() {
+	var (
+		fb      *fakeBackend
+		d       debugger.Debugger
+		fixture goroutineMemoryFixture
+	)
+
+	BeforeEach(func() {
+		bin, err := inspectFixture()
+		Expect(err).NotTo(HaveOccurred())
+
+		fb = newFakeBackend()
+		d = debugger.NewWithBackend(fb, nil)
+		debugger.ExportedLoadDWARF(d, bin)
+		debugger.ExportedForceSuspended(d)
+		fixture = seedGoroutineMemory(fb, d)
+
+		baseline := debugger.ExportedGoroutineSnapshot(d)
+		Expect(observeSnapshot(baseline)).To(Equal(snapshotObservation{
+			Goroutines: []int{101, 102, 103},
+			Threads:    2,
+			Current:    101,
+		}))
+	})
+
+	AfterEach(func() {
+		_ = d.Kill()
+		if !fb.stopped {
+			close(fb.stopCh)
+			fb.stopped = true
+		}
+	})
+
+	DescribeTable("degrades the whole snapshot and preserves its lifecycle baseline",
+		func(faultAddr func() uint64) {
+			fb.failNextReadAt(faultAddr())
+
+			degraded := debugger.ExportedGoroutineSnapshot(d)
+			recovered := debugger.ExportedGoroutineSnapshot(d)
+
+			Expect([]snapshotObservation{
+				observeSnapshot(degraded),
+				observeSnapshot(recovered),
+			}).To(Equal([]snapshotObservation{
+				{Goroutines: []int{1}},
+				{Goroutines: []int{101, 102, 103}, Threads: 2, Current: 101},
+			}))
+		},
+		Entry("when an allgs slot pointer is unreadable", func() uint64 {
+			return allgsArrayAddr + 8
+		}),
+		Entry("when a required g status is unreadable", func() uint64 {
+			return fixture.g[1] + fixture.layout.GAtomicstatus
+		}),
+		Entry("when a required g goid is unreadable", func() uint64 {
+			return fixture.g[1] + fixture.layout.GGoid
+		}),
+		Entry("when an allm link is unreadable", func() uint64 {
+			return fixture.m[0] + fixture.layout.MAlllink
+		}),
+	)
+
+	It("keeps nil, dead, and zero-goid entries as intentional filters", func() {
+		seedU32(fb, fixture.g[2]+fixture.layout.GAtomicstatus, 6)
+		dead := debugger.ExportedGoroutineSnapshot(d)
+
+		seedU32(fb, fixture.g[2]+fixture.layout.GAtomicstatus, 4)
+		liveAgain := debugger.ExportedGoroutineSnapshot(d)
+
+		Expect([]snapshotObservation{
+			observeSnapshot(dead),
+			observeSnapshot(liveAgain),
+		}).To(Equal([]snapshotObservation{
+			{Goroutines: []int{101, 102}, Threads: 2, Current: 101, Exited: []int{103}},
+			{Goroutines: []int{101, 102, 103}, Threads: 2, Current: 101, Created: []int{103}},
+		}))
+	})
+
+	DescribeTable("keeps optional metadata reads best-effort",
+		func(faultAddr func() uint64) {
+			fb.failNextReadAt(faultAddr())
+
+			snap := debugger.ExportedGoroutineSnapshot(d)
+
+			Expect(observeSnapshot(snap)).To(Equal(snapshotObservation{
+				Goroutines: []int{101, 102, 103},
+				Threads:    2,
+				Current:    101,
+			}))
+		},
+		Entry("for a goroutine parent", func() uint64 {
+			return fixture.g[1] + fixture.layout.GParentGoid
+		}),
+		Entry("for a thread id", func() uint64 {
+			return fixture.m[0] + fixture.layout.MProcid
+		}),
+	)
+
+	It("degrades an on-demand Goroutines read instead of returning a partial set", func() {
+		fb.failNextReadAt(allgsArrayAddr + 8)
+
+		gs, err := d.Goroutines()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(goroutineIDs(gs)).To(Equal([]int{1}))
+	})
+})


### PR DESCRIPTION
## Summary

- degrade incomplete `allgs`, required `g`, or `allm` walks to the synthetic snapshot instead of publishing a partial live set
- treat unreadable required status/goid/stack bounds and `allgs`/`allm` membership links as incomplete, while preserving intentional nil/dead/freelist filtering
- keep optional metadata best-effort, distinguish `Complete` from `Clipped`, and avoid substituting an unrelated first goroutine when current identity is unknown
- preserve #192 lifecycle ownership: queries always have empty deltas and never advance `prevGoids`; only complete automatic entry/breakpoint/pause snapshots diff and adopt the baseline
- keep incomplete automatic and query snapshots from clearing or adopting the baseline; preserve one runtime build per stop

No wire-protocol or consumer changes are included.

Fixes #216. Relates to #192, #196, and #218.

## Restack

Restacked onto exact `origin/main` `d9693a3843cf1b7def6cdf7af2e0a94c100ff871`:

| Accepted commit | Restacked commit |
| --- | --- |
| `2c0db98` | `f4241aa` |
| `1d06913` | `19ff4eb` |
| `e8f2ea3` | `c7ee95f` |

`git range-diff` preserves the accepted order and one-to-one intent. Stable patch IDs differ because the patches were resolved against newer main changes. Conflict-only adaptations retained main's synchronized/generalized fake-backend fault injection and #192's `buildSnapshot(trackLifecycle)` split. Restack-only commit `4b1ba23` moves lifecycle assembly after both complete runtime walks and adds degraded-query coverage, so the newer query baseline contract remains intact. Test-only commit `3913002` shares the mutation assertion to satisfy Sonar's new-code duplication gate without changing behavior.

## Regression coverage

The fixture uses three live goroutines with the stopped SP inside G102, not the first entry. It injects failures into `allgs` membership, required status/goid/stack bounds, and `allm` head/link reads. Recovery must still report G103 as exited, proving an incomplete snapshot did not mutate the prior complete baseline. Separate cases pin intentional filtering, optional metadata, synthetic on-demand degradation, independent incomplete/clipped states, and unknown-current behavior.

Mutation proofs killed both baseline-corrupting variants:

- clearing `prevGoids` on goroutine degradation: 6 focused failures
- adopting the partial live set on thread degradation: 3 focused failures

## Validation at `391300285ea3fdfa0cb51bbb611ed242db11231d`

- focused tagged race regressions: 19/19
- `go test -tags bingonative -race -count=1 ./internal/debugger`
- `go test -tags bingonative -race -count=1 ./...`
- `go vet -tags bingonative ./...`
- Linux-context `golangci-lint`: 0 issues
- linux/amd64 server, debugger test binary, and `e2e` integration test binary cross-builds
- full codesigned native `just e2e-darwin`: 23/23
- independent code review: no high-confidence findings

All exact-head checks pass: Go build/tests, Linux and Darwin debugger E2E, both full-stack jobs, VS Code packaging, CodeQL, Darwin verification, and SonarCloud (0.0% new duplicated lines).

## Responsibility split with #196

This PR remains the detection/degradation layer. #196 can consume `Complete` and `Clipped` to report degradation and lower-bound totals without changing the correctness of this snapshot reader.