### PR TITLE
fix(debugger): forward linux signals to stopped threads

### DIFF
--- a/.github/workflows/debugger-e2e.yml
+++ b/.github/workflows/debugger-e2e.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Show ptrace policy
         run: cat /proc/sys/kernel/yama/ptrace_scope || true
 
+      - name: E2E stepping-thread SIGURG preservation
+        run: go test -tags e2e -race -count=1 -v -timeout 120s ./internal/debugger -run '^TestLinuxSteppingThreadSIGURGIsForwardedAfterInstructionStep$'
+
       - name: E2E basic (continue + step-over correctness)
         run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=basic
 

--- a/.github/workflows/debugger-e2e.yml
+++ b/.github/workflows/debugger-e2e.yml
@@ -10,7 +10,8 @@ name: Debugger E2E
 # (correctness), `churn` (multi-thread robustness), `pause` (async interrupt /
 # manual stop), `stepping` (StepInto/StepOut), `inspect`
 # (StackFrames/Locals/Goroutines), `breakpoints` (ClearBreakpoint), `kill`
-# (kill-while-running), `exit` (process exit status), `overlap` (linux-only:
+# (kill-while-running), `exit` (process exit status), `signals` (linux signal
+# forwarding plus the shared Pause suppression control), `overlap` (linux-only:
 # a foreign thread's breakpoint stop arriving mid-single-step), `restart`,
 # `fullstack`
 # (operations driven through the whole client → WebSocket → hub → debugger stack),
@@ -102,6 +103,9 @@ jobs:
 
       - name: E2E exit (process exit status)
         run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=exit
+
+      - name: E2E signals (fatal/ordinary forwarding + Pause suppression)
+        run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=signals
 
       - name: E2E attach (attach to a running process)
         run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=attach

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1113,7 +1113,10 @@ stopped TID and the signal argument to the next ptrace resume:
 5. Pause's main-thread `SIGSTOP` is deliberately excluded from current state,
    preserving manual Pause and leftover-interrupt suppression even when the same
    TID has delayed SIGURG. Clone `SIGSTOP`, `SIGCONT`, ptrace events and spurious
-   breakpoint traps remain internal Wait-loop cases with signal zero.
+   breakpoint traps remain internal Wait-loop cases with signal zero. A raw
+   non-main `SIGSTOP` is not proof that its TID is a new clone: when it belongs
+   to the active `stepTID`, Wait preserves that owner's pending state while
+   re-arming `PTRACE_SINGLESTEP(..., 0)`.
 6. Resume takes a per-TID batch transactionally. Successfully requeued backlog
    entries are not restored if a later requeue fails; the unsent suffix and
    current signal are. A failed public exact-TID `PTRACE_CONT` restores the
@@ -1124,10 +1127,12 @@ stopped TID and the signal argument to the next ptrace resume:
    retry and matching standard signals coalesce; if `ESRCH` meant the TID escaped
    that stop, its fresh delivery goes through `set`, which coalesces it against
    the restored backlog. Internal single-steps leave every pending collection
-   intact. Only a path that has conclusively observed thread/image death clears
-   first. Non-main `Exited`, `Signaled`, and `PTRACE_EVENT_EXIT` branches,
-   held-owner release, and clone initial-stop handling clear their TID **before**
-   any resume, while exec, process exit, Kill/detach, and tracer shutdown purge
+   intact. Conclusive retirement paths — non-main `Exited`, `Signaled`, and
+   `PTRACE_EVENT_EXIT` branches plus held-owner release — clear their TID
+   **before** any resume. The branch treating a non-main `SIGSTOP` as a clone
+   initial stop also clears stale reused-TID state unless that TID is the active
+   step owner; the ambiguous owner case must retain its signal across the
+   signal-zero re-arm. Exec, process exit, Kill/detach, and tracer shutdown purge
    all state to prevent TID reuse. The maps are mutex-protected because `Wait`
    publishes from its goroutine while the engine consumes them; unlike
    `stepQueue`, this state crosses goroutines.
@@ -1145,8 +1150,10 @@ parked-stop count increase; signal outputs plus generic parked traps are not
 proof that a signal was held during a step. Backend mutation gates additionally
 pin failed-continue → signal-zero step → distinct same-TID signal, requiring the
 older signal to be requeued to that TID and the fresh signal to be the exact
-`PTRACE_CONT` argument, plus direct cleanup coverage for all three non-leader
-death branches.
+`PTRACE_CONT` argument; an ambiguous non-main `SIGSTOP` on the active step owner
+must likewise preserve the retained signal through its signal-zero re-arm and
+inject it on the next exact-TID continue. Direct cleanup coverage pins all three
+non-leader death branches.
 
 Deferred-signal transactions necessarily recreate delivery with `tgkill`.
 They preserve every distinct signal number, its target TID, and the backlog's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1086,14 +1086,16 @@ stopped TID and the signal argument to the next ptrace resume:
    single-slot value: another stop may move `lastStopTID`, but cannot transfer or
    clear a different TID's signal. Resume removes state transactionally and
    restores it when requeue or ptrace fails.
-2. `ContinueProcess` and `SingleStep(tid)` take only that exact TID's current
-   signal and pass it as ptrace's data argument. Fatal/default and handled
-   ordinary signals therefore leave their actual signal-delivery stop through
-   `PTRACE_CONT`/`PTRACE_SINGLESTEP` with the exact non-zero value.
-3. SIGURG on the exact `stepTID` is different. Injecting it with
-   `PTRACE_SINGLESTEP(SIGURG)` enters the signal frame and reports a trace trap
-   before the instruction the engine promised to step has executed. The #202
-   `resumeAbsorbed` path therefore saves it in `delayedByTID[tid]`, re-arms the
+2. Only `PTRACE_CONT` injects a pending signal. `PTRACE_SINGLESTEP` always uses
+   signal zero and leaves both pending slots intact: injecting any signal while
+   stepping enters its signal frame and reports a trace trap before the
+   instruction the engine promised to step has executed. This state is normally
+   consumed by the automatic continue from `StopSignal`; it remains observable
+   only when that resume fails and the engine suspends through `haltOnError`, in
+   which case later steps must not lose or prematurely inject it. The next
+   exact-TID continue forwards the actual non-zero value.
+3. SIGURG on the exact `stepTID` additionally needs to survive an absorbed stop.
+   The #202 `resumeAbsorbed` path saves it in `delayedByTID[tid]`, re-arms the
    real instruction step with signal zero, and retains the delayed value through
    further steps. The next continue uses exact-TID `tgkill(SIGURG)` followed by
    `PTRACE_CONT(..., 0)`; only the resulting fresh signal-delivery stop resumes
@@ -1301,10 +1303,11 @@ are detected by a `mach_msg` receive loop.
   `waitLoop` → `stopCh` → engine-loop handoff. Regression coverage is
   `TestLinuxBackend*StopTID*`, run under `-race` in the unit-test workflow.
   Non-main thread exits are absorbed inside `Wait`.
