### PR TITLE
fix(debugger): keep cleared breakpoints disabled

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,7 +274,7 @@ overwritten with a trap (INT3 / BRK). To resume execution we must:
 
 1. Restore the original bytes (`bps.removeFromTable` + `WriteMemory`).
 2. Single-step that one instruction.
-3. Reinstall the trap (`bps.reinstall`).
+3. Reinstall the trap (`bps.reinstall`) if the breakpoint is still enabled.
 4. Then perform the user's intended action (`bpResumeAction`).
 
 See `engine.resumeFromBreakpoint` and the `StopSingleStep` branch of
@@ -292,6 +292,17 @@ See `engine.resumeFromBreakpoint` and the `StopSingleStep` branch of
 Internal sentinel BP files: `<stepover-next>`, `<stepout-return>`,
 `<direct-addr>` (test helper). These get auto-cleared when hit and emit
 `EventStepped`, not `EventBreakpointHit`.
+
+Clearing a breakpoint is final even when the tracee is parked on it or already
+single-stepping off it. A successful parked clear restores the bytes and
+invalidates matching `lastBP` / `lastBPTID`; the live PC was rewound when the
+trap stop arrived, so the next resume can continue directly from the original
+instruction. During an in-flight step-off the entry is intentionally absent
+from the table and its original bytes are already restored: `ClearBreakpoint`
+matches the retained entry by ID, marks it disabled, and succeeds. Completion
+then skips `reinstall` but still performs the saved `bpResumeAction`. Failed
+restoration leaves the entry enabled and all pending state intact. `clearAll`
+applies the same invalidation/cancellation rules for Kill.
 
 If `bps.reinstall` ever fails after a single-step, **suspend instead of
 resuming**. Running without the trap is a runaway process; reporting the
@@ -1137,9 +1148,8 @@ confirmation requests are affected.
 **setBreakpoints is replace-all** (`breakpoints.go`): diff the requested lines
 for a source against `bpByFile` — clear removed, set new, keep unchanged — and
 respond once every slot in the request resolves, in request order. Clearing the
-breakpoint the process is currently parked on re-arms it through the engine's
-step-off path (see the clearbp spec), so the e2e continue-to-exit uses a
-no-breakpoint target, not a clear-then-continue.
+breakpoint the process is currently parked on is supported by the engine and
+pinned by the native `breakpoints` acceptance test on both platforms.
 
 ### Server wiring + multi-client discovery
 

--- a/internal/debugger/breakpoint.go
+++ b/internal/debugger/breakpoint.go
@@ -19,6 +19,10 @@ type breakpointEntry struct {
 	enabled       bool
 }
 
+func (b *breakpointEntry) matchesID(id int) bool {
+	return b != nil && b.id == id
+}
+
 func (b *breakpointEntry) toProtocol() protocol.Breakpoint {
 	return protocol.Breakpoint{
 		ID:      b.id,
@@ -79,14 +83,23 @@ func (t *breakpointTable) set(b Backend, file string, line int, addr uint64) (*b
 func (t *breakpointTable) clear(b Backend, id int) error {
 	entry, ok := t.byID[id]
 	if !ok {
-		return fmt.Errorf("breakpoint %d not found", id)
+		return breakpointNotFound(id)
 	}
 	if err := b.WriteMemory(entry.addr, entry.originalBytes); err != nil {
 		return fmt.Errorf("breakpoint clear: restore bytes at 0x%x: %w", entry.addr, err)
 	}
+	entry.enabled = false
 	delete(t.byID, id)
 	delete(t.byAddr, entry.addr)
 	return nil
+}
+
+func breakpointNotFound(id int) error {
+	return fmt.Errorf("breakpoint %d not found", id)
+}
+
+func (t *breakpointTable) atID(id int) *breakpointEntry {
+	return t.byID[id]
 }
 
 func (t *breakpointTable) atAddr(addr uint64) *breakpointEntry {

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -236,7 +236,7 @@ func (e *engine) Kill() error {
 		// Release any threads held for an in-flight atomic step-over first, so
 		// a detach (attached-process Kill) never leaves them Mach-suspended.
 		e.endThreadStep()
-		e.bps.clearAll(e.backend)
+		e.clearAllBreakpoints()
 		if killErr := e.proc.kill(e.backend, running); killErr != nil {
 			return killErr
 		}
@@ -272,8 +272,48 @@ func (e *engine) SetBreakpoint(file string, line int) (protocol.Breakpoint, erro
 
 func (e *engine) ClearBreakpoint(id int) error {
 	return e.dispatch(func() error {
-		return e.bps.clear(e.backend, id)
+		return e.clearBreakpoint(id)
 	})
+}
+
+func (e *engine) clearBreakpoint(id int) error {
+	if e.steppingOverBP.matchesID(id) {
+		if !e.steppingOverBP.enabled {
+			return breakpointNotFound(id)
+		}
+		// The step-off path already restored the original instruction and
+		// transiently removed this entry from the table. Keep its metadata for
+		// the pending resume action, but make completion skip the reinstall.
+		e.steppingOverBP.enabled = false
+		return nil
+	}
+
+	entry := e.bps.atID(id)
+	if err := e.bps.clear(e.backend, id); err != nil {
+		return err
+	}
+	e.invalidateClearedBreakpoint(entry)
+	return nil
+}
+
+func (e *engine) invalidateClearedBreakpoint(entry *breakpointEntry) {
+	if e.lastBP != entry {
+		return
+	}
+	e.lastBP = nil
+	e.lastBPTID = 0
+}
+
+func (e *engine) clearAllBreakpoints() {
+	e.bps.clearAll(e.backend)
+	if e.lastBP != nil && !e.lastBP.enabled {
+		e.invalidateClearedBreakpoint(e.lastBP)
+	}
+	if e.steppingOverBP != nil {
+		// Its bytes were restored before the single-step began, so no backend
+		// write is needed to clear the transiently table-less entry.
+		e.steppingOverBP.enabled = false
+	}
 }
 
 func (e *engine) Continue() error {
@@ -639,11 +679,13 @@ func (e *engine) handleStop(stop StopEvent) {
 		var err error
 		stop, err = e.populateStopPC(stop, false)
 		if err != nil {
-			// Rearm the in-flight step-over BP and release held threads before
+			// Rearm a still-live in-flight BP and release held threads before
 			// surfacing the error, so the process is left in a clean state.
 			if sob := e.steppingOverBP; sob != nil {
 				e.steppingOverBP = nil
-				_ = e.bps.reinstall(e.backend, sob)
+				if sob.enabled {
+					_ = e.bps.reinstall(e.backend, sob)
+				}
 			}
 			e.endThreadStep()
 			e.setState(stateSuspended)
@@ -654,20 +696,22 @@ func (e *engine) handleStop(stop StopEvent) {
 			"steppingOverBP", e.steppingOverBP != nil)
 		if sob := e.steppingOverBP; sob != nil {
 			e.steppingOverBP = nil
-			if rerr := e.bps.reinstall(e.backend, sob); rerr != nil {
-				// Reinstall failed. Suspend instead of resuming — running
-				// without the trap would let the process loose.
-				e.endThreadStep()
-				e.log.Error("breakpoint reinstall failed — suspending to prevent runaway process",
-					"addr", fmt.Sprintf("0x%x", sob.addr), "err", rerr)
-				e.setState(stateSuspended)
-				e.emitError(protocol.CmdNone, fmt.Errorf("reinstall breakpoint 0x%x: %w", sob.addr, rerr))
-				return
+			if sob.enabled {
+				if rerr := e.bps.reinstall(e.backend, sob); rerr != nil {
+					// Reinstall failed. Suspend instead of resuming — running
+					// without the trap would let the process loose.
+					e.endThreadStep()
+					e.log.Error("breakpoint reinstall failed — suspending to prevent runaway process",
+						"addr", fmt.Sprintf("0x%x", sob.addr), "err", rerr)
+					e.setState(stateSuspended)
+					e.emitError(protocol.CmdNone, fmt.Errorf("reinstall breakpoint 0x%x: %w", sob.addr, rerr))
+					return
+				}
+				e.log.Debug("breakpoint reinstalled", "addr", fmt.Sprintf("0x%x", sob.addr))
 			}
-			// The trap byte is back in place; only now is it safe to release
-			// the threads we held for the atomic step-over.
+			// The original instruction is executable now: either the live trap
+			// was reinstalled or a clear cancelled it while the step was in flight.
 			e.endThreadStep()
-			e.log.Debug("breakpoint reinstalled", "addr", fmt.Sprintf("0x%x", sob.addr))
 			switch e.bpResume {
 			case bpResumeContinue:
 				_ = e.backend.ContinueProcess()
@@ -727,14 +771,16 @@ func (e *engine) handleStop(stop StopEvent) {
 		e.emitStepped(stop)
 
 	case StopSignal:
-		// Reinstall any in-flight step-over BP before resuming or suspending.
+		// Reinstall any still-live in-flight BP before resuming or suspending.
 		if sob := e.steppingOverBP; sob != nil {
 			e.steppingOverBP = nil
-			if rerr := e.bps.reinstall(e.backend, sob); rerr != nil {
-				e.endThreadStep()
-				e.setState(stateSuspended)
-				e.emitError(protocol.CmdNone, fmt.Errorf("reinstall breakpoint 0x%x after signal: %w", sob.addr, rerr))
-				return
+			if sob.enabled {
+				if rerr := e.bps.reinstall(e.backend, sob); rerr != nil {
+					e.endThreadStep()
+					e.setState(stateSuspended)
+					e.emitError(protocol.CmdNone, fmt.Errorf("reinstall breakpoint 0x%x after signal: %w", sob.addr, rerr))
+					return
+				}
 			}
 			e.endThreadStep()
 		}
@@ -1026,8 +1072,8 @@ func (e *engine) stepOut() error {
 }
 
 // resumeFromBreakpoint runs the step-over-software-BP sequence:
-// restore bytes → single-step → reinstall trap (in StopSingleStep handler)
-// → perform action.
+// restore bytes → single-step → conditionally reinstall the still-enabled trap
+// (in StopSingleStep handler) → perform action.
 func (e *engine) resumeFromBreakpoint(action bpResumeAction, retAddr uint64) error {
 	bp := e.lastBP
 	e.lastBP = nil

--- a/internal/debugger/engine_breakpoint_clear_test.go
+++ b/internal/debugger/engine_breakpoint_clear_test.go
@@ -1,0 +1,220 @@
+package debugger_test
+
+import (
+	"errors"
+	"syscall"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/bingosuite/bingo/internal/debugger"
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+var _ = Describe("Breakpoint clear state transitions", func() {
+	const bpAddr = uint64(0x2800)
+
+	var (
+		fb       *fakeBackend
+		d        debugger.Debugger
+		id       int
+		trap     []byte
+		original []byte
+	)
+
+	waitForContinue := func() {
+		select {
+		case <-fb.continueCh:
+		case <-time.After(eventTimeout):
+			Fail("backend ContinueProcess was not called")
+		}
+	}
+
+	expectOriginalInstruction := func() {
+		ExpectWithOffset(1, fb.peekMem(bpAddr, len(trap))).To(Equal(original[:len(trap)]))
+	}
+
+	parkOnBreakpoint := func(tid int) {
+		hitPC := bpAddr
+		if len(trap) == 1 {
+			hitPC++
+		}
+		fb.tids = []int{1}
+		if tid != 1 {
+			fb.tids = append(fb.tids, tid)
+		}
+		fb.regs[tid] = debugger.Registers{PC: hitPC}
+
+		continueAndConsumeContinued(d)
+		waitForContinue()
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopBreakpoint, TID: tid, PC: bpAddr})
+
+		evt := mustNextEvent(d)
+		ExpectWithOffset(1, evt.Kind).To(Equal(protocol.EventBreakpointHit))
+		var payload protocol.BreakpointHitPayload
+		ExpectWithOffset(1, protocol.DecodeEventPayload(evt, &payload)).To(Succeed())
+		ExpectWithOffset(1, payload.Breakpoint.ID).To(Equal(id))
+		ExpectWithOffset(1, fb.regs[tid].PC).To(Equal(bpAddr),
+			"the live PC must remain rewound when a parked breakpoint is cleared")
+	}
+
+	BeforeEach(func() {
+		fb = newFakeBackend()
+		d = debugger.NewWithBackend(fb, nil)
+		trap = debugger.ExportedTrapInstruction()
+		original = []byte{0x48, 0x89, 0xc0, 0x90}
+		fb.seedMem(bpAddr, original)
+		debugger.ExportedForceSuspended(d)
+		id = debugger.ExportedSetBreakpointAt(d, bpAddr)
+	})
+
+	AfterEach(func() {
+		_ = d.Kill()
+		if !fb.stopped {
+			close(fb.stopCh)
+			fb.stopped = true
+		}
+	})
+
+	It("clears the breakpoint currently parked on without scheduling a step-off", func() {
+		parkOnBreakpoint(1)
+
+		Expect(d.ClearBreakpoint(id)).To(Succeed())
+		expectOriginalInstruction()
+		stepsBeforeResume := len(fb.singleStepCalls)
+
+		continueAndConsumeContinued(d)
+		waitForContinue()
+		Expect(fb.singleStepCalls).To(HaveLen(stepsBeforeResume))
+		Expect(d.ClearBreakpoint(id)).To(MatchError(ContainSubstring("not found")))
+	})
+
+	It("cancels an in-flight reinstall and still performs the Continue action", func() {
+		parkOnBreakpoint(1)
+
+		continueAndConsumeContinued(d)
+		Expect(fb.singleStepCalls).To(HaveLen(1))
+		expectOriginalInstruction()
+
+		Expect(d.ClearBreakpoint(id)).To(Succeed())
+		Expect(d.ClearBreakpoint(id)).To(MatchError(ContainSubstring("not found")))
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSingleStep, TID: 1, PC: bpAddr + uint64(len(trap))})
+		waitForContinue()
+
+		expectOriginalInstruction()
+		Expect(d.ClearBreakpoint(id)).To(MatchError(ContainSubstring("not found")))
+	})
+
+	It("cancels an in-flight reinstall and still performs the StepInto action", func() {
+		parkOnBreakpoint(1)
+
+		Expect(d.StepInto()).To(Succeed())
+		Expect(fb.singleStepCalls).To(HaveLen(1))
+		Expect(d.ClearBreakpoint(id)).To(Succeed())
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSingleStep, TID: 1, PC: bpAddr + uint64(len(trap))})
+
+		Expect(mustNextEvent(d).Kind).To(Equal(protocol.EventStepped))
+		expectOriginalInstruction()
+		select {
+		case <-fb.continueCh:
+			Fail("StepInto completion must suspend instead of continuing")
+		default:
+		}
+		Expect(d.ClearBreakpoint(id)).To(MatchError(ContainSubstring("not found")))
+	})
+
+	It("preserves the parked entry when restoring its bytes fails", func() {
+		parkOnBreakpoint(2)
+
+		fb.writeErr = errors.New("injected restore failure")
+		Expect(d.ClearBreakpoint(id)).To(MatchError(ContainSubstring("injected restore failure")))
+		Expect(fb.peekMem(bpAddr, len(trap))).To(Equal(trap))
+
+		continueAndConsumeContinued(d)
+		Expect(fb.singleStepCalls).To(ConsistOf(2),
+			"a failed clear must leave lastBP intact for the normal step-off")
+		expectOriginalInstruction()
+
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSingleStep, TID: 1, PC: bpAddr + uint64(len(trap))})
+		waitForContinue()
+		Expect(fb.peekMem(bpAddr, len(trap))).To(Equal(trap))
+		Expect(d.ClearBreakpoint(id)).To(Succeed(),
+			"successful reinstall must retain the original breakpoint ID")
+		expectOriginalInstruction()
+	})
+
+	It("reinstalls an in-flight breakpoint that was not cleared", func() {
+		parkOnBreakpoint(1)
+
+		continueAndConsumeContinued(d)
+		Expect(fb.singleStepCalls).To(HaveLen(1))
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSingleStep, TID: 1, PC: bpAddr + uint64(len(trap))})
+		waitForContinue()
+
+		Expect(fb.peekMem(bpAddr, len(trap))).To(Equal(trap))
+		Expect(d.ClearBreakpoint(id)).To(Succeed(),
+			"the live entry must return to the table under its original ID")
+	})
+
+	It("does not reinstall a cleared in-flight breakpoint when stop-PC inspection fails", func() {
+		parkOnBreakpoint(1)
+
+		Expect(d.StepInto()).To(Succeed())
+		Expect(d.ClearBreakpoint(id)).To(Succeed())
+		fb.getRegistersErr = errors.New("injected register failure")
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSingleStep, TID: 1})
+
+		evt := mustNextEvent(d)
+		Expect(evt.Kind).To(Equal(protocol.EventError))
+		expectOriginalInstruction()
+		Expect(d.ClearBreakpoint(id)).To(MatchError(ContainSubstring("not found")))
+
+		stepsBeforeRetry := len(fb.singleStepCalls)
+		continueAndConsumeContinued(d)
+		waitForContinue()
+		Expect(fb.singleStepCalls).To(HaveLen(stepsBeforeRetry),
+			"the rejected completion must leave a direct resume path, not resurrect the breakpoint")
+	})
+
+	It("does not reinstall a cleared in-flight breakpoint when a signal interrupts the step", func() {
+		parkOnBreakpoint(1)
+
+		continueAndConsumeContinued(d)
+		Expect(d.ClearBreakpoint(id)).To(Succeed())
+		fb.pushStop(debugger.StopEvent{
+			Reason: debugger.StopSignal,
+			TID:    1,
+			Signal: int(syscall.SIGUSR1),
+		})
+		waitForContinue()
+
+		expectOriginalInstruction()
+		Expect(d.ClearBreakpoint(id)).To(MatchError(ContainSubstring("not found")))
+	})
+
+	It("makes Kill's clearAll path forget a parked breakpoint", func() {
+		parkOnBreakpoint(1)
+
+		debugger.ExportedClearAllBreakpoints(d)
+		expectOriginalInstruction()
+		stepsBeforeResume := len(fb.singleStepCalls)
+
+		continueAndConsumeContinued(d)
+		waitForContinue()
+		Expect(fb.singleStepCalls).To(HaveLen(stepsBeforeResume))
+		Expect(d.ClearBreakpoint(id)).To(MatchError(ContainSubstring("not found")))
+	})
+
+	It("makes Kill's clearAll path cancel an in-flight reinstall", func() {
+		parkOnBreakpoint(1)
+
+		Expect(d.StepInto()).To(Succeed())
+		debugger.ExportedClearAllBreakpoints(d)
+		fb.pushStop(debugger.StopEvent{Reason: debugger.StopSingleStep, TID: 1, PC: bpAddr + uint64(len(trap))})
+
+		Expect(mustNextEvent(d).Kind).To(Equal(protocol.EventStepped))
+		expectOriginalInstruction()
+		Expect(d.ClearBreakpoint(id)).To(MatchError(ContainSubstring("not found")))
+	})
+})

--- a/internal/debugger/engine_test.go
+++ b/internal/debugger/engine_test.go
@@ -33,15 +33,19 @@ type fakeBackend struct {
 	singleStepCalls  []int
 	stopProcessCalls int
 	writtenAt        map[uint64][]byte
+	continueCh       chan struct{}
+	writeErr         error
+	getRegistersErr  error
 }
 
 func newFakeBackend() *fakeBackend {
 	return &fakeBackend{
-		mem:       make(map[uint64]byte),
-		regs:      map[int]debugger.Registers{1: {}},
-		tids:      []int{1},
-		stopCh:    make(chan debugger.StopEvent, 8),
-		writtenAt: make(map[uint64][]byte),
+		mem:        make(map[uint64]byte),
+		regs:       map[int]debugger.Registers{1: {}},
+		tids:       []int{1},
+		stopCh:     make(chan debugger.StopEvent, 8),
+		writtenAt:  make(map[uint64][]byte),
+		continueCh: make(chan struct{}, 16),
 	}
 }
 
@@ -72,7 +76,15 @@ func (f *fakeBackend) peekMem(addr uint64, n int) []byte {
 	return out
 }
 
-func (f *fakeBackend) ContinueProcess() error  { f.continueCalls++; return nil }
+func (f *fakeBackend) ContinueProcess() error {
+	f.continueCalls++
+	select {
+	case f.continueCh <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
 func (f *fakeBackend) StopProcess() error      { f.stopProcessCalls++; return nil }
 func (f *fakeBackend) PauseSignal() int        { return int(syscall.SIGSTOP) }
 func (f *fakeBackend) Threads() ([]int, error) { return f.tids, nil }
@@ -90,6 +102,11 @@ func (f *fakeBackend) ReadMemory(addr uint64, dst []byte) error {
 }
 
 func (f *fakeBackend) WriteMemory(addr uint64, src []byte) error {
+	if f.writeErr != nil {
+		err := f.writeErr
+		f.writeErr = nil
+		return err
+	}
 	cp := make([]byte, len(src))
 	copy(cp, src)
 	f.writtenAt[addr] = cp
@@ -100,6 +117,11 @@ func (f *fakeBackend) WriteMemory(addr uint64, src []byte) error {
 }
 
 func (f *fakeBackend) GetRegisters(tid int) (debugger.Registers, error) {
+	if f.getRegistersErr != nil {
+		err := f.getRegistersErr
+		f.getRegistersErr = nil
+		return debugger.Registers{}, err
+	}
 	return f.regs[tid], nil
 }
 

--- a/internal/debugger/export_test.go
+++ b/internal/debugger/export_test.go
@@ -96,3 +96,13 @@ func ExportedSetBreakpointAtErr(d Debugger, addr uint64) error {
 		return err
 	})
 }
+
+func ExportedClearAllBreakpoints(d Debugger) {
+	e := d.(*engine)
+	if err := e.dispatch(func() error {
+		e.clearAllBreakpoints()
+		return nil
+	}); err != nil {
+		panic("ExportedClearAllBreakpoints: " + err.Error())
+	}
+}

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -212,10 +212,9 @@ func main() {
 `
 
 // twoBPTargetSrc has two distinct breakpoint-able lines in its hot loop (BP_A
-// then BP_B). The ClearBreakpoint spec sets both, then clears A while stopped at
-// B and asserts subsequent Continues only ever stop at B — proving the cleared
-// breakpoint really stops firing. Neither marked line contains a call, so the
-// spec exercises only Continue (never the darwin-fragile step-over path).
+// then BP_B). The ClearBreakpoint spec clears A while stopped on A and asserts
+// subsequent Continues only ever stop at B. Neither marked line contains a call,
+// so the acceptance isolates Continue's software-breakpoint step-off path.
 const twoBPTargetSrc = `package main
 
 import (
@@ -692,17 +691,12 @@ func declareTypedLocalsSpec() {
 	})
 }
 
-// declareClearBreakpointSpec asserts a cleared breakpoint stops firing. It sets
-// two breakpoints (A before B in the loop body), advances until it is stopped at
-// B, clears A (the non-current one — clearing the breakpoint the process is
-// currently parked on re-arms it through the step-off/reinstall path), then
-// Continues several times and asserts every subsequent stop is at B and never at
-// the cleared line A. Runs on both linux and darwin: after clearing A the process
-// is parked on B, so each subsequent Continue single-steps *off* B's armed trap
-// (the restore->single-step->reinstall dance), a path made reliable on darwin by
-// the Mach-exception model (see the scoping note above).
+// declareClearBreakpointSpec asserts that clearing the breakpoint the tracee is
+// currently parked on is final. The live PC was already rewound to A, so clearing
+// A restores executable bytes and the next Continue must run directly to B
+// without a stale step-off reinstall resurrecting A. Runs on both native backends.
 func declareClearBreakpointSpec() {
-	It("stops stopping at a cleared breakpoint", Label("breakpoints"), func() {
+	It("stops stopping at a breakpoint cleared while parked on it", Label("breakpoints"), func() {
 		lineA := markerLine(twoBPTargetSrc, "// BP_A")
 		lineB := markerLine(twoBPTargetSrc, "// BP_B")
 		bin := buildTarget("clearbp_target", twoBPTargetSrc)
@@ -715,23 +709,17 @@ func declareClearBreakpointSpec() {
 		_, err = h.d.SetBreakpoint("clearbp_target.go", lineB)
 		Expect(err).NotTo(HaveOccurred(), "SetBreakpoint B")
 
-		// Advance to A, then to B, so we are parked on B (not A) when we clear A.
+		// Stop on A and clear the breakpoint the tracee is currently parked on.
 		Expect(h.d.Continue()).To(Succeed(), "Continue to A")
 		evt := h.waitFor(15*time.Second,
 			protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
 		Expect(evt.Kind).To(Equal(protocol.EventBreakpointHit), "first stop")
 		Expect(bpLine(evt)).To(Equal(lineA), "first stop is at A")
 
-		Expect(h.d.Continue()).To(Succeed(), "Continue to B")
-		evt = h.waitFor(15*time.Second,
-			protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
-		Expect(evt.Kind).To(Equal(protocol.EventBreakpointHit), "second stop")
-		Expect(bpLine(evt)).To(Equal(lineB), "second stop is at B")
-
 		Expect(h.d.ClearBreakpoint(bpA.ID)).To(Succeed(), "ClearBreakpoint A")
 
 		// With A cleared, every remaining stop in the loop must be B.
-		const rounds = 4
+		const rounds = 6
 		for i := 0; i < rounds; i++ {
 			Expect(h.d.Continue()).To(Succeed(), "Continue #%d after clear", i)
 			evt = h.waitFor(15*time.Second,
@@ -741,6 +729,8 @@ func declareClearBreakpointSpec() {
 			Expect(bpLine(evt)).To(Equal(lineB),
 				"post-clear stop #%d must be at B (%d), not the cleared A (%d)", i, lineB, lineA)
 		}
+		Expect(h.d.ClearBreakpoint(bpA.ID)).To(HaveOccurred(),
+			"the cleared ID must stay absent after repeated step-off completions")
 	})
 }
 

--- a/test/integration/debugger_e2e_dap_test.go
+++ b/test/integration/debugger_e2e_dap_test.go
@@ -207,9 +207,8 @@ func declareDAPEvaluateSpec() {
 // declareDAPExitSpec proves the exited/terminated mapping end to end: a DAP
 // client launches a target with NO breakpoints and lets it run to a clean exit,
 // asserting the adapter emits `exited` (with the code) followed by `terminated`.
-// Kept separate from declareDAPSpec because reaching exit from a breakpoint the
-// process is parked on would re-arm it through the step-off path (see the clearbp
-// spec) — a plain continue from the entry stop is the deterministic exit path.
+// Kept separate from declareDAPSpec so the exit assertion is not coupled to
+// breakpoint cleanup or another loop iteration.
 func declareDAPExitSpec() {
 	It("maps a clean process exit to DAP exited+terminated", Label("dap"), func() {
 		bin := buildTarget("dap_exit_target", dapTargetSrc)


### PR DESCRIPTION
## Summary

- invalidate parked breakpoint state only after a successful clear restores the original instruction
- let clears cancel an in-flight step-off reinstall while preserving its pending resume action
- cover parked, in-flight, failed, clear-all, error, signal, and live-control paths; exercise parked clears on both native backends
- document the corrected software-breakpoint invariant

## Testing

- `go test -tags bingonative -race ./internal/debugger ./internal/hub ./internal/dap`
- `go vet -tags bingonative ./...`
- `just e2e-darwin` (22/22 specs)
- PR `Debugger E2E`: Linux amd64 ptrace job passed, including `breakpoints` and `churn`

Fixes #214