-- User-visible signal stops carry per-TID pending delivery state. `ContinueProcess`
-  and `SingleStep` inject only the signal owned by the exact resumed TID; a
-  parked stop does not install that state until delivery. Pause `SIGSTOP` is
-  excluded and all teardown paths purge it. See
+- User-visible signal stops carry per-TID pending delivery state.
+  `ContinueProcess` injects only the signal owned by the exact resumed TID;
+  `SingleStep` always uses signal zero and preserves that state for a later
+  continue. A parked stop does not install pending state until delivery. Pause
+  `SIGSTOP` is excluded and all teardown paths purge it. See
   [Linux signal forwarding](#linux-signal-forwarding).
 - `ReadMemory` uses **`process_vm_readv(2)`** as the fast path, falling back to
   `PTRACE_PEEKDATA` only when it is unavailable or short-reads. `process_vm_readv`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1095,12 +1095,13 @@ stopped TID and the signal argument to the next ptrace resume:
    which case later steps must not lose or prematurely inject it. The next
    exact-TID continue forwards the actual non-zero value.
 3. SIGURG on the exact `stepTID` additionally needs to survive an absorbed stop.
-   The #202 `resumeAbsorbed` path saves it in `delayedByTID[tid]`, re-arms the
+   The #202 `applyAbsorb` path saves it in `delayedByTID[tid]`, re-arms the
    real instruction step with signal zero, and retains the delayed value through
    further steps. The next continue uses exact-TID `tgkill(SIGURG)` followed by
    `PTRACE_CONT(..., 0)`; only the resulting fresh signal-delivery stop resumes
    with `PTRACE_CONT(..., SIGURG)`. A simultaneous current signal has priority
-   while the delayed SIGURG is requeued, and matching SIGURG instances coalesce.
+   while the delayed SIGURG is requeued, matching SIGURG instances coalesce, and
+   the first delayed signal wins until it has been requeued.
 4. The parked-stop FIFO from #202 retains the signal inside the `StopEvent`.
    Parking never touches pending state. `drainParked` performs the same
    signal-before-TID delivery handoff as a live `Wait` result.
@@ -1109,12 +1110,14 @@ stopped TID and the signal argument to the next ptrace resume:
    TID has delayed SIGURG. Clone `SIGSTOP`, `SIGCONT`, ptrace events and spurious
    breakpoint traps remain internal Wait-loop cases with signal zero.
 6. Internal continues clear current state only for their own TID and preserve or
-   requeue delayed state; internal single-steps suppress current state but retain
-   delayed SIGURG. A non-main thread's death clears both slots **before** any
-   exit-stop continue, while exec, process exit, Kill/detach and tracer shutdown
-   purge all state to prevent TID reuse. The maps are mutex-protected because
-   `Wait` publishes from its goroutine while the engine consumes them; unlike
-   `stepQueue`, this state crosses goroutines.
+   requeue delayed state; internal single-steps leave both slots intact. A failed
+   exact-TID continue restores the captured current signal even for `ESRCH`;
+   only a path that has conclusively observed thread/image death clears first.
+   Non-main thread exit, held-owner release and clone initial-stop handling clear
+   their TID **before** any resume, while exec, process exit, Kill/detach and
+   tracer shutdown purge all state to prevent TID reuse. The maps are
+   mutex-protected because `Wait` publishes from its goroutine while the engine
+   consumes them; unlike `stepQueue`, this state crosses goroutines.
 
 The host-agnostic map tests, linux backend raw ptrace-tuple tests, the `signals`
 E2E label (one SIGSEGV/SIGABRT output followed by signal death, one handled
@@ -1127,6 +1130,12 @@ discriminator pins two one-byte instruction advances, exact
 return, and post-handler exit. The overlap spec must observe a signal-specific
 parked-stop count increase; signal outputs plus generic parked traps are not
 proof that a signal was held during a step.
+
+The delayed-SIGURG transaction necessarily recreates delivery with `tgkill`.
+It preserves the exact signal number and target TID, but not the original
+`siginfo_t` or ordering relative to signals that arrive during the re-step.
+Preserving those details requires the broader wait-ownership work, not a
+process-global pending-signal scalar in this layer.
 
 **Composition constraint for #205:** a future process-wide wait broker may own
 the raw `wait4`, but it must route the complete `(TID, signal)` status to the
@@ -1360,7 +1369,7 @@ are detected by a `mach_msg` receive loop.
   launch→run→Kill cycle (`BINGO_E2E_KILL_ITERS`).
 - `SIGURG` re-delivery is mandatory here too. A sibling SIGURG is re-delivered
   immediately on that sibling's continue. A SIGURG on `stepTID` consumes the
-  outstanding step, so `resumeAbsorbed` reissues the instruction step with zero
+  outstanding step, so `applyAbsorb` reissues the instruction step with zero
   and saves SIGURG per TID; the next continue requeues it to that TID and forwards
   it only from the fresh signal-delivery stop. Never use
   `PTRACE_SINGLESTEP(SIGURG)` or inject delayed SIGURG directly from the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -486,14 +486,14 @@ state after such a write is a separate problem — do not add disabled-breakpoin
 protocol/state here.
 
 Note also that this rule covers the *reporting* of halts, not every internal
-resume: five `handleStop` paths still ignore `ContinueProcess`'s error (the
-spurious-trap advance, `bpResumeContinue`, the successful `StepOut`
-continuation, the leftover-pause-signal suppression, and the ordinary-signal
-auto-resume). If one of those ever fails, the engine records `stateRunning` for
-a tracee that never resumed and no event is emitted at all — the same class of
-liveness loss from the other direction. None has a confirmed backend
-reachability, so none is fixed or filed yet; **do not treat this class as
-globally closed.**
+resume: the spurious-trap advance still ignores `ContinueProcess`'s error. If it
+fails, the engine records `stateRunning` for a tracee that never resumed and no
+event is emitted at all — the same class of liveness loss from the other
+direction. It has no confirmed backend reachability, so **do not treat this
+class as globally closed.** Every resume that can consume or requeue delayed
+SIGURG does check the error: post-breakpoint Continue/StepOver/StepOut,
+ordinary-signal auto-resume, and stale-Pause suppression all report
+`EventError` followed by suspending `EventPaused`.
 
 The sites are `populateBreakpointStop` and retired-sentinel verification/
 recovery failure (`StopBreakpoint`),
@@ -675,19 +675,13 @@ acknowledgement in rule 5 (see the locking note below):
    `bpResumeStep` whose instruction is itself the `clone` reports an
    `EventStepped` PC one instruction beyond single-step semantics. That is a
    real, very narrow inaccuracy rather than a purely cosmetic one — accepted
-   because the alternative it replaces is a hard freeze. And the absorbed
-   signal is swallowed on that thread: `stepQueue.planAbsorb` chooses the
-   primitive and the delivered signal together, forwarding the signal on the
-   continue path and zeroing it on the re-arm. `PTRACE_SINGLESTEP` with a signal
-   makes the kernel build the signal frame first, so the instruction that
-   executes is the handler's, not the one under the step — the engine would then
-   reinstall the trap over an instruction that never ran and re-report the same
-   breakpoint when the handler returns. `SIGURG` is the **only** signal any
-   absorb site passes (every other passes 0), this is exactly what the pre-park
-   `SIGURG` branch already did, and the runtime sets the goroutine's preempt flag
-   before signalling, so a dropped delivery costs preemption latency and nothing
-   else. Forwarding a signal *through* a re-armed step is a per-TID
-   signal-forwarding question, not a park-queue one, and is out of scope here.
+   because the alternative it replaces is a hard    freeze. A signal-delivery stop happens before the interrupted instruction, so
+   re-arming there executes the promised instruction exactly. `PTRACE_SINGLESTEP`
+   always uses signal 0: injecting a signal would enter the handler frame before
+   executing the instruction the engine is stepping. SIGURG is instead retained
+   per TID through the re-step, requeued to that exact TID, and forwarded only
+   from the resulting fresh signal-delivery stop; see
+   [Linux signal forwarding](#linux-signal-forwarding).
 
    The decision is pure and table-tested, but a branch choosing to consult it is
    not, and that gap was real rather than theoretical: with a live tracee as the
@@ -1087,32 +1081,50 @@ delivery, so a synchronous fault immediately refaults and fatal signals never
 terminate (issue #206). The backend owns the fix because only it knows both the
 stopped TID and the signal argument to the next ptrace resume:
 
-1. A surfaced `StopSignal` is recorded in `pendingSignals[tid]` **before**
-   `lastStopTID` publishes that TID. A pending signal is never a process-wide or
+1. A surfaced `StopSignal` is recorded in `currentByTID[tid]` **before**
+   `lastStopTID` publishes that TID. A pending signal is never process-wide or a
    single-slot value: another stop may move `lastStopTID`, but cannot transfer or
-   clear a different TID's signal.
-2. `ContinueProcess` and `SingleStep(tid)` atomically take only that exact TID's
-   signal and pass it as ptrace's data argument. Taking is one-shot even when the
-   ptrace call fails, so a stale signal cannot be injected by a later retry.
-3. The parked-stop FIFO from #202 retains the signal inside the `StopEvent`.
+   clear a different TID's signal. Resume removes state transactionally and
+   restores it when requeue or ptrace fails.
+2. `ContinueProcess` and `SingleStep(tid)` take only that exact TID's current
+   signal and pass it as ptrace's data argument. Fatal/default and handled
+   ordinary signals therefore leave their actual signal-delivery stop through
+   `PTRACE_CONT`/`PTRACE_SINGLESTEP` with the exact non-zero value.
+3. SIGURG on the exact `stepTID` is different. Injecting it with
+   `PTRACE_SINGLESTEP(SIGURG)` enters the signal frame and reports a trace trap
+   before the instruction the engine promised to step has executed. The #202
+   `resumeAbsorbed` path therefore saves it in `delayedByTID[tid]`, re-arms the
+   real instruction step with signal zero, and retains the delayed value through
+   further steps. The next continue uses exact-TID `tgkill(SIGURG)` followed by
+   `PTRACE_CONT(..., 0)`; only the resulting fresh signal-delivery stop resumes
+   with `PTRACE_CONT(..., SIGURG)`. A simultaneous current signal has priority
+   while the delayed SIGURG is requeued, and matching SIGURG instances coalesce.
+4. The parked-stop FIFO from #202 retains the signal inside the `StopEvent`.
    Parking never touches pending state. `drainParked` performs the same
    signal-before-TID delivery handoff as a live `Wait` result.
-4. Pause's main-thread `SIGSTOP` is deliberately excluded from pending state,
-   preserving manual Pause and leftover-interrupt suppression. Clone `SIGSTOP`,
-   `SIGURG`, `SIGCONT`, ptrace events and spurious breakpoint traps remain
-   internal Wait-loop cases with their existing explicit resume signal.
-5. Every internal continue/single-step clears pending state only for its own TID;
-   process exit, Kill/detach and tracer shutdown purge all of it. The map is
-   mutex-protected because `Wait` publishes from its goroutine while the engine
-   consumes it; unlike `stepQueue`, this state crosses goroutines.
+5. Pause's main-thread `SIGSTOP` is deliberately excluded from current state,
+   preserving manual Pause and leftover-interrupt suppression even when the same
+   TID has delayed SIGURG. Clone `SIGSTOP`, `SIGCONT`, ptrace events and spurious
+   breakpoint traps remain internal Wait-loop cases with signal zero.
+6. Internal continues clear current state only for their own TID and preserve or
+   requeue delayed state; internal single-steps suppress current state but retain
+   delayed SIGURG. A non-main thread's death clears both slots **before** any
+   exit-stop continue, while exec, process exit, Kill/detach and tracer shutdown
+   purge all state to prevent TID reuse. The maps are mutex-protected because
+   `Wait` publishes from its goroutine while the engine consumes them; unlike
+   `stepQueue`, this state crosses goroutines.
 
 The host-agnostic map tests, linux backend raw ptrace-tuple tests, the `signals`
 E2E label (one SIGSEGV/SIGABRT output followed by signal death, one handled
 thread-directed ordinary signal with post-delivery sibling progress, and Pause
-suppression), and the foreign-signal `overlap` spec are the regression gates.
-The overlap spec must observe a signal-specific parked-stop count increase;
-signal outputs plus generic parked traps are not proof that a signal was held
-during a step.
+suppression), the handler-returning stepping-thread SIGURG discriminator in
+[sigurg_step_e2e_linux_amd64_test.go](internal/debugger/sigurg_step_e2e_linux_amd64_test.go),
+and the foreign-signal `overlap` spec are the regression gates. The focused
+discriminator pins two one-byte instruction advances, exact
+`tgkill → PTRACE_CONT(0) → fresh stop → PTRACE_CONT(SIGURG)` tuples, handler
+return, and post-handler exit. The overlap spec must observe a signal-specific
+parked-stop count increase; signal outputs plus generic parked traps are not
+proof that a signal was held during a step.
 
 **Composition constraint for #205:** a future process-wide wait broker may own
 the raw `wait4`, but it must route the complete `(TID, signal)` status to the
@@ -1343,9 +1355,13 @@ are detected by a `mach_msg` receive loop.
   on a Mach port, not `wait4`, so its `killProcess` `Wait4(pid)` is always the
   sole reaper and ignores `running`.) Regression guard: the `kill` e2e loops the
   launch→run→Kill cycle (`BINGO_E2E_KILL_ITERS`).
-- `SIGURG` re-delivery is mandatory here too — but only the `stepTID` thread is
-  re-single-stepped on SIGURG; a SIGURG on any other thread is re-delivered and
-  that thread continued.
+- `SIGURG` re-delivery is mandatory here too. A sibling SIGURG is re-delivered
+  immediately on that sibling's continue. A SIGURG on `stepTID` consumes the
+  outstanding step, so `resumeAbsorbed` reissues the instruction step with zero
+  and saves SIGURG per TID; the next continue requeues it to that TID and forwards
+  it only from the fresh signal-delivery stop. Never use
+  `PTRACE_SINGLESTEP(SIGURG)` or inject delayed SIGURG directly from the
+  single-step SIGTRAP stop.
 
 ## DWARF reader notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -579,15 +579,15 @@ acknowledgement in rule 5 (see the locking note below):
    `stepping`. This is what guarantees a same-address sibling is delivered only
    after the reinstall, so it resolves to a real breakpoint rather than the
    spurious-trap path.
-4. **`recordStop` runs on delivery only.** Never at park time — moving the resume
+4. **Current-stop state is installed on delivery only.** Never at park time —
+   moving the resume
    target to a thread the engine is not working on is precisely the corruption
    being fixed. The same rule covers the stop's **signal**, which is why the
    queue holds whole `StopEvent`s: the signal is a field of the parked event,
-   not backend state, so it cannot be observed against a thread other than its
-   own and there is no separate signal record to keep in step with `recordStop`
-   (the ordering hazard issue #204 raises for pending signals). Do not hoist the
-   signal — or any other per-stop datum — into `linuxBackend`; that would
-   reintroduce exactly that ordering obligation.
+   not current backend state. `drainParked` moves it into the per-TID pending
+   signal map only when the event is released, immediately before publishing
+   `lastStopTID`; recording it at park time would let another stop consume it
+   against the wrong thread (issue #206).
 5. **A dead stepped thread closes through an internal reconciliation boundary.**
    `interruptStepIfStepped` clears hardware ownership (`stepping`/`stepTID`) when
    the exact stepped TID exits, because its completion can never arrive, but it
@@ -627,7 +627,7 @@ acknowledgement in rule 5 (see the locking note below):
    ptrace op. `ESRCH`/`ENOENT` is benign — the anchor was mid-exit and simply
    finished dying, which is what the release asked for. Any other failure leaves
    the hold in place **and the gate closed**, and the engine halts suspended
-   (`Error → Paused`, no new `waitLoop`) rather than resuming past a thread
+   (   `Error → Paused`, no new `waitLoop`) rather than resuming past a thread
    nothing will ever deliver. `ContinueProcess`/`SingleStep` already refuse while
    `stepExitPending`, so both halt paths make Kill/Restart the only recovery.
    No path leaks a held owner: it is discharged on a successful acknowledgement,
@@ -926,7 +926,7 @@ distinguish safe recovery from the mid-instruction path.
   `wait4` frame survives in the timeout dump. Fixing it belongs with #205/#217,
   not here.
 
-**No lock, and none is needed.** `parked` is touched only inside `Wait`.
+**No lock on the queue, and none is needed.** `parked` is touched only inside `Wait`.
 Successive `Wait` calls run on different one-shot `waitLoop` goroutines that the
 engine starts with `go e.waitLoop()` **after** consuming the previous `Wait`'s
 result from `stopCh`, so no two ever overlap; that channel-and-goroutine-start
@@ -934,7 +934,9 @@ chain is also what orders the `stepping`/`stepTID` writes the engine makes in
 between (`SingleStep` sets them, `ContinueProcess` clears them) and the
 `completeStepThreadExit` acknowledgement against the next `Wait`'s reads.
 Only the cumulative diagnostic counters are atomic because native tests read
-them concurrently; do not add a queue mutex.
+them concurrently; do not add a queue mutex. This no-lock rule applies only to
+`stepQueue`: pending signals cross from `Wait` to the engine loop and therefore
+have their own mutex.
 
 Regression gates: the classifier table, the queue-mechanics tests **and** the
 resume-decision tests covering rules 7–11 in
@@ -1072,6 +1074,48 @@ so the held-interrupt assertion is the spec's own flake risk — at 40 cycles it
 would fail spuriously ~0.9^40 ≈ 1.5% of the time. 70 takes that to ~0.06% and
 still costs only ~88s at the slowest per-cycle rate yet observed. Lowering it
 re-introduces the flake; raising it much further runs into the watchdog.
+
+## Linux signal forwarding
+
+Source: [pending_signal.go](internal/debugger/pending_signal.go) plus the
+delivery and resume wiring in
+[backend_linux_amd64.go](internal/debugger/backend_linux_amd64.go).
+
+Linux ptrace reports an ordinary or fatal signal as a signal-delivery stop. The
+engine emits one `EventOutput` and resumes; resuming with signal `0` suppresses
+delivery, so a synchronous fault immediately refaults and fatal signals never
+terminate (issue #206). The backend owns the fix because only it knows both the
+stopped TID and the signal argument to the next ptrace resume:
+
+1. A surfaced `StopSignal` is recorded in `pendingSignals[tid]` **before**
+   `lastStopTID` publishes that TID. A pending signal is never a process-wide or
+   single-slot value: another stop may move `lastStopTID`, but cannot transfer or
+   clear a different TID's signal.
+2. `ContinueProcess` and `SingleStep(tid)` atomically take only that exact TID's
+   signal and pass it as ptrace's data argument. Taking is one-shot even when the
+   ptrace call fails, so a stale signal cannot be injected by a later retry.
+3. The parked-stop FIFO from #202 retains the signal inside the `StopEvent`.
+   Parking never touches pending state. `drainParked` performs the same
+   signal-before-TID delivery handoff as a live `Wait` result.
+4. Pause's main-thread `SIGSTOP` is deliberately excluded from pending state,
+   preserving manual Pause and leftover-interrupt suppression. Clone `SIGSTOP`,
+   `SIGURG`, `SIGCONT`, ptrace events and spurious breakpoint traps remain
+   internal Wait-loop cases with their existing explicit resume signal.
+5. Every internal continue/single-step clears pending state only for its own TID;
+   process exit, Kill/detach and tracer shutdown purge all of it. The map is
+   mutex-protected because `Wait` publishes from its goroutine while the engine
+   consumes it; unlike `stepQueue`, this state crosses goroutines.
+
+The host-agnostic map tests, linux backend resume-argument tests, the `signals`
+E2E label (one SIGSEGV/SIGABRT output followed by signal death, one handled
+thread-directed ordinary signal with sibling progress, and Pause suppression),
+and the foreign-signal `overlap` spec are the regression gates.
+
+**Composition constraint for #205:** a future process-wide wait broker may own
+the raw `wait4`, but it must route the complete `(TID, signal)` status to the
+owning session/backend and preserve FIFO order. Pending signal state stays
+per-session and per-TID; it must not move into one process-global broker slot or
+be installed before the owning backend actually delivers the stop.
 
 ## Architecture-specific traps
 
@@ -1242,6 +1286,11 @@ are detected by a `mach_msg` receive loop.
   `waitLoop` → `stopCh` → engine-loop handoff. Regression coverage is
   `TestLinuxBackend*StopTID*`, run under `-race` in the unit-test workflow.
   Non-main thread exits are absorbed inside `Wait`.
+- User-visible signal stops carry per-TID pending delivery state. `ContinueProcess`
+  and `SingleStep` inject only the signal owned by the exact resumed TID; a
+  parked stop does not install that state until delivery. Pause `SIGSTOP` is
+  excluded and all teardown paths purge it. See
+  [Linux signal forwarding](#linux-signal-forwarding).
 - `ReadMemory` uses **`process_vm_readv(2)`** as the fast path, falling back to
   `PTRACE_PEEKDATA` only when it is unavailable or short-reads. `process_vm_readv`
   bulk-copies the whole buffer in one syscall and — unlike ptrace ops — is NOT
@@ -2492,7 +2541,8 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   (StackFrames chain + Locals + Goroutines at a breakpoint), `breakpoints`
   (a cleared breakpoint stops firing), `kill` (Kill terminates a
   freely-running tracee), `exit` (EventProcessExited reports the tracee's real
-  exit code), `overlap` (linux-only: a foreign thread's breakpoint stop
+  exit code), `signals` (linux-only: fatal and ordinary signal forwarding plus
+  the shared Pause-suppression control), `overlap` (linux-only: a foreign thread's breakpoint stop
   surfacing while another thread single-steps off a software breakpoint —
   issue #199), `attach` (attach by PID to an already-running tracee — one the
   debugger did not launch — then breakpoint it), `concurrency` (the
@@ -2523,12 +2573,12 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   breakpoint stops (reads the `debugger.DarwinTaskPortSendRefs` hook), a check
   meaningless on the ptrace backend.
 
-  **Platform scoping — both containers run the full set.** The darwin container
-  wires the same specs as linux: `basic`, `stepping`, `breakpoints`, `churn`,
+  **Platform scoping — both containers run the shared set.** The darwin container
+  wires the same shared specs as linux: `basic`, `stepping`, `breakpoints`, `churn`,
   `kill`, `exit`, `attach`, `concurrency`, `pause`, `inspect`, `restart`,
-  `fullstack`, and `dap`,
-  plus the
-  darwin-only `hygiene` (Mach exception port-right leak regression). This was NOT
+  `fullstack`, and `dap`. Linux additionally runs `signals` and `overlap`;
+  darwin additionally runs the
+  `hygiene` Mach exception port-right leak regression. This was NOT
   always so:
   under the old darwin wait4/ptrace model the step-off-an-armed-trap specs
   (`basic`, `stepping`, `breakpoints`, `churn`) and `kill` (kill-while-running)
@@ -2831,6 +2881,8 @@ just e2e-darwin                            # native darwin/arm64 Mach-exception 
 # Filter to one label, e.g. only the correctness gate (package path must come
 # before the -ginkgo.* flag so `go test` doesn't mistake it for the package):
 go test -tags e2e -race ./test/integration -ginkgo.label-filter=basic
+# Linux signal delivery and its Pause suppression control:
+go test -tags e2e -race ./test/integration -ginkgo.label-filter=signals
 # The full-stack spec exercises client → WebSocket → hub → debugger → tracee:
 go test -tags e2e -race ./test/integration -ginkgo.label-filter=fullstack
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1106,10 +1106,13 @@ stopped TID and the signal argument to the next ptrace resume:
    mutex-protected because `Wait` publishes from its goroutine while the engine
    consumes it; unlike `stepQueue`, this state crosses goroutines.
 
-The host-agnostic map tests, linux backend resume-argument tests, the `signals`
+The host-agnostic map tests, linux backend raw ptrace-tuple tests, the `signals`
 E2E label (one SIGSEGV/SIGABRT output followed by signal death, one handled
-thread-directed ordinary signal with sibling progress, and Pause suppression),
-and the foreign-signal `overlap` spec are the regression gates.
+thread-directed ordinary signal with post-delivery sibling progress, and Pause
+suppression), and the foreign-signal `overlap` spec are the regression gates.
+The overlap spec must observe a signal-specific parked-stop count increase;
+signal outputs plus generic parked traps are not proof that a signal was held
+during a step.
 
 **Composition constraint for #205:** a future process-wide wait broker may own
 the raw `wait4`, but it must route the complete `(TID, signal)` status to the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1082,12 +1082,16 @@ terminate (issue #206). The backend owns the fix because only it knows both the
 stopped TID and the signal argument to the next ptrace resume:
 
 1. A surfaced `StopSignal` is recorded in `currentByTID[tid]` **before**
-   `lastStopTID` publishes that TID. A pending signal is never process-wide or a
-   single-slot value: another stop may move `lastStopTID`, but cannot transfer or
-   clear a different TID's signal. Resume removes state transactionally and
-   restores it when requeue or ptrace fails.
+   `lastStopTID` publishes that TID. If a distinct signal for that TID arrives
+   while an older current signal is retained across a failed continue or a
+   signal-zero step, the older signal moves to `backlogByTID[tid]` instead of
+   being overwritten; matching standard signals coalesce. The newest delivered
+   stop stays current because it is the signal the exact next `PTRACE_CONT` must
+   inject, while the displaced signals are requeued to that TID in capture order.
+   Pending state is never process-wide: another stop may move `lastStopTID`, but
+   cannot transfer or clear a different TID's signals.
 2. Only `PTRACE_CONT` injects a pending signal. `PTRACE_SINGLESTEP` always uses
-   signal zero and leaves both pending slots intact: injecting any signal while
+   signal zero and leaves all pending state intact: injecting any signal while
    stepping enters its signal frame and reports a trace trap before the
    instruction the engine promised to step has executed. This state is normally
    consumed by the automatic continue from `StopSignal`; it remains observable
@@ -1100,8 +1104,9 @@ stopped TID and the signal argument to the next ptrace resume:
    further steps. The next continue uses exact-TID `tgkill(SIGURG)` followed by
    `PTRACE_CONT(..., 0)`; only the resulting fresh signal-delivery stop resumes
    with `PTRACE_CONT(..., SIGURG)`. A simultaneous current signal has priority
-   while the delayed SIGURG is requeued, matching SIGURG instances coalesce, and
-   the first delayed signal wins until it has been requeued.
+   while the displaced-signal backlog and delayed SIGURG are requeued, matching
+   instances coalesce, and the first delayed signal wins until it has been
+   requeued.
 4. The parked-stop FIFO from #202 retains the signal inside the `StopEvent`.
    Parking never touches pending state. `drainParked` performs the same
    signal-before-TID delivery handoff as a live `Wait` result.
@@ -1109,15 +1114,23 @@ stopped TID and the signal argument to the next ptrace resume:
    preserving manual Pause and leftover-interrupt suppression even when the same
    TID has delayed SIGURG. Clone `SIGSTOP`, `SIGCONT`, ptrace events and spurious
    breakpoint traps remain internal Wait-loop cases with signal zero.
-6. Internal continues clear current state only for their own TID and preserve or
-   requeue delayed state; internal single-steps leave both slots intact. A failed
-   exact-TID continue restores the captured current signal even for `ESRCH`;
-   only a path that has conclusively observed thread/image death clears first.
-   Non-main thread exit, held-owner release and clone initial-stop handling clear
-   their TID **before** any resume, while exec, process exit, Kill/detach and
-   tracer shutdown purge all state to prevent TID reuse. The maps are
-   mutex-protected because `Wait` publishes from its goroutine while the engine
-   consumes them; unlike `stepQueue`, this state crosses goroutines.
+6. Resume takes a per-TID batch transactionally. Successfully requeued backlog
+   entries are not restored if a later requeue fails; the unsent suffix and
+   current signal are. A failed public exact-TID `PTRACE_CONT` restores the
+   current signal even for `ESRCH`, while already-requeued entries stay owned by
+   the kernel. Internal continue retains the established conservative rollback:
+   on ptrace failure it restores the whole captured batch because retirement has
+   not been established. A stopped TID cannot deliver the first requeue before
+   retry and matching standard signals coalesce; if `ESRCH` meant the TID escaped
+   that stop, its fresh delivery goes through `set`, which coalesces it against
+   the restored backlog. Internal single-steps leave every pending collection
+   intact. Only a path that has conclusively observed thread/image death clears
+   first. Non-main `Exited`, `Signaled`, and `PTRACE_EVENT_EXIT` branches,
+   held-owner release, and clone initial-stop handling clear their TID **before**
+   any resume, while exec, process exit, Kill/detach, and tracer shutdown purge
+   all state to prevent TID reuse. The maps are mutex-protected because `Wait`
+   publishes from its goroutine while the engine consumes them; unlike
+   `stepQueue`, this state crosses goroutines.
 
 The host-agnostic map tests, linux backend raw ptrace-tuple tests, the `signals`
 E2E label (one SIGSEGV/SIGABRT output followed by signal death, one handled
@@ -1129,13 +1142,19 @@ discriminator pins two one-byte instruction advances, exact
 `tgkill → PTRACE_CONT(0) → fresh stop → PTRACE_CONT(SIGURG)` tuples, handler
 return, and post-handler exit. The overlap spec must observe a signal-specific
 parked-stop count increase; signal outputs plus generic parked traps are not
-proof that a signal was held during a step.
+proof that a signal was held during a step. Backend mutation gates additionally
+pin failed-continue → signal-zero step → distinct same-TID signal, requiring the
+older signal to be requeued to that TID and the fresh signal to be the exact
+`PTRACE_CONT` argument, plus direct cleanup coverage for all three non-leader
+death branches.
 
-The delayed-SIGURG transaction necessarily recreates delivery with `tgkill`.
-It preserves the exact signal number and target TID, but not the original
-`siginfo_t` or ordering relative to signals that arrive during the re-step.
-Preserving those details requires the broader wait-ownership work, not a
-process-global pending-signal scalar in this layer.
+Deferred-signal transactions necessarily recreate delivery with `tgkill`.
+They preserve every distinct signal number, its target TID, and the backlog's
+requeue-attempt order, but not the original `siginfo_t`; once multiple standard
+signals are kernel-pending, Linux chooses their delivery order, and signals that
+arrive concurrently during requeue or the re-step may interleave. Preserving
+that provenance and delivery ordering requires the broader wait-ownership work,
+not a process-global pending-signal scalar in this layer.
 
 **Composition constraint for #205:** a future process-wide wait broker may own
 the raw `wait4`, but it must route the complete `(TID, signal)` status to the

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -441,16 +441,16 @@ func (b *linuxBackend) ContinueProcess() error {
 	}
 	b.endStep()
 	tid := b.traceTID()
-	signal, delayed := b.pendingSignals.takeForContinue(tid)
-	if err := b.requeueSignal(tid, delayed); err != nil {
-		b.pendingSignals.restore(tid, signal, delayed)
+	pending := b.pendingSignals.takeForContinue(tid)
+	requeued, err := b.requeueSignals(tid, pending.deferred)
+	if err != nil {
+		b.pendingSignals.restore(tid, pending.withoutDeferredPrefix(requeued))
 		return err
 	}
-	var err error
-	b.execPtrace(func() { err = b.ptraceCont(tid, signal) })
+	b.execPtrace(func() { err = b.ptraceCont(tid, pending.current) })
 	if err != nil {
-		b.pendingSignals.restore(tid, signal, 0)
-		return fmt.Errorf("PTRACE_CONT tid %d signal %d: %w", tid, signal, err)
+		b.pendingSignals.restore(tid, pendingSignalBatch{current: pending.current})
+		return fmt.Errorf("PTRACE_CONT tid %d signal %d: %w", tid, pending.current, err)
 	}
 	return nil
 }
@@ -936,19 +936,24 @@ func (b *linuxBackend) continueIfTraceeExists(tid int, signal int) error {
 	if tid == 0 {
 		return nil
 	}
-	current, resumeSignal, delayed := b.pendingSignals.takeForExplicitResume(tid, signal)
-	if err := b.requeueSignal(tid, delayed); err != nil {
-		b.pendingSignals.restore(tid, current, delayed)
+	pending, resumeSignal := b.pendingSignals.takeForExplicitResume(tid, signal)
+	requeued, err := b.requeueSignals(tid, pending.deferred)
+	if err != nil {
+		b.pendingSignals.restore(tid, pending.withoutDeferredPrefix(requeued))
 		return err
 	}
-	var err error
 	if b.contFn != nil {
 		err = b.contFn(tid, resumeSignal)
 	} else {
 		b.execPtrace(func() { err = b.ptraceCont(tid, resumeSignal) })
 	}
 	if err != nil {
-		b.pendingSignals.restore(tid, current, delayed)
+		// A failed internal resume does not prove retirement. The TID remains
+		// ptrace-stopped, so successfully requeued standard signals cannot be
+		// delivered before a retry and matching tgkill calls coalesce; if ESRCH
+		// instead meant it escaped the stop, set coalesces the fresh delivery
+		// against the restored batch.
+		b.pendingSignals.restore(tid, pending)
 		if !isNoSuchProcess(err) {
 			return err
 		}
@@ -1009,6 +1014,15 @@ func (b *linuxBackend) applyAbsorb(plan absorbPlan, tid int) error {
 		return b.singleStepIfTraceeExists(tid)
 	}
 	return b.continueIfTraceeExists(tid, plan.signal)
+}
+
+func (b *linuxBackend) requeueSignals(tid int, signals []int) (int, error) {
+	for i, signal := range signals {
+		if err := b.requeueSignal(tid, signal); err != nil {
+			return i, err
+		}
+	}
+	return len(signals), nil
 }
 
 func (b *linuxBackend) requeueSignal(tid, signal int) error {

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -137,10 +137,16 @@ type linuxBackend struct {
 	// back into a bare PTRACE_CONT passed the entire unit suite. Scripting the
 	// wait statuses is what makes those branches executable, so the mutation
 	// fails a test instead of shipping a freeze.
-	waitFn     func(ws *syscall.WaitStatus) (int, error)
-	contFn     func(tid int, signal int) error
-	stepFn     func(tid int) error
-	eventMsgFn func(tid int) (uint, error)
+	waitFn         func(ws *syscall.WaitStatus) (int, error)
+	contFn         func(tid int, signal int) error
+	stepFn         func(tid int) error
+	eventMsgFn     func(tid int) (uint, error)
+	pendingSignals pendingSignals
+
+	// Nil in production; tests inject these to pin the exact TID/signal pair
+	// passed to ptrace without launching a tracee.
+	ptraceContFn       func(tid, signal int) error
+	ptraceSingleStepFn func(tid, signal int) error
 }
 
 // eventMsg reads the message the kernel attached to a PTRACE_EVENT stop: the
@@ -166,8 +172,8 @@ func (b *linuxBackend) waitAny(ws *syscall.WaitStatus) (int, error) {
 	return syscall.Wait4(-1, ws, syscall.WALL, nil)
 }
 
-// drainParked returns the next held stop if one may be surfaced now, recording
-// it as the current stop.
+// drainParked returns the next held stop if one may be surfaced now, installing
+// its current-TID and pending-signal state together.
 //
 // lastStopTID is updated here, on delivery, and never at park time — from this
 // point the delivered thread is the one the engine acts on, and the one the
@@ -177,7 +183,7 @@ func (b *linuxBackend) drainParked() (StopEvent, bool) {
 	if !ok {
 		return StopEvent{}, false
 	}
-	b.recordStop(ev.TID)
+	b.recordDeliveredStop(ev)
 	return ev, true
 }
 
@@ -266,7 +272,10 @@ func (b *linuxBackend) leaderExitPendingForTest() bool { return b.leaderExitStas
 
 // closeTracer releases the dedicated tracer thread. The engine calls this after
 // its loop exits (process gone), when no further ptrace ops can be issued.
-func (b *linuxBackend) closeTracer() { b.tracer.close() }
+func (b *linuxBackend) closeTracer() {
+	b.purge()
+	b.tracer.close()
+}
 
 const linuxPtraceOptions = syscall.PTRACE_O_TRACEEXIT |
 	syscall.PTRACE_O_TRACEEXEC |
@@ -349,6 +358,12 @@ func attachToProcess(b Backend, pid int) error {
 // attached one. running reports whether the engine's waitLoop is in flight —
 // true for a running tracee, false for one suspended at a stop.
 func killProcess(b Backend, pid int, cmd *exec.Cmd, running bool) error {
+	if lb, ok := b.(*linuxBackend); ok {
+		// stepQueue stays wait-loop-owned while a running tracee still has a
+		// waitLoop in flight; only the synchronized signal state is safe to
+		// clear from the engine goroutine.
+		defer lb.pendingSignals.purge()
+	}
 	if cmd != nil {
 		// SIGKILL via the OS handle is not a ptrace op, so it is safe from any
 		// thread and keeps Kill responsive even if the tracer thread is busy.
@@ -425,10 +440,11 @@ func (b *linuxBackend) ContinueProcess() error {
 	}
 	b.endStep()
 	tid := b.traceTID()
+	signal := b.pendingSignals.take(tid)
 	var err error
-	b.execPtrace(func() { err = syscall.PtraceCont(tid, 0) })
+	b.execPtrace(func() { err = b.ptraceCont(tid, signal) })
 	if err != nil {
-		return fmt.Errorf("PTRACE_CONT tid %d: %w", tid, err)
+		return fmt.Errorf("PTRACE_CONT tid %d signal %d: %w", tid, signal, err)
 	}
 	return nil
 }
@@ -438,10 +454,11 @@ func (b *linuxBackend) SingleStep(tid int) error {
 		return fmt.Errorf("PTRACE_SINGLESTEP: stepped-thread exit is awaiting breakpoint reconciliation; kill or restart to recover")
 	}
 	b.beginStep(tid)
+	signal := b.pendingSignals.take(tid)
 	var err error
-	b.execPtrace(func() { err = syscall.PtraceSingleStep(tid) })
+	b.execPtrace(func() { err = b.ptraceSingleStep(tid, signal) })
 	if err != nil {
-		return fmt.Errorf("PTRACE_SINGLESTEP tid %d: %w", tid, err)
+		return fmt.Errorf("PTRACE_SINGLESTEP tid %d signal %d: %w", tid, signal, err)
 	}
 	return nil
 }
@@ -455,9 +472,9 @@ func (b *linuxBackend) SingleStep(tid int) error {
 // could be lost. Targeting the main thread (whose TID equals the tgid) makes
 // the signal surface from Wait() as StopEvent{StopSignal, SIGSTOP} with
 // TID==b.pid, where the engine's manual-stop detection turns it into
-// EventPaused. The engine never injects this SIGSTOP back (Continue resumes
-// with signal 0), so it triggers no group-stop and resume is a plain
-// ContinueProcess. ESRCH (thread already gone) is an idempotent no-op,
+// EventPaused. recordDeliveredStop excludes this SIGSTOP from pending delivery,
+// so Continue resumes with signal 0; it triggers no group-stop and resume is a
+// plain ContinueProcess. ESRCH (thread already gone) is an idempotent no-op,
 // matching process.kill. tgkill is a plain signal syscall,
 // not a ptrace op, so it need not run on the tracer thread.
 func (b *linuxBackend) StopProcess() error {
@@ -608,6 +625,11 @@ func (b *linuxBackend) Threads() ([]int, error) {
 // `go` statement after consuming the previous Wait's result — so each Wait
 // happens-after the previous one, along with the step-state writes the engine
 // makes in between.
+//
+// A delivered StopSignal also installs pendingSignals[tid] before lastStopTID is
+// published. The map is mutex-protected because Wait writes it and the engine
+// consumes it on resume; keeping it per TID prevents another stop from stealing
+// or clearing the signal.
 //
 // wait4 runs on the calling (waitLoop) thread, NOT the tracer thread: waiting
 // for a tracee is legal from any thread of the tracer process, and keeping it
@@ -770,11 +792,12 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 					b.park(StopEvent{Reason: reason, TID: tid})
 					continue
 				}
-				b.recordStop(tid)
+				ev := StopEvent{Reason: reason, TID: tid}
+				b.recordDeliveredStop(ev)
 				if reason == StopSingleStep {
 					b.endStep()
 				}
-				return StopEvent{Reason: reason, TID: tid}, nil
+				return ev, nil
 
 			default:
 				// An unrecognised PTRACE_EVENT. With exactly TRACEEXIT,
@@ -842,12 +865,13 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 			b.park(StopEvent{Reason: reason, TID: tid, Signal: int(sig)})
 			continue
 		}
-		b.recordStop(tid)
-		return StopEvent{
+		ev := StopEvent{
 			Reason: reason,
 			TID:    tid,
 			Signal: int(sig),
-		}, nil
+		}
+		b.recordDeliveredStop(ev)
+		return ev, nil
 	}
 }
 
@@ -871,6 +895,22 @@ func (b *linuxBackend) recordStop(tid int) {
 	}
 }
 
+// recordDeliveredStop installs a signal before publishing its TID as the
+// current resume target. Outside teardown, a concurrent reader may observe the
+// previous TID, but it cannot observe the new TID without the signal that
+// belongs to it.
+func (b *linuxBackend) recordDeliveredStop(ev StopEvent) {
+	if ev.Reason == StopSignal && ev.Signal != b.PauseSignal() {
+		b.pendingSignals.set(ev.TID, ev.Signal)
+	}
+	b.recordStop(ev.TID)
+}
+
+func (b *linuxBackend) purge() {
+	b.stepQueue.purge()
+	b.pendingSignals.purge()
+}
+
 func isNoSuchProcess(err error) bool {
 	return errors.Is(err, syscall.ESRCH) || errors.Is(err, os.ErrNotExist)
 }
@@ -883,11 +923,12 @@ func (b *linuxBackend) continueIfTraceeExists(tid int, signal int) error {
 	if tid == 0 {
 		return nil
 	}
+	b.pendingSignals.clear(tid)
 	var err error
 	if b.contFn != nil {
 		err = b.contFn(tid, signal)
 	} else {
-		b.execPtrace(func() { err = syscall.PtraceCont(tid, signal) })
+		b.execPtrace(func() { err = b.ptraceCont(tid, signal) })
 	}
 	if err != nil && !isNoSuchProcess(err) {
 		return err
@@ -899,11 +940,12 @@ func (b *linuxBackend) singleStepIfTraceeExists(tid int) error {
 	if tid == 0 {
 		return nil
 	}
+	b.pendingSignals.clear(tid)
 	var err error
 	if b.stepFn != nil {
 		err = b.stepFn(tid)
 	} else {
-		b.execPtrace(func() { err = syscall.PtraceSingleStep(tid) })
+		b.execPtrace(func() { err = b.ptraceSingleStep(tid, 0) })
 	}
 	if err != nil && !isNoSuchProcess(err) {
 		return err
@@ -942,4 +984,30 @@ func (b *linuxBackend) applyAbsorb(plan absorbPlan, tid int) error {
 		return b.singleStepIfTraceeExists(tid)
 	}
 	return b.continueIfTraceeExists(tid, plan.signal)
+}
+
+func (b *linuxBackend) ptraceCont(tid, signal int) error {
+	if b.ptraceContFn != nil {
+		return b.ptraceContFn(tid, signal)
+	}
+	return syscall.PtraceCont(tid, signal)
+}
+
+func (b *linuxBackend) ptraceSingleStep(tid, signal int) error {
+	if b.ptraceSingleStepFn != nil {
+		return b.ptraceSingleStepFn(tid, signal)
+	}
+	_, _, errno := syscall.Syscall6(
+		syscall.SYS_PTRACE,
+		uintptr(syscall.PTRACE_SINGLESTEP),
+		uintptr(tid),
+		0,
+		uintptr(signal),
+		0,
+		0,
+	)
+	if errno != 0 {
+		return errno
+	}
+	return nil
 }

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -146,6 +146,7 @@ type linuxBackend struct {
 	// Nil in production; tests inject this at the raw syscall seam to pin the
 	// exact ptrace request, TID, and signal without launching a tracee.
 	ptraceSyscall6Fn func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno)
+	tgkillFn         func(tgid, tid int, signal syscall.Signal) error
 }
 
 // eventMsg reads the message the kernel attached to a PTRACE_EVENT stop: the
@@ -440,10 +441,15 @@ func (b *linuxBackend) ContinueProcess() error {
 	}
 	b.endStep()
 	tid := b.traceTID()
-	signal := b.pendingSignals.take(tid)
+	signal, delayed := b.pendingSignals.takeForContinue(tid)
+	if err := b.requeueSignal(tid, delayed); err != nil {
+		b.pendingSignals.restore(tid, signal, delayed)
+		return err
+	}
 	var err error
 	b.execPtrace(func() { err = b.ptraceCont(tid, signal) })
 	if err != nil {
+		b.pendingSignals.restore(tid, signal, 0)
 		return fmt.Errorf("PTRACE_CONT tid %d signal %d: %w", tid, signal, err)
 	}
 	return nil
@@ -454,10 +460,11 @@ func (b *linuxBackend) SingleStep(tid int) error {
 		return fmt.Errorf("PTRACE_SINGLESTEP: stepped-thread exit is awaiting breakpoint reconciliation; kill or restart to recover")
 	}
 	b.beginStep(tid)
-	signal := b.pendingSignals.take(tid)
+	signal := b.pendingSignals.takeForStep(tid)
 	var err error
 	b.execPtrace(func() { err = b.ptraceSingleStep(tid, signal) })
 	if err != nil {
+		b.pendingSignals.restore(tid, signal, 0)
 		return fmt.Errorf("PTRACE_SINGLESTEP tid %d signal %d: %w", tid, signal, err)
 	}
 	return nil
@@ -675,12 +682,14 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 				return b.commitLeaderExit(
 					StopEvent{Reason: StopExited, TID: tid, ExitCode: ws.ExitStatus()}, true), nil
 			}
+			b.pendingSignals.clear(tid)
 			b.interruptStepIfStepped(tid)
 			continue
 		}
 
 		if ws.Signaled() {
 			if tid != b.pid {
+				b.pendingSignals.clear(tid)
 				b.interruptStepIfStepped(tid)
 				continue
 			}
@@ -708,6 +717,7 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 
 			case syscall.PTRACE_EVENT_EXIT:
 				if tid != b.pid {
+					b.pendingSignals.clear(tid)
 					if err := b.absorbStop(absorbThreadExit, tid, 0); err != nil {
 						return StopEvent{}, fmt.Errorf("PTRACE_CONT exiting thread tid %d: %w", tid, err)
 					}
@@ -772,6 +782,7 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 				// PTRACE_O_TRACEEXEC, and Restart runs on a brand-new debugger.
 				formerTID, _ := b.eventMsg(tid)
 				retracted := b.retractLeaderExit()
+				b.pendingSignals.purge()
 				b.abortStep()
 				return StopEvent{}, fmt.Errorf(
 					"%w (PTRACE_EVENT_EXEC reported under pid %d, "+
@@ -919,18 +930,26 @@ func isNoChildProcess(err error) bool {
 	return errors.Is(err, syscall.ECHILD)
 }
 
+// continueIfTraceeExists is the only internal continue path. A SIGURG delayed
+// through a single-step is first requeued to the same TID and resumed with
+// signal zero; only the resulting signal-delivery stop may inject SIGURG.
 func (b *linuxBackend) continueIfTraceeExists(tid int, signal int) error {
 	if tid == 0 {
 		return nil
 	}
-	b.pendingSignals.clear(tid)
+	resumeSignal, delayed := b.pendingSignals.takeForExplicitResume(tid, signal)
+	if err := b.requeueSignal(tid, delayed); err != nil {
+		b.pendingSignals.restore(tid, 0, delayed)
+		return err
+	}
 	var err error
 	if b.contFn != nil {
-		err = b.contFn(tid, signal)
+		err = b.contFn(tid, resumeSignal)
 	} else {
-		b.execPtrace(func() { err = b.ptraceCont(tid, signal) })
+		b.execPtrace(func() { err = b.ptraceCont(tid, resumeSignal) })
 	}
 	if err != nil && !isNoSuchProcess(err) {
+		b.pendingSignals.restore(tid, 0, delayed)
 		return err
 	}
 	return nil
@@ -940,7 +959,7 @@ func (b *linuxBackend) singleStepIfTraceeExists(tid int) error {
 	if tid == 0 {
 		return nil
 	}
-	b.pendingSignals.clear(tid)
+	b.pendingSignals.takeForStep(tid)
 	var err error
 	if b.stepFn != nil {
 		err = b.stepFn(tid)
@@ -958,6 +977,11 @@ func (b *linuxBackend) singleStepIfTraceeExists(tid int) error {
 // stop per resume, so absorbing an event on the thread the engine is stepping
 // consumes that step, and a plain continue there would silently cancel it while
 // the step gate stays latched. See stepQueue.planAbsorb.
+//
+// A signal absorbed on the stepped thread is delayed through the signal-zero
+// re-step. Injecting it with PTRACE_SINGLESTEP would stop in the handler's signal
+// frame before the requested instruction executes. The next continue requeues
+// it to the same TID and forwards it from a fresh signal-delivery stop.
 //
 // Callers handle plan.fail themselves, because each failing branch has its own
 // diagnosis to report.
@@ -980,10 +1004,30 @@ func (b *linuxBackend) applyAbsorb(plan absorbPlan, tid int) error {
 		return nil
 	}
 	if plan.mode == resumeSingleStep {
+		b.pendingSignals.delay(tid, plan.signal)
 		b.countStepRearm()
 		return b.singleStepIfTraceeExists(tid)
 	}
 	return b.continueIfTraceeExists(tid, plan.signal)
+}
+
+func (b *linuxBackend) requeueSignal(tid, signal int) error {
+	if signal == 0 {
+		return nil
+	}
+	tgkill := syscall.Tgkill
+	if b.tgkillFn != nil {
+		tgkill = b.tgkillFn
+	}
+	if err := tgkill(b.pid, tid, syscall.Signal(signal)); err != nil {
+		return fmt.Errorf("requeue signal %d to tid %d: %w", signal, tid, err)
+	}
+	return nil
+}
+
+func (b *linuxBackend) continueWithoutPendingSignals(tid int) error {
+	b.pendingSignals.clear(tid)
+	return b.continueIfTraceeExists(tid, 0)
 }
 
 func (b *linuxBackend) ptraceCont(tid, signal int) error {

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -196,14 +196,14 @@ func (b *linuxBackend) drainParked() (StopEvent, bool) {
 // it would run a thread whose stop the engine has not been told about. The
 // release itself runs through the tracer thread like every other ptrace op.
 // ESRCH/ENOENT is benign — the thread was mid-exit and simply finished dying —
-// and continueIfTraceeExists already treats it as success.
+// and continueWithoutPendingSignals already treats it as success.
 //
 // A non-benign failure leaves the gate CLOSED and the hold in place. Nothing may
 // drain past a thread we could not release, and reporting the error lets the
 // engine halt suspended rather than resume into a state it cannot describe.
 func (b *linuxBackend) completeStepThreadExit() error {
 	if tid, ok := b.heldStepOwner(); ok {
-		if err := b.continueIfTraceeExists(tid, 0); err != nil {
+		if err := b.continueWithoutPendingSignals(tid); err != nil {
 			return fmt.Errorf("release step owner tid %d held to reconcile its exit: %w", tid, err)
 		}
 		b.clearHeldStepOwner()
@@ -363,7 +363,7 @@ func killProcess(b Backend, pid int, cmd *exec.Cmd, running bool) error {
 		// stepQueue stays wait-loop-owned while a running tracee still has a
 		// waitLoop in flight; only the synchronized signal state is safe to
 		// clear from the engine goroutine.
-		defer lb.pendingSignals.purge()
+		lb.pendingSignals.purge()
 	}
 	if cmd != nil {
 		// SIGKILL via the OS handle is not a ptrace op, so it is safe from any
@@ -418,7 +418,7 @@ func (b *linuxBackend) reapAfterKill() {
 		switch {
 		case err == nil:
 			if ws.Stopped() {
-				_ = b.continueIfTraceeExists(wpid, 0)
+				_ = b.continueWithoutPendingSignals(wpid)
 			}
 			// Exited/Signaled: that thread is reaped; loop for the rest.
 		case isNoChildProcess(err):
@@ -798,7 +798,7 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 					// is mid-step. It stays ptrace-stopped where it is; the
 					// engine sees it only once the step has completed and the
 					// trap being stepped over is back in place.
-					b.park(StopEvent{Reason: reason, TID: tid})
+					b.park(StopEvent{Reason: reason, TID: tid, Signal: int(sig)})
 					continue
 				}
 				ev := StopEvent{Reason: reason, TID: tid}
@@ -844,6 +844,7 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 			// A brand-new thread is never the one being stepped, but route the
 			// resume through the same helper so no absorb site can drift back
 			// into an unguarded continue.
+			b.pendingSignals.clear(tid)
 			if err := b.absorbStop(absorbNewThread, tid, 0); err != nil {
 				return StopEvent{}, fmt.Errorf("resume new thread tid %d: %w", tid, err)
 			}
@@ -935,9 +936,9 @@ func (b *linuxBackend) continueIfTraceeExists(tid int, signal int) error {
 	if tid == 0 {
 		return nil
 	}
-	resumeSignal, delayed := b.pendingSignals.takeForExplicitResume(tid, signal)
+	current, resumeSignal, delayed := b.pendingSignals.takeForExplicitResume(tid, signal)
 	if err := b.requeueSignal(tid, delayed); err != nil {
-		b.pendingSignals.restore(tid, 0, delayed)
+		b.pendingSignals.restore(tid, current, delayed)
 		return err
 	}
 	var err error
@@ -946,9 +947,11 @@ func (b *linuxBackend) continueIfTraceeExists(tid int, signal int) error {
 	} else {
 		b.execPtrace(func() { err = b.ptraceCont(tid, resumeSignal) })
 	}
-	if err != nil && !isNoSuchProcess(err) {
-		b.pendingSignals.restore(tid, 0, delayed)
-		return err
+	if err != nil {
+		b.pendingSignals.restore(tid, current, delayed)
+		if !isNoSuchProcess(err) {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -460,12 +460,10 @@ func (b *linuxBackend) SingleStep(tid int) error {
 		return fmt.Errorf("PTRACE_SINGLESTEP: stepped-thread exit is awaiting breakpoint reconciliation; kill or restart to recover")
 	}
 	b.beginStep(tid)
-	signal := b.pendingSignals.takeForStep(tid)
 	var err error
-	b.execPtrace(func() { err = b.ptraceSingleStep(tid, signal) })
+	b.execPtrace(func() { err = b.ptraceSingleStep(tid) })
 	if err != nil {
-		b.pendingSignals.restore(tid, signal, 0)
-		return fmt.Errorf("PTRACE_SINGLESTEP tid %d signal %d: %w", tid, signal, err)
+		return fmt.Errorf("PTRACE_SINGLESTEP tid %d: %w", tid, err)
 	}
 	return nil
 }
@@ -959,12 +957,11 @@ func (b *linuxBackend) singleStepIfTraceeExists(tid int) error {
 	if tid == 0 {
 		return nil
 	}
-	b.pendingSignals.takeForStep(tid)
 	var err error
 	if b.stepFn != nil {
 		err = b.stepFn(tid)
 	} else {
-		b.execPtrace(func() { err = b.ptraceSingleStep(tid, 0) })
+		b.execPtrace(func() { err = b.ptraceSingleStep(tid) })
 	}
 	if err != nil && !isNoSuchProcess(err) {
 		return err
@@ -1034,8 +1031,8 @@ func (b *linuxBackend) ptraceCont(tid, signal int) error {
 	return b.ptraceResume(syscall.PTRACE_CONT, tid, signal)
 }
 
-func (b *linuxBackend) ptraceSingleStep(tid, signal int) error {
-	return b.ptraceResume(syscall.PTRACE_SINGLESTEP, tid, signal)
+func (b *linuxBackend) ptraceSingleStep(tid int) error {
+	return b.ptraceResume(syscall.PTRACE_SINGLESTEP, tid, 0)
 }
 
 func (b *linuxBackend) ptraceResume(request, tid, signal int) error {

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -143,10 +143,9 @@ type linuxBackend struct {
 	eventMsgFn     func(tid int) (uint, error)
 	pendingSignals pendingSignals
 
-	// Nil in production; tests inject these to pin the exact TID/signal pair
-	// passed to ptrace without launching a tracee.
-	ptraceContFn       func(tid, signal int) error
-	ptraceSingleStepFn func(tid, signal int) error
+	// Nil in production; tests inject this at the raw syscall seam to pin the
+	// exact ptrace request, TID, and signal without launching a tracee.
+	ptraceSyscall6Fn func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno)
 }
 
 // eventMsg reads the message the kernel attached to a PTRACE_EVENT stop: the
@@ -988,19 +987,21 @@ func (b *linuxBackend) applyAbsorb(plan absorbPlan, tid int) error {
 }
 
 func (b *linuxBackend) ptraceCont(tid, signal int) error {
-	if b.ptraceContFn != nil {
-		return b.ptraceContFn(tid, signal)
-	}
-	return syscall.PtraceCont(tid, signal)
+	return b.ptraceResume(syscall.PTRACE_CONT, tid, signal)
 }
 
 func (b *linuxBackend) ptraceSingleStep(tid, signal int) error {
-	if b.ptraceSingleStepFn != nil {
-		return b.ptraceSingleStepFn(tid, signal)
+	return b.ptraceResume(syscall.PTRACE_SINGLESTEP, tid, signal)
+}
+
+func (b *linuxBackend) ptraceResume(request, tid, signal int) error {
+	call := syscall.Syscall6
+	if b.ptraceSyscall6Fn != nil {
+		call = b.ptraceSyscall6Fn
 	}
-	_, _, errno := syscall.Syscall6(
+	_, _, errno := call(
 		syscall.SYS_PTRACE,
-		uintptr(syscall.PTRACE_SINGLESTEP),
+		uintptr(request),
 		uintptr(tid),
 		0,
 		uintptr(signal),

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -270,10 +270,11 @@ func (b *linuxBackend) commitLeaderExit(observed StopEvent, haveObserved bool) S
 // leaderExitPendingForTest reports whether a terminal is being withheld.
 func (b *linuxBackend) leaderExitPendingForTest() bool { return b.leaderExitStashed }
 
-// closeTracer releases the dedicated tracer thread. The engine calls this after
-// its loop exits (process gone), when no further ptrace ops can be issued.
+// closeTracer releases the dedicated tracer thread after engine shutdown.
+// A terminal waitLoop may still be unwinding, so its lock-free step queue
+// remains Wait-owned; only synchronized pending-signal state is cleared here.
 func (b *linuxBackend) closeTracer() {
-	b.purge()
+	b.pendingSignals.purge()
 	b.tracer.close()
 }
 

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -834,17 +834,16 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 		}
 
 		if sig == syscall.SIGSTOP && tid != b.pid {
-			// A newly cloned thread's initial group-stop. With
-			// PTRACE_O_TRACECLONE the kernel auto-attaches it and it inherits
-			// our ptrace options, so we just resume THIS thread. Crucially we
-			// must NOT touch the rest of the group: another thread may be
-			// stopped at a breakpoint waiting for the engine, and a
-			// group-continue here would let it run away (the exact "parking the
-			// thread group" hazard that kept clone tracing disabled before).
-			// A brand-new thread is never the one being stepped, but route the
-			// resume through the same helper so no absorb site can drift back
-			// into an unguarded continue.
-			b.pendingSignals.clear(tid)
+			// This is normally a new clone's initial group-stop, but the raw
+			// predicate is not proof of newness: an existing worker, including
+			// the active step owner, can report the same stop. Clearing that
+			// owner's retained signal would lose it when the step is re-armed
+			// with signal zero. Other TIDs retain the established reuse cleanup.
+			if b.resumeFor(tid) != resumeSingleStep {
+				b.pendingSignals.clear(tid)
+			}
+			// Resume only this thread. A group-continue could release a sibling
+			// parked at a breakpoint before the engine has handled its stop.
 			if err := b.absorbStop(absorbNewThread, tid, 0); err != nil {
 				return StopEvent{}, fmt.Errorf("resume new thread tid %d: %w", tid, err)
 			}

--- a/internal/debugger/backend_linux_amd64_test.go
+++ b/internal/debugger/backend_linux_amd64_test.go
@@ -425,7 +425,7 @@ func TestLinuxBackendInternalResumesClearPendingSignal(t *testing.T) {
 	}
 }
 
-func TestLinuxKillCleanupDoesNotTouchWaitOwnedQueue(t *testing.T) {
+func TestLinuxEngineCleanupDoesNotTouchWaitOwnedQueue(t *testing.T) {
 	const tid = 7001
 	b, _ := newRecordingLinuxBackend(t, tid)
 	b.pendingSignals.set(tid, int(syscall.SIGSEGV))
@@ -439,6 +439,10 @@ func TestLinuxKillCleanupDoesNotTouchWaitOwnedQueue(t *testing.T) {
 	}
 	if got := len(b.parked); got != 1 {
 		t.Fatalf("parked stops after kill cleanup = %d, want 1 retained for the wait loop", got)
+	}
+	b.closeTracer()
+	if got := len(b.parked); got != 1 {
+		t.Fatalf("parked stops after tracer cleanup = %d, want 1 retained for the wait loop", got)
 	}
 }
 

--- a/internal/debugger/backend_linux_amd64_test.go
+++ b/internal/debugger/backend_linux_amd64_test.go
@@ -22,6 +22,12 @@ type linuxResumeCall struct {
 	a6      uintptr
 }
 
+type linuxTgkillCall struct {
+	tgid   int
+	tid    int
+	signal int
+}
+
 func wantLinuxResume(request, tid, signal int) linuxResumeCall {
 	return linuxResumeCall{
 		trap:    syscall.SYS_PTRACE,
@@ -373,7 +379,7 @@ func TestLinuxBackendSingleStepForwardsOnlyMatchingTIDSignal(t *testing.T) {
 	}
 }
 
-func TestLinuxBackendFailedResumeStillConsumesPendingSignal(t *testing.T) {
+func TestLinuxBackendFailedResumeRetainsPendingSignal(t *testing.T) {
 	const tid = 5001
 	errInjected := syscall.EIO
 	b, calls := newRecordingLinuxBackend(t, tid)
@@ -400,7 +406,7 @@ func TestLinuxBackendFailedResumeStillConsumesPendingSignal(t *testing.T) {
 
 	want := []linuxResumeCall{
 		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGSEGV)),
-		wantLinuxResume(syscall.PTRACE_CONT, tid, 0),
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGSEGV)),
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
@@ -452,10 +458,179 @@ func TestLinuxBackendInternalResumesClearOnlyTheirPendingSignal(t *testing.T) {
 	}
 }
 
+func TestLinuxBackendSteppedSIGURGWaitsForFreshDeliveryStop(t *testing.T) {
+	const (
+		pid = 6101
+		tid = 6102
+	)
+	b, calls := newRecordingLinuxBackend(t, pid)
+	var tgkills []linuxTgkillCall
+	b.tgkillFn = func(tgid, targetTID int, signal syscall.Signal) error {
+		tgkills = append(tgkills, linuxTgkillCall{tgid: tgid, tid: targetTID, signal: int(signal)})
+		return nil
+	}
+	b.recordStop(tid)
+
+	b.beginStep(tid)
+	if err := b.resumeAbsorbed(tid, int(syscall.SIGURG)); err != nil {
+		t.Fatalf("resumeAbsorbed(step SIGURG) error = %v", err)
+	}
+	b.endStep()
+	if err := b.SingleStep(tid); err != nil {
+		t.Fatalf("second SingleStep() error = %v", err)
+	}
+	b.endStep()
+
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("ContinueProcess() error = %v", err)
+	}
+	if err := b.resumeAbsorbed(tid, int(syscall.SIGURG)); err != nil {
+		t.Fatalf("resumeAbsorbed(fresh SIGURG delivery) error = %v", err)
+	}
+
+	wantResumes := []linuxResumeCall{
+		wantLinuxResume(syscall.PTRACE_SINGLESTEP, tid, 0),
+		wantLinuxResume(syscall.PTRACE_SINGLESTEP, tid, 0),
+		wantLinuxResume(syscall.PTRACE_CONT, tid, 0),
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGURG)),
+	}
+	if !reflect.DeepEqual(*calls, wantResumes) {
+		t.Fatalf("resume calls = %+v, want %+v", *calls, wantResumes)
+	}
+	wantTgkills := []linuxTgkillCall{{tgid: pid, tid: tid, signal: int(syscall.SIGURG)}}
+	if !reflect.DeepEqual(tgkills, wantTgkills) {
+		t.Fatalf("tgkill calls = %+v, want exact-TID requeue %+v", tgkills, wantTgkills)
+	}
+}
+
+func TestLinuxBackendCurrentSignalPrecedesDelayedSIGURG(t *testing.T) {
+	const (
+		pid = 6201
+		tid = 6202
+	)
+	b, calls := newRecordingLinuxBackend(t, pid)
+	var tgkills []linuxTgkillCall
+	b.tgkillFn = func(tgid, targetTID int, signal syscall.Signal) error {
+		tgkills = append(tgkills, linuxTgkillCall{tgid: tgid, tid: targetTID, signal: int(signal)})
+		return nil
+	}
+	b.pendingSignals.delay(tid, int(syscall.SIGURG))
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGUSR1)})
+
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("ContinueProcess() error = %v", err)
+	}
+	if err := b.resumeAbsorbed(tid, int(syscall.SIGURG)); err != nil {
+		t.Fatalf("resumeAbsorbed(fresh SIGURG delivery) error = %v", err)
+	}
+
+	wantResumes := []linuxResumeCall{
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGUSR1)),
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGURG)),
+	}
+	if !reflect.DeepEqual(*calls, wantResumes) {
+		t.Fatalf("resume calls = %+v, want %+v", *calls, wantResumes)
+	}
+	wantTgkills := []linuxTgkillCall{{tgid: pid, tid: tid, signal: int(syscall.SIGURG)}}
+	if !reflect.DeepEqual(tgkills, wantTgkills) {
+		t.Fatalf("tgkill calls = %+v, want %+v", tgkills, wantTgkills)
+	}
+}
+
+func TestLinuxBackendPauseStillSuppressesSIGSTOPWithDelayedSIGURG(t *testing.T) {
+	const tid = 6301
+	b, calls := newRecordingLinuxBackend(t, tid)
+	var tgkills []linuxTgkillCall
+	b.tgkillFn = func(tgid, targetTID int, signal syscall.Signal) error {
+		tgkills = append(tgkills, linuxTgkillCall{tgid: tgid, tid: targetTID, signal: int(signal)})
+		return nil
+	}
+	b.pendingSignals.delay(tid, int(syscall.SIGURG))
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: b.PauseSignal()})
+
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("ContinueProcess() error = %v", err)
+	}
+	if err := b.resumeAbsorbed(tid, int(syscall.SIGURG)); err != nil {
+		t.Fatalf("resumeAbsorbed(fresh SIGURG delivery) error = %v", err)
+	}
+
+	wantResumes := []linuxResumeCall{
+		wantLinuxResume(syscall.PTRACE_CONT, tid, 0),
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGURG)),
+	}
+	if !reflect.DeepEqual(*calls, wantResumes) {
+		t.Fatalf("resume calls = %+v, want SIGSTOP suppressed: %+v", *calls, wantResumes)
+	}
+	wantTgkills := []linuxTgkillCall{{tgid: tid, tid: tid, signal: int(syscall.SIGURG)}}
+	if !reflect.DeepEqual(tgkills, wantTgkills) {
+		t.Fatalf("tgkill calls = %+v, want %+v", tgkills, wantTgkills)
+	}
+}
+
+func TestLinuxBackendFailedSIGURGRequeueRestoresDelayedSignal(t *testing.T) {
+	const tid = 6401
+	b, calls := newRecordingLinuxBackend(t, tid)
+	var attempts []linuxTgkillCall
+	b.tgkillFn = func(tgid, targetTID int, signal syscall.Signal) error {
+		attempts = append(attempts, linuxTgkillCall{tgid: tgid, tid: targetTID, signal: int(signal)})
+		if len(attempts) == 1 {
+			return syscall.EAGAIN
+		}
+		return nil
+	}
+	b.pendingSignals.delay(tid, int(syscall.SIGURG))
+
+	if err := b.ContinueProcess(); !errors.Is(err, syscall.EAGAIN) {
+		t.Fatalf("ContinueProcess() error = %v, want %v", err, syscall.EAGAIN)
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("ptrace calls after failed requeue = %+v, want none", *calls)
+	}
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("retry ContinueProcess() error = %v", err)
+	}
+	wantTgkills := []linuxTgkillCall{
+		{tgid: tid, tid: tid, signal: int(syscall.SIGURG)},
+		{tgid: tid, tid: tid, signal: int(syscall.SIGURG)},
+	}
+	if !reflect.DeepEqual(attempts, wantTgkills) {
+		t.Fatalf("tgkill attempts = %+v, want %+v", attempts, wantTgkills)
+	}
+	want := []linuxResumeCall{wantLinuxResume(syscall.PTRACE_CONT, tid, 0)}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
+	}
+}
+
+func TestLinuxBackendExitingThreadDropsCurrentAndDelayedSignals(t *testing.T) {
+	const tid = 6501
+	b, calls := newRecordingLinuxBackend(t, tid)
+	b.pendingSignals.set(tid, int(syscall.SIGUSR1))
+	b.pendingSignals.delay(tid, int(syscall.SIGURG))
+	b.tgkillFn = func(tgid, targetTID int, signal syscall.Signal) error {
+		t.Fatalf("tgkill(%d, %d, %d) called for exiting thread", tgid, targetTID, signal)
+		return nil
+	}
+
+	if err := b.continueWithoutPendingSignals(tid); err != nil {
+		t.Fatalf("continueWithoutPendingSignals() error = %v", err)
+	}
+
+	want := []linuxResumeCall{wantLinuxResume(syscall.PTRACE_CONT, tid, 0)}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
+	}
+	if got := b.pendingSignals.take(tid); got != 0 {
+		t.Fatalf("pending signal after exit resume = %d, want 0", got)
+	}
+}
+
 func TestLinuxEngineCleanupDoesNotTouchWaitOwnedQueue(t *testing.T) {
 	const tid = 7001
 	b, _ := newRecordingLinuxBackend(t, tid)
 	b.pendingSignals.set(tid, int(syscall.SIGSEGV))
+	b.pendingSignals.delay(tid, int(syscall.SIGURG))
 	b.park(StopEvent{Reason: StopBreakpoint, TID: tid + 1})
 
 	if err := killProcess(b, tid, nil, true); err != nil {

--- a/internal/debugger/backend_linux_amd64_test.go
+++ b/internal/debugger/backend_linux_amd64_test.go
@@ -13,9 +13,22 @@ import (
 )
 
 type linuxResumeCall struct {
-	op     string
-	tid    int
-	signal int
+	trap    uintptr
+	request uintptr
+	tid     uintptr
+	addr    uintptr
+	signal  uintptr
+	a5      uintptr
+	a6      uintptr
+}
+
+func wantLinuxResume(request, tid, signal int) linuxResumeCall {
+	return linuxResumeCall{
+		trap:    syscall.SYS_PTRACE,
+		request: uintptr(request),
+		tid:     uintptr(tid),
+		signal:  uintptr(signal),
+	}
 }
 
 func newRecordingLinuxBackend(t *testing.T, pid int) (*linuxBackend, *[]linuxResumeCall) {
@@ -24,13 +37,11 @@ func newRecordingLinuxBackend(t *testing.T, pid int) (*linuxBackend, *[]linuxRes
 	b := &linuxBackend{
 		pid:    pid,
 		tracer: newTracerThread(),
-		ptraceContFn: func(tid, signal int) error {
-			*calls = append(*calls, linuxResumeCall{op: "continue", tid: tid, signal: signal})
-			return nil
-		},
-		ptraceSingleStepFn: func(tid, signal int) error {
-			*calls = append(*calls, linuxResumeCall{op: "step", tid: tid, signal: signal})
-			return nil
+		ptraceSyscall6Fn: func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
+			*calls = append(*calls, linuxResumeCall{
+				trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
+			})
+			return 0, 0, 0
 		},
 	}
 	t.Cleanup(b.closeTracer)
@@ -288,8 +299,8 @@ func TestLinuxBackendContinueForwardsDeliveredSignalOnce(t *testing.T) {
 	}
 
 	want := []linuxResumeCall{
-		{op: "continue", tid: tid, signal: int(syscall.SIGSEGV)},
-		{op: "continue", tid: tid, signal: 0},
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGSEGV)),
+		wantLinuxResume(syscall.PTRACE_CONT, tid, 0),
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
@@ -314,8 +325,8 @@ func TestLinuxBackendPendingSignalDoesNotTransferOrGetClearedByAnotherStop(t *te
 	}
 
 	want := []linuxResumeCall{
-		{op: "continue", tid: other, signal: 0},
-		{op: "continue", tid: signalled, signal: int(syscall.SIGABRT)},
+		wantLinuxResume(syscall.PTRACE_CONT, other, 0),
+		wantLinuxResume(syscall.PTRACE_CONT, signalled, int(syscall.SIGABRT)),
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
@@ -331,7 +342,7 @@ func TestLinuxBackendPauseSignalIsNeverForwarded(t *testing.T) {
 		t.Fatalf("ContinueProcess() error = %v", err)
 	}
 
-	want := []linuxResumeCall{{op: "continue", tid: tid, signal: 0}}
+	want := []linuxResumeCall{wantLinuxResume(syscall.PTRACE_CONT, tid, 0)}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
 	}
@@ -354,8 +365,8 @@ func TestLinuxBackendSingleStepForwardsOnlyMatchingTIDSignal(t *testing.T) {
 	}
 
 	want := []linuxResumeCall{
-		{op: "step", tid: other, signal: 0},
-		{op: "step", tid: signalled, signal: int(syscall.SIGUSR1)},
+		wantLinuxResume(syscall.PTRACE_SINGLESTEP, other, 0),
+		wantLinuxResume(syscall.PTRACE_SINGLESTEP, signalled, int(syscall.SIGUSR1)),
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
@@ -364,41 +375,53 @@ func TestLinuxBackendSingleStepForwardsOnlyMatchingTIDSignal(t *testing.T) {
 
 func TestLinuxBackendFailedResumeStillConsumesPendingSignal(t *testing.T) {
 	const tid = 5001
-	errInjected := errors.New("ptrace failed")
+	errInjected := syscall.EIO
 	b, calls := newRecordingLinuxBackend(t, tid)
 	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGSEGV)})
-	b.ptraceContFn = func(gotTID, signal int) error {
-		*calls = append(*calls, linuxResumeCall{op: "continue", tid: gotTID, signal: signal})
-		return errInjected
+	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
+		*calls = append(*calls, linuxResumeCall{
+			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
+		})
+		return 0, 0, errInjected
 	}
 
 	if err := b.ContinueProcess(); !errors.Is(err, errInjected) {
 		t.Fatalf("ContinueProcess() error = %v, want %v", err, errInjected)
 	}
-	b.ptraceContFn = func(gotTID, signal int) error {
-		*calls = append(*calls, linuxResumeCall{op: "continue", tid: gotTID, signal: signal})
-		return nil
+	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
+		*calls = append(*calls, linuxResumeCall{
+			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
+		})
+		return 0, 0, 0
 	}
 	if err := b.ContinueProcess(); err != nil {
 		t.Fatalf("retry ContinueProcess() error = %v", err)
 	}
 
 	want := []linuxResumeCall{
-		{op: "continue", tid: tid, signal: int(syscall.SIGSEGV)},
-		{op: "continue", tid: tid, signal: 0},
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGSEGV)),
+		wantLinuxResume(syscall.PTRACE_CONT, tid, 0),
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
 	}
 }
 
-func TestLinuxBackendInternalResumesClearPendingSignal(t *testing.T) {
-	const tid = 6001
+func TestLinuxBackendInternalResumesClearOnlyTheirPendingSignal(t *testing.T) {
+	const (
+		tid             = 6001
+		unrelatedTID    = 6002
+		unrelatedSignal = int(syscall.SIGUSR2)
+	)
 	b, calls := newRecordingLinuxBackend(t, tid)
 
 	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGSEGV)})
+	b.pendingSignals.set(unrelatedTID, unrelatedSignal)
 	if err := b.continueIfTraceeExists(tid, int(syscall.SIGURG)); err != nil {
 		t.Fatalf("continueIfTraceeExists() error = %v", err)
+	}
+	if got := b.pendingSignals.take(unrelatedTID); got != unrelatedSignal {
+		t.Fatalf("internal continue changed unrelated TID's signal: got %d, want %d", got, unrelatedSignal)
 	}
 	b.recordStop(tid)
 	if err := b.ContinueProcess(); err != nil {
@@ -406,8 +429,12 @@ func TestLinuxBackendInternalResumesClearPendingSignal(t *testing.T) {
 	}
 
 	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGABRT)})
+	b.pendingSignals.set(unrelatedTID, unrelatedSignal)
 	if err := b.singleStepIfTraceeExists(tid); err != nil {
 		t.Fatalf("singleStepIfTraceeExists() error = %v", err)
+	}
+	if got := b.pendingSignals.take(unrelatedTID); got != unrelatedSignal {
+		t.Fatalf("internal single-step changed unrelated TID's signal: got %d, want %d", got, unrelatedSignal)
 	}
 	b.recordStop(tid)
 	if err := b.ContinueProcess(); err != nil {
@@ -415,10 +442,10 @@ func TestLinuxBackendInternalResumesClearPendingSignal(t *testing.T) {
 	}
 
 	want := []linuxResumeCall{
-		{op: "continue", tid: tid, signal: int(syscall.SIGURG)},
-		{op: "continue", tid: tid, signal: 0},
-		{op: "step", tid: tid, signal: 0},
-		{op: "continue", tid: tid, signal: 0},
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGURG)),
+		wantLinuxResume(syscall.PTRACE_CONT, tid, 0),
+		wantLinuxResume(syscall.PTRACE_SINGLESTEP, tid, 0),
+		wantLinuxResume(syscall.PTRACE_CONT, tid, 0),
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
@@ -570,7 +597,7 @@ func TestLinuxBackendHeldSignalSurfacesOnlyWithItsOwnStop(t *testing.T) {
 	if err := b.ContinueProcess(); err != nil {
 		t.Fatalf("ContinueProcess() for delivered signal error = %v", err)
 	}
-	wantResume := []linuxResumeCall{{op: "continue", tid: signaled, signal: 11}}
+	wantResume := []linuxResumeCall{wantLinuxResume(syscall.PTRACE_CONT, signaled, 11)}
 	if !reflect.DeepEqual(*calls, wantResume) {
 		t.Fatalf("resume calls = %+v, want delivered signal on its own tid: %+v", *calls, wantResume)
 	}

--- a/internal/debugger/backend_linux_amd64_test.go
+++ b/internal/debugger/backend_linux_amd64_test.go
@@ -1938,6 +1938,56 @@ func TestLinuxWaitCloneAbsorbPreservesPendingSignalOnSteppedThread(t *testing.T)
 	}
 }
 
+func TestLinuxWaitPreservesAPendingSignalWhenAbsorbingSIGSTOPOnTheSteppedThread(t *testing.T) {
+	const (
+		pid     = 9171
+		stepped = 9172
+	)
+	b, calls := newRecordingLinuxBackend(t, pid)
+	b.recordDeliveredStop(StopEvent{
+		Reason: StopSignal,
+		TID:    stepped,
+		Signal: int(syscall.SIGUSR1),
+	})
+	b.ptraceSyscall6Fn = recordingPtraceSyscall(calls, syscall.EIO)
+	if err := b.ContinueProcess(); !errors.Is(err, syscall.EIO) {
+		t.Fatalf("ContinueProcess() error = %v, want %v", err, syscall.EIO)
+	}
+
+	b.ptraceSyscall6Fn = recordingPtraceSyscall(calls, 0)
+	if err := b.SingleStep(stepped); err != nil {
+		t.Fatalf("SingleStep() error = %v", err)
+	}
+	script := &scriptedWait{stops: []scriptedStop{
+		{tid: stepped, status: stoppedAt(syscall.SIGSTOP, 0)},
+		{tid: stepped, status: stoppedAt(syscall.SIGTRAP, 0)},
+	}}
+	script.install(b)
+	// Keep wait4 scripted while the re-arm goes through the raw ptrace recorder.
+	b.stepFn = nil
+
+	ev, err := b.Wait()
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if ev.Reason != StopSingleStep || ev.TID != stepped {
+		t.Fatalf("Wait() = %+v, want the re-armed step completion on tid %d", ev, stepped)
+	}
+
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("ContinueProcess() after absorbed SIGSTOP error = %v", err)
+	}
+	wantCalls := []linuxResumeCall{
+		wantLinuxResume(syscall.PTRACE_CONT, stepped, int(syscall.SIGUSR1)),
+		wantLinuxResume(syscall.PTRACE_SINGLESTEP, stepped, 0),
+		wantLinuxResume(syscall.PTRACE_SINGLESTEP, stepped, 0),
+		wantLinuxResume(syscall.PTRACE_CONT, stepped, int(syscall.SIGUSR1)),
+	}
+	if !reflect.DeepEqual(*calls, wantCalls) {
+		t.Fatalf("ptrace calls = %+v, want retained exact-TID signal tuples %+v", *calls, wantCalls)
+	}
+}
+
 func TestLinuxWaitClearsReusedTIDStateBeforeNewThreadResume(t *testing.T) {
 	const (
 		pid       = 9201

--- a/internal/debugger/backend_linux_amd64_test.go
+++ b/internal/debugger/backend_linux_amd64_test.go
@@ -4,6 +4,7 @@ package debugger
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
 	"reflect"
 	"strings"
@@ -452,6 +453,72 @@ func TestLinuxBackendFailedResumeRetainsPendingSignal(t *testing.T) {
 	}
 }
 
+func TestLinuxBackendFailedResumeESRCHRetainsPendingSignal(t *testing.T) {
+	const tid = 5501
+	b, calls := newRecordingLinuxBackend(t, tid)
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGSEGV)})
+	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
+		*calls = append(*calls, linuxResumeCall{
+			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
+		})
+		return 0, 0, syscall.ESRCH
+	}
+
+	if err := b.ContinueProcess(); !errors.Is(err, syscall.ESRCH) {
+		t.Fatalf("ContinueProcess() error = %v, want %v", err, syscall.ESRCH)
+	}
+	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
+		*calls = append(*calls, linuxResumeCall{
+			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
+		})
+		return 0, 0, 0
+	}
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("retry ContinueProcess() error = %v", err)
+	}
+
+	want := []linuxResumeCall{
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGSEGV)),
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGSEGV)),
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("resume calls = %+v, want exact ESRCH retry tuple %+v", *calls, want)
+	}
+}
+
+func TestLinuxBackendInternalResumeESRCHRetainsPendingSignal(t *testing.T) {
+	const tid = 5751
+	b, calls := newRecordingLinuxBackend(t, tid)
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGABRT)})
+	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
+		*calls = append(*calls, linuxResumeCall{
+			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
+		})
+		return 0, 0, syscall.ESRCH
+	}
+
+	if err := b.continueIfTraceeExists(tid, 0); err != nil {
+		t.Fatalf("continueIfTraceeExists() error = %v", err)
+	}
+	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
+		*calls = append(*calls, linuxResumeCall{
+			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
+		})
+		return 0, 0, 0
+	}
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("ContinueProcess() after ESRCH error = %v", err)
+	}
+
+	want := []linuxResumeCall{
+		wantLinuxResume(syscall.PTRACE_CONT, tid, 0),
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGABRT)),
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("resume calls = %+v, want retained exact signal %+v", *calls, want)
+	}
+}
+
 func TestLinuxBackendInternalResumesDoNotTransferPendingSignals(t *testing.T) {
 	const (
 		tid             = 6001
@@ -511,8 +578,8 @@ func TestLinuxBackendSteppedSIGURGWaitsForFreshDeliveryStop(t *testing.T) {
 	b.recordStop(tid)
 
 	b.beginStep(tid)
-	if err := b.resumeAbsorbed(tid, int(syscall.SIGURG)); err != nil {
-		t.Fatalf("resumeAbsorbed(step SIGURG) error = %v", err)
+	if err := b.absorbStop(absorbPreempt, tid, int(syscall.SIGURG)); err != nil {
+		t.Fatalf("absorbStop(step SIGURG) error = %v", err)
 	}
 	b.endStep()
 	if err := b.SingleStep(tid); err != nil {
@@ -523,8 +590,8 @@ func TestLinuxBackendSteppedSIGURGWaitsForFreshDeliveryStop(t *testing.T) {
 	if err := b.ContinueProcess(); err != nil {
 		t.Fatalf("ContinueProcess() error = %v", err)
 	}
-	if err := b.resumeAbsorbed(tid, int(syscall.SIGURG)); err != nil {
-		t.Fatalf("resumeAbsorbed(fresh SIGURG delivery) error = %v", err)
+	if err := b.absorbStop(absorbPreempt, tid, int(syscall.SIGURG)); err != nil {
+		t.Fatalf("absorbStop(fresh SIGURG delivery) error = %v", err)
 	}
 
 	wantResumes := []linuxResumeCall{
@@ -559,8 +626,8 @@ func TestLinuxBackendCurrentSignalPrecedesDelayedSIGURG(t *testing.T) {
 	if err := b.ContinueProcess(); err != nil {
 		t.Fatalf("ContinueProcess() error = %v", err)
 	}
-	if err := b.resumeAbsorbed(tid, int(syscall.SIGURG)); err != nil {
-		t.Fatalf("resumeAbsorbed(fresh SIGURG delivery) error = %v", err)
+	if err := b.absorbStop(absorbPreempt, tid, int(syscall.SIGURG)); err != nil {
+		t.Fatalf("absorbStop(fresh SIGURG delivery) error = %v", err)
 	}
 
 	wantResumes := []linuxResumeCall{
@@ -590,8 +657,8 @@ func TestLinuxBackendPauseStillSuppressesSIGSTOPWithDelayedSIGURG(t *testing.T) 
 	if err := b.ContinueProcess(); err != nil {
 		t.Fatalf("ContinueProcess() error = %v", err)
 	}
-	if err := b.resumeAbsorbed(tid, int(syscall.SIGURG)); err != nil {
-		t.Fatalf("resumeAbsorbed(fresh SIGURG delivery) error = %v", err)
+	if err := b.absorbStop(absorbPreempt, tid, int(syscall.SIGURG)); err != nil {
+		t.Fatalf("absorbStop(fresh SIGURG delivery) error = %v", err)
 	}
 
 	wantResumes := []linuxResumeCall{
@@ -643,12 +710,21 @@ func TestLinuxBackendFailedSIGURGRequeueRestoresDelayedSignal(t *testing.T) {
 }
 
 func TestLinuxBackendExitingThreadDropsCurrentAndDelayedSignals(t *testing.T) {
-	const tid = 6501
-	b, calls := newRecordingLinuxBackend(t, tid)
+	const (
+		tid             = 6501
+		otherTID        = 6502
+		unrelatedSignal = int(syscall.SIGUSR2)
+	)
+	b := &linuxBackend{pid: tid}
+	var calls []linuxResumeCall
 	b.pendingSignals.set(tid, int(syscall.SIGUSR1))
 	b.pendingSignals.delay(tid, int(syscall.SIGURG))
-	b.tgkillFn = func(tgid, targetTID int, signal syscall.Signal) error {
-		t.Fatalf("tgkill(%d, %d, %d) called for exiting thread", tgid, targetTID, signal)
+	b.pendingSignals.set(otherTID, unrelatedSignal)
+	b.contFn = func(targetTID int, signal int) error {
+		calls = append(calls, wantLinuxResume(syscall.PTRACE_CONT, targetTID, signal))
+		if got := b.pendingSignals.take(targetTID); got != 0 {
+			return fmt.Errorf("pending signal %d remained when exiting tid %d resumed", got, targetTID)
+		}
 		return nil
 	}
 
@@ -657,11 +733,14 @@ func TestLinuxBackendExitingThreadDropsCurrentAndDelayedSignals(t *testing.T) {
 	}
 
 	want := []linuxResumeCall{wantLinuxResume(syscall.PTRACE_CONT, tid, 0)}
-	if !reflect.DeepEqual(*calls, want) {
-		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("resume calls = %+v, want %+v", calls, want)
 	}
 	if got := b.pendingSignals.take(tid); got != 0 {
 		t.Fatalf("pending signal after exit resume = %d, want 0", got)
+	}
+	if got := b.pendingSignals.take(otherTID); got != unrelatedSignal {
+		t.Fatalf("unrelated signal after exit resume = %d, want %d", got, unrelatedSignal)
 	}
 }
 
@@ -970,6 +1049,7 @@ func TestLinuxBackendApplyAbsorbCarriesOutThePlan(t *testing.T) {
 
 	t.Run("absorbing on the stepped thread re-arms the step and holds the gate", func(t *testing.T) {
 		b := newBackend()
+		b.pendingSignals.set(stepped, int(syscall.SIGUSR1))
 		before := b.stepRearmCount()
 		if err := b.applyAbsorb(b.planAbsorb(absorbPreempt, stepped, sigurg), stepped); err != nil {
 			t.Fatalf("applyAbsorb(absorbPreempt) error = %v", err)
@@ -979,6 +1059,12 @@ func TestLinuxBackendApplyAbsorbCarriesOutThePlan(t *testing.T) {
 		}
 		if _, ok := b.releasable(); ok {
 			t.Fatal("the gate opened while the re-armed step is still in flight")
+		}
+		if got := b.pendingSignals.take(stepped); got != int(syscall.SIGUSR1) {
+			t.Fatalf("current signal after re-arm = %d, want %d", got, syscall.SIGUSR1)
+		}
+		if got := b.pendingSignals.take(stepped); got != sigurg {
+			t.Fatalf("delayed signal after re-arm = %d, want %d", got, sigurg)
 		}
 	})
 
@@ -1607,6 +1693,66 @@ func TestLinuxWaitMarksFatalStopsSessionInvalidating(t *testing.T) {
 	}
 }
 
+func TestLinuxWaitCloneAbsorbPreservesPendingSignalOnSteppedThread(t *testing.T) {
+	const (
+		pid     = 9151
+		stepped = 9152
+	)
+	b := &linuxBackend{pid: pid}
+	script := &scriptedWait{stops: []scriptedStop{
+		{tid: stepped, status: stoppedAt(syscall.SIGTRAP, syscall.PTRACE_EVENT_CLONE)},
+		{tid: stepped, status: stoppedAt(syscall.SIGTRAP, 0)},
+	}}
+	script.install(b)
+	b.pendingSignals.set(stepped, int(syscall.SIGUSR1))
+	b.beginStep(stepped)
+
+	ev, err := b.Wait()
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if ev.Reason != StopSingleStep || ev.TID != stepped {
+		t.Fatalf("Wait() = %+v, want the re-armed step completion on tid %d", ev, stepped)
+	}
+	want := []resumeOp{{step: true, tid: stepped}}
+	if !reflect.DeepEqual(script.ops, want) {
+		t.Fatalf("resume ops = %+v, want %+v", script.ops, want)
+	}
+	if got := b.pendingSignals.take(stepped); got != int(syscall.SIGUSR1) {
+		t.Fatalf("pending signal after clone absorb = %d, want %d", got, syscall.SIGUSR1)
+	}
+}
+
+func TestLinuxWaitClearsReusedTIDStateBeforeNewThreadResume(t *testing.T) {
+	const (
+		pid       = 9201
+		newThread = 9202
+	)
+	b := &linuxBackend{pid: pid}
+	script := &scriptedWait{stops: []scriptedStop{
+		{tid: newThread, status: stoppedAt(syscall.SIGSTOP, 0)},
+		{tid: pid, status: exitedWith(0)},
+	}}
+	script.install(b)
+	b.pendingSignals.set(newThread, int(syscall.SIGUSR1))
+	b.pendingSignals.delay(newThread, int(syscall.SIGURG))
+	b.contFn = func(tid int, signal int) error {
+		if got := b.pendingSignals.take(tid); got != 0 {
+			return fmt.Errorf("stale signal %d remained on reused tid %d", got, tid)
+		}
+		script.ops = append(script.ops, resumeOp{tid: tid, signal: signal})
+		return nil
+	}
+
+	if _, err := b.Wait(); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	want := []resumeOp{{tid: newThread}}
+	if !reflect.DeepEqual(script.ops, want) {
+		t.Fatalf("resume ops = %+v, want %+v", script.ops, want)
+	}
+}
+
 // TestLinuxWaitAlwaysFailsOnExec pins scope A: a post-startup PTRACE_EVENT_EXEC
 // terminates the session unconditionally.
 //
@@ -1647,6 +1793,8 @@ func TestLinuxWaitAlwaysFailsOnExec(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			b := &linuxBackend{pid: pid}
+			b.pendingSignals.set(pid, int(syscall.SIGUSR1))
+			b.pendingSignals.delay(stepped, int(syscall.SIGURG))
 			script := &scriptedWait{stops: []scriptedStop{
 				{tid: tc.execTID, status: stoppedAt(syscall.SIGTRAP, syscall.PTRACE_EVENT_EXEC)},
 			}}
@@ -1682,6 +1830,12 @@ func TestLinuxWaitAlwaysFailsOnExec(t *testing.T) {
 			}
 			if tid, ok := b.heldStepOwner(); ok {
 				t.Fatalf("heldStepOwner() = (%d, %v) after the exec abort, want the obligation dropped", tid, ok)
+			}
+			if got := b.pendingSignals.take(pid); got != 0 {
+				t.Fatalf("pending signal after exec abort = %d, want process-wide purge", got)
+			}
+			if got := b.pendingSignals.take(stepped); got != 0 {
+				t.Fatalf("delayed signal after exec abort = %d, want process-wide purge", got)
 			}
 		})
 	}
@@ -1914,6 +2068,8 @@ func TestLinuxWaitHoldsTheDyingStepOwnerAsItsOwnAnchor(t *testing.T) {
 	if got := b.heldStepOwnerCount(); got != 1 {
 		t.Fatalf("heldStepOwnerCount() = %d, want 1", got)
 	}
+	b.pendingSignals.set(stepped, int(syscall.SIGUSR1))
+	b.pendingSignals.delay(stepped, int(syscall.SIGURG))
 
 	if err := b.completeStepThreadExit(); err != nil {
 		t.Fatalf("completeStepThreadExit() = %v, want success", err)
@@ -1926,6 +2082,9 @@ func TestLinuxWaitHoldsTheDyingStepOwnerAsItsOwnAnchor(t *testing.T) {
 	}
 	if tid, ok := b.heldStepOwner(); ok {
 		t.Fatalf("heldStepOwner() = (%d, %v) after release, want nothing held", tid, ok)
+	}
+	if got := b.pendingSignals.take(stepped); got != 0 {
+		t.Fatalf("pending signal after held-owner release = %d, want 0", got)
 	}
 
 	if err := b.completeStepThreadExit(); err != nil {
@@ -1951,6 +2110,8 @@ func TestLinuxWaitTreatsADeadHeldOwnerAsReleased(t *testing.T) {
 	b.beginStep(stepped)
 	b.interruptStepIfStepped(stepped)
 	b.holdStepOwner(stepped)
+	b.pendingSignals.set(stepped, int(syscall.SIGUSR1))
+	b.pendingSignals.delay(stepped, int(syscall.SIGURG))
 	b.contFn = func(int, int) error { return syscall.ESRCH }
 
 	if err := b.completeStepThreadExit(); err != nil {
@@ -1961,6 +2122,9 @@ func TestLinuxWaitTreatsADeadHeldOwnerAsReleased(t *testing.T) {
 	}
 	if b.stepExitPending {
 		t.Fatal("the gate stayed closed after a benign release")
+	}
+	if got := b.pendingSignals.take(stepped); got != 0 {
+		t.Fatalf("pending signal after ESRCH release = %d, want 0 for conclusively dying owner", got)
 	}
 }
 

--- a/internal/debugger/backend_linux_amd64_test.go
+++ b/internal/debugger/backend_linux_amd64_test.go
@@ -993,94 +993,104 @@ func TestLinuxBackendWaitDrainsBeforeBlocking(t *testing.T) {
 // The resumes are issued against thread ids that do not exist, so ptrace fails
 // with ESRCH and the backend swallows it; the bookkeeping under test still runs.
 func TestLinuxBackendApplyAbsorbCarriesOutThePlan(t *testing.T) {
+	t.Run("a dying stepped thread hands the gate to engine reconciliation", testApplyAbsorbThreadExit)
+	t.Run("absorbing on the stepped thread re-arms the step and holds the gate", testApplyAbsorbSteppedPreempt)
+	t.Run("absorbing on any other thread neither re-arms nor opens the gate", testApplyAbsorbForeignPreempt)
+}
+
+func newApplyAbsorbBackend(t *testing.T) *linuxBackend {
 	const (
 		pid     = 7001
 		stepped = 7002
 		foreign = 7003
-		sigurg  = 23
 	)
 
-	newBackend := func() *linuxBackend {
-		b := &linuxBackend{pid: pid, tracer: newTracerThread()}
-		t.Cleanup(b.closeTracer)
-		b.recordStop(pid)
-		b.beginStep(stepped)
-		b.park(StopEvent{Reason: StopBreakpoint, TID: foreign})
-		return b
+	b := &linuxBackend{pid: pid, tracer: newTracerThread()}
+	t.Cleanup(b.closeTracer)
+	b.recordStop(pid)
+	b.beginStep(stepped)
+	b.park(StopEvent{Reason: StopBreakpoint, TID: foreign})
+	return b
+}
+
+// A dead step owner does not simply release the gate: the engine still owns
+// the breakpoint that was lifted for that step, and delivering the held stop
+// before it is reinstalled loses the trap for good.
+func testApplyAbsorbThreadExit(t *testing.T) {
+	const (
+		stepped = 7002
+		foreign = 7003
+	)
+	b := newApplyAbsorbBackend(t)
+	if err := b.applyAbsorb(b.planAbsorb(absorbThreadExit, stepped, 0), stepped); err != nil {
+		t.Fatalf("applyAbsorb(absorbThreadExit) error = %v", err)
+	}
+	if b.stepping {
+		t.Fatal("hardware-step ownership survived its thread's death")
+	}
+	if ev, ok := b.releasable(); ok {
+		t.Fatalf("released %+v before breakpoint reconciliation", ev)
 	}
 
-	// A dead step owner does not simply release the gate: the engine still owns
-	// the breakpoint that was lifted for that step, and delivering the held stop
-	// before it is reinstalled loses the trap for good. The handoff is therefore
-	// three-phase, and each phase is asserted here because skipping any one of
-	// them either freezes the wait loop or drops a breakpoint silently. In
-	// particular, reporting the boundary must NOT release the stop on its own:
-	// only the engine's acknowledgement may, or the reinstall is racing a
-	// sibling that has already been handed to the engine.
-	t.Run("a dying stepped thread hands the gate to engine reconciliation", func(t *testing.T) {
-		b := newBackend()
-		if err := b.applyAbsorb(b.planAbsorb(absorbThreadExit, stepped, 0), stepped); err != nil {
-			t.Fatalf("applyAbsorb(absorbThreadExit) error = %v", err)
-		}
-		if b.stepping {
-			t.Fatal("hardware-step ownership survived its thread's death")
-		}
-		if ev, ok := b.releasable(); ok {
-			t.Fatalf("released %+v before breakpoint reconciliation", ev)
-		}
+	boundary, ok := b.stepExitBoundary()
+	if !ok || boundary.Reason != StopStepThreadExited || boundary.TID != foreign {
+		t.Fatalf("stepExitBoundary() = (%+v, %t), want StopStepThreadExited anchored to the held stop's tid %d",
+			boundary, ok, foreign)
+	}
+	if ev, ok := b.releasable(); ok {
+		t.Fatalf("reporting the boundary released %+v; only the engine's acknowledgement may", ev)
+	}
 
-		boundary, ok := b.stepExitBoundary()
-		if !ok || boundary.Reason != StopStepThreadExited || boundary.TID != foreign {
-			t.Fatalf("stepExitBoundary() = (%+v, %t), want StopStepThreadExited anchored to the held stop's tid %d",
-				boundary, ok, foreign)
-		}
-		if ev, ok := b.releasable(); ok {
-			t.Fatalf("reporting the boundary released %+v; only the engine's acknowledgement may", ev)
-		}
+	if err := b.completeStepThreadExit(); err != nil {
+		t.Fatalf("completeStepThreadExit() = %v, want success", err)
+	}
+	ev, ok := b.releasable()
+	if !ok || ev.TID != foreign {
+		t.Fatalf("released (%+v, %t), want the held stop on tid %d after reconciliation", ev, ok, foreign)
+	}
+}
 
-		if err := b.completeStepThreadExit(); err != nil {
-			t.Fatalf("completeStepThreadExit() = %v, want success", err)
-		}
-		ev, ok := b.releasable()
-		if !ok || ev.TID != foreign {
-			t.Fatalf("released (%+v, %t), want the held stop on tid %d after reconciliation", ev, ok, foreign)
-		}
-	})
+func testApplyAbsorbSteppedPreempt(t *testing.T) {
+	const (
+		stepped = 7002
+		sigurg  = 23
+	)
+	b := newApplyAbsorbBackend(t)
+	b.pendingSignals.set(stepped, int(syscall.SIGUSR1))
+	before := b.stepRearmCount()
+	if err := b.applyAbsorb(b.planAbsorb(absorbPreempt, stepped, sigurg), stepped); err != nil {
+		t.Fatalf("applyAbsorb(absorbPreempt) error = %v", err)
+	}
+	if after := b.stepRearmCount(); after != before+1 {
+		t.Fatalf("step re-arms = %d, want %d: the consumed step was not re-armed", after, before+1)
+	}
+	if _, ok := b.releasable(); ok {
+		t.Fatal("the gate opened while the re-armed step is still in flight")
+	}
+	if got := b.pendingSignals.take(stepped); got != int(syscall.SIGUSR1) {
+		t.Fatalf("current signal after re-arm = %d, want %d", got, syscall.SIGUSR1)
+	}
+	if got := b.pendingSignals.take(stepped); got != sigurg {
+		t.Fatalf("delayed signal after re-arm = %d, want %d", got, sigurg)
+	}
+}
 
-	t.Run("absorbing on the stepped thread re-arms the step and holds the gate", func(t *testing.T) {
-		b := newBackend()
-		b.pendingSignals.set(stepped, int(syscall.SIGUSR1))
-		before := b.stepRearmCount()
-		if err := b.applyAbsorb(b.planAbsorb(absorbPreempt, stepped, sigurg), stepped); err != nil {
-			t.Fatalf("applyAbsorb(absorbPreempt) error = %v", err)
-		}
-		if after := b.stepRearmCount(); after != before+1 {
-			t.Fatalf("step re-arms = %d, want %d: the consumed step was not re-armed", after, before+1)
-		}
-		if _, ok := b.releasable(); ok {
-			t.Fatal("the gate opened while the re-armed step is still in flight")
-		}
-		if got := b.pendingSignals.take(stepped); got != int(syscall.SIGUSR1) {
-			t.Fatalf("current signal after re-arm = %d, want %d", got, syscall.SIGUSR1)
-		}
-		if got := b.pendingSignals.take(stepped); got != sigurg {
-			t.Fatalf("delayed signal after re-arm = %d, want %d", got, sigurg)
-		}
-	})
-
-	t.Run("absorbing on any other thread neither re-arms nor opens the gate", func(t *testing.T) {
-		b := newBackend()
-		before := b.stepRearmCount()
-		if err := b.applyAbsorb(b.planAbsorb(absorbPreempt, foreign, sigurg), foreign); err != nil {
-			t.Fatalf("applyAbsorb(absorbPreempt) error = %v", err)
-		}
-		if after := b.stepRearmCount(); after != before {
-			t.Fatalf("step re-arms = %d, want %d: a foreign thread must not re-arm the step", after, before)
-		}
-		if _, ok := b.releasable(); ok {
-			t.Fatal("a foreign absorb opened the step gate")
-		}
-	})
+func testApplyAbsorbForeignPreempt(t *testing.T) {
+	const (
+		foreign = 7003
+		sigurg  = 23
+	)
+	b := newApplyAbsorbBackend(t)
+	before := b.stepRearmCount()
+	if err := b.applyAbsorb(b.planAbsorb(absorbPreempt, foreign, sigurg), foreign); err != nil {
+		t.Fatalf("applyAbsorb(absorbPreempt) error = %v", err)
+	}
+	if after := b.stepRearmCount(); after != before {
+		t.Fatalf("step re-arms = %d, want %d: a foreign thread must not re-arm the step", after, before)
+	}
+	if _, ok := b.releasable(); ok {
+		t.Fatal("a foreign absorb opened the step gate")
+	}
 }
 
 // resumeOp records one ptrace resume the wait loop issued.
@@ -1792,52 +1802,57 @@ func TestLinuxWaitAlwaysFailsOnExec(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			b := &linuxBackend{pid: pid}
-			b.pendingSignals.set(pid, int(syscall.SIGUSR1))
-			b.pendingSignals.delay(stepped, int(syscall.SIGURG))
-			script := &scriptedWait{stops: []scriptedStop{
-				{tid: tc.execTID, status: stoppedAt(syscall.SIGTRAP, syscall.PTRACE_EVENT_EXEC)},
-			}}
-			script.install(b)
-			if tc.inStep {
-				b.beginStep(stepped)
-				b.park(StopEvent{Reason: StopBreakpoint, TID: foreign})
-				b.holdStepOwner(stepped)
-			}
-
-			_, err := b.Wait()
-			if err == nil {
-				t.Fatal("Wait() succeeded on an exec; the image every breakpoint " +
-					"belongs to is gone and the session cannot continue")
-			}
-			if !strings.Contains(err.Error(), "process image") {
-				t.Fatalf("Wait() error = %q, want it to name the image replacement", err)
-			}
-			if strings.Contains(err.Error(), "single-stepped") {
-				t.Fatalf("Wait() error = %q, must not claim the reported pid was the "+
-					"stepped thread: after execve the kernel reports the leader's pid", err)
-			}
-			if len(script.ops) != 0 {
-				t.Fatalf("resume ops = %+v, want none: the exec stop must not be "+
-					"continued into an image the debugger cannot describe", script.ops)
-			}
-			if b.stepping || b.stepExitPending {
-				t.Fatalf("step state survived the exec abort: stepping=%v stepExitPending=%v",
-					b.stepping, b.stepExitPending)
-			}
-			if b.parkedDepthForTest() != 0 {
-				t.Fatal("held stops survived the exec abort; they name threads of an image that is gone")
-			}
-			if tid, ok := b.heldStepOwner(); ok {
-				t.Fatalf("heldStepOwner() = (%d, %v) after the exec abort, want the obligation dropped", tid, ok)
-			}
-			if got := b.pendingSignals.take(pid); got != 0 {
-				t.Fatalf("pending signal after exec abort = %d, want process-wide purge", got)
-			}
-			if got := b.pendingSignals.take(stepped); got != 0 {
-				t.Fatalf("delayed signal after exec abort = %d, want process-wide purge", got)
-			}
+			assertLinuxWaitFailsOnExec(t, pid, stepped, foreign, tc.execTID, tc.inStep)
 		})
+	}
+}
+
+func assertLinuxWaitFailsOnExec(t *testing.T, pid, stepped, foreign, execTID int, inStep bool) {
+	t.Helper()
+	b := &linuxBackend{pid: pid}
+	b.pendingSignals.set(pid, int(syscall.SIGUSR1))
+	b.pendingSignals.delay(stepped, int(syscall.SIGURG))
+	script := &scriptedWait{stops: []scriptedStop{
+		{tid: execTID, status: stoppedAt(syscall.SIGTRAP, syscall.PTRACE_EVENT_EXEC)},
+	}}
+	script.install(b)
+	if inStep {
+		b.beginStep(stepped)
+		b.park(StopEvent{Reason: StopBreakpoint, TID: foreign})
+		b.holdStepOwner(stepped)
+	}
+
+	_, err := b.Wait()
+	if err == nil {
+		t.Fatal("Wait() succeeded on an exec; the image every breakpoint " +
+			"belongs to is gone and the session cannot continue")
+	}
+	if !strings.Contains(err.Error(), "process image") {
+		t.Fatalf("Wait() error = %q, want it to name the image replacement", err)
+	}
+	if strings.Contains(err.Error(), "single-stepped") {
+		t.Fatalf("Wait() error = %q, must not claim the reported pid was the "+
+			"stepped thread: after execve the kernel reports the leader's pid", err)
+	}
+	if len(script.ops) != 0 {
+		t.Fatalf("resume ops = %+v, want none: the exec stop must not be "+
+			"continued into an image the debugger cannot describe", script.ops)
+	}
+	if b.stepping || b.stepExitPending {
+		t.Fatalf("step state survived the exec abort: stepping=%v stepExitPending=%v",
+			b.stepping, b.stepExitPending)
+	}
+	if b.parkedDepthForTest() != 0 {
+		t.Fatal("held stops survived the exec abort; they name threads of an image that is gone")
+	}
+	if tid, ok := b.heldStepOwner(); ok {
+		t.Fatalf("heldStepOwner() = (%d, %v) after the exec abort, want the obligation dropped", tid, ok)
+	}
+	if got := b.pendingSignals.take(pid); got != 0 {
+		t.Fatalf("pending signal after exec abort = %d, want process-wide purge", got)
+	}
+	if got := b.pendingSignals.take(stepped); got != 0 {
+		t.Fatalf("delayed signal after exec abort = %d, want process-wide purge", got)
 	}
 }
 

--- a/internal/debugger/backend_linux_amd64_test.go
+++ b/internal/debugger/backend_linux_amd64_test.go
@@ -354,7 +354,7 @@ func TestLinuxBackendPauseSignalIsNeverForwarded(t *testing.T) {
 	}
 }
 
-func TestLinuxBackendSingleStepForwardsOnlyMatchingTIDSignal(t *testing.T) {
+func TestLinuxBackendSingleStepPreservesSignalUntilMatchingTIDContinues(t *testing.T) {
 	const (
 		signalled = 4002
 		other     = 4003
@@ -369,10 +369,49 @@ func TestLinuxBackendSingleStepForwardsOnlyMatchingTIDSignal(t *testing.T) {
 	if err := b.SingleStep(signalled); err != nil {
 		t.Fatalf("SingleStep(signalled) error = %v", err)
 	}
+	b.endStep()
+	b.recordStop(signalled)
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("ContinueProcess(signalled) error = %v", err)
+	}
 
 	want := []linuxResumeCall{
 		wantLinuxResume(syscall.PTRACE_SINGLESTEP, other, 0),
-		wantLinuxResume(syscall.PTRACE_SINGLESTEP, signalled, int(syscall.SIGUSR1)),
+		wantLinuxResume(syscall.PTRACE_SINGLESTEP, signalled, 0),
+		wantLinuxResume(syscall.PTRACE_CONT, signalled, int(syscall.SIGUSR1)),
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
+	}
+}
+
+func TestLinuxBackendFailedSingleStepRetainsPendingSignal(t *testing.T) {
+	const tid = 4501
+	b, calls := newRecordingLinuxBackend(t, tid)
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGSEGV)})
+	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
+		*calls = append(*calls, linuxResumeCall{
+			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
+		})
+		return 0, 0, syscall.EIO
+	}
+
+	if err := b.SingleStep(tid); !errors.Is(err, syscall.EIO) {
+		t.Fatalf("SingleStep() error = %v, want %v", err, syscall.EIO)
+	}
+	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
+		*calls = append(*calls, linuxResumeCall{
+			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
+		})
+		return 0, 0, 0
+	}
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("ContinueProcess() error = %v", err)
+	}
+
+	want := []linuxResumeCall{
+		wantLinuxResume(syscall.PTRACE_SINGLESTEP, tid, 0),
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGSEGV)),
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
@@ -413,7 +452,7 @@ func TestLinuxBackendFailedResumeRetainsPendingSignal(t *testing.T) {
 	}
 }
 
-func TestLinuxBackendInternalResumesClearOnlyTheirPendingSignal(t *testing.T) {
+func TestLinuxBackendInternalResumesDoNotTransferPendingSignals(t *testing.T) {
 	const (
 		tid             = 6001
 		unrelatedTID    = 6002
@@ -451,7 +490,7 @@ func TestLinuxBackendInternalResumesClearOnlyTheirPendingSignal(t *testing.T) {
 		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGURG)),
 		wantLinuxResume(syscall.PTRACE_CONT, tid, 0),
 		wantLinuxResume(syscall.PTRACE_SINGLESTEP, tid, 0),
-		wantLinuxResume(syscall.PTRACE_CONT, tid, 0),
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGABRT)),
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("resume calls = %+v, want %+v", *calls, want)

--- a/internal/debugger/backend_linux_amd64_test.go
+++ b/internal/debugger/backend_linux_amd64_test.go
@@ -49,6 +49,13 @@ func recordingPtraceSyscall(calls *[]linuxResumeCall, errno syscall.Errno) func(
 	}
 }
 
+func recordingTgkill(calls *[]linuxTgkillCall) func(int, int, syscall.Signal) error {
+	return func(tgid, tid int, signal syscall.Signal) error {
+		*calls = append(*calls, linuxTgkillCall{tgid: tgid, tid: tid, signal: int(signal)})
+		return nil
+	}
+}
+
 func newRecordingLinuxBackend(t *testing.T, pid int) (*linuxBackend, *[]linuxResumeCall) {
 	t.Helper()
 	calls := &[]linuxResumeCall{}
@@ -462,6 +469,132 @@ func TestLinuxBackendFailedResumeESRCHRetainsPendingSignal(t *testing.T) {
 	}
 }
 
+func TestLinuxBackendDistinctSignalDuringStepPreservesBothExactTIDResumes(t *testing.T) {
+	const (
+		pid = 5601
+		tid = 5602
+	)
+	b, calls := newRecordingLinuxBackend(t, pid)
+	var tgkills []linuxTgkillCall
+	b.tgkillFn = recordingTgkill(&tgkills)
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGUSR1)})
+	b.ptraceSyscall6Fn = recordingPtraceSyscall(calls, syscall.EIO)
+
+	if err := b.ContinueProcess(); !errors.Is(err, syscall.EIO) {
+		t.Fatalf("ContinueProcess() error = %v, want %v", err, syscall.EIO)
+	}
+	b.ptraceSyscall6Fn = recordingPtraceSyscall(calls, 0)
+	if err := b.SingleStep(tid); err != nil {
+		t.Fatalf("SingleStep() error = %v", err)
+	}
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGUSR2)})
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("ContinueProcess() after distinct signal error = %v", err)
+	}
+
+	wantResumes := []linuxResumeCall{
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGUSR1)),
+		wantLinuxResume(syscall.PTRACE_SINGLESTEP, tid, 0),
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGUSR2)),
+	}
+	if !reflect.DeepEqual(*calls, wantResumes) {
+		t.Fatalf("resume calls = %+v, want exact tuples %+v", *calls, wantResumes)
+	}
+	wantTgkills := []linuxTgkillCall{{
+		tgid: pid, tid: tid, signal: int(syscall.SIGUSR1),
+	}}
+	if !reflect.DeepEqual(tgkills, wantTgkills) {
+		t.Fatalf("tgkill calls = %+v, want older signal requeued to exact tid %+v", tgkills, wantTgkills)
+	}
+	if pending := b.pendingSignals.takeForContinue(tid); pending.current != 0 ||
+		len(pending.deferred) != 0 {
+		t.Fatalf("pending signals after successful continue = %+v, want empty", pending)
+	}
+}
+
+func TestLinuxBackendPartialDeferredRequeueRestoresOnlyUnsentSignals(t *testing.T) {
+	const (
+		pid = 5701
+		tid = 5702
+	)
+	b, calls := newRecordingLinuxBackend(t, pid)
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGUSR1)})
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGUSR2)})
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGALRM)})
+	b.pendingSignals.delay(tid, int(syscall.SIGURG))
+
+	var attempts []linuxTgkillCall
+	b.tgkillFn = func(tgid, targetTID int, signal syscall.Signal) error {
+		attempts = append(attempts, linuxTgkillCall{tgid: tgid, tid: targetTID, signal: int(signal)})
+		if len(attempts) == 2 {
+			return syscall.EAGAIN
+		}
+		return nil
+	}
+
+	if err := b.ContinueProcess(); !errors.Is(err, syscall.EAGAIN) {
+		t.Fatalf("ContinueProcess() error = %v, want %v", err, syscall.EAGAIN)
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("ptrace calls after failed requeue = %+v, want none", *calls)
+	}
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("retry ContinueProcess() error = %v", err)
+	}
+
+	wantAttempts := []linuxTgkillCall{
+		{tgid: pid, tid: tid, signal: int(syscall.SIGUSR1)},
+		{tgid: pid, tid: tid, signal: int(syscall.SIGUSR2)},
+		{tgid: pid, tid: tid, signal: int(syscall.SIGUSR2)},
+		{tgid: pid, tid: tid, signal: int(syscall.SIGURG)},
+	}
+	if !reflect.DeepEqual(attempts, wantAttempts) {
+		t.Fatalf("tgkill attempts = %+v, want successful prefixes not restored %+v", attempts, wantAttempts)
+	}
+	wantResumes := []linuxResumeCall{
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGALRM)),
+	}
+	if !reflect.DeepEqual(*calls, wantResumes) {
+		t.Fatalf("resume calls = %+v, want newest signal injected %+v", *calls, wantResumes)
+	}
+}
+
+func TestLinuxBackendFailedResumeDoesNotRestoreRequeuedSignals(t *testing.T) {
+	const (
+		pid = 5721
+		tid = 5722
+	)
+	b, calls := newRecordingLinuxBackend(t, pid)
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGUSR1)})
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGUSR2)})
+
+	var tgkills []linuxTgkillCall
+	b.tgkillFn = recordingTgkill(&tgkills)
+	b.ptraceSyscall6Fn = recordingPtraceSyscall(calls, syscall.EIO)
+	if err := b.ContinueProcess(); !errors.Is(err, syscall.EIO) {
+		t.Fatalf("ContinueProcess() error = %v, want %v", err, syscall.EIO)
+	}
+
+	b.ptraceSyscall6Fn = recordingPtraceSyscall(calls, 0)
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("retry ContinueProcess() error = %v", err)
+	}
+
+	wantTgkills := []linuxTgkillCall{{
+		tgid: pid, tid: tid, signal: int(syscall.SIGUSR1),
+	}}
+	if !reflect.DeepEqual(tgkills, wantTgkills) {
+		t.Fatalf("tgkill calls = %+v, want already-requeued signal sent only once %+v", tgkills, wantTgkills)
+	}
+	wantResumes := []linuxResumeCall{
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGUSR2)),
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGUSR2)),
+	}
+	if !reflect.DeepEqual(*calls, wantResumes) {
+		t.Fatalf("resume calls = %+v, want current signal retained across failure %+v", *calls, wantResumes)
+	}
+}
+
 func TestLinuxBackendInternalResumeESRCHRetainsPendingSignal(t *testing.T) {
 	const tid = 5751
 	b, calls := newRecordingLinuxBackend(t, tid)
@@ -482,6 +615,45 @@ func TestLinuxBackendInternalResumeESRCHRetainsPendingSignal(t *testing.T) {
 	}
 	if !reflect.DeepEqual(*calls, want) {
 		t.Fatalf("resume calls = %+v, want retained exact signal %+v", *calls, want)
+	}
+}
+
+func TestLinuxBackendInternalResumeESRCHRetainsRequeuedSignals(t *testing.T) {
+	const (
+		pid = 5771
+		tid = 5772
+	)
+	b, calls := newRecordingLinuxBackend(t, pid)
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGUSR1)})
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGUSR2)})
+
+	var tgkills []linuxTgkillCall
+	b.tgkillFn = recordingTgkill(&tgkills)
+	b.ptraceSyscall6Fn = recordingPtraceSyscall(calls, syscall.ESRCH)
+	if err := b.continueIfTraceeExists(tid, 0); err != nil {
+		t.Fatalf("continueIfTraceeExists() error = %v", err)
+	}
+
+	b.ptraceSyscall6Fn = recordingPtraceSyscall(calls, 0)
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("ContinueProcess() after ESRCH error = %v", err)
+	}
+
+	// The failed CONT leaves the TID stopped, so the second standard signal
+	// requeue coalesces with the first instead of creating another delivery.
+	wantTgkills := []linuxTgkillCall{
+		{tgid: pid, tid: tid, signal: int(syscall.SIGUSR1)},
+		{tgid: pid, tid: tid, signal: int(syscall.SIGUSR1)},
+	}
+	if !reflect.DeepEqual(tgkills, wantTgkills) {
+		t.Fatalf("tgkill calls = %+v, want conservative ESRCH retry %+v", tgkills, wantTgkills)
+	}
+	wantResumes := []linuxResumeCall{
+		wantLinuxResume(syscall.PTRACE_CONT, tid, 0),
+		wantLinuxResume(syscall.PTRACE_CONT, tid, int(syscall.SIGUSR2)),
+	}
+	if !reflect.DeepEqual(*calls, wantResumes) {
+		t.Fatalf("resume calls = %+v, want exact retry tuples %+v", *calls, wantResumes)
 	}
 }
 
@@ -537,10 +709,7 @@ func TestLinuxBackendSteppedSIGURGWaitsForFreshDeliveryStop(t *testing.T) {
 	)
 	b, calls := newRecordingLinuxBackend(t, pid)
 	var tgkills []linuxTgkillCall
-	b.tgkillFn = func(tgid, targetTID int, signal syscall.Signal) error {
-		tgkills = append(tgkills, linuxTgkillCall{tgid: tgid, tid: targetTID, signal: int(signal)})
-		return nil
-	}
+	b.tgkillFn = recordingTgkill(&tgkills)
 	b.recordStop(tid)
 
 	b.beginStep(tid)
@@ -582,10 +751,7 @@ func TestLinuxBackendCurrentSignalPrecedesDelayedSIGURG(t *testing.T) {
 	)
 	b, calls := newRecordingLinuxBackend(t, pid)
 	var tgkills []linuxTgkillCall
-	b.tgkillFn = func(tgid, targetTID int, signal syscall.Signal) error {
-		tgkills = append(tgkills, linuxTgkillCall{tgid: tgid, tid: targetTID, signal: int(signal)})
-		return nil
-	}
+	b.tgkillFn = recordingTgkill(&tgkills)
 	b.pendingSignals.delay(tid, int(syscall.SIGURG))
 	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGUSR1)})
 
@@ -613,10 +779,7 @@ func TestLinuxBackendPauseStillSuppressesSIGSTOPWithDelayedSIGURG(t *testing.T) 
 	const tid = 6301
 	b, calls := newRecordingLinuxBackend(t, tid)
 	var tgkills []linuxTgkillCall
-	b.tgkillFn = func(tgid, targetTID int, signal syscall.Signal) error {
-		tgkills = append(tgkills, linuxTgkillCall{tgid: tgid, tid: targetTID, signal: int(signal)})
-		return nil
-	}
+	b.tgkillFn = recordingTgkill(&tgkills)
 	b.pendingSignals.delay(tid, int(syscall.SIGURG))
 	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: b.PauseSignal()})
 
@@ -707,6 +870,78 @@ func TestLinuxBackendExitingThreadDropsCurrentAndDelayedSignals(t *testing.T) {
 	}
 	if got := b.pendingSignals.take(otherTID); got != unrelatedSignal {
 		t.Fatalf("unrelated signal after exit resume = %d, want %d", got, unrelatedSignal)
+	}
+}
+
+func TestLinuxWaitDeathPathsClearOnlyDeadTIDSignals(t *testing.T) {
+	tests := []struct {
+		name   string
+		status syscall.WaitStatus
+	}{
+		{name: "wait reports exited", status: exitedWith(7)},
+		{name: "wait reports signaled", status: signaledBy(syscall.SIGKILL)},
+		{name: "ptrace event exit", status: stoppedAt(syscall.SIGTRAP, syscall.PTRACE_EVENT_EXIT)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			testLinuxWaitDeathPathClearsOnlyDeadTIDSignals(t, tc.status)
+		})
+	}
+}
+
+func testLinuxWaitDeathPathClearsOnlyDeadTIDSignals(t *testing.T, status syscall.WaitStatus) {
+	t.Helper()
+	const (
+		pid        = 6601
+		deadTID    = 6602
+		otherTID   = 6603
+		observerID = 6604
+	)
+	leaderStatus := uint(exitedWith(71))
+	b := &linuxBackend{pid: pid}
+	script := &scriptedWait{stops: []scriptedStop{
+		{tid: deadTID, status: status},
+		{tid: observerID, status: stoppedAt(syscall.SIGUSR2, 0)},
+	}}
+	script.install(b)
+	b.noteLeaderExit(leaderStatus, true)
+
+	b.pendingSignals.set(deadTID, int(syscall.SIGUSR1))
+	b.pendingSignals.set(deadTID, int(syscall.SIGUSR2))
+	b.pendingSignals.delay(deadTID, int(syscall.SIGURG))
+	b.pendingSignals.set(otherTID, int(syscall.SIGALRM))
+	b.pendingSignals.set(otherTID, int(syscall.SIGTERM))
+	b.pendingSignals.delay(otherTID, int(syscall.SIGURG))
+
+	var tgkills []linuxTgkillCall
+	b.tgkillFn = recordingTgkill(&tgkills)
+
+	ev, err := b.Wait()
+	if err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	if ev.Reason != StopSignal || ev.TID != observerID {
+		t.Fatalf("Wait() = %+v, want observer signal stop on tid %d", ev, observerID)
+	}
+	assertPendingSignalBatch(t, "dead tid", b.pendingSignals.takeForContinue(deadTID), pendingSignalBatch{})
+	assertPendingSignalBatch(t, "unrelated tid", b.pendingSignals.takeForContinue(otherTID), pendingSignalBatch{
+		current:  int(syscall.SIGTERM),
+		deferred: []int{int(syscall.SIGALRM), int(syscall.SIGURG)},
+	})
+	if len(tgkills) != 0 {
+		t.Fatalf("tgkill calls = %+v, want none while retiring tid %d", tgkills, deadTID)
+	}
+	if !b.leaderExitStashed || b.leaderExitStatus != leaderStatus {
+		t.Fatalf("leader exit changed to stashed=%v status=%d, want stashed status %d",
+			b.leaderExitStashed, b.leaderExitStatus, leaderStatus)
+	}
+}
+
+func assertPendingSignalBatch(t *testing.T, label string, got, want pendingSignalBatch) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s pending state = %+v, want %+v", label, got, want)
 	}
 }
 
@@ -1114,6 +1349,10 @@ func stoppedAt(sig syscall.Signal, event int) syscall.WaitStatus {
 
 func exitedWith(code int) syscall.WaitStatus {
 	return syscall.WaitStatus(uint32(code) << 8)
+}
+
+func signaledBy(signal syscall.Signal) syscall.WaitStatus {
+	return syscall.WaitStatus(signal)
 }
 
 // TestLinuxWaitResumesTheSteppedThreadWithASingleStep executes every wait-loop

--- a/internal/debugger/backend_linux_amd64_test.go
+++ b/internal/debugger/backend_linux_amd64_test.go
@@ -5,11 +5,37 @@ package debugger
 import (
 	"errors"
 	"os/exec"
+	"reflect"
 	"strings"
 	"sync"
 	"syscall"
 	"testing"
 )
+
+type linuxResumeCall struct {
+	op     string
+	tid    int
+	signal int
+}
+
+func newRecordingLinuxBackend(t *testing.T, pid int) (*linuxBackend, *[]linuxResumeCall) {
+	t.Helper()
+	calls := &[]linuxResumeCall{}
+	b := &linuxBackend{
+		pid:    pid,
+		tracer: newTracerThread(),
+		ptraceContFn: func(tid, signal int) error {
+			*calls = append(*calls, linuxResumeCall{op: "continue", tid: tid, signal: signal})
+			return nil
+		},
+		ptraceSingleStepFn: func(tid, signal int) error {
+			*calls = append(*calls, linuxResumeCall{op: "step", tid: tid, signal: signal})
+			return nil
+		},
+	}
+	t.Cleanup(b.closeTracer)
+	return b, calls
+}
 
 func TestLinuxBackendTraceTIDDefaultsToPID(t *testing.T) {
 	const pid = 1001
@@ -249,6 +275,173 @@ func testLinuxBackendStoppedMemoryStopTIDOrdered(t *testing.T) {
 	}
 }
 
+func TestLinuxBackendContinueForwardsDeliveredSignalOnce(t *testing.T) {
+	const tid = 1002
+	b, calls := newRecordingLinuxBackend(t, 1001)
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGSEGV)})
+
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("ContinueProcess() error = %v", err)
+	}
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("second ContinueProcess() error = %v", err)
+	}
+
+	want := []linuxResumeCall{
+		{op: "continue", tid: tid, signal: int(syscall.SIGSEGV)},
+		{op: "continue", tid: tid, signal: 0},
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
+	}
+}
+
+func TestLinuxBackendPendingSignalDoesNotTransferOrGetClearedByAnotherStop(t *testing.T) {
+	const (
+		signalled = 2002
+		other     = 2003
+	)
+	b, calls := newRecordingLinuxBackend(t, 2001)
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: signalled, Signal: int(syscall.SIGABRT)})
+
+	b.recordStop(other)
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("ContinueProcess(other) error = %v", err)
+	}
+	b.recordStop(signalled)
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("ContinueProcess(signalled) error = %v", err)
+	}
+
+	want := []linuxResumeCall{
+		{op: "continue", tid: other, signal: 0},
+		{op: "continue", tid: signalled, signal: int(syscall.SIGABRT)},
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
+	}
+}
+
+func TestLinuxBackendPauseSignalIsNeverForwarded(t *testing.T) {
+	const tid = 3001
+	b, calls := newRecordingLinuxBackend(t, tid)
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: b.PauseSignal()})
+
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("ContinueProcess() error = %v", err)
+	}
+
+	want := []linuxResumeCall{{op: "continue", tid: tid, signal: 0}}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
+	}
+}
+
+func TestLinuxBackendSingleStepForwardsOnlyMatchingTIDSignal(t *testing.T) {
+	const (
+		signalled = 4002
+		other     = 4003
+	)
+	b, calls := newRecordingLinuxBackend(t, 4001)
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: signalled, Signal: int(syscall.SIGUSR1)})
+
+	if err := b.SingleStep(other); err != nil {
+		t.Fatalf("SingleStep(other) error = %v", err)
+	}
+	b.endStep()
+	if err := b.SingleStep(signalled); err != nil {
+		t.Fatalf("SingleStep(signalled) error = %v", err)
+	}
+
+	want := []linuxResumeCall{
+		{op: "step", tid: other, signal: 0},
+		{op: "step", tid: signalled, signal: int(syscall.SIGUSR1)},
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
+	}
+}
+
+func TestLinuxBackendFailedResumeStillConsumesPendingSignal(t *testing.T) {
+	const tid = 5001
+	errInjected := errors.New("ptrace failed")
+	b, calls := newRecordingLinuxBackend(t, tid)
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGSEGV)})
+	b.ptraceContFn = func(gotTID, signal int) error {
+		*calls = append(*calls, linuxResumeCall{op: "continue", tid: gotTID, signal: signal})
+		return errInjected
+	}
+
+	if err := b.ContinueProcess(); !errors.Is(err, errInjected) {
+		t.Fatalf("ContinueProcess() error = %v, want %v", err, errInjected)
+	}
+	b.ptraceContFn = func(gotTID, signal int) error {
+		*calls = append(*calls, linuxResumeCall{op: "continue", tid: gotTID, signal: signal})
+		return nil
+	}
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("retry ContinueProcess() error = %v", err)
+	}
+
+	want := []linuxResumeCall{
+		{op: "continue", tid: tid, signal: int(syscall.SIGSEGV)},
+		{op: "continue", tid: tid, signal: 0},
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
+	}
+}
+
+func TestLinuxBackendInternalResumesClearPendingSignal(t *testing.T) {
+	const tid = 6001
+	b, calls := newRecordingLinuxBackend(t, tid)
+
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGSEGV)})
+	if err := b.continueIfTraceeExists(tid, int(syscall.SIGURG)); err != nil {
+		t.Fatalf("continueIfTraceeExists() error = %v", err)
+	}
+	b.recordStop(tid)
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("ContinueProcess() after internal continue error = %v", err)
+	}
+
+	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGABRT)})
+	if err := b.singleStepIfTraceeExists(tid); err != nil {
+		t.Fatalf("singleStepIfTraceeExists() error = %v", err)
+	}
+	b.recordStop(tid)
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("ContinueProcess() after internal step error = %v", err)
+	}
+
+	want := []linuxResumeCall{
+		{op: "continue", tid: tid, signal: int(syscall.SIGURG)},
+		{op: "continue", tid: tid, signal: 0},
+		{op: "step", tid: tid, signal: 0},
+		{op: "continue", tid: tid, signal: 0},
+	}
+	if !reflect.DeepEqual(*calls, want) {
+		t.Fatalf("resume calls = %+v, want %+v", *calls, want)
+	}
+}
+
+func TestLinuxKillCleanupDoesNotTouchWaitOwnedQueue(t *testing.T) {
+	const tid = 7001
+	b, _ := newRecordingLinuxBackend(t, tid)
+	b.pendingSignals.set(tid, int(syscall.SIGSEGV))
+	b.park(StopEvent{Reason: StopBreakpoint, TID: tid + 1})
+
+	if err := killProcess(b, tid, nil, true); err != nil {
+		t.Fatalf("killProcess() error = %v", err)
+	}
+	if got := b.pendingSignals.take(tid); got != 0 {
+		t.Fatalf("pending signal after kill cleanup = %d, want 0", got)
+	}
+	if got := len(b.parked); got != 1 {
+		t.Fatalf("parked stops after kill cleanup = %d, want 1 retained for the wait loop", got)
+	}
+}
+
 // The tests below pin the part of the wait-side park queue that is specific to
 // this backend: WHEN lastStopTID moves. The ordering and gating rules live on
 // the platform-neutral stepQueue and are covered in waitpark_test.go.
@@ -325,18 +518,15 @@ func TestLinuxBackendDrainParkedRecordsOnDeliveryOnly(t *testing.T) {
 }
 
 // TestLinuxBackendHeldSignalSurfacesOnlyWithItsOwnStop pins the ordering issue
-// #204 raises for pending signals. A held stop's signal must not become
+// #206 raises for pending signals. A held stop's signal must not become
 // observable before the stop it belongs to, and it must arrive in the same
 // operation that repoints traceTID at the signalled thread — otherwise the
 // engine would report or suppress a signal against whichever thread happened to
 // be the resume target at the time.
 //
-// The queue is immune to that class by construction rather than by ordering
-// discipline: the signal is a field of the parked StopEvent, so there is no
-// separate signal record that could be written at park time and later
-// overwritten. This test is what stops a future refactor from hoisting the
-// signal into backend state, where it would need — and could silently lose —
-// that discipline.
+// While parked, the signal stays in the StopEvent. Delivery installs it in the
+// per-TID pending map before publishing traceTID; the final resume assertion
+// pins that handoff end to end.
 func TestLinuxBackendHeldSignalSurfacesOnlyWithItsOwnStop(t *testing.T) {
 	const (
 		pid      = 2001
@@ -345,7 +535,7 @@ func TestLinuxBackendHeldSignalSurfacesOnlyWithItsOwnStop(t *testing.T) {
 		later    = 2004
 	)
 
-	b := &linuxBackend{pid: pid}
+	b, calls := newRecordingLinuxBackend(t, pid)
 	b.beginStep(stepped)
 	b.recordStop(stepped)
 
@@ -372,6 +562,13 @@ func TestLinuxBackendHeldSignalSurfacesOnlyWithItsOwnStop(t *testing.T) {
 	// but resume — or POKEDATA into — the wrong thread.
 	if got := b.traceTID(); got != signaled {
 		t.Fatalf("traceTID() = %d when delivering the signal, want the signalled thread %d", got, signaled)
+	}
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("ContinueProcess() for delivered signal error = %v", err)
+	}
+	wantResume := []linuxResumeCall{{op: "continue", tid: signaled, signal: 11}}
+	if !reflect.DeepEqual(*calls, wantResume) {
+		t.Fatalf("resume calls = %+v, want delivered signal on its own tid: %+v", *calls, wantResume)
 	}
 
 	// The next held stop carries no signal, and delivering it must not leave the

--- a/internal/debugger/backend_linux_amd64_test.go
+++ b/internal/debugger/backend_linux_amd64_test.go
@@ -38,18 +38,24 @@ func wantLinuxResume(request, tid, signal int) linuxResumeCall {
 	}
 }
 
+func recordingPtraceSyscall(calls *[]linuxResumeCall, errno syscall.Errno) func(
+	trap, a1, a2, a3, a4, a5, a6 uintptr,
+) (uintptr, uintptr, syscall.Errno) {
+	return func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
+		*calls = append(*calls, linuxResumeCall{
+			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
+		})
+		return 0, 0, errno
+	}
+}
+
 func newRecordingLinuxBackend(t *testing.T, pid int) (*linuxBackend, *[]linuxResumeCall) {
 	t.Helper()
 	calls := &[]linuxResumeCall{}
 	b := &linuxBackend{
-		pid:    pid,
-		tracer: newTracerThread(),
-		ptraceSyscall6Fn: func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
-			*calls = append(*calls, linuxResumeCall{
-				trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
-			})
-			return 0, 0, 0
-		},
+		pid:              pid,
+		tracer:           newTracerThread(),
+		ptraceSyscall6Fn: recordingPtraceSyscall(calls, 0),
 	}
 	t.Cleanup(b.closeTracer)
 	return b, calls
@@ -390,22 +396,12 @@ func TestLinuxBackendFailedSingleStepRetainsPendingSignal(t *testing.T) {
 	const tid = 4501
 	b, calls := newRecordingLinuxBackend(t, tid)
 	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGSEGV)})
-	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
-		*calls = append(*calls, linuxResumeCall{
-			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
-		})
-		return 0, 0, syscall.EIO
-	}
+	b.ptraceSyscall6Fn = recordingPtraceSyscall(calls, syscall.EIO)
 
 	if err := b.SingleStep(tid); !errors.Is(err, syscall.EIO) {
 		t.Fatalf("SingleStep() error = %v, want %v", err, syscall.EIO)
 	}
-	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
-		*calls = append(*calls, linuxResumeCall{
-			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
-		})
-		return 0, 0, 0
-	}
+	b.ptraceSyscall6Fn = recordingPtraceSyscall(calls, 0)
 	if err := b.ContinueProcess(); err != nil {
 		t.Fatalf("ContinueProcess() error = %v", err)
 	}
@@ -424,22 +420,12 @@ func TestLinuxBackendFailedResumeRetainsPendingSignal(t *testing.T) {
 	errInjected := syscall.EIO
 	b, calls := newRecordingLinuxBackend(t, tid)
 	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGSEGV)})
-	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
-		*calls = append(*calls, linuxResumeCall{
-			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
-		})
-		return 0, 0, errInjected
-	}
+	b.ptraceSyscall6Fn = recordingPtraceSyscall(calls, errInjected)
 
 	if err := b.ContinueProcess(); !errors.Is(err, errInjected) {
 		t.Fatalf("ContinueProcess() error = %v, want %v", err, errInjected)
 	}
-	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
-		*calls = append(*calls, linuxResumeCall{
-			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
-		})
-		return 0, 0, 0
-	}
+	b.ptraceSyscall6Fn = recordingPtraceSyscall(calls, 0)
 	if err := b.ContinueProcess(); err != nil {
 		t.Fatalf("retry ContinueProcess() error = %v", err)
 	}
@@ -457,22 +443,12 @@ func TestLinuxBackendFailedResumeESRCHRetainsPendingSignal(t *testing.T) {
 	const tid = 5501
 	b, calls := newRecordingLinuxBackend(t, tid)
 	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGSEGV)})
-	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
-		*calls = append(*calls, linuxResumeCall{
-			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
-		})
-		return 0, 0, syscall.ESRCH
-	}
+	b.ptraceSyscall6Fn = recordingPtraceSyscall(calls, syscall.ESRCH)
 
 	if err := b.ContinueProcess(); !errors.Is(err, syscall.ESRCH) {
 		t.Fatalf("ContinueProcess() error = %v, want %v", err, syscall.ESRCH)
 	}
-	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
-		*calls = append(*calls, linuxResumeCall{
-			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
-		})
-		return 0, 0, 0
-	}
+	b.ptraceSyscall6Fn = recordingPtraceSyscall(calls, 0)
 	if err := b.ContinueProcess(); err != nil {
 		t.Fatalf("retry ContinueProcess() error = %v", err)
 	}
@@ -490,22 +466,12 @@ func TestLinuxBackendInternalResumeESRCHRetainsPendingSignal(t *testing.T) {
 	const tid = 5751
 	b, calls := newRecordingLinuxBackend(t, tid)
 	b.recordDeliveredStop(StopEvent{Reason: StopSignal, TID: tid, Signal: int(syscall.SIGABRT)})
-	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
-		*calls = append(*calls, linuxResumeCall{
-			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
-		})
-		return 0, 0, syscall.ESRCH
-	}
+	b.ptraceSyscall6Fn = recordingPtraceSyscall(calls, syscall.ESRCH)
 
 	if err := b.continueIfTraceeExists(tid, 0); err != nil {
 		t.Fatalf("continueIfTraceeExists() error = %v", err)
 	}
-	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
-		*calls = append(*calls, linuxResumeCall{
-			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
-		})
-		return 0, 0, 0
-	}
+	b.ptraceSyscall6Fn = recordingPtraceSyscall(calls, 0)
 	if err := b.ContinueProcess(); err != nil {
 		t.Fatalf("ContinueProcess() after ESRCH error = %v", err)
 	}
@@ -720,7 +686,7 @@ func TestLinuxBackendExitingThreadDropsCurrentAndDelayedSignals(t *testing.T) {
 	b.pendingSignals.set(tid, int(syscall.SIGUSR1))
 	b.pendingSignals.delay(tid, int(syscall.SIGURG))
 	b.pendingSignals.set(otherTID, unrelatedSignal)
-	b.contFn = func(targetTID int, signal int) error {
+	b.contFn = func(targetTID, signal int) error {
 		calls = append(calls, wantLinuxResume(syscall.PTRACE_CONT, targetTID, signal))
 		if got := b.pendingSignals.take(targetTID); got != 0 {
 			return fmt.Errorf("pending signal %d remained when exiting tid %d resumed", got, targetTID)
@@ -1746,7 +1712,7 @@ func TestLinuxWaitClearsReusedTIDStateBeforeNewThreadResume(t *testing.T) {
 	script.install(b)
 	b.pendingSignals.set(newThread, int(syscall.SIGUSR1))
 	b.pendingSignals.delay(newThread, int(syscall.SIGURG))
-	b.contFn = func(tid int, signal int) error {
+	b.contFn = func(tid, signal int) error {
 		if got := b.pendingSignals.take(tid); got != 0 {
 			return fmt.Errorf("stale signal %d remained on reused tid %d", got, tid)
 		}

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -825,7 +825,11 @@ func (e *engine) handleStop(stop StopEvent) {
 			e.endThreadStep()
 			switch e.bpResume {
 			case bpResumeContinue:
-				_ = e.backend.ContinueProcess()
+				if err := e.backend.ContinueProcess(); err != nil {
+					e.setState(stateSuspended)
+					e.haltOnError(protocol.CmdContinue, fmt.Errorf("continue after breakpoint step: %w", err), stop)
+					return
+				}
 				e.setState(stateRunning)
 				go e.waitLoop()
 			case bpResumeStep:
@@ -848,10 +852,15 @@ func (e *engine) handleStop(stop StopEvent) {
 								e.setState(stateRunning)
 								go e.waitLoop()
 								return
-							} else if entry != nil {
-								_ = e.bps.clear(e.backend, entry.id)
+							} else {
+								if entry != nil {
+									_ = e.bps.clear(e.backend, entry.id)
+								}
 								e.stepOverFile = ""
 								e.stepOverLine = 0
+								e.setState(stateSuspended)
+								e.haltOnError(protocol.CmdStepOver, fmt.Errorf("continue after source step breakpoint: %w", cerr), stop)
+								return
 							}
 						} else {
 							e.log.Warn("sourceStepOver: set "+stepOverNextFile+" failed",
@@ -882,7 +891,11 @@ func (e *engine) handleStop(stop StopEvent) {
 						fmt.Errorf("StepOut: set return breakpoint: %w", setErr), stop)
 					return
 				}
-				_ = e.backend.ContinueProcess()
+				if err := e.backend.ContinueProcess(); err != nil {
+					e.setState(stateSuspended)
+					e.haltOnError(protocol.CmdStepOut, fmt.Errorf("continue after StepOut breakpoint: %w", err), stop)
+					return
+				}
 				e.setState(stateRunning)
 				go e.waitLoop()
 			}
@@ -967,13 +980,21 @@ func (e *engine) handleStop(stop StopEvent) {
 			// silently — surfacing it as output or EventPaused would be bogus.
 			// The linux backend excludes PauseSignal from pending delivery, so
 			// ContinueProcess resumes with signal 0.
-			_ = e.backend.ContinueProcess()
+			if err := e.backend.ContinueProcess(); err != nil {
+				e.setState(stateSuspended)
+				e.haltOnError(protocol.CmdNone, fmt.Errorf("continue after stale pause signal: %w", err), stop)
+				return
+			}
 			e.setState(stateRunning)
 			go e.waitLoop()
 			return
 		}
 		e.emitOutput("stderr", fmt.Sprintf("signal %d", stop.Signal))
-		_ = e.backend.ContinueProcess()
+		if err := e.backend.ContinueProcess(); err != nil {
+			e.setState(stateSuspended)
+			e.haltOnError(protocol.CmdNone, fmt.Errorf("continue after signal %d on thread %d: %w", stop.Signal, stop.TID, err), stop)
+			return
+		}
 		e.setState(stateRunning)
 		go e.waitLoop()
 	}

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -965,7 +965,8 @@ func (e *engine) handleStop(stop StopEvent) {
 			// raced a self-stop (breakpoint/step won and cleared
 			// manualStopPending), leaving the signal queued. Suppress it
 			// silently — surfacing it as output or EventPaused would be bogus.
-			// Continue discards it (ContinueProcess resumes with signal 0).
+			// The linux backend excludes PauseSignal from pending delivery, so
+			// ContinueProcess resumes with signal 0.
 			_ = e.backend.ContinueProcess()
 			e.setState(stateRunning)
 			go e.waitLoop()

--- a/internal/debugger/engine_halt_test.go
+++ b/internal/debugger/engine_halt_test.go
@@ -235,8 +235,6 @@ var _ = Describe("asynchronous halts in handleStop", func() {
 		fb.failContinue(errInjected)
 		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSingleStep, TID: 1, PC: bpAddr + 4})
 		expectHaltReported(d, "continue after breakpoint step")
-		expectHaltReported(d, "continue after breakpoint step")
-
 		fb.clearFaults()
 		Expect(d.Continue()).To(Succeed(), "the session must remain resumable")
 	})

--- a/internal/debugger/engine_halt_test.go
+++ b/internal/debugger/engine_halt_test.go
@@ -226,6 +226,21 @@ var _ = Describe("asynchronous halts in handleStop", func() {
 		Expect(d.Continue()).To(Succeed(), "the session must remain resumable")
 	})
 
+	It("reports a halt when Continue cannot resume after the breakpoint step", func() {
+		const bpAddr = uint64(0x4150)
+		arriveAtBreakpoint(fb, d, bpAddr)
+
+		continueAndConsumeContinued(d)
+
+		fb.failContinue(errInjected)
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSingleStep, TID: 1, PC: bpAddr + 4})
+		expectHaltReported(d, "continue after breakpoint step")
+		expectHaltReported(d, "continue after breakpoint step")
+
+		fb.clearFaults()
+		Expect(d.Continue()).To(Succeed(), "the session must remain resumable")
+	})
+
 	// Site D — StopSingleStep/bpResumeStepOut: the temporary return breakpoint
 	// cannot be set. Uniquely, this site left the engine in stateRunning while
 	// the tracee was halted, so it also has to correct the state.
@@ -252,6 +267,24 @@ var _ = Describe("asynchronous halts in handleStop", func() {
 		Expect(fb.continueCount()).To(BeNumerically(">", before))
 	})
 
+	It("reports a halt when StepOut cannot continue after setting its return breakpoint", func() {
+		const bpAddr = uint64(0x4250)
+		const retAddr = uint64(0x9950)
+		arriveAtBreakpoint(fb, d, bpAddr)
+		seedFrameChain(fb, bpAddr, 0x7200, 0x7300, retAddr)
+		fb.seedMem(retAddr, []byte{0x90, 0x90, 0x90, 0x90, 0x90})
+
+		Expect(d.StepOut()).To(Succeed())
+
+		fb.failContinue(errInjected)
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSingleStep, TID: 1, PC: bpAddr + 4})
+
+		expectHaltReported(d, "continue after StepOut breakpoint")
+
+		fb.clearFaults()
+		Expect(d.Continue()).To(Succeed(), "the session must remain resumable")
+	})
+
 	// Site E — StopSignal: in-flight step-over reinstall failure.
 	It("reports a halt when a signal interrupts an unreinstallable step-over", func() {
 		const bpAddr = uint64(0x4300)
@@ -268,6 +301,31 @@ var _ = Describe("asynchronous halts in handleStop", func() {
 		before := fb.continueCount()
 		Expect(d.Continue()).To(Succeed(), "the session must remain resumable")
 		Expect(fb.continueCount()).To(BeNumerically(">", before))
+	})
+
+	It("reports a halt when an ordinary signal cannot be resumed", func() {
+		runWithWaitLoop(d)
+
+		fb.failContinue(errInjected)
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSignal, TID: 1, Signal: 10})
+
+		Expect(mustNextEvent(d).Kind).To(Equal(protocol.EventOutput))
+		expectHaltReported(d, "continue after signal 10 on thread 1")
+
+		fb.clearFaults()
+		Expect(d.Continue()).To(Succeed(), "the session must remain resumable")
+	})
+
+	It("reports a halt when a stale Pause signal cannot be suppressed", func() {
+		runWithWaitLoop(d)
+
+		fb.failContinue(errInjected)
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSignal, TID: 1, Signal: fb.PauseSignal()})
+
+		expectHaltReported(d, "continue after stale pause signal")
+
+		fb.clearFaults()
+		Expect(d.Continue()).To(Succeed(), "the session must remain resumable")
 	})
 
 	// The suspending event is the load-bearing half: emit drops events when the

--- a/internal/debugger/pending_signal.go
+++ b/internal/debugger/pending_signal.go
@@ -1,0 +1,45 @@
+package debugger
+
+import "sync"
+
+// pendingSignals keeps Linux signal-delivery stops attached to the TID that
+// produced them until that exact thread is resumed. Wait writes from its
+// one-shot goroutine while ContinueProcess and SingleStep consume on the engine
+// loop, so this state needs synchronization even though the parked-stop FIFO
+// does not.
+type pendingSignals struct {
+	mu    sync.Mutex
+	byTID map[int]int
+}
+
+func (p *pendingSignals) set(tid, signal int) {
+	if tid == 0 || signal == 0 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.byTID == nil {
+		p.byTID = make(map[int]int)
+	}
+	p.byTID[tid] = signal
+}
+
+func (p *pendingSignals) take(tid int) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	signal := p.byTID[tid]
+	delete(p.byTID, tid)
+	return signal
+}
+
+func (p *pendingSignals) clear(tid int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.byTID, tid)
+}
+
+func (p *pendingSignals) purge() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.byTID = nil
+}

--- a/internal/debugger/pending_signal.go
+++ b/internal/debugger/pending_signal.go
@@ -6,8 +6,8 @@ import "sync"
 // produced them until that exact thread is resumed. A current signal-delivery
 // stop has priority over SIGURG delayed through an interrupted single-step, but
 // the two cannot overwrite each other. Wait writes from its one-shot goroutine
-// while ContinueProcess and SingleStep consume on the engine loop, so this state
-// needs synchronization even though the parked-stop FIFO does not.
+// while ContinueProcess consumes on the engine loop, so this state needs
+// synchronization even though the parked-stop FIFO does not.
 type pendingSignals struct {
 	mu           sync.Mutex
 	currentByTID map[int]int
@@ -61,14 +61,6 @@ func (p *pendingSignals) takeForContinue(tid int) (signal, delayed int) {
 		return signal, 0
 	}
 	return signal, delayed
-}
-
-func (p *pendingSignals) takeForStep(tid int) int {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	signal := p.currentByTID[tid]
-	delete(p.currentByTID, tid)
-	return signal
 }
 
 func (p *pendingSignals) takeForExplicitResume(tid, signal int) (resumeSignal, delayed int) {

--- a/internal/debugger/pending_signal.go
+++ b/internal/debugger/pending_signal.go
@@ -35,6 +35,9 @@ func (p *pendingSignals) delay(tid, signal int) {
 	if p.delayedByTID == nil {
 		p.delayedByTID = make(map[int]int)
 	}
+	if p.delayedByTID[tid] != 0 {
+		return
+	}
 	p.delayedByTID[tid] = signal
 }
 
@@ -63,16 +66,17 @@ func (p *pendingSignals) takeForContinue(tid int) (signal, delayed int) {
 	return signal, delayed
 }
 
-func (p *pendingSignals) takeForExplicitResume(tid, signal int) (resumeSignal, delayed int) {
+func (p *pendingSignals) takeForExplicitResume(tid, signal int) (current, resumeSignal, delayed int) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	current = p.currentByTID[tid]
 	delete(p.currentByTID, tid)
 	delayed = p.delayedByTID[tid]
 	delete(p.delayedByTID, tid)
 	if signal == delayed {
-		return signal, 0
+		return current, signal, 0
 	}
-	return signal, delayed
+	return current, signal, delayed
 }
 
 func (p *pendingSignals) restore(tid, signal, delayed int) {
@@ -85,13 +89,17 @@ func (p *pendingSignals) restore(tid, signal, delayed int) {
 		if p.currentByTID == nil {
 			p.currentByTID = make(map[int]int)
 		}
-		p.currentByTID[tid] = signal
+		if p.currentByTID[tid] == 0 {
+			p.currentByTID[tid] = signal
+		}
 	}
 	if delayed != 0 {
 		if p.delayedByTID == nil {
 			p.delayedByTID = make(map[int]int)
 		}
-		p.delayedByTID[tid] = delayed
+		if p.delayedByTID[tid] == 0 {
+			p.delayedByTID[tid] = delayed
+		}
 	}
 }
 

--- a/internal/debugger/pending_signal.go
+++ b/internal/debugger/pending_signal.go
@@ -3,15 +3,40 @@ package debugger
 import "sync"
 
 // pendingSignals keeps Linux signal-delivery stops attached to the TID that
-// produced them until that exact thread is resumed. A current signal-delivery
-// stop has priority over SIGURG delayed through an interrupted single-step, but
-// the two cannot overwrite each other. Wait writes from its one-shot goroutine
-// while ContinueProcess consumes on the engine loop, so this state needs
+// produced them until that exact thread is resumed. The newest delivered stop
+// stays current for the next PTRACE_CONT; older distinct signals displaced by a
+// later stop remain in capture order ahead of SIGURG delayed through an
+// interrupted single-step. Wait writes from its one-shot goroutine while
+// ContinueProcess consumes on the engine loop, so this state needs
 // synchronization even though the parked-stop FIFO does not.
 type pendingSignals struct {
 	mu           sync.Mutex
 	currentByTID map[int]int
+	backlogByTID map[int][]int
 	delayedByTID map[int]int
+}
+
+type pendingSignalBatch struct {
+	current  int
+	deferred []int
+}
+
+func (b pendingSignalBatch) withoutDeferredPrefix(count int) pendingSignalBatch {
+	if count >= len(b.deferred) {
+		b.deferred = nil
+	} else {
+		b.deferred = append([]int(nil), b.deferred[count:]...)
+	}
+	return b
+}
+
+func (b *pendingSignalBatch) removeDeferred(signal int) {
+	for i, queued := range b.deferred {
+		if queued == signal {
+			b.deferred = append(b.deferred[:i], b.deferred[i+1:]...)
+			return
+		}
+	}
 }
 
 func (p *pendingSignals) set(tid, signal int) {
@@ -20,6 +45,17 @@ func (p *pendingSignals) set(tid, signal int) {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if current := p.currentByTID[tid]; current != 0 {
+		if current == signal {
+			return
+		}
+		delete(p.currentByTID, tid)
+		p.addBacklogLocked(tid, current)
+	}
+	p.removeBacklogLocked(tid, signal)
+	if p.delayedByTID[tid] == signal {
+		delete(p.delayedByTID, tid)
+	}
 	if p.currentByTID == nil {
 		p.currentByTID = make(map[int]int)
 	}
@@ -32,6 +68,9 @@ func (p *pendingSignals) delay(tid, signal int) {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
+	if p.currentByTID[tid] == signal || containsSignal(p.backlogByTID[tid], signal) {
+		return
+	}
 	if p.delayedByTID == nil {
 		p.delayedByTID = make(map[int]int)
 	}
@@ -48,65 +87,121 @@ func (p *pendingSignals) take(tid int) int {
 		delete(p.currentByTID, tid)
 		return signal
 	}
+	if backlog := p.backlogByTID[tid]; len(backlog) > 0 {
+		signal := backlog[0]
+		if len(backlog) == 1 {
+			delete(p.backlogByTID, tid)
+		} else {
+			p.backlogByTID[tid] = backlog[1:]
+		}
+		return signal
+	}
 	signal := p.delayedByTID[tid]
 	delete(p.delayedByTID, tid)
 	return signal
 }
 
-func (p *pendingSignals) takeForContinue(tid int) (signal, delayed int) {
+func (p *pendingSignals) takeForContinue(tid int) pendingSignalBatch {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	signal = p.currentByTID[tid]
-	delete(p.currentByTID, tid)
-	delayed = p.delayedByTID[tid]
-	delete(p.delayedByTID, tid)
-	if signal == delayed {
-		return signal, 0
-	}
-	return signal, delayed
+	batch := p.takeBatchLocked(tid)
+	return batch
 }
 
-func (p *pendingSignals) takeForExplicitResume(tid, signal int) (current, resumeSignal, delayed int) {
+func (p *pendingSignals) takeForExplicitResume(tid, signal int) (pendingSignalBatch, int) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	current = p.currentByTID[tid]
-	delete(p.currentByTID, tid)
-	delayed = p.delayedByTID[tid]
-	delete(p.delayedByTID, tid)
-	if signal == delayed {
-		return current, signal, 0
-	}
-	return current, signal, delayed
+	batch := p.takeBatchLocked(tid)
+	batch.removeDeferred(signal)
+	return batch, signal
 }
 
-func (p *pendingSignals) restore(tid, signal, delayed int) {
+func (p *pendingSignals) takeBatchLocked(tid int) pendingSignalBatch {
+	batch := pendingSignalBatch{
+		current:  p.currentByTID[tid],
+		deferred: append([]int(nil), p.backlogByTID[tid]...),
+	}
+	if delayed := p.delayedByTID[tid]; delayed != 0 &&
+		delayed != batch.current &&
+		!containsSignal(batch.deferred, delayed) {
+		batch.deferred = append(batch.deferred, delayed)
+	}
+	delete(p.currentByTID, tid)
+	delete(p.backlogByTID, tid)
+	delete(p.delayedByTID, tid)
+	return batch
+}
+
+func (p *pendingSignals) restore(tid int, batch pendingSignalBatch) {
 	if tid == 0 {
 		return
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if signal != 0 {
-		if p.currentByTID == nil {
-			p.currentByTID = make(map[int]int)
-		}
-		if p.currentByTID[tid] == 0 {
-			p.currentByTID[tid] = signal
+
+	if batch.current != 0 {
+		if current := p.currentByTID[tid]; current == 0 {
+			p.removeBacklogLocked(tid, batch.current)
+			if p.delayedByTID[tid] == batch.current {
+				delete(p.delayedByTID, tid)
+			}
+			if p.currentByTID == nil {
+				p.currentByTID = make(map[int]int)
+			}
+			p.currentByTID[tid] = batch.current
+		} else if current != batch.current {
+			p.addBacklogLocked(tid, batch.current)
 		}
 	}
-	if delayed != 0 {
-		if p.delayedByTID == nil {
-			p.delayedByTID = make(map[int]int)
+
+	for _, signal := range batch.deferred {
+		p.addBacklogLocked(tid, signal)
+	}
+}
+
+func (p *pendingSignals) addBacklogLocked(tid, signal int) {
+	if signal == 0 ||
+		p.currentByTID[tid] == signal ||
+		p.delayedByTID[tid] == signal ||
+		containsSignal(p.backlogByTID[tid], signal) {
+		return
+	}
+	if p.backlogByTID == nil {
+		p.backlogByTID = make(map[int][]int)
+	}
+	p.backlogByTID[tid] = append(p.backlogByTID[tid], signal)
+}
+
+func (p *pendingSignals) removeBacklogLocked(tid, signal int) {
+	backlog := p.backlogByTID[tid]
+	for i, queued := range backlog {
+		if queued != signal {
+			continue
 		}
-		if p.delayedByTID[tid] == 0 {
-			p.delayedByTID[tid] = delayed
+		backlog = append(backlog[:i], backlog[i+1:]...)
+		if len(backlog) == 0 {
+			delete(p.backlogByTID, tid)
+		} else {
+			p.backlogByTID[tid] = backlog
+		}
+		return
+	}
+}
+
+func containsSignal(signals []int, signal int) bool {
+	for _, queued := range signals {
+		if queued == signal {
+			return true
 		}
 	}
+	return false
 }
 
 func (p *pendingSignals) clear(tid int) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	delete(p.currentByTID, tid)
+	delete(p.backlogByTID, tid)
 	delete(p.delayedByTID, tid)
 }
 
@@ -114,5 +209,6 @@ func (p *pendingSignals) purge() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.currentByTID = nil
+	p.backlogByTID = nil
 	p.delayedByTID = nil
 }

--- a/internal/debugger/pending_signal.go
+++ b/internal/debugger/pending_signal.go
@@ -3,13 +3,15 @@ package debugger
 import "sync"
 
 // pendingSignals keeps Linux signal-delivery stops attached to the TID that
-// produced them until that exact thread is resumed. Wait writes from its
-// one-shot goroutine while ContinueProcess and SingleStep consume on the engine
-// loop, so this state needs synchronization even though the parked-stop FIFO
-// does not.
+// produced them until that exact thread is resumed. A current signal-delivery
+// stop has priority over SIGURG delayed through an interrupted single-step, but
+// the two cannot overwrite each other. Wait writes from its one-shot goroutine
+// while ContinueProcess and SingleStep consume on the engine loop, so this state
+// needs synchronization even though the parked-stop FIFO does not.
 type pendingSignals struct {
-	mu    sync.Mutex
-	byTID map[int]int
+	mu           sync.Mutex
+	currentByTID map[int]int
+	delayedByTID map[int]int
 }
 
 func (p *pendingSignals) set(tid, signal int) {
@@ -18,28 +20,99 @@ func (p *pendingSignals) set(tid, signal int) {
 	}
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.byTID == nil {
-		p.byTID = make(map[int]int)
+	if p.currentByTID == nil {
+		p.currentByTID = make(map[int]int)
 	}
-	p.byTID[tid] = signal
+	p.currentByTID[tid] = signal
+}
+
+func (p *pendingSignals) delay(tid, signal int) {
+	if tid == 0 || signal == 0 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.delayedByTID == nil {
+		p.delayedByTID = make(map[int]int)
+	}
+	p.delayedByTID[tid] = signal
 }
 
 func (p *pendingSignals) take(tid int) int {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	signal := p.byTID[tid]
-	delete(p.byTID, tid)
+	if signal := p.currentByTID[tid]; signal != 0 {
+		delete(p.currentByTID, tid)
+		return signal
+	}
+	signal := p.delayedByTID[tid]
+	delete(p.delayedByTID, tid)
 	return signal
+}
+
+func (p *pendingSignals) takeForContinue(tid int) (signal, delayed int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	signal = p.currentByTID[tid]
+	delete(p.currentByTID, tid)
+	delayed = p.delayedByTID[tid]
+	delete(p.delayedByTID, tid)
+	if signal == delayed {
+		return signal, 0
+	}
+	return signal, delayed
+}
+
+func (p *pendingSignals) takeForStep(tid int) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	signal := p.currentByTID[tid]
+	delete(p.currentByTID, tid)
+	return signal
+}
+
+func (p *pendingSignals) takeForExplicitResume(tid, signal int) (resumeSignal, delayed int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.currentByTID, tid)
+	delayed = p.delayedByTID[tid]
+	delete(p.delayedByTID, tid)
+	if signal == delayed {
+		return signal, 0
+	}
+	return signal, delayed
+}
+
+func (p *pendingSignals) restore(tid, signal, delayed int) {
+	if tid == 0 {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if signal != 0 {
+		if p.currentByTID == nil {
+			p.currentByTID = make(map[int]int)
+		}
+		p.currentByTID[tid] = signal
+	}
+	if delayed != 0 {
+		if p.delayedByTID == nil {
+			p.delayedByTID = make(map[int]int)
+		}
+		p.delayedByTID[tid] = delayed
+	}
 }
 
 func (p *pendingSignals) clear(tid int) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	delete(p.byTID, tid)
+	delete(p.currentByTID, tid)
+	delete(p.delayedByTID, tid)
 }
 
 func (p *pendingSignals) purge() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.byTID = nil
+	p.currentByTID = nil
+	p.delayedByTID = nil
 }

--- a/internal/debugger/pending_signal_test.go
+++ b/internal/debugger/pending_signal_test.go
@@ -88,6 +88,21 @@ func TestPendingSignalsDelayedSignalSurvivesLaterCurrentSignal(t *testing.T) {
 	}
 }
 
+func TestPendingSignalsDelayedSignalIsFirstWins(t *testing.T) {
+	var pending pendingSignals
+	const tid = 4001
+
+	pending.delay(tid, 23)
+	pending.delay(tid, 24)
+
+	if got := pending.take(tid); got != 23 {
+		t.Fatalf("take = %d, want first delayed signal 23", got)
+	}
+	if got := pending.take(tid); got != 0 {
+		t.Fatalf("second take = %d, want 0", got)
+	}
+}
+
 func TestPendingSignalsContinueSeparatesCurrentFromDelayed(t *testing.T) {
 	var pending pendingSignals
 	const (
@@ -132,6 +147,22 @@ func TestPendingSignalsContinueCoalescesMatchingSignal(t *testing.T) {
 	}
 }
 
+func TestPendingSignalsRestoreDoesNotReplaceNewerState(t *testing.T) {
+	var pending pendingSignals
+	const tid = 5751
+
+	pending.set(tid, 10)
+	pending.delay(tid, 23)
+	pending.restore(tid, 11, 24)
+
+	if got := pending.take(tid); got != 10 {
+		t.Fatalf("first take = %d, want existing current signal 10", got)
+	}
+	if got := pending.take(tid); got != 23 {
+		t.Fatalf("second take = %d, want existing delayed signal 23", got)
+	}
+}
+
 func TestPendingSignalsExplicitResumeRequeuesDelayedSignal(t *testing.T) {
 	var pending pendingSignals
 	const (
@@ -140,20 +171,21 @@ func TestPendingSignalsExplicitResumeRequeuesDelayedSignal(t *testing.T) {
 	)
 
 	pending.delay(tid, delayedSignal)
-	signal, delayed := pending.takeForExplicitResume(tid, 0)
-	if signal != 0 || delayed != delayedSignal {
-		t.Fatalf("signal-zero resume = (%d, %d), want (0, %d)", signal, delayed, delayedSignal)
+	current, signal, delayed := pending.takeForExplicitResume(tid, 0)
+	if current != 0 || signal != 0 || delayed != delayedSignal {
+		t.Fatalf("signal-zero resume = (%d, %d, %d), want (0, 0, %d)", current, signal, delayed, delayedSignal)
 	}
 
 	pending.delay(tid, delayedSignal)
-	signal, delayed = pending.takeForExplicitResume(tid, delayedSignal)
-	if signal != delayedSignal || delayed != 0 {
-		t.Fatalf("matching resume = (%d, %d), want (%d, 0)", signal, delayed, delayedSignal)
+	current, signal, delayed = pending.takeForExplicitResume(tid, delayedSignal)
+	if current != 0 || signal != delayedSignal || delayed != 0 {
+		t.Fatalf("matching resume = (%d, %d, %d), want (0, %d, 0)", current, signal, delayed, delayedSignal)
 	}
 
+	pending.set(tid, 11)
 	pending.delay(tid, delayedSignal)
-	signal, delayed = pending.takeForExplicitResume(tid, 10)
-	if signal != 10 || delayed != delayedSignal {
-		t.Fatalf("different resume = (%d, %d), want (10, %d)", signal, delayed, delayedSignal)
+	current, signal, delayed = pending.takeForExplicitResume(tid, 10)
+	if current != 11 || signal != 10 || delayed != delayedSignal {
+		t.Fatalf("different resume = (%d, %d, %d), want (11, 10, %d)", current, signal, delayed, delayedSignal)
 	}
 }

--- a/internal/debugger/pending_signal_test.go
+++ b/internal/debugger/pending_signal_test.go
@@ -38,6 +38,7 @@ func TestPendingSignalsClearOnlyRequestedScope(t *testing.T) {
 	pending.set(0, 11)
 	pending.set(firstTID, 0)
 	pending.set(firstTID, 11)
+	pending.set(firstTID, 12)
 	pending.set(secondTID, 6)
 	pending.delay(firstTID, 23)
 	pending.delay(secondTID, 24)
@@ -54,7 +55,9 @@ func TestPendingSignalsClearOnlyRequestedScope(t *testing.T) {
 	}
 
 	pending.set(firstTID, 11)
+	pending.set(firstTID, 12)
 	pending.set(secondTID, 6)
+	pending.set(secondTID, 7)
 	pending.delay(firstTID, 23)
 	pending.delay(secondTID, 24)
 	pending.purge()
@@ -107,27 +110,35 @@ func TestPendingSignalsContinueSeparatesCurrentFromDelayed(t *testing.T) {
 	var pending pendingSignals
 	const (
 		tid           = 5001
+		olderSignal   = 12
 		delayedSignal = 23
 		currentSignal = 10
 	)
 
 	pending.delay(tid, delayedSignal)
+	pending.set(tid, olderSignal)
 	pending.set(tid, currentSignal)
 
-	signal, delayed := pending.takeForContinue(tid)
-	if signal != currentSignal || delayed != delayedSignal {
-		t.Fatalf("takeForContinue = (%d, %d), want (%d, %d)", signal, delayed, currentSignal, delayedSignal)
+	batch := pending.takeForContinue(tid)
+	if batch.current != currentSignal ||
+		len(batch.deferred) != 2 ||
+		batch.deferred[0] != olderSignal ||
+		batch.deferred[1] != delayedSignal {
+		t.Fatalf("takeForContinue = %+v, want current %d, backlog [%d], delayed %d", batch, currentSignal, olderSignal, delayedSignal)
 	}
 	if got := pending.take(tid); got != 0 {
 		t.Fatalf("take after takeForContinue = %d, want 0", got)
 	}
 
-	pending.restore(tid, signal, delayed)
+	pending.restore(tid, batch)
 	if got := pending.take(tid); got != currentSignal {
 		t.Fatalf("first take after restore = %d, want %d", got, currentSignal)
 	}
+	if got := pending.take(tid); got != olderSignal {
+		t.Fatalf("second take after restore = %d, want %d", got, olderSignal)
+	}
 	if got := pending.take(tid); got != delayedSignal {
-		t.Fatalf("second take after restore = %d, want %d", got, delayedSignal)
+		t.Fatalf("third take after restore = %d, want %d", got, delayedSignal)
 	}
 }
 
@@ -141,25 +152,74 @@ func TestPendingSignalsContinueCoalescesMatchingSignal(t *testing.T) {
 	pending.delay(tid, signal)
 	pending.set(tid, signal)
 
-	current, delayed := pending.takeForContinue(tid)
-	if current != signal || delayed != 0 {
-		t.Fatalf("takeForContinue = (%d, %d), want (%d, 0)", current, delayed, signal)
+	batch := pending.takeForContinue(tid)
+	if batch.current != signal || len(batch.deferred) != 0 {
+		t.Fatalf("takeForContinue = %+v, want current %d only", batch, signal)
 	}
 }
 
-func TestPendingSignalsRestoreDoesNotReplaceNewerState(t *testing.T) {
+func TestPendingSignalsFreshSignalCoalescesMatchingBacklog(t *testing.T) {
+	var pending pendingSignals
+	const (
+		tid    = 5601
+		first  = 10
+		second = 12
+	)
+
+	pending.set(tid, first)
+	pending.set(tid, second)
+	pending.set(tid, first)
+
+	assertPendingSignalSequence(t, &pending, tid, first, second)
+}
+
+func TestPendingSignalsFreshSignalCoalescesMatchingDelayed(t *testing.T) {
+	var pending pendingSignals
+	const (
+		tid     = 5651
+		current = 10
+		delayed = 23
+	)
+
+	pending.delay(tid, delayed)
+	pending.set(tid, current)
+	pending.set(tid, delayed)
+
+	assertPendingSignalSequence(t, &pending, tid, delayed, current)
+}
+
+func TestPendingSignalsRestoreCoalescesCurrentWithExistingDelayed(t *testing.T) {
+	var pending pendingSignals
+	const (
+		tid    = 5701
+		signal = 23
+	)
+
+	pending.delay(tid, signal)
+	pending.restore(tid, pendingSignalBatch{current: signal})
+
+	assertPendingSignalSequence(t, &pending, tid, signal)
+}
+
+func TestPendingSignalsRestorePreservesNewerAndExtractedState(t *testing.T) {
 	var pending pendingSignals
 	const tid = 5751
 
 	pending.set(tid, 10)
 	pending.delay(tid, 23)
-	pending.restore(tid, 11, 24)
+	pending.restore(tid, pendingSignalBatch{current: 11, deferred: []int{24}})
 
 	if got := pending.take(tid); got != 10 {
 		t.Fatalf("first take = %d, want existing current signal 10", got)
 	}
+	if got := pending.take(tid); got != 11 {
+		t.Fatalf("second take = %d, want restored current signal 11", got)
+	}
+	if got := pending.take(tid); got != 24 {
+		t.Fatalf("third take = %d, want restored delayed signal 24", got)
+	}
 	if got := pending.take(tid); got != 23 {
-		t.Fatalf("second take = %d, want existing delayed signal 23", got)
+		t.Fatalf("fourth take = %d, want existing delayed signal 23", got)
 	}
 }
 
@@ -171,21 +231,57 @@ func TestPendingSignalsExplicitResumeRequeuesDelayedSignal(t *testing.T) {
 	)
 
 	pending.delay(tid, delayedSignal)
-	current, signal, delayed := pending.takeForExplicitResume(tid, 0)
-	if current != 0 || signal != 0 || delayed != delayedSignal {
-		t.Fatalf("signal-zero resume = (%d, %d, %d), want (0, 0, %d)", current, signal, delayed, delayedSignal)
+	batch, signal := pending.takeForExplicitResume(tid, 0)
+	if batch.current != 0 || signal != 0 ||
+		len(batch.deferred) != 1 || batch.deferred[0] != delayedSignal {
+		t.Fatalf("signal-zero resume = (%+v, %d), want delayed %d and signal 0", batch, signal, delayedSignal)
 	}
 
 	pending.delay(tid, delayedSignal)
-	current, signal, delayed = pending.takeForExplicitResume(tid, delayedSignal)
-	if current != 0 || signal != delayedSignal || delayed != 0 {
-		t.Fatalf("matching resume = (%d, %d, %d), want (0, %d, 0)", current, signal, delayed, delayedSignal)
+	batch, signal = pending.takeForExplicitResume(tid, delayedSignal)
+	if batch.current != 0 || signal != delayedSignal || len(batch.deferred) != 0 {
+		t.Fatalf("matching resume = (%+v, %d), want empty batch and signal %d", batch, signal, delayedSignal)
 	}
 
 	pending.set(tid, 11)
 	pending.delay(tid, delayedSignal)
-	current, signal, delayed = pending.takeForExplicitResume(tid, 10)
-	if current != 11 || signal != 10 || delayed != delayedSignal {
-		t.Fatalf("different resume = (%d, %d, %d), want (11, 10, %d)", current, signal, delayed, delayedSignal)
+	batch, signal = pending.takeForExplicitResume(tid, 10)
+	if batch.current != 11 || signal != 10 ||
+		len(batch.deferred) != 1 || batch.deferred[0] != delayedSignal {
+		t.Fatalf("different resume = (%+v, %d), want current 11, signal 10, delayed %d", batch, signal, delayedSignal)
+	}
+}
+
+func TestPendingSignalsDistinctCurrentSignalsKeepNewestCurrent(t *testing.T) {
+	var pending pendingSignals
+	const (
+		tid    = 6251
+		first  = 10
+		second = 12
+		third  = 15
+	)
+
+	pending.set(tid, first)
+	pending.set(tid, second)
+	pending.set(tid, third)
+
+	batch := pending.takeForContinue(tid)
+	if batch.current != third ||
+		len(batch.deferred) != 2 ||
+		batch.deferred[0] != first ||
+		batch.deferred[1] != second {
+		t.Fatalf("takeForContinue = %+v, want current %d and backlog [%d %d]", batch, third, first, second)
+	}
+}
+
+func assertPendingSignalSequence(t *testing.T, pending *pendingSignals, tid int, want ...int) {
+	t.Helper()
+	for i, signal := range want {
+		if got := pending.take(tid); got != signal {
+			t.Fatalf("take %d = %d, want %d", i+1, got, signal)
+		}
+	}
+	if got := pending.take(tid); got != 0 {
+		t.Fatalf("take after expected sequence = %d, want 0", got)
 	}
 }

--- a/internal/debugger/pending_signal_test.go
+++ b/internal/debugger/pending_signal_test.go
@@ -39,6 +39,8 @@ func TestPendingSignalsClearOnlyRequestedScope(t *testing.T) {
 	pending.set(firstTID, 0)
 	pending.set(firstTID, 11)
 	pending.set(secondTID, 6)
+	pending.delay(firstTID, 23)
+	pending.delay(secondTID, 24)
 	pending.clear(firstTID)
 
 	if got := pending.take(firstTID); got != 0 {
@@ -47,14 +49,130 @@ func TestPendingSignalsClearOnlyRequestedScope(t *testing.T) {
 	if got := pending.take(secondTID); got != 6 {
 		t.Fatalf("clearing first tid changed second: got %d, want 6", got)
 	}
+	if got := pending.take(secondTID); got != 24 {
+		t.Fatalf("clearing first tid changed second's delayed signal: got %d, want 24", got)
+	}
 
 	pending.set(firstTID, 11)
 	pending.set(secondTID, 6)
+	pending.delay(firstTID, 23)
+	pending.delay(secondTID, 24)
 	pending.purge()
 	if got := pending.take(firstTID); got != 0 {
 		t.Fatalf("take(first tid) after purge = %d, want 0", got)
 	}
 	if got := pending.take(secondTID); got != 0 {
 		t.Fatalf("take(second tid) after purge = %d, want 0", got)
+	}
+}
+
+func TestPendingSignalsDelayedSignalSurvivesLaterCurrentSignal(t *testing.T) {
+	var pending pendingSignals
+	const (
+		tid           = 3001
+		delayedSignal = 23
+		currentSignal = 10
+	)
+
+	pending.delay(tid, delayedSignal)
+	pending.set(tid, currentSignal)
+
+	if got := pending.take(tid); got != currentSignal {
+		t.Fatalf("first take = %d, want current signal %d", got, currentSignal)
+	}
+	if got := pending.take(tid); got != delayedSignal {
+		t.Fatalf("second take = %d, want delayed signal %d", got, delayedSignal)
+	}
+	if got := pending.take(tid); got != 0 {
+		t.Fatalf("third take = %d, want 0", got)
+	}
+}
+
+func TestPendingSignalsStepConsumesOnlyCurrentSignal(t *testing.T) {
+	var pending pendingSignals
+	const (
+		tid           = 4001
+		delayedSignal = 23
+		currentSignal = 10
+	)
+
+	pending.delay(tid, delayedSignal)
+	pending.set(tid, currentSignal)
+
+	if got := pending.takeForStep(tid); got != currentSignal {
+		t.Fatalf("takeForStep = %d, want current signal %d", got, currentSignal)
+	}
+	if got := pending.take(tid); got != delayedSignal {
+		t.Fatalf("delayed signal after takeForStep = %d, want %d", got, delayedSignal)
+	}
+}
+
+func TestPendingSignalsContinueSeparatesCurrentFromDelayed(t *testing.T) {
+	var pending pendingSignals
+	const (
+		tid           = 5001
+		delayedSignal = 23
+		currentSignal = 10
+	)
+
+	pending.delay(tid, delayedSignal)
+	pending.set(tid, currentSignal)
+
+	signal, delayed := pending.takeForContinue(tid)
+	if signal != currentSignal || delayed != delayedSignal {
+		t.Fatalf("takeForContinue = (%d, %d), want (%d, %d)", signal, delayed, currentSignal, delayedSignal)
+	}
+	if got := pending.take(tid); got != 0 {
+		t.Fatalf("take after takeForContinue = %d, want 0", got)
+	}
+
+	pending.restore(tid, signal, delayed)
+	if got := pending.take(tid); got != currentSignal {
+		t.Fatalf("first take after restore = %d, want %d", got, currentSignal)
+	}
+	if got := pending.take(tid); got != delayedSignal {
+		t.Fatalf("second take after restore = %d, want %d", got, delayedSignal)
+	}
+}
+
+func TestPendingSignalsContinueCoalescesMatchingSignal(t *testing.T) {
+	var pending pendingSignals
+	const (
+		tid    = 5501
+		signal = 23
+	)
+
+	pending.delay(tid, signal)
+	pending.set(tid, signal)
+
+	current, delayed := pending.takeForContinue(tid)
+	if current != signal || delayed != 0 {
+		t.Fatalf("takeForContinue = (%d, %d), want (%d, 0)", current, delayed, signal)
+	}
+}
+
+func TestPendingSignalsExplicitResumeRequeuesDelayedSignal(t *testing.T) {
+	var pending pendingSignals
+	const (
+		tid           = 6001
+		delayedSignal = 23
+	)
+
+	pending.delay(tid, delayedSignal)
+	signal, delayed := pending.takeForExplicitResume(tid, 0)
+	if signal != 0 || delayed != delayedSignal {
+		t.Fatalf("signal-zero resume = (%d, %d), want (0, %d)", signal, delayed, delayedSignal)
+	}
+
+	pending.delay(tid, delayedSignal)
+	signal, delayed = pending.takeForExplicitResume(tid, delayedSignal)
+	if signal != delayedSignal || delayed != 0 {
+		t.Fatalf("matching resume = (%d, %d), want (%d, 0)", signal, delayed, delayedSignal)
+	}
+
+	pending.delay(tid, delayedSignal)
+	signal, delayed = pending.takeForExplicitResume(tid, 10)
+	if signal != 10 || delayed != delayedSignal {
+		t.Fatalf("different resume = (%d, %d), want (10, %d)", signal, delayed, delayedSignal)
 	}
 }

--- a/internal/debugger/pending_signal_test.go
+++ b/internal/debugger/pending_signal_test.go
@@ -1,0 +1,60 @@
+package debugger
+
+import "testing"
+
+func TestPendingSignalsStayWithTheirTID(t *testing.T) {
+	var pending pendingSignals
+	const (
+		firstTID     = 1001
+		secondTID    = 1002
+		firstSignal  = 11
+		secondSignal = 6
+	)
+
+	pending.set(firstTID, firstSignal)
+	pending.set(secondTID, secondSignal)
+
+	if got := pending.take(9999); got != 0 {
+		t.Fatalf("take(unrelated tid) = %d, want 0", got)
+	}
+	if got := pending.take(secondTID); got != secondSignal {
+		t.Fatalf("take(second tid) = %d, want %d", got, secondSignal)
+	}
+	if got := pending.take(secondTID); got != 0 {
+		t.Fatalf("second take(second tid) = %d, want one-shot 0", got)
+	}
+	if got := pending.take(firstTID); got != firstSignal {
+		t.Fatalf("taking second tid lost first signal: got %d, want %d", got, firstSignal)
+	}
+}
+
+func TestPendingSignalsClearOnlyRequestedScope(t *testing.T) {
+	var pending pendingSignals
+	const (
+		firstTID  = 2001
+		secondTID = 2002
+	)
+
+	pending.set(0, 11)
+	pending.set(firstTID, 0)
+	pending.set(firstTID, 11)
+	pending.set(secondTID, 6)
+	pending.clear(firstTID)
+
+	if got := pending.take(firstTID); got != 0 {
+		t.Fatalf("take(cleared tid) = %d, want 0", got)
+	}
+	if got := pending.take(secondTID); got != 6 {
+		t.Fatalf("clearing first tid changed second: got %d, want 6", got)
+	}
+
+	pending.set(firstTID, 11)
+	pending.set(secondTID, 6)
+	pending.purge()
+	if got := pending.take(firstTID); got != 0 {
+		t.Fatalf("take(first tid) after purge = %d, want 0", got)
+	}
+	if got := pending.take(secondTID); got != 0 {
+		t.Fatalf("take(second tid) after purge = %d, want 0", got)
+	}
+}

--- a/internal/debugger/pending_signal_test.go
+++ b/internal/debugger/pending_signal_test.go
@@ -88,25 +88,6 @@ func TestPendingSignalsDelayedSignalSurvivesLaterCurrentSignal(t *testing.T) {
 	}
 }
 
-func TestPendingSignalsStepConsumesOnlyCurrentSignal(t *testing.T) {
-	var pending pendingSignals
-	const (
-		tid           = 4001
-		delayedSignal = 23
-		currentSignal = 10
-	)
-
-	pending.delay(tid, delayedSignal)
-	pending.set(tid, currentSignal)
-
-	if got := pending.takeForStep(tid); got != currentSignal {
-		t.Fatalf("takeForStep = %d, want current signal %d", got, currentSignal)
-	}
-	if got := pending.take(tid); got != delayedSignal {
-		t.Fatalf("delayed signal after takeForStep = %d, want %d", got, delayedSignal)
-	}
-}
-
 func TestPendingSignalsContinueSeparatesCurrentFromDelayed(t *testing.T) {
 	var pending pendingSignals
 	const (

--- a/internal/debugger/sigurg_step_e2e_linux_amd64_test.go
+++ b/internal/debugger/sigurg_step_e2e_linux_amd64_test.go
@@ -89,8 +89,16 @@ func buildSteppingSIGURGTarget(t *testing.T) (string, uint64) {
 	return "", 0
 }
 
-func TestLinuxSteppingThreadSIGURGIsForwardedAfterInstructionStep(t *testing.T) {
-	binary, stepPC := buildSteppingSIGURGTarget(t)
+type steppingSIGURGTracee struct {
+	t        *testing.T
+	backend  *linuxBackend
+	pid      int
+	cmd      *exec.Cmd
+	finished bool
+}
+
+func startSteppingSIGURGTracee(t *testing.T, binary string) *steppingSIGURGTracee {
+	t.Helper()
 	b := newBackend().(*linuxBackend)
 	pid, cmd, err := startTracedProcess(b, binary, nil, nil)
 	if err != nil {
@@ -98,98 +106,109 @@ func TestLinuxSteppingThreadSIGURGIsForwardedAfterInstructionStep(t *testing.T) 
 		t.Fatalf("start target: %v", err)
 	}
 	b.setPID(pid)
-	finished := false
-	defer func() {
-		if !finished {
-			_ = cmd.Process.Kill()
-			b.reapAfterKill()
-		}
-		b.closeTracer()
-	}()
+	tracee := &steppingSIGURGTracee{t: t, backend: b, pid: pid, cmd: cmd}
+	t.Cleanup(tracee.cleanup)
+	return tracee
+}
 
-	if err := b.ContinueProcess(); err != nil {
-		t.Fatalf("continue to ready stop: %v", err)
+func (p *steppingSIGURGTracee) cleanup() {
+	if !p.finished {
+		_ = p.cmd.Process.Kill()
+		p.backend.reapAfterKill()
 	}
-	ready, err := b.Wait()
+	p.backend.closeTracer()
+}
+
+func (p *steppingSIGURGTracee) prepare(stepPC uint64) {
+	p.t.Helper()
+	if err := p.backend.ContinueProcess(); err != nil {
+		p.t.Fatalf("continue to ready stop: %v", err)
+	}
+	ready, err := p.backend.Wait()
 	if err != nil {
-		t.Fatalf("wait for ready stop: %v", err)
+		p.t.Fatalf("wait for ready stop: %v", err)
 	}
-	if ready.Reason != StopSignal || ready.TID != pid || ready.Signal != int(syscall.SIGSTOP) {
-		t.Fatalf("ready stop = %+v, want main-thread SIGSTOP", ready)
+	if ready.Reason != StopSignal || ready.TID != p.pid || ready.Signal != int(syscall.SIGSTOP) {
+		p.t.Fatalf("ready stop = %+v, want main-thread SIGSTOP", ready)
 	}
 
-	regs, err := b.GetRegisters(pid)
+	regs, err := p.backend.GetRegisters(p.pid)
 	if err != nil {
-		t.Fatalf("read ready registers: %v", err)
+		p.t.Fatalf("read ready registers: %v", err)
 	}
 	regs.PC = stepPC
-	if err := b.SetRegisters(pid, regs); err != nil {
-		t.Fatalf("set step target PC: %v", err)
+	if err := p.backend.SetRegisters(p.pid, regs); err != nil {
+		p.t.Fatalf("set step target PC: %v", err)
 	}
+}
 
-	var resumeCalls []linuxResumeCall
-	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
-		resumeCalls = append(resumeCalls, linuxResumeCall{
+func (p *steppingSIGURGTracee) recordCalls(resumeCalls *[]linuxResumeCall, tgkillCalls *[]linuxTgkillCall) {
+	p.backend.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
+		*resumeCalls = append(*resumeCalls, linuxResumeCall{
 			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
 		})
 		return syscall.Syscall6(trap, a1, a2, a3, a4, a5, a6)
 	}
-	var tgkillCalls []linuxTgkillCall
-	b.tgkillFn = func(tgid, targetTID int, signal syscall.Signal) error {
-		tgkillCalls = append(tgkillCalls, linuxTgkillCall{tgid: tgid, tid: targetTID, signal: int(signal)})
+	p.backend.tgkillFn = func(tgid, targetTID int, signal syscall.Signal) error {
+		*tgkillCalls = append(*tgkillCalls, linuxTgkillCall{tgid: tgid, tid: targetTID, signal: int(signal)})
 		return syscall.Tgkill(tgid, targetTID, signal)
 	}
+}
 
-	if err := syscall.Tgkill(pid, pid, syscall.SIGURG); err != nil {
-		t.Fatalf("queue initial SIGURG: %v", err)
+func (p *steppingSIGURGTracee) queueSIGURG() {
+	p.t.Helper()
+	if err := syscall.Tgkill(p.pid, p.pid, syscall.SIGURG); err != nil {
+		p.t.Fatalf("queue initial SIGURG: %v", err)
 	}
-	if err := b.SingleStep(pid); err != nil {
-		t.Fatalf("first SingleStep: %v", err)
-	}
-	first, err := b.Wait()
-	if err != nil {
-		t.Fatalf("wait for first step: %v", err)
-	}
-	if first.Reason != StopSingleStep || first.TID != pid {
-		t.Fatalf("first stop = %+v, want StopSingleStep on tid %d", first, pid)
-	}
-	regs, err = b.GetRegisters(pid)
-	if err != nil {
-		t.Fatalf("read first-step registers: %v", err)
-	}
-	if regs.PC != stepPC+1 {
-		t.Fatalf("first-step PC = 0x%x, want 0x%x", regs.PC, stepPC+1)
-	}
+}
 
-	if err := b.SingleStep(pid); err != nil {
-		t.Fatalf("second SingleStep: %v", err)
+func (p *steppingSIGURGTracee) requireStep(name string, wantPC uint64) {
+	p.t.Helper()
+	if err := p.backend.SingleStep(p.pid); err != nil {
+		p.t.Fatalf("%s SingleStep: %v", name, err)
 	}
-	second, err := b.Wait()
+	stop, err := p.backend.Wait()
 	if err != nil {
-		t.Fatalf("wait for second step: %v", err)
+		p.t.Fatalf("wait for %s step: %v", name, err)
 	}
-	if second.Reason != StopSingleStep || second.TID != pid {
-		t.Fatalf("second stop = %+v, want StopSingleStep on tid %d", second, pid)
+	if stop.Reason != StopSingleStep || stop.TID != p.pid {
+		p.t.Fatalf("%s stop = %+v, want StopSingleStep on tid %d", name, stop, p.pid)
 	}
-	regs, err = b.GetRegisters(pid)
+	regs, err := p.backend.GetRegisters(p.pid)
 	if err != nil {
-		t.Fatalf("read second-step registers: %v", err)
+		p.t.Fatalf("read %s-step registers: %v", name, err)
 	}
-	if regs.PC != stepPC+2 {
-		t.Fatalf("second-step PC = 0x%x, want 0x%x", regs.PC, stepPC+2)
+	if regs.PC != wantPC {
+		p.t.Fatalf("%s-step PC = 0x%x, want 0x%x", name, regs.PC, wantPC)
 	}
+}
 
-	if err := b.ContinueProcess(); err != nil {
-		t.Fatalf("continue with delayed SIGURG: %v", err)
+func (p *steppingSIGURGTracee) continueToHandlerExit() {
+	p.t.Helper()
+	if err := p.backend.ContinueProcess(); err != nil {
+		p.t.Fatalf("continue with delayed SIGURG: %v", err)
 	}
-	terminal, err := b.Wait()
+	terminal, err := p.backend.Wait()
 	if err != nil {
-		t.Fatalf("wait for terminal stop: %v", err)
+		p.t.Fatalf("wait for terminal stop: %v", err)
 	}
 	if terminal.Reason != StopExited || terminal.ExitCode != 42 {
-		t.Fatalf("terminal stop = %+v, want handler-returning exit 42", terminal)
+		p.t.Fatalf("terminal stop = %+v, want handler-returning exit 42", terminal)
 	}
+}
 
+func (p *steppingSIGURGTracee) finish() {
+	_ = p.cmd.Wait()
+	p.finished = true
+}
+
+func requireSteppingSIGURGCalls(
+	t *testing.T,
+	pid int,
+	resumeCalls []linuxResumeCall,
+	tgkillCalls []linuxTgkillCall,
+) {
+	t.Helper()
 	wantResumes := []linuxResumeCall{
 		wantLinuxResume(syscall.PTRACE_SINGLESTEP, pid, 0),
 		wantLinuxResume(syscall.PTRACE_SINGLESTEP, pid, 0),
@@ -205,7 +224,20 @@ func TestLinuxSteppingThreadSIGURGIsForwardedAfterInstructionStep(t *testing.T) 
 	if !reflect.DeepEqual(tgkillCalls, wantTgkills) {
 		t.Fatalf("tgkill calls = %+v, want exact-TID requeue %+v", tgkillCalls, wantTgkills)
 	}
+}
 
-	_ = cmd.Wait()
-	finished = true
+func TestLinuxSteppingThreadSIGURGIsForwardedAfterInstructionStep(t *testing.T) {
+	binary, stepPC := buildSteppingSIGURGTarget(t)
+	tracee := startSteppingSIGURGTracee(t, binary)
+	tracee.prepare(stepPC)
+
+	var resumeCalls []linuxResumeCall
+	var tgkillCalls []linuxTgkillCall
+	tracee.recordCalls(&resumeCalls, &tgkillCalls)
+	tracee.queueSIGURG()
+	tracee.requireStep("first", stepPC+1)
+	tracee.requireStep("second", stepPC+2)
+	tracee.continueToHandlerExit()
+	requireSteppingSIGURGCalls(t, tracee.pid, resumeCalls, tgkillCalls)
+	tracee.finish()
 }

--- a/internal/debugger/sigurg_step_e2e_linux_amd64_test.go
+++ b/internal/debugger/sigurg_step_e2e_linux_amd64_test.go
@@ -1,0 +1,211 @@
+//go:build e2e && linux && amd64
+
+package debugger
+
+import (
+	"debug/elf"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"syscall"
+	"testing"
+)
+
+const steppingSIGURGTargetSource = `
+#include <signal.h>
+#include <unistd.h>
+
+volatile sig_atomic_t handled;
+
+static void handle_sigurg(int signal) {
+	(void)signal;
+	handled = 1;
+}
+
+extern void step_target(void);
+
+__asm__(
+	".text\n"
+	".globl step_target\n"
+	".type step_target,@function\n"
+	"step_target:\n"
+	"nop\n"
+	"nop\n"
+	"cmpl $1, handled(%rip)\n"
+	"jne 1f\n"
+	"mov $42, %edi\n"
+	"jmp 2f\n"
+	"1:\n"
+	"mov $43, %edi\n"
+	"2:\n"
+	"mov $60, %eax\n"
+	"syscall\n"
+	".size step_target, .-step_target\n"
+);
+
+int main(void) {
+	struct sigaction action = {0};
+	action.sa_handler = handle_sigurg;
+	sigemptyset(&action.sa_mask);
+	if (sigaction(SIGURG, &action, 0) != 0) {
+		return 91;
+	}
+	raise(SIGSTOP);
+	for (;;) {
+		pause();
+	}
+}
+`
+
+func buildSteppingSIGURGTarget(t *testing.T) (string, uint64) {
+	t.Helper()
+	dir := t.TempDir()
+	source := filepath.Join(dir, "target.c")
+	binary := filepath.Join(dir, "target")
+	if err := os.WriteFile(source, []byte(steppingSIGURGTargetSource), 0o600); err != nil {
+		t.Fatalf("write target source: %v", err)
+	}
+	cmd := exec.Command("cc", "-O0", "-g", "-fno-pie", "-no-pie", "-o", binary, source)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build target: %v\n%s", err, output)
+	}
+
+	file, err := elf.Open(binary)
+	if err != nil {
+		t.Fatalf("open target ELF: %v", err)
+	}
+	defer file.Close()
+	symbols, err := file.Symbols()
+	if err != nil {
+		t.Fatalf("read target symbols: %v", err)
+	}
+	for _, symbol := range symbols {
+		if symbol.Name == "step_target" {
+			return binary, symbol.Value
+		}
+	}
+	t.Fatal("step_target symbol not found")
+	return "", 0
+}
+
+func TestLinuxSteppingThreadSIGURGIsForwardedAfterInstructionStep(t *testing.T) {
+	binary, stepPC := buildSteppingSIGURGTarget(t)
+	b := newBackend().(*linuxBackend)
+	pid, cmd, err := startTracedProcess(b, binary, nil, nil)
+	if err != nil {
+		b.closeTracer()
+		t.Fatalf("start target: %v", err)
+	}
+	b.setPID(pid)
+	finished := false
+	defer func() {
+		if !finished {
+			_ = cmd.Process.Kill()
+			b.reapAfterKill()
+		}
+		b.closeTracer()
+	}()
+
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("continue to ready stop: %v", err)
+	}
+	ready, err := b.Wait()
+	if err != nil {
+		t.Fatalf("wait for ready stop: %v", err)
+	}
+	if ready.Reason != StopSignal || ready.TID != pid || ready.Signal != int(syscall.SIGSTOP) {
+		t.Fatalf("ready stop = %+v, want main-thread SIGSTOP", ready)
+	}
+
+	regs, err := b.GetRegisters(pid)
+	if err != nil {
+		t.Fatalf("read ready registers: %v", err)
+	}
+	regs.PC = stepPC
+	if err := b.SetRegisters(pid, regs); err != nil {
+		t.Fatalf("set step target PC: %v", err)
+	}
+
+	var resumeCalls []linuxResumeCall
+	b.ptraceSyscall6Fn = func(trap, a1, a2, a3, a4, a5, a6 uintptr) (uintptr, uintptr, syscall.Errno) {
+		resumeCalls = append(resumeCalls, linuxResumeCall{
+			trap: trap, request: a1, tid: a2, addr: a3, signal: a4, a5: a5, a6: a6,
+		})
+		return syscall.Syscall6(trap, a1, a2, a3, a4, a5, a6)
+	}
+	var tgkillCalls []linuxTgkillCall
+	b.tgkillFn = func(tgid, targetTID int, signal syscall.Signal) error {
+		tgkillCalls = append(tgkillCalls, linuxTgkillCall{tgid: tgid, tid: targetTID, signal: int(signal)})
+		return syscall.Tgkill(tgid, targetTID, signal)
+	}
+
+	if err := syscall.Tgkill(pid, pid, syscall.SIGURG); err != nil {
+		t.Fatalf("queue initial SIGURG: %v", err)
+	}
+	if err := b.SingleStep(pid); err != nil {
+		t.Fatalf("first SingleStep: %v", err)
+	}
+	first, err := b.Wait()
+	if err != nil {
+		t.Fatalf("wait for first step: %v", err)
+	}
+	if first.Reason != StopSingleStep || first.TID != pid {
+		t.Fatalf("first stop = %+v, want StopSingleStep on tid %d", first, pid)
+	}
+	regs, err = b.GetRegisters(pid)
+	if err != nil {
+		t.Fatalf("read first-step registers: %v", err)
+	}
+	if regs.PC != stepPC+1 {
+		t.Fatalf("first-step PC = 0x%x, want 0x%x", regs.PC, stepPC+1)
+	}
+
+	if err := b.SingleStep(pid); err != nil {
+		t.Fatalf("second SingleStep: %v", err)
+	}
+	second, err := b.Wait()
+	if err != nil {
+		t.Fatalf("wait for second step: %v", err)
+	}
+	if second.Reason != StopSingleStep || second.TID != pid {
+		t.Fatalf("second stop = %+v, want StopSingleStep on tid %d", second, pid)
+	}
+	regs, err = b.GetRegisters(pid)
+	if err != nil {
+		t.Fatalf("read second-step registers: %v", err)
+	}
+	if regs.PC != stepPC+2 {
+		t.Fatalf("second-step PC = 0x%x, want 0x%x", regs.PC, stepPC+2)
+	}
+
+	if err := b.ContinueProcess(); err != nil {
+		t.Fatalf("continue with delayed SIGURG: %v", err)
+	}
+	terminal, err := b.Wait()
+	if err != nil {
+		t.Fatalf("wait for terminal stop: %v", err)
+	}
+	if terminal.Reason != StopExited || terminal.ExitCode != 42 {
+		t.Fatalf("terminal stop = %+v, want handler-returning exit 42", terminal)
+	}
+
+	wantResumes := []linuxResumeCall{
+		wantLinuxResume(syscall.PTRACE_SINGLESTEP, pid, 0),
+		wantLinuxResume(syscall.PTRACE_SINGLESTEP, pid, 0),
+		wantLinuxResume(syscall.PTRACE_SINGLESTEP, pid, 0),
+		wantLinuxResume(syscall.PTRACE_CONT, pid, 0),
+		wantLinuxResume(syscall.PTRACE_CONT, pid, int(syscall.SIGURG)),
+		wantLinuxResume(syscall.PTRACE_CONT, pid, 0),
+	}
+	if !reflect.DeepEqual(resumeCalls, wantResumes) {
+		t.Fatalf("resume calls = %+v, want exact delayed-delivery sequence %+v", resumeCalls, wantResumes)
+	}
+	wantTgkills := []linuxTgkillCall{{tgid: pid, tid: pid, signal: int(syscall.SIGURG)}}
+	if !reflect.DeepEqual(tgkillCalls, wantTgkills) {
+		t.Fatalf("tgkill calls = %+v, want exact-TID requeue %+v", tgkillCalls, wantTgkills)
+	}
+
+	_ = cmd.Wait()
+	finished = true
+}

--- a/internal/debugger/waitpark.go
+++ b/internal/debugger/waitpark.go
@@ -396,7 +396,7 @@ func (q *stepQueue) planAbsorb(kind absorbKind, tid int, signal int) absorbPlan 
 		return absorbPlan{mode: resumeContinue, signal: 0}
 	default:
 		if q.resumeFor(tid) == resumeSingleStep {
-			return absorbPlan{mode: resumeSingleStep, signal: 0}
+			return absorbPlan{mode: resumeSingleStep, signal: signal}
 		}
 		return absorbPlan{mode: resumeContinue, signal: signal}
 	}

--- a/internal/debugger/waitpark_test.go
+++ b/internal/debugger/waitpark_test.go
@@ -538,18 +538,15 @@ func TestStepQueueAbortStepLiftsTheGateAndDropsHeldStops(t *testing.T) {
 	}
 }
 
-// TestStepQueuePlanResumeForwardsSignalsExceptOnTheSteppedThread pins the
-// signal half of an absorbed resume.
+// A signal carried by an absorbed stop must remain in the plan even when that
+// plan re-arms a step. applyAbsorb stores it for a later continue while the
+// PTRACE_SINGLESTEP itself still uses signal zero.
 //
 // SIGURG is the only signal any absorb site passes here, and it must reach the
 // thread again on the continue path or Go loses a preemption it was told to
-// take. The stepped thread is the deliberate exception: re-arming its step with
-// the signal attached would execute the handler's first instruction instead of
-// the instruction under the step, so the engine would reinstall the trap over an
-// instruction that never ran and report the same breakpoint again on return.
-//
-// A mutation that forwards the signal on the re-arm path, or that drops it on
-// the continue path, fails here.
+// take. Injecting it on the re-arm would execute the handler's first instruction
+// instead of the instruction under the step, so primitive selection and signal
+// retention are deliberately separate decisions.
 // TestStepQueuePlanAbsorbCoversEveryWaitBranch pins what each wait-loop branch
 // does to an in-flight step. Every branch that resumes a thread inline routes
 // through planAbsorb, so this table is the gate on all of them at once: before
@@ -588,8 +585,8 @@ func TestPlanAbsorbRearmsTheStepItConsumedOnTheSteppedThread(t *testing.T) {
 		if got.fail || got.mode != resumeSingleStep {
 			t.Fatalf("kind %d on the stepped thread = %+v, want a re-armed step", kind, got)
 		}
-		if got.signal != 0 {
-			t.Fatalf("kind %d re-armed the step carrying signal %d, want none", kind, got.signal)
+		if got.signal != absorbSignal {
+			t.Fatalf("kind %d re-armed the step after losing signal %d: got %+v", kind, absorbSignal, got)
 		}
 		if got.stepThreadExits {
 			t.Fatalf("kind %d marked the live stepped thread as exiting", kind)
@@ -718,7 +715,7 @@ func TestPlanAbsorbNeverRearmsOrRefusesWithNoStepInFlight(t *testing.T) {
 	}
 }
 
-func TestStepQueuePlanAbsorbForwardsSignalsExceptOnTheSteppedThread(t *testing.T) {
+func TestStepQueuePlanAbsorbRetainsSignalsAcrossStepRearm(t *testing.T) {
 	const (
 		stepped = 4600
 		foreign = 4700
@@ -735,7 +732,7 @@ func TestStepQueuePlanAbsorbForwardsSignalsExceptOnTheSteppedThread(t *testing.T
 		wantSignal int
 	}{
 		{"foreign thread mid-step keeps its signal", true, stepped, foreign, sigurg, resumeContinue, sigurg},
-		{"stepped thread drops its signal", true, stepped, stepped, sigurg, resumeSingleStep, 0},
+		{"stepped thread retains its signal for delayed delivery", true, stepped, stepped, sigurg, resumeSingleStep, sigurg},
 		{"idle queue keeps the signal", false, 0, foreign, sigurg, resumeContinue, sigurg},
 		{"idle queue keeps it even for the last stepped tid", false, stepped, stepped, sigurg, resumeContinue, sigurg},
 		{"a zero signal stays zero on continue", true, stepped, foreign, 0, resumeContinue, 0},

--- a/internal/debugger/waitpark_test.go
+++ b/internal/debugger/waitpark_test.go
@@ -151,9 +151,9 @@ func TestStepQueueReleasesFIFO(t *testing.T) {
 // TestStepQueuePreservesEveryStopField pins that a held stop is delivered whole.
 // The signal in particular travels inside the parked StopEvent rather than in
 // backend state, which is why the queue has no pending-signal ordering problem
-// to solve (see issue #204): there is no separate signal record that could be
-// written when the stop is parked and read against a different thread later.
-// If a refactor ever moves the signal out of the event, this test fails.
+// to solve (see issue #206): the per-TID pending state is installed only after
+// this queue releases the event for delivery. If a refactor ever moves the
+// signal out of the parked event, this test fails.
 func TestStepQueuePreservesEveryStopField(t *testing.T) {
 	want := []StopEvent{
 		{Reason: StopSignal, TID: 21, Signal: 11},

--- a/justfile
+++ b/justfile
@@ -133,8 +133,9 @@ integration:
 # Runs every label (no filter): `basic` correctness, `churn` robustness, `pause`
 # async-interrupt, `stepping` (StepInto/StepOut), `inspect` (StackFrames/Locals/
 # Goroutines), `breakpoints` (ClearBreakpoint), `kill` (kill-while-running),
-# `exit` (real exit code), `attach` (attach by PID to a running process),
-# `restart`, and `fullstack` transport, all under -race.
+# `exit` (real exit code), `signals` (linux signal forwarding + Pause control),
+# `attach` (attach by PID to a running process), `restart`, and `fullstack`
+# transport, all under -race.
 e2e-linux:
 	go test -tags e2e -race -count=1 -v -timeout 600s ./test/integration
 

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -398,7 +398,7 @@ func declareChurnSpec() {
 // couldn't be cleanly discarded), the next Pause's signal would never surface
 // and waitFor would time out.
 func declarePauseSpec() {
-	It("interrupts a running process on demand and resumes, repeatedly", Label("pause"), func() {
+	It("interrupts a running process on demand and resumes, repeatedly", Label("pause", "signals"), func() {
 		bin := buildTarget("pause_target", basicTargetSrc)
 
 		h := newE2EHarness(bin)
@@ -414,13 +414,36 @@ func declarePauseSpec() {
 			time.Sleep(20 * time.Millisecond)
 
 			Expect(h.d.Pause()).To(Succeed(), "Pause #%d", i)
-			evt := h.waitFor(15*time.Second,
-				protocol.EventPaused, protocol.EventProcessExited, protocol.EventError)
+			evt := awaitPauseWithoutSignalOutput(h.d.Events(), 15*time.Second)
 			Expect(evt.Kind).To(Equal(protocol.EventPaused),
 				"Pause #%d expected Paused, got %s: %s", i, evt.Kind, evt.Payload)
 		}
 		AddReportEntry("pause-iterations", iters)
 	})
+}
+
+func awaitPauseWithoutSignalOutput(events <-chan protocol.Event, timeout time.Duration) protocol.Event {
+	GinkgoHelper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case evt, ok := <-events:
+			if !ok {
+				Fail("events channel closed while waiting for Paused")
+			}
+			switch evt.Kind {
+			case protocol.EventPaused, protocol.EventProcessExited, protocol.EventError:
+				return evt
+			case protocol.EventOutput:
+				var out protocol.OutputPayload
+				if json.Unmarshal(evt.Payload, &out) == nil && strings.HasPrefix(out.Content, "signal ") {
+					Fail(fmt.Sprintf("Pause control signal surfaced as output: %q", out.Content))
+				}
+			}
+		case <-deadline:
+			Fail(fmt.Sprintf("TIMEOUT after %s waiting for Paused (possible hang)", timeout))
+		}
+	}
 }
 
 // --- new operation specs (stepping / inspect / breakpoints / kill) ---

--- a/test/integration/debugger_e2e_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_linux_amd64_test.go
@@ -192,9 +192,6 @@ func main() {
 	for atomic.LoadInt64(&signalledProgress) == 0 || atomic.LoadInt64(&siblingProgress) == 0 {
 		runtime.Gosched()
 	}
-	signalledBefore := atomic.LoadInt64(&signalledProgress)
-	siblingBefore := atomic.LoadInt64(&siblingProgress)
-
 	if err := syscall.Tgkill(os.Getpid(), signalledTID, syscall.SIGUSR1); err != nil {
 		os.Exit(91)
 	}
@@ -203,6 +200,8 @@ func main() {
 	case <-time.After(5 * time.Second):
 		os.Exit(92)
 	}
+	signalledBefore := atomic.LoadInt64(&signalledProgress)
+	siblingBefore := atomic.LoadInt64(&siblingProgress)
 
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
@@ -961,6 +960,8 @@ func declareStepOverlapSignalSpec() {
 	It("resumes the thread that stopped when a foreign signal lands mid-step",
 		Label("overlap"), func() {
 			p, bpA, bpB := setupOverlap("overlap_signal_target", overlapSignalTargetSrc)
+			parkedSignalsBefore, ok := debugger.LinuxParkedSignalCount(p.h.d)
+			Expect(ok).To(BeTrue(), "parked-signal hook unavailable")
 
 			iters := envInt("BINGO_E2E_OVERLAP_SIGNAL_ITERS", 40)
 			// Machine steps per cycle. A foreign signal is only *held* if it
@@ -1050,7 +1051,7 @@ func declareStepOverlapSignalSpec() {
 			// a lost signal number could not have shown up.
 			parkedSignals, ok := debugger.LinuxParkedSignalCount(p.h.d)
 			Expect(ok).To(BeTrue(), "parked-signal hook unavailable")
-			Expect(parkedSignals).To(BeNumerically(">", 0),
+			Expect(parkedSignals).To(BeNumerically(">", parkedSignalsBefore),
 				"no signal stop was ever held back across %d cycles x %d steps: "+
 					"the queued signal path was not exercised", iters, steps)
 			// Liveness: threads are still making progress at the end of the
@@ -1076,7 +1077,7 @@ func declareStepOverlapSignalSpec() {
 			Expect(ok).To(BeTrue(), "step-rearm hook unavailable")
 
 			AddReportEntry("overlap-signal-parked-stops", parked)
-			AddReportEntry("overlap-signal-parked-signal-stops", parkedSignals)
+			AddReportEntry("overlap-signal-parked-signal-stops", parkedSignals-parkedSignalsBefore)
 			AddReportEntry("overlap-signal-values", fmt.Sprintf("%v", p.signalValues))
 			AddReportEntry("overlap-signal-step-rearms", rearms)
 		})

--- a/test/integration/debugger_e2e_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_linux_amd64_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -60,14 +61,42 @@ const signalTargetExitOK = 43
 const segvSignalTargetSrc = `package main
 
 import (
-	"os/signal"
+	"os"
+	"runtime"
 	"syscall"
+	"unsafe"
 )
 
 var sinkByte byte
 
+type kernelSigaction struct {
+	handler  uintptr
+	flags    uintptr
+	restorer uintptr
+	mask     uint64
+}
+
+func resetToDefault(sig syscall.Signal) {
+	// os/signal.Reset still lets Go translate synchronous faults into exit(2);
+	// this target needs kernel signal death to exercise StopKilled.
+	action := kernelSigaction{}
+	_, _, errno := syscall.RawSyscall6(
+		syscall.SYS_RT_SIGACTION,
+		uintptr(sig),
+		uintptr(unsafe.Pointer(&action)),
+		0,
+		unsafe.Sizeof(action.mask),
+		0,
+		0,
+	)
+	runtime.KeepAlive(&action)
+	if errno != 0 {
+		os.Exit(89)
+	}
+}
+
 func main() {
-	signal.Reset(syscall.SIGSEGV)
+	resetToDefault(syscall.SIGSEGV)
 	var p *byte
 	sinkByte = *p
 }
@@ -77,13 +106,39 @@ const abortSignalTargetSrc = `package main
 
 import (
 	"os"
-	"os/signal"
 	"runtime"
 	"syscall"
+	"unsafe"
 )
 
+type kernelSigaction struct {
+	handler  uintptr
+	flags    uintptr
+	restorer uintptr
+	mask     uint64
+}
+
+func resetToDefault(sig syscall.Signal) {
+	// os/signal.Reset still lets Go translate fatal signals into exit(2); this
+	// target needs kernel signal death to exercise StopKilled.
+	action := kernelSigaction{}
+	_, _, errno := syscall.RawSyscall6(
+		syscall.SYS_RT_SIGACTION,
+		uintptr(sig),
+		uintptr(unsafe.Pointer(&action)),
+		0,
+		unsafe.Sizeof(action.mask),
+		0,
+		0,
+	)
+	runtime.KeepAlive(&action)
+	if errno != 0 {
+		os.Exit(89)
+	}
+}
+
 func main() {
-	signal.Reset(syscall.SIGABRT)
+	resetToDefault(syscall.SIGABRT)
 	if err := syscall.Tgkill(os.Getpid(), syscall.Gettid(), syscall.SIGABRT); err != nil {
 		os.Exit(90)
 	}
@@ -179,6 +234,7 @@ func declareSignalForwardingSpec() {
 		for _, tc := range cases {
 			By(tc.name)
 			bin := buildTarget("signal_"+strings.ToLower(tc.name)+"_target", tc.src)
+			assertSignalDeath(bin, tc.signal)
 			h := newE2EHarness(bin)
 			h.waitFor(15*time.Second, protocol.EventStepped)
 
@@ -196,6 +252,17 @@ func declareSignalForwardingSpec() {
 			Expect(h.d.Continue()).To(Succeed(), "Continue into SIGUSR1 target")
 			awaitSignalExit(h.d.Events(), syscall.SIGUSR1, signalTargetExitOK)
 		})
+}
+
+func assertSignalDeath(bin string, signal syscall.Signal) {
+	GinkgoHelper()
+	err := exec.Command(bin).Run()
+	var exitErr *exec.ExitError
+	Expect(errors.As(err, &exitErr)).To(BeTrue(), "%s should terminate from %s, got %v", bin, signal, err)
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	Expect(ok).To(BeTrue(), "%s returned a non-wait exit status", bin)
+	Expect(status.Signaled()).To(BeTrue(), "%s exited normally with status %d", bin, status.ExitStatus())
+	Expect(status.Signal()).To(Equal(signal), "%s terminated from the wrong signal", bin)
 }
 
 func awaitSignalExit(events <-chan protocol.Event, signal syscall.Signal, wantExit int) {

--- a/test/integration/debugger_e2e_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_linux_amd64_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Linux amd64 debugger backend (ptrace) E2E", Label("linux"), fu
 	declareDAPExitSpec()
 	declareDAPMultiClientSpec()
 	declareDAPJoinSpec()
+	declareSignalForwardingSpec()
 	declareStepOverlapSpec()
 	declareStepOverlapStepIntoSpec()
 	declareStepOverlapSignalSpec()
@@ -53,6 +54,187 @@ var _ = Describe("Linux amd64 debugger backend (ptrace) E2E", Label("linux"), fu
 	declareStepOwnerHoldSpec()
 	declareLeaderRetirementSpec()
 })
+
+const signalTargetExitOK = 43
+
+const segvSignalTargetSrc = `package main
+
+import (
+	"os/signal"
+	"syscall"
+)
+
+var sinkByte byte
+
+func main() {
+	signal.Reset(syscall.SIGSEGV)
+	var p *byte
+	sinkByte = *p
+}
+`
+
+const abortSignalTargetSrc = `package main
+
+import (
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+)
+
+func main() {
+	signal.Reset(syscall.SIGABRT)
+	if err := syscall.Tgkill(os.Getpid(), syscall.Gettid(), syscall.SIGABRT); err != nil {
+		os.Exit(90)
+	}
+	for {
+		runtime.Gosched()
+	}
+}
+`
+
+// ordinarySignalTargetSrc directs one handled signal at a known locked thread
+// while a sibling thread keeps making progress. Exit 43 proves all three
+// outcomes: SIGUSR1 reached the tracee, the signalled thread was the one resumed,
+// and another thread was not stranded by the resume.
+const ordinarySignalTargetSrc = `package main
+
+import (
+	"os"
+	"os/signal"
+	"runtime"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+var (
+	signalledProgress int64
+	siblingProgress   int64
+)
+
+func runCounter(counter *int64, tid chan<- int) {
+	runtime.LockOSThread()
+	if tid != nil {
+		tid <- syscall.Gettid()
+	}
+	for {
+		atomic.AddInt64(counter, 1)
+		time.Sleep(100 * time.Microsecond)
+	}
+}
+
+func main() {
+	runtime.GOMAXPROCS(2)
+	received := make(chan os.Signal, 1)
+	signal.Notify(received, syscall.SIGUSR1)
+
+	tid := make(chan int, 1)
+	go runCounter(&signalledProgress, tid)
+	go runCounter(&siblingProgress, nil)
+	signalledTID := <-tid
+
+	for atomic.LoadInt64(&signalledProgress) == 0 || atomic.LoadInt64(&siblingProgress) == 0 {
+		runtime.Gosched()
+	}
+	signalledBefore := atomic.LoadInt64(&signalledProgress)
+	siblingBefore := atomic.LoadInt64(&siblingProgress)
+
+	if err := syscall.Tgkill(os.Getpid(), signalledTID, syscall.SIGUSR1); err != nil {
+		os.Exit(91)
+	}
+	select {
+	case <-received:
+	case <-time.After(5 * time.Second):
+		os.Exit(92)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt64(&signalledProgress) > signalledBefore &&
+			atomic.LoadInt64(&siblingProgress) > siblingBefore {
+			os.Exit(43)
+		}
+		runtime.Gosched()
+	}
+	os.Exit(93)
+}
+`
+
+// declareSignalForwardingSpec is the native regression for issue #206. A
+// signal-delivery stop must produce one Output event, then the signal must be
+// injected into the exact stopped TID so the target either dies from its fatal
+// signal or observes its handled signal and exits normally.
+func declareSignalForwardingSpec() {
+	It("forwards fatal signals once and reaches signal death", Label("signals"), func() {
+		cases := []struct {
+			name   string
+			src    string
+			signal syscall.Signal
+		}{
+			{name: "SIGSEGV", src: segvSignalTargetSrc, signal: syscall.SIGSEGV},
+			{name: "SIGABRT", src: abortSignalTargetSrc, signal: syscall.SIGABRT},
+		}
+
+		for _, tc := range cases {
+			By(tc.name)
+			bin := buildTarget("signal_"+strings.ToLower(tc.name)+"_target", tc.src)
+			h := newE2EHarness(bin)
+			h.waitFor(15*time.Second, protocol.EventStepped)
+
+			Expect(h.d.Continue()).To(Succeed(), "Continue into %s", tc.name)
+			awaitSignalExit(h.d.Events(), tc.signal, -1)
+		}
+	})
+
+	It("delivers an ordinary signal to its stopped thread without stranding its sibling",
+		Label("signals"), func() {
+			bin := buildTarget("signal_usr1_target", ordinarySignalTargetSrc)
+			h := newE2EHarness(bin)
+			h.waitFor(15*time.Second, protocol.EventStepped)
+
+			Expect(h.d.Continue()).To(Succeed(), "Continue into SIGUSR1 target")
+			awaitSignalExit(h.d.Events(), syscall.SIGUSR1, signalTargetExitOK)
+		})
+}
+
+func awaitSignalExit(events <-chan protocol.Event, signal syscall.Signal, wantExit int) {
+	GinkgoHelper()
+	wantOutput := fmt.Sprintf("signal %d", signal)
+	outputs := 0
+	deadline := time.After(20 * time.Second)
+
+	for {
+		select {
+		case evt, ok := <-events:
+			if !ok {
+				Fail(fmt.Sprintf("events closed before ProcessExited after %s", signal))
+			}
+			switch evt.Kind {
+			case protocol.EventOutput:
+				var out protocol.OutputPayload
+				Expect(json.Unmarshal(evt.Payload, &out)).To(Succeed(), "decode Output after %s", signal)
+				if strings.HasPrefix(out.Content, "signal ") {
+					Expect(out.Stream).To(Equal("stderr"), "signal output stream")
+					Expect(out.Content).To(Equal(wantOutput), "reported signal")
+					outputs++
+				}
+			case protocol.EventProcessExited:
+				var exited protocol.ProcessExitedPayload
+				Expect(json.Unmarshal(evt.Payload, &exited)).To(Succeed(), "decode ProcessExited after %s", signal)
+				Expect(outputs).To(Equal(1),
+					"%s must be reported exactly once before exit; a larger count is the refault loop", signal)
+				Expect(exited.ExitCode).To(Equal(wantExit), "ProcessExited after %s", signal)
+				return
+			case protocol.EventError:
+				Fail(fmt.Sprintf("debugger error after %s: %s", signal, evt.Payload))
+			}
+		case <-deadline:
+			Fail(fmt.Sprintf("TIMEOUT after %s: no ProcessExited after %s (possible suppressed-signal refault loop)",
+				20*time.Second, signal))
+		}
+	}
+}
 
 // overlapTargetSrc pounds two breakpoint-able lines from several
 // LockOSThread'd goroutines at once, so a sibling thread's SIGTRAP reliably
@@ -432,10 +614,9 @@ func declareStepOverlapSpec() {
 // where another spinner is single-stepping off a trap — the foreign StopSignal
 // case, as opposed to the foreign SIGTRAP the plain overlap target produces.
 //
-// SIGUSR1 is used because ptrace intercepts it before delivery and the engine
-// resumes with signal 0, so the tracee never observes it: the storm changes the
-// debugger's workload without changing the target's behaviour. Its exact number
-// is asserted by the spec, so do not swap it for another signal.
+// SIGUSR1 is handled explicitly so forwarding it changes only an atomic counter.
+// Its exact number is asserted by the spec, so do not swap it for another
+// signal.
 //
 // The storm also sends SIGCONT, which the wait loop absorbs rather than
 // reporting. That is the reachable trigger for the absorb-resume rule: when it
@@ -448,6 +629,7 @@ const overlapSignalTargetSrc = `package main
 
 import (
 	"os"
+	"os/signal"
 	"runtime"
 	"sync/atomic"
 	"syscall"
@@ -481,6 +663,13 @@ func main() {
 	for i := int64(0); i < 6; i++ {
 		go spin(i)
 	}
+	signals := make(chan os.Signal, 64)
+	signal.Notify(signals, syscall.SIGUSR1)
+	go func() {
+		for range signals {
+			atomic.AddInt64(&sink, 1)
+		}
+	}()
 	pid := os.Getpid()
 	go func() {
 		for {


### PR DESCRIPTION
## Summary

- Restacks #221 directly onto `main` at `a41c05bfed3403e1af66569d4490acca90a78c22` after #242 landed.
- Keeps surfaced Linux signals owned by the exact stopped TID until that thread resumes, including stops parked behind another thread's single-step and failed resume retries.
- Injects ordinary/fatal signals only through `PTRACE_CONT` on that TID. Every `PTRACE_SINGLESTEP` remains signal-zero.
- Preserves exact-stepTID `SIGURG` by delaying it per TID, requeueing it with exact-TID `tgkill`, then forwarding it only from the resulting fresh delivery stop.
- Preserves distinct pending signals, Pause suppression, stepped-`SIGSTOP` ownership, and scoped thread/exec/Kill/tracer cleanup.
- Preserves #242's disabled-breakpoint owner-death handling: cleared in-flight entries are not reinstalled, the Linux reconciliation gate still opens, and restored-byte history safely handles delayed same-address stops.
- Contains only the same 12 #221 signal commits. No inherited #202/#242 history or duplicate retired-sentinel correction is present.

Closes #206.

## Restack evidence

- Old remote head: `ac5f8ff2fc8fcd945ea05aaf383ffb3f8d9af2bf`
- New head: `4daa2296ce678200a226bcc2529f057baeb567ca`
- Old range: `83e0be812f32c476fb03e4cd9346641728889c28..ac5f8ff2fc8fcd945ea05aaf383ffb3f8d9af2bf`
- New range: `a41c05bfed3403e1af66569d4490acca90a78c22..4daa2296ce678200a226bcc2529f057baeb567ca`
- Merge base is exactly `a41c05bfed3403e1af66569d4490acca90a78c22`; the new range contains exactly 12 commits.
- Every old/new commit pair has the same stable patch ID. The aggregate range patch ID is unchanged: `580e39485a8b0a168367fe7441e356a20e4d0e4a`.
- `git range-diff` pairs all 12 commits in order. Eleven display `=`; the first implementation commit displays `!` only because its `AGENTS.md` hunk is anchored after #242's expanded owner-death documentation. Its stable patch ID is identical (`6042994b8bb8d09f423d2f439c5c93242a5f05e0`).
- #242's dedicated `engine_breakpoint_clear_test.go` and `engine_stepqueue_test.go` blobs are unchanged from the base. The final engine keeps every `sob.enabled` owner-death guard and `retiredClearedBreakpointBytes` recovery path.

## Local validation

- `gofmt` and `goimports`: clean
- `go test -tags bingonative -race -count=1 ./internal/debugger`: pass
- `go test -tags bingonative -race -count=1 ./test/integration`: pass
- `go test -tags bingonative -count=1 ./...`: pass
- `go vet -tags bingonative ./...`: pass
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 golangci-lint run`: 0 issues
- Linux `internal/debugger` and `test/integration` E2E test binaries cross-compile successfully as static `linux/amd64` ELF executables
- `just e2e-darwin`: **22/22 passed** on exact head `4daa2296ce678200a226bcc2529f057baeb567ca`
- Focused post-restack code review: no findings

Native Linux ptrace execution remains delegated to fresh CI. The workflow retains the dedicated handler-returning exact-stepTID `SIGURG` E2E, the `signals` label for fatal/ordinary forwarding plus Pause suppression, and the existing overlap/mutation gates.