### PR TITLE
fix(debugger): preserve stopped goroutine beyond scan cap

### DIFF
--- a/.github/workflows/debugger-e2e.yml
+++ b/.github/workflows/debugger-e2e.yml
@@ -116,6 +116,9 @@ jobs:
       - name: E2E concurrency (goroutine/thread snapshot foundation)
         run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=concurrency
 
+      - name: E2E current goroutine (bounded scan control)
+        run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=current-goroutine
+
       # linux-only: Wait4(-1, WALL) is what lets a foreign thread's stop arrive
       # mid-single-step (issue #199). The darwin receive loop parks stragglers
       # itself, so the linux park queue has no counterpart to exercise there.
@@ -195,6 +198,10 @@ jobs:
       - name: E2E concurrency (goroutine/thread snapshot foundation)
         if: runner.environment == 'self-hosted'
         run: ./e2e.test -test.v -test.timeout 300s -ginkgo.label-filter=concurrency
+
+      - name: E2E current goroutine (bounded scan control)
+        if: runner.environment == 'self-hosted'
+        run: ./e2e.test -test.v -test.timeout 300s -ginkgo.label-filter=current-goroutine
 
       - name: E2E hygiene (Mach port-right leak regression)
         if: runner.environment == 'self-hosted'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1631,10 +1631,9 @@ new `Thread`, new `GoroutineSnapshotPayload`, new `EventGoroutineSnapshot` +
 auto-emitted on exactly the suspends that can change the concurrency picture —
 **breakpoint hit, pause, and the launch/attach entry stop** — and on demand via
 `CmdGoroutineSnapshot`. It is **NOT** emitted per step: `emitStepped` stays cheap
-(uses only the bounded register/stopped-M current lookup, never an `allgs` scan)
-to protect the fragile single-step/step-over path from a rich per-step walk while
-still reporting a precise stopped goroutine whenever targeted identity is
-available. `emitBreakpointHit`
+(walks frames for the stopped TID but performs no `runtime.allgs`, `runtime.allm`,
+or current-g metadata reads, and reports synthetic ID 0) to protect the fragile
+single-step/step-over path from per-step runtime inspection. `emitBreakpointHit`
 / `emitPaused` build the snapshot **once**, embed its current goroutine in the
 stop event, then stream the same snapshot — one build, no double scan, no double
 delta pass. Because the event is dual-purpose (push *and* query answer), the
@@ -1703,19 +1702,22 @@ around `snapshotFrom` pin the seam's semantics but cannot catch a rewiring.
 
 **Graceful fallback.** Every read is best-effort. `resolveGoLayout` marks the
 layout invalid if any required `g`/`gobuf`/`stack`/`m` offset is missing, and any
-unreadable `allgs` header/slot, required `g` status/goid/stack bound, or
-required targeted-current/allm link degrades the whole snapshot to one synthetic
-unknown goroutine (`ID:0, Status:"unknown"`, current PC) rather than returning a
-partial live set, changing `prevGoids`, or erroring the stop. Both stack bounds
-are required for every included live goroutine: without them SP containment
-cannot rule that goroutine in or out as the stopped one. Intentional
-nil/dead/freelist entries remain filters, and optional metadata remains
-best-effort. This distinction is load-bearing on Linux: ptrace stops only the
-reporting thread, so sibling runtime mutations can race the walk; only backends
-that stop the world make the reads race-free. If every required read succeeds
-but the bounded current lookup misses, `Current` remains 0 and the stop event
-embeds the same ID-0 unknown — `currentGoroutineFrom` must never borrow the first
-real goroutine. This preserves honest behavior for stripped binaries,
+unreadable `allgs` header/slot, required `g` status/goid/stack bound, stack-only
+tail entry, or rooted exact-M/allm link degrades the whole snapshot to one
+synthetic unknown goroutine (`ID:0, Status:"unknown"`, current PC) rather than
+returning a partial live set, changing `prevGoids`, or erroring the stop. The
+arm64 X28 chain is different: it is a speculative ABI hint, not a runtime root,
+so an unreadable or invalid candidate (`g`, `g.m`, `m.g0`, or `m.gsignal`) is a
+complete miss and the reader falls through without discarding the rich set.
+Both stack bounds are required for every included live goroutine: without them
+SP containment cannot rule that goroutine in or out as the stopped one.
+Intentional nil/dead/freelist entries remain filters, and optional metadata
+remains best-effort. This distinction is load-bearing on Linux: ptrace stops
+only the reporting thread, so sibling runtime mutations can race the walk; only
+backends that stop the world make the reads race-free. If every required read
+succeeds but the bounded current lookup misses, `Current` remains 0 and the stop
+event embeds the same ID-0 unknown — `currentGoroutineFrom` must never borrow the
+first real goroutine. This preserves honest behavior for stripped binaries,
 attach-without-DWARF, pre-runtime-init entry stops, zeroed/unreadable registers,
 and scheduler-stack stops whose `m.curg` cannot be resolved.
 
@@ -1757,22 +1759,31 @@ inside the `maxGoroutineScan=8192` rich `runtime.allgs` prefix. If that misses:
    containment; if X28 names g0/gsignal instead, the reader follows
    `g.m → m.curg`, verifies `curg.m == m`, and marks that live positive-goid
    goroutine current without requiring its stack to contain the scheduler SP.
+   Any unreadable or invalid link in this speculative chain is a miss, not
+   snapshot degradation.
 2. On linux/amd64, `FS_BASE` is not a stable `*g` address under external
    linking. Linux ptrace TIDs and `runtime.m.procid` are the same kernel TID, so
    the reader searches for the exact stopped M, then resolves `m.curg` as above.
    The ordinary `allm` window remains `maxThreadScan=2048`; one additional
    targeted-only 2048-M continuation reads only `procid`/`alllink` until the
-   match. Darwin never compares its Mach thread port to `m.procid` (a pthread).
+   match, for a strict maximum of 4096 inspected M nodes. Darwin never compares
+   its Mach thread port to `m.procid` (a pthread).
 3. A final stack-only pass examines at most one additional
    `maxGoroutineScan` `allgs` range, reading pointer + stack bounds until a
-   match.
+   match. Together with the rich prefix, no more than 16,384 allgs slots are
+   inspected.
 
 A current goroutine already in the rich prefix is replaced in place; a
 beyond-prefix match is fully decoded once and prepended as an anchor excluded
 from lifecycle deltas. `readThreads` likewise keeps its rich prefix capped and
 may append exactly one current-M anchor found by a bounded goid-only
 continuation, so thread/current identity stays coherent without unbounded
-latency. If every bounded path misses, identity is unknown rather than guessed.
+latency. On Linux, a concurrent runtime mutation or M transition can make a
+required exact-M read inconsistent because only the reporting TID is stopped;
+that case deliberately degrades instead of reporting a potentially wrong goid.
+If the exact M lies beyond the 4096-node bound and SP containment cannot identify
+a user stack (for example a g0 stop), identity remains unknown rather than
+guessed.
 A non-current goroutine's `CurrentLoc` uses `gobuf.pc` (where it resumes); the
 current one uses the live PC. Status strings are hardcoded (stable across Go
 versions); wait-reason strings are read dynamically from
@@ -2323,7 +2334,8 @@ otherwise the host can wait forever for an acknowledgement from a dead document.
 Preserve the strict nonce CSP, `dist`-only `localResourceRoots`,
 DOM/textContent rendering, deterministic capped cycle-safe tree, bounded
 lifecycle history, and multi-session selector. Filtering searches the full
-validated snapshot (up to the protocol's 5,000-goroutine bound) before applying
+validated snapshot (up to the scanner's 8,193-entry rich-prefix-plus-anchor
+bound) before applying
 the 500-node rendering cap, re-lays out each match with at most four ancestors,
 and resets fit so a deep or previously capped match cannot remain invisible.
 Empty results keep Fit/zoom callbacks safe even without an SVG scene. SVG
@@ -2847,7 +2859,8 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   control plus an opt-in over-cap proof selected by
   `BINGO_E2E_CURRENT_GOROUTINES`; the 20,000-goroutine proof is deliberately not
   part of every suite because the existing 8,192-entry rich decode is costly
-  under `-race`), and `restart` (hub-level
+  under `-race`; both native workflow jobs permanently run the small control),
+  and `restart` (hub-level
   kill+relaunch reinstalls
   breakpoints and reruns from the top), all driving `debugger.Debugger`
   in-process (except `restart`/`fullstack`/`dap`, which go through the stack); plus

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2429,7 +2429,8 @@ collapsed to exactly one entry: the current goroutine if that explicit
 Goroutines query resolves it, otherwise a transport-only
 `stopped goroutine (unknown)`. A resolved query restores normal full responses
 for later requests. `stackTrace` returns the stopped stack only for that current
-handle and empty frames for every other thread id; bingo cannot unwind arbitrary
+handle or a request that preserves the omitted/non-positive stop id, and empty
+frames for every other positive thread id; bingo cannot unwind arbitrary
 goroutines yet.
 
 `EventContinued` → DAP `continued` **only for out-of-band resumes**. The Handler

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1631,8 +1631,10 @@ new `Thread`, new `GoroutineSnapshotPayload`, new `EventGoroutineSnapshot` +
 auto-emitted on exactly the suspends that can change the concurrency picture —
 **breakpoint hit, pause, and the launch/attach entry stop** — and on demand via
 `CmdGoroutineSnapshot`. It is **NOT** emitted per step: `emitStepped` stays cheap
-(embeds an ID-0 synthetic unknown goroutine, no `allgs` scan) to protect the fragile
-single-step/step-over path from extra per-step memory reads. `emitBreakpointHit`
+(uses only the bounded register/stopped-M current lookup, never an `allgs` scan)
+to protect the fragile single-step/step-over path from a rich per-step walk while
+still reporting a precise stopped goroutine whenever targeted identity is
+available. `emitBreakpointHit`
 / `emitPaused` build the snapshot **once**, embed its current goroutine in the
 stop event, then stream the same snapshot — one build, no double scan, no double
 delta pass. Because the event is dual-purpose (push *and* query answer), the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1618,7 +1618,11 @@ and streams a `GoroutineSnapshotPayload` carrying: the goroutine set with
 (the `go` statement, gopc), the thread set, the current goroutine, and
 **created/exited goid deltas** since the previous snapshot.
 
-**Version 1.1** (`pkg/protocol`): reshaped `Goroutine` (added `ParentID`,
+**Version 1.3** (`pkg/protocol`): reserves goroutine ID 0 with status `unknown`
+for a synthetic unresolved stopped goroutine. Consumers must not attribute that
+stop to a real goid; DAP omits its optional `stopped.threadId`.
+
+**Version 1.1** reshaped `Goroutine` (added `ParentID`,
 `StartLoc`, `CreatedLoc`, `ThreadID`, `Current`; renamed `GoLoc`→`CreatedLoc`),
 new `Thread`, new `GoroutineSnapshotPayload`, new `EventGoroutineSnapshot` +
 `CmdGoroutineSnapshot`.
@@ -1627,7 +1631,7 @@ new `Thread`, new `GoroutineSnapshotPayload`, new `EventGoroutineSnapshot` +
 auto-emitted on exactly the suspends that can change the concurrency picture —
 **breakpoint hit, pause, and the launch/attach entry stop** — and on demand via
 `CmdGoroutineSnapshot`. It is **NOT** emitted per step: `emitStepped` stays cheap
-(embeds a synthetic single goroutine, no `allgs` scan) to protect the fragile
+(embeds an ID-0 synthetic unknown goroutine, no `allgs` scan) to protect the fragile
 single-step/step-over path from extra per-step memory reads. `emitBreakpointHit`
 / `emitPaused` build the snapshot **once**, embed its current goroutine in the
 stop event, then stream the same snapshot — one build, no double scan, no double
@@ -1696,18 +1700,22 @@ made lifecycle-tracking or the automatic path non-tracking; the unit tests
 around `snapshotFrom` pin the seam's semantics but cannot catch a rewiring.
 
 **Graceful fallback.** Every read is best-effort. `resolveGoLayout` marks the
-layout invalid if any required `g`/`gobuf`/`stack`/`m` offset is missing, and an
-unreadable `allgs` header/slot, required `g` status/goid/stack bound, or `allm`
-head/link degrades the whole snapshot to the legacy single synthetic goroutine
-(`ID:1, Status:"waiting"`, current PC) rather than returning a partial live set
-or erroring the stop. Both stack bounds are required for every included live
-goroutine: without them SP containment cannot rule that goroutine in or out as
-the stopped one. Intentional nil/dead/freelist entries remain filters, and
-optional metadata remains best-effort. This distinction is load-bearing on
-Linux: ptrace stops only the reporting thread, so sibling runtime mutations can
-race the walk; only backends that stop the world make the reads race-free. This
-also preserves behavior for stripped binaries / attach-without-DWARF and keeps
-the `fakeBackend` engine unit tests green.
+layout invalid if any required `g`/`gobuf`/`stack`/`m` offset is missing, and any
+unreadable `allgs` header/slot, required `g` status/goid/stack bound, or
+required targeted-current/allm link degrades the whole snapshot to one synthetic
+unknown goroutine (`ID:0, Status:"unknown"`, current PC) rather than returning a
+partial live set, changing `prevGoids`, or erroring the stop. Both stack bounds
+are required for every included live goroutine: without them SP containment
+cannot rule that goroutine in or out as the stopped one. Intentional
+nil/dead/freelist entries remain filters, and optional metadata remains
+best-effort. This distinction is load-bearing on Linux: ptrace stops only the
+reporting thread, so sibling runtime mutations can race the walk; only backends
+that stop the world make the reads race-free. If every required read succeeds
+but the bounded current lookup misses, `Current` remains 0 and the stop event
+embeds the same ID-0 unknown — `currentGoroutineFrom` must never borrow the first
+real goroutine. This preserves honest behavior for stripped binaries,
+attach-without-DWARF, pre-runtime-init entry stops, zeroed/unreadable registers,
+and scheduler-stack stops whose `m.curg` cannot be resolved.
 
 **Coherent metadata reads — the half degradation can't cover.** Degradation
 answers reads that *fail*. It cannot answer reads that all *succeed* while
@@ -1739,25 +1747,31 @@ and its read **order** is the whole mechanism:
 Worst case under the correct order is missing a goroutine created during the
 read, which the runtime explicitly sanctions for lock-free readers. See #235.
 
-**Current goroutine = SP-containment** (platform-independent): the stopped
-thread's SP within `[g.stack.lo, g.stack.hi)`. Discovery is independent of the
-`maxGoroutineScan=8192` rich `runtime.allgs` prefix, so a large target cannot
-make BreakpointHit/Paused identify the prefix's first unrelated goroutine while
-frames come from the real stopped TID. The engine first resolves an O(1)
-architecture candidate where the ABI provides a stable one (arm64: X28 is
-`*g`) and accepts it only after the same SP-containment check. On linux/amd64,
-`FS_BASE` is not a stable `*g` address under external linking, so the reader
-walks the bounded `runtime.allm` list and tests each `m.curg` by SP containment
-instead of hardcoding an ELF TLS offset. If neither path resolves the current
-goroutine, a final pass examines at most one additional `maxGoroutineScan`
-`allgs` entry range, reading only pointer + stack bounds until a match. A
-beyond-prefix match is fully decoded once and prepended as the current anchor;
-the rich scan and both fallbacks remain bounded under corrupt metadata.
-Unreadable required data in either the rich walk or a targeted anchor lookup
-degrades the whole snapshot and leaves `prevGoids` unchanged; a bounded miss is
-complete and reports unknown rather than substituting the first unrelated
-entry. The current *thread* is the M whose `curg` goid equals the current goid. A
-non-current goroutine's `CurrentLoc` uses `gobuf.pc` (where it resumes); the
+**Current goroutine discovery is independent and bounded.** SP containment
+(`g.stack.lo <= stopped SP < g.stack.hi`) identifies ordinary user-stack stops
+inside the `maxGoroutineScan=8192` rich `runtime.allgs` prefix. If that misses:
+
+1. On arm64, X28 provides the stopped `*g`. A user `g` is validated by SP
+   containment; if X28 names g0/gsignal instead, the reader follows
+   `g.m → m.curg`, verifies `curg.m == m`, and marks that live positive-goid
+   goroutine current without requiring its stack to contain the scheduler SP.
+2. On linux/amd64, `FS_BASE` is not a stable `*g` address under external
+   linking. Linux ptrace TIDs and `runtime.m.procid` are the same kernel TID, so
+   the reader searches for the exact stopped M, then resolves `m.curg` as above.
+   The ordinary `allm` window remains `maxThreadScan=2048`; one additional
+   targeted-only 2048-M continuation reads only `procid`/`alllink` until the
+   match. Darwin never compares its Mach thread port to `m.procid` (a pthread).
+3. A final stack-only pass examines at most one additional
+   `maxGoroutineScan` `allgs` range, reading pointer + stack bounds until a
+   match.
+
+A current goroutine already in the rich prefix is replaced in place; a
+beyond-prefix match is fully decoded once and prepended as an anchor excluded
+from lifecycle deltas. `readThreads` likewise keeps its rich prefix capped and
+may append exactly one current-M anchor found by a bounded goid-only
+continuation, so thread/current identity stays coherent without unbounded
+latency. If every bounded path misses, identity is unknown rather than guessed.
+A non-current goroutine's `CurrentLoc` uses `gobuf.pc` (where it resumes); the
 current one uses the live PC. Status strings are hardcoded (stable across Go
 versions); wait-reason strings are read dynamically from
 `runtime.waitReasonStrings`. Goroutines with goid<=0 or status `_Gdead` (scan
@@ -2214,7 +2228,7 @@ target metadata, architecture, mode, and entitlements.
 The extension package version is the installed-runtime upgrade boundary:
 material shipped behavior changes must bump both `package.json` and the lockfile
 or VS Code can retain an older bundle under the same identity. The manifest test
-and package verifier pin the current version (**0.3.1**) in source and VSIX
+and package verifier pin the current version (**0.3.2**) in source and VSIX
 metadata.
 The root Run and Debug dropdown exposes exactly two `"type":"bingo"` choices:
 launch one of five progressive examples through a `pickString`, and join a
@@ -2291,7 +2305,7 @@ activation and keys observers by `DebugSession.id`, never
 
 **Concurrency webview ownership/security.** The extension host, not the
 webview, owns one bounded WebSocket observer/model per live DAP session. It
-reuses the normalized management endpoint, validates protocol 1.2 envelopes,
+reuses the normalized management endpoint, validates protocol 1.3 envelopes,
 payload/string/count limits and seq gaps, and reconnects only while the DAP
 session lives. It sends `CmdGoroutineSnapshot` once after every successful
 WebSocket join and thereafter only for explicit Refresh—never run control.
@@ -2363,9 +2377,9 @@ session.
 - `initialized` fires immediately (the target image is already loaded, so
   breakpoints resolve right away — there is no entry stop to wait for).
 - `onSessionState` (`events.go`) consumes that welcome **once** (gated on
-  `awaitingWelcome`): `suspended`→`suspended=true` + `stopped reason=pause` (tid
-  defaults to 1 — the engine inspects the currently-stopped goroutine regardless
-  of the DAP threadId); `exited`→`terminated`; idle/running→nothing. For the
+  `awaitingWelcome`): `suspended`→`suspended=true` + `stopped reason=pause`
+  (`threadId` omitted until a stop identifies a positive goid);
+  `exited`→`terminated`; idle/running→nothing. For the
   normal launch/attach path `awaitingWelcome` is never set, so it is a no-op
   there (the entry stop drives the initial state instead).
 - `onConfigurationDone`'s `joining` branch responds to the attach but does NOT
@@ -2386,6 +2400,12 @@ state on the join path (see *Joining an existing session*);
 ignored** (WebSocket-only concurrency stream with no DAP equivalent; translating
 it would corrupt the `threads`→`EventGoroutines` FIFO — see the goroutine
 snapshot section).
+
+Suspending events carry the runtime goid when it is known. An ID-0 synthetic
+unknown omits DAP's optional `stopped.threadId`; never clamp an unresolved stop
+to 1, because that identifies the unrelated real g1. `threads` responses may
+still assign the lone synthetic entry a transport-only positive handle because
+DAP requires every listed `Thread.id` to be non-zero.
 
 `EventContinued` → DAP `continued` **only for out-of-band resumes**. The Handler
 increments `pendingContinues` before enqueuing its OWN continue and decrements it
@@ -3190,11 +3210,11 @@ through the justfile.
 ## When you change something
 
 - **Wire protocol** (`pkg/protocol`): bump `Version` for breaking changes,
-  and update the round-trip table in `protocol_test.go`. Currently **1.2** (the
-  reshaped `Variable` — added `Kind` + `Children` for the type-aware expandable
-  tree — and the new `CmdEvaluate`/`EventEvaluate` name-only evaluate command/
-  event with `EvaluatePayloadCmd`/`EvaluatePayload`). 1.1 had reshaped
-  `Goroutine` and added `Thread`/`GoroutineSnapshotPayload` +
+  and update the round-trip table in `protocol_test.go`. Currently **1.3**
+  (goroutine ID 0/status `unknown` is the synthetic unresolved stop identity).
+  1.2 reshaped `Variable` with `Kind` + `Children` for the type-aware expandable
+  tree and added the name-only `CmdEvaluate`/`EventEvaluate` command/event. 1.1
+  reshaped `Goroutine` and added `Thread`/`GoroutineSnapshotPayload` +
   `EventGoroutineSnapshot`/`CmdGoroutineSnapshot`.
 - **Management API** (`internal/server`): `ManagementAPIVersion` is independent
   of the wire protocol. Bump it for incompatible `/api/health` or management

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1667,6 +1667,10 @@ session must not report every goroutine as "created"). A **degraded** snapshot
 for both automatic and on-demand snapshots: neither kind may clear or adopt a
 baseline from an incomplete walk.
 
+A current goroutine anchored from beyond the capped rich scan is also excluded
+from this baseline: it is present for stop identity, but switching between two
+still-live tail goroutines must not fabricate created/exited deltas.
+
 **Automatic snapshots alone own the baseline.** `prevGoids` is the *only*
 lifecycle memory, so whoever advances it decides what the next automatic
 snapshot can report. The on-demand `CmdGoroutineSnapshot` path is therefore a
@@ -1736,15 +1740,28 @@ Worst case under the correct order is missing a goroutine created during the
 read, which the runtime explicitly sanctions for lock-free readers. See #235.
 
 **Current goroutine = SP-containment** (platform-independent): the stopped
-thread's SP within `[g.stack.lo, g.stack.hi)`. The current *thread* is the M
-whose `curg` goid equals the current goid. A non-current goroutine's
-`CurrentLoc` uses `gobuf.pc` (where it resumes); the current one uses the live
-PC. If a complete but clipped scan has not found the current goroutine, stop
-events report unknown rather than substituting the first unrelated entry.
-Status strings are hardcoded (stable across Go versions); wait-reason strings
-are read dynamically from `runtime.waitReasonStrings`. Goroutines with goid<=0
-or status `_Gdead` (scan bit stripped) are filtered out — their exit surfaces
-in the next Exited delta.
+thread's SP within `[g.stack.lo, g.stack.hi)`. Discovery is independent of the
+`maxGoroutineScan=8192` rich `runtime.allgs` prefix, so a large target cannot
+make BreakpointHit/Paused identify the prefix's first unrelated goroutine while
+frames come from the real stopped TID. The engine first resolves an O(1)
+architecture candidate where the ABI provides a stable one (arm64: X28 is
+`*g`) and accepts it only after the same SP-containment check. On linux/amd64,
+`FS_BASE` is not a stable `*g` address under external linking, so the reader
+walks the bounded `runtime.allm` list and tests each `m.curg` by SP containment
+instead of hardcoding an ELF TLS offset. If neither path resolves the current
+goroutine, a final pass examines at most one additional `maxGoroutineScan`
+`allgs` entry range, reading only pointer + stack bounds until a match. A
+beyond-prefix match is fully decoded once and prepended as the current anchor;
+the rich scan and both fallbacks remain bounded under corrupt metadata.
+Unreadable required data in either the rich walk or a targeted anchor lookup
+degrades the whole snapshot and leaves `prevGoids` unchanged; a bounded miss is
+complete and reports unknown rather than substituting the first unrelated
+entry. The current *thread* is the M whose `curg` goid equals the current goid. A
+non-current goroutine's `CurrentLoc` uses `gobuf.pc` (where it resumes); the
+current one uses the live PC. Status strings are hardcoded (stable across Go
+versions); wait-reason strings are read dynamically from
+`runtime.waitReasonStrings`. Goroutines with goid<=0 or status `_Gdead` (scan
+bit stripped) are filtered out — their exit surfaces in the next Exited delta.
 
 **Note on `go f(args)` wrappers.** A goroutine started with arguments gets a
 compiler-generated `<caller>.gowrapN` closure as its startpc, so `StartLoc`
@@ -2803,8 +2820,12 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   debugger did not launch — then breakpoint it), `concurrency` (the
   goroutine/thread snapshot data foundation — drives a known spawn-tree target
   and asserts parent linkage, start/created locations, the thread set with a
-  single current thread, and created/exited lifecycle deltas across stops), and
-  `restart` (hub-level
+  single current thread, and created/exited lifecycle deltas across stops),
+  `current-goroutine` (a small native stop/frame/snapshot/thread coherence
+  control plus an opt-in over-cap proof selected by
+  `BINGO_E2E_CURRENT_GOROUTINES`; the 20,000-goroutine proof is deliberately not
+  part of every suite because the existing 8,192-entry rich decode is costly
+  under `-race`), and `restart` (hub-level
   kill+relaunch reinstalls
   breakpoints and reruns from the top), all driving `debugger.Debugger`
   in-process (except `restart`/`fullstack`/`dap`, which go through the stack); plus
@@ -2830,7 +2851,7 @@ side `chan error` — every debugger outcome, failures included, rides the singl
 
   **Platform scoping — both containers run the shared set.** The darwin container
   wires the same shared specs as linux: `basic`, `stepping`, `breakpoints`, `churn`,
-  `kill`, `exit`, `attach`, `concurrency`, `pause`, `inspect`, `restart`,
+  `kill`, `exit`, `attach`, `concurrency`, `current-goroutine`, `pause`, `inspect`, `restart`,
   `fullstack`, and `dap`. Linux additionally runs `signals` and `overlap`;
   darwin additionally runs the
   `hygiene` Mach exception port-right leak regression. This was NOT

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2322,7 +2322,9 @@ reuses the normalized management endpoint, validates protocol 1.3 envelopes,
 payload/string/count limits and seq gaps, and reconnects only while the DAP
 session lives. It sends `CmdGoroutineSnapshot` once after every successful
 WebSocket join and thereafter only for explicit Refresh—never run control.
-The recreatable webview receives validated view models through a
+The observer accepts at most 8 MiB per envelope and 8,193 goroutines (the rich
+8,192 prefix plus one current anchor); the recreatable webview receives
+validated view models through a
 ready/rendered-ack protocol. Every document has a generation token; async
 `postMessage` completions may mutate delivery state only while their captured
 view and generation are current, even when an old and new render share a
@@ -2418,8 +2420,17 @@ snapshot section).
 Suspending events carry the runtime goid when it is known. An ID-0 synthetic
 unknown omits DAP's optional `stopped.threadId`; never clamp an unresolved stop
 to 1, because that identifies the unrelated real g1. `threads` responses may
-still assign the lone synthetic entry a transport-only positive handle because
-DAP requires every listed `Thread.id` to be non-zero.
+still assign a synthetic entry a transport-only positive handle because DAP
+requires every listed `Thread.id` to be non-zero. VS Code interprets an omitted
+`stopped.threadId` as a request to fetch every returned thread's stack. To keep
+the cheap synthetic step honest without amplifying one step into thousands of
+identical `CmdFrames`, the first `threads` response after an unknown stop is
+collapsed to exactly one entry: the current goroutine if that explicit
+Goroutines query resolves it, otherwise a transport-only
+`stopped goroutine (unknown)`. A resolved query restores normal full responses
+for later requests. `stackTrace` returns the stopped stack only for that current
+handle and empty frames for every other thread id; bingo cannot unwind arbitrary
+goroutines yet.
 
 `EventContinued` → DAP `continued` **only for out-of-band resumes**. The Handler
 increments `pendingContinues` before enqueuing its OWN continue and decrements it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2431,7 +2431,8 @@ Goroutines query resolves it, otherwise a transport-only
 for later requests. `stackTrace` returns the stopped stack only for that current
 handle or a request that preserves the omitted/non-positive stop id, and empty
 frames for every other positive thread id; bingo cannot unwind arbitrary
-goroutines yet.
+goroutines yet. `cmd/dapcli` therefore retains an omitted stop id as zero
+instead of carrying a stale positive id into `stackTrace`.
 
 `EventContinued` → DAP `continued` **only for out-of-band resumes**. The Handler
 increments `pendingContinues` before enqueuing its OWN continue and decrements it

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Frontends can identify and reuse a compatible bingo process through
 {
   "service": "bingo",
   "managementApiVersion": 1,
-  "wireProtocolVersion": "1.2",
+  "wireProtocolVersion": "1.3",
   "instanceId": "4dd4dfdd-7f55-41a5-bd95-c086ce6f3c2a",
   "dap": {
     "enabled": true,
@@ -121,7 +121,7 @@ Build and install the repository's companion extension:
 just vscode-install
 ```
 
-The capability-safe graphical concurrency runtime requires extension version **0.3.1 or
+The capability-safe graphical concurrency runtime requires extension version **0.3.2 or
 newer**. After installing or updating the VSIX, run **Developer: Reload Window**
 once so the current extension host activates the new bundle.
 
@@ -164,8 +164,8 @@ from a terminal with
 `code --new-window --extensionDevelopmentPath="$PWD/editors/vscode" "$PWD"`.
 Compatible manually-started servers remain supported and are reused.
 
-The **Bingo Concurrency** Activity Bar view was introduced in 0.3.0; use 0.3.1
-or newer so managed-server reuse requires the session-discovery capability.
+The **Bingo Concurrency** Activity Bar view was introduced in 0.3.0; use 0.3.2
+or newer for wire 1.3 and honest unknown stopped-goroutine rendering.
 Press F5, choose one of the five progressive examples, and the view
 automatically follows the exact DAP-created session over WebSocket—no session
 ID copy is needed. It visualizes the goroutine spawn tree, OS threads, current

--- a/cmd/dapcli/main.go
+++ b/cmd/dapcli/main.go
@@ -67,7 +67,7 @@ type dapCLI struct {
 	// stateMu guards the fields below.
 	stateMu    sync.Mutex
 	configured bool // handshake past `initialized`: breakpoints go on the wire now
-	curThread  int  // most recent stopped threadId (DAP requires one on control ops)
+	curThread  int  // most recent stopped threadId; zero preserves unknown identity
 	bpsByFile  map[string][]breakpoint
 	sessionID  string
 
@@ -91,7 +91,6 @@ func main() {
 		reader:    bufio.NewReader(conn),
 		pending:   make(map[int]chan godap.Message),
 		bpsByFile: make(map[string][]breakpoint),
-		curThread: 1,
 	}
 	go h.readLoop()
 
@@ -626,9 +625,6 @@ func (h *dapCLI) thread() int {
 }
 
 func (h *dapCLI) setThread(tid int) {
-	if tid == 0 {
-		return
-	}
 	h.stateMu.Lock()
 	h.curThread = tid
 	h.stateMu.Unlock()

--- a/cmd/dapcli/main_test.go
+++ b/cmd/dapcli/main_test.go
@@ -86,6 +86,14 @@ func TestReadLoopContinuesAfterSessionAnnouncement(t *testing.T) {
 	}).WithTimeout(time.Second).Should(Equal("session-live"))
 }
 
+func TestSetThreadPreservesUnknownStopIdentity(t *testing.T) {
+	h := &dapCLI{curThread: 7}
+	h.setThread(0)
+	if got := h.thread(); got != 0 {
+		t.Fatalf("thread = %d, want unknown stopped thread 0", got)
+	}
+}
+
 func writeDAPFrame(buffer *bytes.Buffer, content string) {
 	_, _ = fmt.Fprintf(buffer, "Content-Length: %d\r\n\r\n%s", len(content), content)
 }

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -10,7 +10,7 @@ bingo speaks two protocols against **one** debug session at the same time:
   the OS-thread set, and created/exited lifecycle deltas — streams here as
   `EventGoroutineSnapshot`.
 
-The VS Code 0.3.1 extension wires both together automatically: DAP drives while
+The VS Code 0.3.2 extension wires both together automatically: DAP drives while
 the **Bingo Concurrency** Activity Bar view observes the exact session over
 WebSocket. `cmd/wsmon` remains the terminal observer for non-VS Code workflows.
 
@@ -40,7 +40,7 @@ architecture behind this.
   just vscode-install
   ```
 
-  Automatic graphical telemetry requires **bingosuite.bingo 0.3.1 or newer**. Run
+  Automatic graphical telemetry requires **bingosuite.bingo 0.3.2 or newer**. Run
   **Developer: Reload Window** once after installation or update. The companion
   owns debugger type `"bingo"` and connects directly to bingo's DAP listener;
   it neither invokes nor validates `dlv`, and it does not replace the Go
@@ -177,5 +177,6 @@ repaints with the new round's workers — the plumbing, end to end.
 - Snapshots stream on **breakpoint / pause / entry**, not per single-step (steps
   stay cheap). Use the driver's breakpoints/continue to advance between frames.
 - If the tracee is a stripped binary or stopped before runtime init, the snapshot
-  degrades to a single synthetic goroutine; both observers render the degraded
-  state rather than failing the debug session.
+  degrades to a single synthetic goroutine (`id: 0`, status `unknown`); both
+  observers render the degraded state rather than assigning the stop to an
+  unrelated real goroutine or failing the debug session.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -20,10 +20,11 @@ just vscode-install
 ```
 
 This builds, verifies, and installs `dist/bingo-<platform>.vsix`. The graphical
-concurrency view debuted in 0.3.0; **0.3.1** adds capability-safe managed-server
-reuse and is the minimum supported version. Rerun the command to update, then run
-**Developer: Reload Window** once so the active extension host loads the new
-bundle. Package without installing with `just vscode-package`. Uninstall with:
+concurrency view debuted in 0.3.0; **0.3.2** adds wire 1.3's honest unknown
+stopped-goroutine rendering and is the minimum supported version. Rerun the
+command to update, then run **Developer: Reload Window** once so the active
+extension host loads the new bundle. Package without installing with
+`just vscode-package`. Uninstall with:
 
 ```sh
 code --uninstall-extension bingosuite.bingo

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bingo",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bingo",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "ws": "8.18.3"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "bingo",
   "displayName": "bingo Debugger",
   "description": "Debug Go concurrency with bingo's DAP adapter and live goroutine visualization.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "publisher": "bingosuite",
   "license": "MIT",
   "private": true,

--- a/editors/vscode/scripts/smoke-server.mjs
+++ b/editors/vscode/scripts/smoke-server.mjs
@@ -78,7 +78,7 @@ try {
   if (
     health.service !== "bingo" ||
     health.managementApiVersion !== 1 ||
-    health.wireProtocolVersion !== "1.2" ||
+    health.wireProtocolVersion !== "1.3" ||
     health.dap?.enabled !== true ||
     health.dap.sessionEventVersion !== 1 ||
     health.dap.address !== `127.0.0.1:${String(dapPort)}` ||

--- a/editors/vscode/scripts/verify-package.mjs
+++ b/editors/vscode/scripts/verify-package.mjs
@@ -13,7 +13,7 @@ import { spawnSync } from "node:child_process";
 import { currentTarget } from "./platform.mjs";
 
 const target = currentTarget();
-const expectedExtensionVersion = "0.3.1";
+const expectedExtensionVersion = "0.3.2";
 const vsix = fileURLToPath(
   new URL(`../../../dist/bingo-${target}.vsix`, import.meta.url),
 );

--- a/editors/vscode/src/health.ts
+++ b/editors/vscode/src/health.ts
@@ -5,7 +5,7 @@ import { sessionDAPEventVersion } from "./sessionEvent.js";
 
 export const bingoServiceIdentity = "bingo";
 export const managementApiVersion = 1;
-export const wireProtocolVersion = "1.2";
+export const wireProtocolVersion = "1.3";
 export const dapSessionEventVersion = sessionDAPEventVersion;
 export const minimumHealthProbeTimeoutMs = 25;
 

--- a/editors/vscode/src/messages.ts
+++ b/editors/vscode/src/messages.ts
@@ -48,7 +48,7 @@ export function decodeWebviewMessage(value: unknown): WebviewMessage {
       exactKeys(message, ["type", "id"]);
       return {
         type: "selectGoroutine",
-        id: safeInteger(message.id, "goroutine id", 1),
+        id: safeInteger(message.id, "goroutine id", 0),
       };
     case "selectSession":
       exactKeys(message, ["type", "id"]);

--- a/editors/vscode/src/model.ts
+++ b/editors/vscode/src/model.ts
@@ -88,9 +88,5 @@ function isDegraded(snapshot: Snapshot): boolean {
     return false;
   }
   const goroutine = snapshot.goroutines[0];
-  return (
-    goroutine?.startLoc.file.length === 0 &&
-    goroutine.createdLoc.file.length === 0 &&
-    goroutine.currentLoc.file.length === 0
-  ) ?? false;
+  return goroutine?.id === 0 && goroutine.status === "unknown" && goroutine.current === true;
 }

--- a/editors/vscode/src/telemetry.ts
+++ b/editors/vscode/src/telemetry.ts
@@ -3,7 +3,7 @@ import { TextDecoder } from "node:util";
 export const wireProtocolVersion = "1.3";
 export const snapshotCommandKind = "GoroutineSnapshot";
 export const maximumEnvelopeBytes = 2 * 1024 * 1024;
-export const maximumGoroutines = 5000;
+export const maximumGoroutines = 8193;
 export const maximumThreads = 2049;
 export const maximumStringLength = 4096;
 

--- a/editors/vscode/src/telemetry.ts
+++ b/editors/vscode/src/telemetry.ts
@@ -1,10 +1,10 @@
 import { TextDecoder } from "node:util";
 
-export const wireProtocolVersion = "1.2";
+export const wireProtocolVersion = "1.3";
 export const snapshotCommandKind = "GoroutineSnapshot";
 export const maximumEnvelopeBytes = 2 * 1024 * 1024;
 export const maximumGoroutines = 5000;
-export const maximumThreads = 2048;
+export const maximumThreads = 2049;
 export const maximumStringLength = 4096;
 
 const maximumPayloadNodes = 20_000;
@@ -263,7 +263,7 @@ function decodeGoroutine(value: unknown, label: string): Goroutine {
     label,
   );
   return {
-    id: integer(item.id, `${label}.id`, 1),
+    id: integer(item.id, `${label}.id`, 0),
     parentId: optionalInteger(item.parentId, `${label}.parentId`),
     status: boundedString(item.status, `${label}.status`),
     waitReason: optionalString(item.waitReason, `${label}.waitReason`),

--- a/editors/vscode/src/telemetry.ts
+++ b/editors/vscode/src/telemetry.ts
@@ -2,7 +2,7 @@ import { TextDecoder } from "node:util";
 
 export const wireProtocolVersion = "1.3";
 export const snapshotCommandKind = "GoroutineSnapshot";
-export const maximumEnvelopeBytes = 2 * 1024 * 1024;
+export const maximumEnvelopeBytes = 8 * 1024 * 1024;
 export const maximumGoroutines = 8193;
 export const maximumThreads = 2049;
 export const maximumStringLength = 4096;
@@ -166,7 +166,7 @@ export function decodeEvent(data: TelemetryData): DecodedEvent {
 function decodeText(data: TelemetryData): string {
   const bytes = dataBytes(data);
   if (bytes > maximumEnvelopeBytes) {
-    throw new Error("telemetry event exceeds 2 MiB");
+    throw new Error("telemetry event exceeds 8 MiB");
   }
   if (typeof data === "string") {
     return data;

--- a/editors/vscode/test/fixtures.ts
+++ b/editors/vscode/test/fixtures.ts
@@ -60,7 +60,7 @@ export function envelope(
   payload: unknown,
 ): Buffer {
   return Buffer.from(
-    JSON.stringify({ v: "1.2", kind, seq, payload }),
+    JSON.stringify({ v: "1.3", kind, seq, payload }),
     "utf8",
   );
 }

--- a/editors/vscode/test/health.test.ts
+++ b/editors/vscode/test/health.test.ts
@@ -22,7 +22,7 @@ function health(overrides: Record<string, unknown> = {}): string {
   return JSON.stringify({
     service: "bingo",
     managementApiVersion: 1,
-    wireProtocolVersion: "1.2",
+    wireProtocolVersion: "1.3",
     instanceId: "instance-1",
     dap: {
       enabled: true,

--- a/editors/vscode/test/manifest.test.ts
+++ b/editors/vscode/test/manifest.test.ts
@@ -12,7 +12,7 @@ const manifest = requireRecord(
 const contributes = requireRecord(manifest.contributes);
 const debuggers = requireArray(contributes.debuggers);
 const debuggerContribution = requireRecord(debuggers[0]);
-const expectedExtensionVersion = "0.3.1";
+const expectedExtensionVersion = "0.3.2";
 
 describe("extension manifest", () => {
   it("versions the managed-server runtime as an installable upgrade", () => {

--- a/editors/vscode/test/messages.test.ts
+++ b/editors/vscode/test/messages.test.ts
@@ -15,6 +15,10 @@ describe("webview message codec", () => {
       { type: "selectGoroutine", id: 42 },
     );
     assert.deepEqual(
+      decodeWebviewMessage({ type: "selectGoroutine", id: 0 }),
+      { type: "selectGoroutine", id: 0 },
+    );
+    assert.deepEqual(
       decodeWebviewMessage({
         type: "rendered",
         generation: 3,

--- a/editors/vscode/test/model.test.ts
+++ b/editors/vscode/test/model.test.ts
@@ -5,6 +5,7 @@ import {
   appendLifecycle,
   maximumTimelineEntries,
   serializeSnapshot,
+  toSessionViewModel,
   type SessionModel,
 } from "../src/model.js";
 import { snapshot } from "./fixtures.js";
@@ -56,5 +57,41 @@ describe("concurrency model", () => {
       };
     };
     assert.equal(decoded.snapshot.goroutines[0].waitReason, "</script><img src=x onerror=alert(1)>");
+  });
+
+  it("recognizes an unknown synthetic snapshot even when its stop location resolved", () => {
+    const base = snapshot();
+    const view = toSessionViewModel({
+      debugSessionId: "debug",
+      debugSessionName: "debug",
+      sessionId: "session",
+      connection: "connected",
+      sessionState: "suspended",
+      clients: 1,
+      lastStop: "",
+      error: "",
+      seqGap: "",
+      lastSeq: 1,
+      snapshot: {
+        ...base,
+        current: 0,
+        goroutines: [{
+          ...base.goroutines[0]!,
+          id: 0,
+          status: "unknown",
+          current: true,
+          currentLoc: {
+            file: "/tmp/main.go",
+            line: 42,
+            function: "main.run",
+          },
+        }],
+        threads: [],
+      },
+      selectedGoroutine: 0,
+      timeline: [],
+    });
+
+    assert.equal(view.degraded, true);
   });
 });

--- a/editors/vscode/test/observer.test.ts
+++ b/editors/vscode/test/observer.test.ts
@@ -104,7 +104,7 @@ describe("telemetry observer", () => {
     socket.open();
     assert.equal(socket.sent.length, 1);
     assert.deepEqual(JSON.parse(socket.sent[0]!), {
-      v: "1.2",
+      v: "1.3",
       kind: "GoroutineSnapshot",
       payload: {},
     });

--- a/editors/vscode/test/telemetry.test.ts
+++ b/editors/vscode/test/telemetry.test.ts
@@ -66,14 +66,14 @@ describe("telemetry codec", () => {
     assert.equal(maximumGoroutines, 8193);
     const accepted = Array.from(
       { length: maximumGoroutines },
-      (_, index) => minimalGoroutine(index + 1),
+      (_, index) => goroutine(index + 1),
     );
-    const decoded = decodeEvent(
-      envelope(1, "GoroutineSnapshot", {
-        ...snapshot(),
-        goroutines: accepted,
-      }),
-    );
+    const acceptedEnvelope = envelope(1, "GoroutineSnapshot", {
+      ...snapshot(),
+      goroutines: accepted,
+    });
+    assert.ok(acceptedEnvelope.byteLength > 2 * 1024 * 1024);
+    const decoded = decodeEvent(acceptedEnvelope);
     assert.equal(decoded.snapshot?.goroutines.length, 8193);
 
     assert.throws(
@@ -99,7 +99,7 @@ describe("telemetry codec", () => {
     );
     assert.throws(
       () => decodeEvent("x".repeat(maximumEnvelopeBytes + 1)),
-      /exceeds 2 MiB/,
+      /exceeds 8 MiB/,
     );
     assert.throws(
       () =>

--- a/editors/vscode/test/telemetry.test.ts
+++ b/editors/vscode/test/telemetry.test.ts
@@ -12,6 +12,12 @@ import {
 import { envelope, goroutine, snapshot, thread } from "./fixtures.js";
 
 describe("telemetry codec", () => {
+  const minimalGoroutine = (id: number) => ({
+    id,
+    status: "waiting",
+    currentLoc: { file: "", line: 0 },
+  });
+
   it("decodes protocol 1.3 snapshots and emits only the read-only command", () => {
     const decoded = decodeEvent(envelope(1, "GoroutineSnapshot", snapshot()));
     assert.equal(decoded.kind, "GoroutineSnapshot");
@@ -56,6 +62,35 @@ describe("telemetry codec", () => {
     assert.equal(decoded.snapshot?.threads.length, maximumThreads);
   });
 
+  it("accepts 8193 goroutines and rejects 8194", () => {
+    assert.equal(maximumGoroutines, 8193);
+    const accepted = Array.from(
+      { length: maximumGoroutines },
+      (_, index) => minimalGoroutine(index + 1),
+    );
+    const decoded = decodeEvent(
+      envelope(1, "GoroutineSnapshot", {
+        ...snapshot(),
+        goroutines: accepted,
+      }),
+    );
+    assert.equal(decoded.snapshot?.goroutines.length, 8193);
+
+    assert.throws(
+      () =>
+        decodeEvent(
+          envelope(2, "GoroutineSnapshot", {
+            ...snapshot(),
+            goroutines: [
+              ...accepted,
+              minimalGoroutine(maximumGoroutines + 1),
+            ],
+          }),
+        ),
+      /8193 item limit/,
+    );
+  });
+
   it("rejects malformed, incompatible, oversized, and hostile payloads", () => {
     assert.throws(() => decodeEvent("{"), /valid JSON/);
     assert.throws(
@@ -65,19 +100,6 @@ describe("telemetry codec", () => {
     assert.throws(
       () => decodeEvent("x".repeat(maximumEnvelopeBytes + 1)),
       /exceeds 2 MiB/,
-    );
-    assert.throws(
-      () =>
-        decodeEvent(
-          envelope(1, "GoroutineSnapshot", {
-            ...snapshot(),
-            goroutines: Array.from(
-              { length: maximumGoroutines + 1 },
-              (_, index) => goroutine(index + 1),
-            ),
-          }),
-        ),
-      /item limit/,
     );
     assert.throws(
       () =>

--- a/editors/vscode/test/telemetry.test.ts
+++ b/editors/vscode/test/telemetry.test.ts
@@ -5,18 +5,19 @@ import {
   decodeEvent,
   maximumEnvelopeBytes,
   maximumGoroutines,
+  maximumThreads,
   SequenceTracker,
   snapshotCommand,
 } from "../src/telemetry.js";
-import { envelope, goroutine, snapshot } from "./fixtures.js";
+import { envelope, goroutine, snapshot, thread } from "./fixtures.js";
 
 describe("telemetry codec", () => {
-  it("decodes protocol 1.2 snapshots and emits only the read-only command", () => {
+  it("decodes protocol 1.3 snapshots and emits only the read-only command", () => {
     const decoded = decodeEvent(envelope(1, "GoroutineSnapshot", snapshot()));
     assert.equal(decoded.kind, "GoroutineSnapshot");
     assert.equal(decoded.snapshot?.goroutines[0]?.id, 1);
     assert.deepEqual(JSON.parse(snapshotCommand()), {
-      v: "1.2",
+      v: "1.3",
       kind: "GoroutineSnapshot",
       payload: {},
     });
@@ -31,6 +32,28 @@ describe("telemetry codec", () => {
     );
     assert.deepEqual(decoded.snapshot?.goroutines, []);
     assert.deepEqual(decoded.snapshot?.threads, []);
+  });
+
+  it("accepts the synthetic unknown goroutine id", () => {
+    const decoded = decodeEvent(
+      envelope(
+        1,
+        "GoroutineSnapshot",
+        snapshot([goroutine(0, 0, { status: "unknown", current: true })], []),
+      ),
+    );
+    assert.equal(decoded.snapshot?.goroutines[0]?.id, 0);
+    assert.equal(decoded.snapshot?.goroutines[0]?.status, "unknown");
+  });
+
+  it("accepts the bounded rich thread prefix plus current anchor", () => {
+    const threads = Array.from({ length: maximumThreads }, (_, index) =>
+      thread(index + 1),
+    );
+    const decoded = decodeEvent(
+      envelope(1, "GoroutineSnapshot", snapshot(undefined, threads)),
+    );
+    assert.equal(decoded.snapshot?.threads.length, maximumThreads);
   });
 
   it("rejects malformed, incompatible, oversized, and hostile payloads", () => {
@@ -80,7 +103,7 @@ describe("telemetry codec", () => {
       () =>
         decodeEvent(
           JSON.stringify({
-            v: "1.2",
+            v: "1.3",
             kind: "Continued",
             seq: 1,
             payload: {},
@@ -93,7 +116,7 @@ describe("telemetry codec", () => {
       () =>
         decodeEvent(
           JSON.stringify({
-            v: "1.2",
+            v: "1.3",
             kind: "FutureEvent",
             seq: 1,
             payload: {},

--- a/editors/vscode/test/vscodeIntegration.ts
+++ b/editors/vscode/test/vscodeIntegration.ts
@@ -330,7 +330,7 @@ class FakeTelemetryServer {
           readonly payload?: unknown;
         };
         assert.deepEqual(command, {
-          v: "1.2",
+          v: "1.3",
           kind: "GoroutineSnapshot",
           payload: {},
         });
@@ -377,7 +377,7 @@ class FakeTelemetryServer {
     this.#sequence += 1;
     socket.send(
       JSON.stringify({
-        v: "1.2",
+        v: "1.3",
         kind,
         seq: this.#sequence,
         payload,

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -78,13 +78,6 @@ func (h *Handler) onSessionState(evt protocol.Event) {
 	}
 	h.awaitingWelcome = false
 	tid := h.curThreadID
-	if tid == 0 {
-		// No stop event has been seen yet on a freshly-joined suspended session,
-		// so we have no goroutine id. DAP requires a threadId; the engine
-		// inspects the currently-stopped goroutine regardless, so a synthetic
-		// id is safe here.
-		tid = 1
-	}
 	switch p.State {
 	case protocol.StateSuspended:
 		h.suspended = true
@@ -124,7 +117,7 @@ func stopGoroutine(evt protocol.Event) protocol.Goroutine {
 }
 
 func (h *Handler) onStop(evt protocol.Event) {
-	tid := threadID(stopGoroutine(evt).ID)
+	tid := stoppedThreadID(stopGoroutine(evt).ID)
 
 	h.mu.Lock()
 	// Every stop is a fresh memory snapshot; drop variable subtrees cached

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -81,6 +81,7 @@ func (h *Handler) onSessionState(evt protocol.Event) {
 	switch p.State {
 	case protocol.StateSuspended:
 		h.suspended = true
+		h.stopThreadUnknown = tid == 0
 		h.mu.Unlock()
 		h.sendStopped("pause", tid)
 	case protocol.StateExited:
@@ -127,6 +128,7 @@ func (h *Handler) onStop(evt protocol.Event) {
 	restarting := h.restarting
 	stopOnEntry := h.stopOnEntry
 	h.curThreadID = tid
+	h.stopThreadUnknown = tid == 0
 
 	// The first stop after Launch/Attach is the entry stop: fire `initialized`
 	// (breakpoints can now resolve against the loaded image) but withhold the
@@ -198,6 +200,7 @@ func (h *Handler) onProcessExited(evt protocol.Event) {
 	h.mu.Lock()
 	h.suspended = false
 	h.sessionState = protocol.StateExited
+	h.stopThreadUnknown = false
 	h.mu.Unlock()
 
 	h.send(&godap.ExitedEvent{Event: h.event("exited"), Body: godap.ExitedEventBody{ExitCode: p.ExitCode}})
@@ -339,6 +342,7 @@ func (h *Handler) onFrames(evt protocol.Event) {
 func (h *Handler) onGoroutines(evt protocol.Event) {
 	var p protocol.GoroutinesPayload
 	_ = protocol.DecodeEventPayload(evt, &p)
+	current, resolved := dapStoppedThread(p.Goroutines)
 
 	h.mu.Lock()
 	seq, ok := 0, false
@@ -346,14 +350,27 @@ func (h *Handler) onGoroutines(evt protocol.Event) {
 		seq, ok = h.threadsQ[0], true
 		h.threadsQ = h.threadsQ[1:]
 	}
+	collapse := ok && h.stopThreadUnknown
+	if collapse {
+		h.curThreadID = current.Id
+		if resolved {
+			h.stopThreadUnknown = false
+		}
+	} else if ok && resolved {
+		h.curThreadID = current.Id
+	}
 	h.mu.Unlock()
 
 	if !ok {
 		return
 	}
+	threads := dapThreads(p.Goroutines)
+	if collapse {
+		threads = []godap.Thread{current}
+	}
 	h.send(&godap.ThreadsResponse{
 		Response: h.response(seq, "threads"),
-		Body:     godap.ThreadsResponseBody{Threads: dapThreads(p.Goroutines)},
+		Body:     godap.ThreadsResponseBody{Threads: threads},
 	})
 }
 

--- a/internal/dap/handler.go
+++ b/internal/dap/handler.go
@@ -95,6 +95,11 @@ type Handler struct {
 	startCmd      string
 	restartReqSeq int
 	curThreadID   int
+	// stopThreadUnknown records that the suspending event honestly omitted
+	// stopped.threadId. The first subsequent threads response is collapsed to
+	// one resolved or synthetic stopped-thread handle so clients do not request
+	// the same stopped stack once for every goroutine.
+	stopThreadUnknown bool
 
 	// restartWasSuspended is the suspended view this connection held when it
 	// issued the in-flight restart, captured before onRestart clears it

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -689,6 +689,19 @@ func TestHandshakeLaunchToBreakpoint(t *testing.T) {
 	}
 }
 
+func TestUnknownBreakpointStopOmitsThreadID(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+
+	hh.inject(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{
+		Goroutine: protocol.Goroutine{Status: "unknown", Current: true},
+	})
+	stopped := recvType[*godap.StoppedEvent](hh)
+	if stopped.Body.ThreadId != 0 {
+		t.Errorf("threadId = %d, want omitted for unknown goroutine", stopped.Body.ThreadId)
+	}
+}
+
 func TestOwnContinueIsSuppressed(t *testing.T) {
 	hh := newHarness(t)
 	hh.doHandshake(t)

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -48,6 +48,18 @@ func (r *cmdRecorder) kinds() []protocol.CommandKind {
 	return out
 }
 
+func (r *cmdRecorder) count(kind protocol.CommandKind) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var count int
+	for _, cmd := range r.cmds {
+		if cmd.Kind == kind {
+			count++
+		}
+	}
+	return count
+}
+
 // waitForCommand polls until a command of kind appears or the deadline passes.
 func (r *cmdRecorder) waitForCommand(t *testing.T, kind protocol.CommandKind) protocol.Command {
 	t.Helper()
@@ -86,18 +98,6 @@ func (r *cmdRecorder) waitForCommands(t *testing.T, kind protocol.CommandKind, c
 	}
 	t.Fatalf("timed out waiting for %d commands of kind %s; saw %v", count, kind, r.kinds())
 	return nil
-}
-
-func (r *cmdRecorder) count(kind protocol.CommandKind) int {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	count := 0
-	for _, cmd := range r.cmds {
-		if cmd.Kind == kind {
-			count++
-		}
-	}
-	return count
 }
 
 func (r *cmdRecorder) requireNoAdditionalCommands(t *testing.T, kind protocol.CommandKind, expected int) {
@@ -1164,7 +1164,9 @@ func TestStackTraceAndVariablesCorrelation(t *testing.T) {
 	}
 
 	// stackTrace → Frames command → EventFrames → StackTraceResponse.
-	hh.sendReq("stackTrace", &godap.StackTraceRequest{})
+	hh.sendReq("stackTrace", &godap.StackTraceRequest{
+		Arguments: godap.StackTraceArguments{ThreadId: 1},
+	})
 	hh.cmds.waitForCommand(t, protocol.CmdFrames)
 	hh.inject(protocol.EventFrames, protocol.FramesPayload{Frames: []protocol.Frame{
 		{Index: 0, Location: protocol.Location{Function: "main.f", File: "/x/main.go", Line: 12}},
@@ -1430,6 +1432,82 @@ func TestUnknownStepOmitsThreadID(t *testing.T) {
 	}
 	if stopped.Body.ThreadId != 0 {
 		t.Errorf("threadId = %d, want omitted for unknown goroutine", stopped.Body.ThreadId)
+	}
+
+	hh.sendReq("threads", &godap.ThreadsRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdGoroutines)
+	hh.inject(protocol.EventGoroutines, protocol.GoroutinesPayload{
+		Goroutines: []protocol.Goroutine{
+			{ID: 1, Status: "waiting"},
+			{ID: 7, Status: "running", Current: true},
+			{ID: 9, Status: "waiting"},
+		},
+	})
+	threads := recvType[*godap.ThreadsResponse](hh)
+	if len(threads.Body.Threads) != 1 || threads.Body.Threads[0].Id != 7 {
+		t.Fatalf("threads after unknown stop = %+v, want only resolved current g7", threads.Body.Threads)
+	}
+
+	framesBefore := hh.cmds.count(protocol.CmdFrames)
+	hh.sendReq("stackTrace", &godap.StackTraceRequest{
+		Arguments: godap.StackTraceArguments{ThreadId: 1},
+	})
+	nonCurrent := recvType[*godap.StackTraceResponse](hh)
+	if len(nonCurrent.Body.StackFrames) != 0 {
+		t.Fatalf("non-current stack = %+v, want empty", nonCurrent.Body.StackFrames)
+	}
+	if got := hh.cmds.count(protocol.CmdFrames); got != framesBefore {
+		t.Fatalf("non-current stack enqueued %d CmdFrames, want %d", got, framesBefore)
+	}
+
+	hh.sendReq("stackTrace", &godap.StackTraceRequest{
+		Arguments: godap.StackTraceArguments{ThreadId: 7},
+	})
+	hh.cmds.waitForCommand(t, protocol.CmdFrames)
+	hh.inject(protocol.EventFrames, protocol.FramesPayload{Frames: []protocol.Frame{{
+		Index:    0,
+		Location: protocol.Location{Function: "main.worker", File: "/x/main.go", Line: 20},
+	}}})
+	current := recvType[*godap.StackTraceResponse](hh)
+	if len(current.Body.StackFrames) != 1 || current.Body.StackFrames[0].Name != "main.worker" {
+		t.Fatalf("current stack = %+v", current.Body.StackFrames)
+	}
+}
+
+func TestUnknownStepUsesOneSyntheticStackTarget(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	hh.inject(protocol.EventStepped, protocol.SteppedPayload{
+		Goroutine: protocol.Goroutine{Status: "unknown", Current: true},
+	})
+	_ = recvType[*godap.StoppedEvent](hh)
+
+	hh.sendReq("threads", &godap.ThreadsRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdGoroutines)
+	hh.inject(protocol.EventGoroutines, protocol.GoroutinesPayload{
+		Goroutines: []protocol.Goroutine{
+			{ID: 1, Status: "waiting"},
+			{ID: 9, Status: "waiting"},
+		},
+	})
+	threads := recvType[*godap.ThreadsResponse](hh)
+	if len(threads.Body.Threads) != 1 ||
+		threads.Body.Threads[0].Id != 1 ||
+		threads.Body.Threads[0].Name != "stopped goroutine (unknown)" {
+		t.Fatalf("threads after unresolved stop = %+v", threads.Body.Threads)
+	}
+
+	hh.sendReq("stackTrace", &godap.StackTraceRequest{
+		Arguments: godap.StackTraceArguments{ThreadId: 1},
+	})
+	hh.cmds.waitForCommand(t, protocol.CmdFrames)
+	hh.inject(protocol.EventFrames, protocol.FramesPayload{Frames: []protocol.Frame{{
+		Index:    0,
+		Location: protocol.Location{Function: "main.worker", File: "/x/main.go", Line: 20},
+	}}})
+	stack := recvType[*godap.StackTraceResponse](hh)
+	if len(stack.Body.StackFrames) != 1 || stack.Body.StackFrames[0].Name != "main.worker" {
+		t.Fatalf("synthetic stopped stack = %+v", stack.Body.StackFrames)
 	}
 }
 
@@ -1907,7 +1985,7 @@ func TestJoinExistingSuspendedSession(t *testing.T) {
 	hh.sendReq("threads", &godap.ThreadsRequest{})
 	hh.cmds.waitForCommand(t, protocol.CmdGoroutines)
 	hh.inject(protocol.EventGoroutines, protocol.GoroutinesPayload{
-		Goroutines: []protocol.Goroutine{{ID: 7, Status: "running"}},
+		Goroutines: []protocol.Goroutine{{ID: 7, Status: "running", Current: true}},
 	})
 	thr := recvType[*godap.ThreadsResponse](hh)
 	if len(thr.Body.Threads) != 1 || thr.Body.Threads[0].Id != 7 {

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -1417,6 +1417,22 @@ func TestDisconnectQueuesKillBeforeFailedResponse(t *testing.T) {
 	}
 }
 
+func TestUnknownStepOmitsThreadID(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	hh.inject(protocol.EventStepped, protocol.SteppedPayload{
+		Goroutine: protocol.Goroutine{Status: "unknown", Current: true},
+	})
+
+	stopped := recvType[*godap.StoppedEvent](hh)
+	if stopped.Body.Reason != "step" {
+		t.Errorf("reason = %q, want step", stopped.Body.Reason)
+	}
+	if stopped.Body.ThreadId != 0 {
+		t.Errorf("threadId = %d, want omitted for unknown goroutine", stopped.Body.ThreadId)
+	}
+}
+
 func TestDisconnectTerminatesLaunchedDebuggee(t *testing.T) {
 	hh := newHarness(t)
 	hh.doHandshake(t)

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -1460,9 +1460,7 @@ func TestUnknownStepOmitsThreadID(t *testing.T) {
 		t.Fatalf("non-current stack enqueued %d CmdFrames, want %d", got, framesBefore)
 	}
 
-	hh.sendReq("stackTrace", &godap.StackTraceRequest{
-		Arguments: godap.StackTraceArguments{ThreadId: 7},
-	})
+	hh.sendReq("stackTrace", &godap.StackTraceRequest{})
 	hh.cmds.waitForCommand(t, protocol.CmdFrames)
 	hh.inject(protocol.EventFrames, protocol.FramesPayload{Frames: []protocol.Frame{{
 		Index:    0,
@@ -1470,7 +1468,7 @@ func TestUnknownStepOmitsThreadID(t *testing.T) {
 	}}})
 	current := recvType[*godap.StackTraceResponse](hh)
 	if len(current.Body.StackFrames) != 1 || current.Body.StackFrames[0].Name != "main.worker" {
-		t.Fatalf("current stack = %+v", current.Body.StackFrames)
+		t.Fatalf("thread-id-free current stack = %+v", current.Body.StackFrames)
 	}
 }
 
@@ -1508,6 +1506,26 @@ func TestUnknownStepUsesOneSyntheticStackTarget(t *testing.T) {
 	stack := recvType[*godap.StackTraceResponse](hh)
 	if len(stack.Body.StackFrames) != 1 || stack.Body.StackFrames[0].Name != "main.worker" {
 		t.Fatalf("synthetic stopped stack = %+v", stack.Body.StackFrames)
+	}
+}
+
+func TestUnknownStepServesStackWithoutThreadQuery(t *testing.T) {
+	hh := newHarness(t)
+	hh.doHandshake(t)
+	hh.inject(protocol.EventStepped, protocol.SteppedPayload{
+		Goroutine: protocol.Goroutine{Status: "unknown", Current: true},
+	})
+	_ = recvType[*godap.StoppedEvent](hh)
+
+	hh.sendReq("stackTrace", &godap.StackTraceRequest{})
+	hh.cmds.waitForCommand(t, protocol.CmdFrames)
+	hh.inject(protocol.EventFrames, protocol.FramesPayload{Frames: []protocol.Frame{{
+		Index:    0,
+		Location: protocol.Location{Function: "main.worker", File: "/x/main.go", Line: 20},
+	}}})
+	stack := recvType[*godap.StackTraceResponse](hh)
+	if len(stack.Body.StackFrames) != 1 || stack.Body.StackFrames[0].Name != "main.worker" {
+		t.Fatalf("thread-id-free stack = %+v", stack.Body.StackFrames)
 	}
 }
 

--- a/internal/dap/requests.go
+++ b/internal/dap/requests.go
@@ -371,12 +371,21 @@ func (h *Handler) onThreads(req *godap.ThreadsRequest) {
 func (h *Handler) onStackTrace(req *godap.StackTraceRequest) {
 	h.mu.Lock()
 	suspended := h.suspended
-	if suspended {
+	currentThreadID := h.curThreadID
+	requestedThreadID := req.Arguments.ThreadId
+	if suspended && currentThreadID > 0 && requestedThreadID == currentThreadID {
 		h.framesQ = append(h.framesQ, req.Seq)
 	}
 	h.mu.Unlock()
 
 	if !suspended {
+		h.send(&godap.StackTraceResponse{
+			Response: h.response(req.Seq, "stackTrace"),
+			Body:     godap.StackTraceResponseBody{StackFrames: []godap.StackFrame{}},
+		})
+		return
+	}
+	if currentThreadID == 0 || requestedThreadID != currentThreadID {
 		h.send(&godap.StackTraceResponse{
 			Response: h.response(req.Seq, "stackTrace"),
 			Body:     godap.StackTraceResponseBody{StackFrames: []godap.StackFrame{}},

--- a/internal/dap/requests.go
+++ b/internal/dap/requests.go
@@ -373,7 +373,9 @@ func (h *Handler) onStackTrace(req *godap.StackTraceRequest) {
 	suspended := h.suspended
 	currentThreadID := h.curThreadID
 	requestedThreadID := req.Arguments.ThreadId
-	if suspended && currentThreadID > 0 && requestedThreadID == currentThreadID {
+	servable := suspended &&
+		(requestedThreadID <= 0 || currentThreadID > 0 && requestedThreadID == currentThreadID)
+	if servable {
 		h.framesQ = append(h.framesQ, req.Seq)
 	}
 	h.mu.Unlock()
@@ -385,7 +387,7 @@ func (h *Handler) onStackTrace(req *godap.StackTraceRequest) {
 		})
 		return
 	}
-	if currentThreadID == 0 || requestedThreadID != currentThreadID {
+	if !servable {
 		h.send(&godap.StackTraceResponse{
 			Response: h.response(req.Seq, "stackTrace"),
 			Body:     godap.StackTraceResponseBody{StackFrames: []godap.StackFrame{}},

--- a/internal/dap/translate.go
+++ b/internal/dap/translate.go
@@ -9,12 +9,20 @@ import (
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
 
-// DAP has a single-threaded stop model keyed by threadId; bingo reports the
-// stopped goroutine. A goroutine id of 0 (runtime g0 / not yet assigned) is not
-// a valid DAP threadId, so clamp to 1. threadID keeps that mapping in one place.
+// DAP thread-list entries require an id. A synthetic bingo goroutine has ID 0,
+// so threadID gives it a transport-only handle without claiming a runtime goid.
 func threadID(goroutineID int) int {
 	if goroutineID < 1 {
 		return 1
+	}
+	return goroutineID
+}
+
+// stopped.threadId is optional. Omit it when bingo cannot identify a runtime
+// goroutine instead of pointing the stop at an unrelated real goroutine.
+func stoppedThreadID(goroutineID int) int {
+	if goroutineID < 1 {
+		return 0
 	}
 	return goroutineID
 }

--- a/internal/dap/translate.go
+++ b/internal/dap/translate.go
@@ -113,11 +113,28 @@ func dapThreads(gs []protocol.Goroutine) []godap.Thread {
 	}
 	out := make([]godap.Thread, 0, len(gs))
 	for _, g := range gs {
-		name := "goroutine " + strconv.Itoa(g.ID)
-		if g.Status != "" {
-			name += " (" + g.Status + ")"
-		}
-		out = append(out, godap.Thread{Id: threadID(g.ID), Name: name})
+		out = append(out, dapThread(g))
 	}
 	return out
+}
+
+func dapThread(g protocol.Goroutine) godap.Thread {
+	name := "goroutine " + strconv.Itoa(g.ID)
+	if g.Status != "" {
+		name += " (" + g.Status + ")"
+	}
+	return godap.Thread{Id: threadID(g.ID), Name: name}
+}
+
+// dapStoppedThread returns the one thread a client should inspect after a stop
+// whose event omitted threadId. A fresh Goroutines query can often resolve the
+// identity while the process is suspended; otherwise ID 1 is explicitly a
+// transport-only synthetic handle, not a claim that runtime g1 stopped.
+func dapStoppedThread(gs []protocol.Goroutine) (godap.Thread, bool) {
+	for _, g := range gs {
+		if g.Current && g.ID > 0 {
+			return dapThread(g), true
+		}
+	}
+	return godap.Thread{Id: 1, Name: "stopped goroutine (unknown)"}, false
 }

--- a/internal/dap/translate_test.go
+++ b/internal/dap/translate_test.go
@@ -115,6 +115,23 @@ func TestDapThreadsMapsGoroutines(t *testing.T) {
 	}
 }
 
+func TestDapStoppedThread(t *testing.T) {
+	resolved, ok := dapStoppedThread([]protocol.Goroutine{
+		{ID: 1, Status: "waiting"},
+		{ID: 7, Status: "running", Current: true},
+	})
+	if !ok || resolved.Id != 7 || resolved.Name != "goroutine 7 (running)" {
+		t.Fatalf("resolved stopped thread = %+v, %v", resolved, ok)
+	}
+
+	unknown, ok := dapStoppedThread([]protocol.Goroutine{
+		{ID: 1, Status: "waiting"},
+	})
+	if ok || unknown.Id != 1 || unknown.Name != "stopped goroutine (unknown)" {
+		t.Fatalf("unknown stopped thread = %+v, %v", unknown, ok)
+	}
+}
+
 func TestBuildVarTree(t *testing.T) {
 	h := &Handler{varCache: make(map[int][]godap.Variable)}
 	out := h.buildVarTree([]protocol.Variable{

--- a/internal/dap/translate_test.go
+++ b/internal/dap/translate_test.go
@@ -1,6 +1,8 @@
 package dap
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	godap "github.com/google/go-dap"
@@ -14,6 +16,25 @@ func TestThreadIDClampsToOne(t *testing.T) {
 		if got := threadID(in); got != want {
 			t.Errorf("threadID(%d) = %d, want %d", in, got, want)
 		}
+	}
+}
+
+func TestStoppedThreadIDOmittedWhenUnknown(t *testing.T) {
+	cases := map[int]int{-5: 0, 0: 0, 1: 1, 7: 7}
+	for in, want := range cases {
+		if got := stoppedThreadID(in); got != want {
+			t.Errorf("stoppedThreadID(%d) = %d, want %d", in, got, want)
+		}
+	}
+	raw, err := json.Marshal(godap.StoppedEventBody{
+		Reason:   "pause",
+		ThreadId: stoppedThreadID(0),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "threadId") {
+		t.Fatalf("unknown stopped body = %s, want threadId omitted", raw)
 	}
 }
 

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -1439,18 +1439,28 @@ func (e *engine) collectFrames(tid int) ([]protocol.Frame, error) {
 	if e.dw == nil {
 		return nil, nil
 	}
+	frames, _, _, err := e.collectFramesAndRegisters(tid)
+	return frames, err
+}
+
+func (e *engine) collectFramesAndRegisters(
+	tid int,
+) ([]protocol.Frame, int, Registers, error) {
 	if tid == 0 {
 		threads, err := e.backend.Threads()
 		if err != nil || len(threads) == 0 {
-			return nil, fmt.Errorf("StackFrames: no threads")
+			return nil, 0, Registers{}, fmt.Errorf("StackFrames: no threads")
 		}
 		tid = threads[0]
 	}
 	regs, err := e.backend.GetRegisters(tid)
 	if err != nil {
-		return nil, fmt.Errorf("StackFrames: %w", err)
+		return nil, tid, Registers{}, fmt.Errorf("StackFrames: %w", err)
 	}
-	return e.dw.FramesForStack(e.walkStack(regs)), nil
+	if e.dw == nil {
+		return nil, tid, regs, nil
+	}
+	return e.dw.FramesForStack(e.walkStack(regs)), tid, regs, nil
 }
 
 func (e *engine) walkStack(regs Registers) []uint64 {
@@ -1607,7 +1617,7 @@ func (e *engine) emitStepped(stop StopEvent) {
 	// Completing a step suspends for a self-stop, which cancels any pending
 	// Pause the same way a breakpoint hit does (see emitBreakpointHit).
 	e.manualStopPending = false
-	frames, _ := e.collectFrames(stop.TID)
+	frames, tid, regs, regsErr := e.collectFramesAndRegisters(stop.TID)
 	loc := protocol.Location{}
 	if e.dw != nil {
 		loc = e.dw.locationForPC(stop.PC)
@@ -1616,11 +1626,15 @@ func (e *engine) emitStepped(stop StopEvent) {
 	if len(frames) > 0 {
 		currentLoc = frames[0].Location
 	}
+	current := unknownGoroutine(currentLoc)
+	if regsErr == nil {
+		current = e.targetedCurrentGoroutine(currentLoc, tid, regs)
+	}
 	// Steps are high-frequency and must stay cheap: identify the stopped
 	// goroutine through bounded register/stopped-M reads without scanning allgs.
 	// The rich snapshot remains limited to breakpoint/pause/entry stops.
 	e.emit(protocol.EventStepped, protocol.SteppedPayload{
-		Goroutine: e.targetedCurrentGoroutine(currentLoc),
+		Goroutine: current,
 		Location:  loc,
 		Frames:    frames,
 	})

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -1560,9 +1560,13 @@ func (e *engine) emitBreakpointHit(bp *breakpointEntry, stop StopEvent) {
 	// the stop event, then the full snapshot is streamed as its own event. One
 	// build avoids a double allgs scan and a double lifecycle-delta pass.
 	snap := e.goroutineSnapshot()
+	currentLoc := e.locForPC(stop.PC)
+	if len(frames) > 0 {
+		currentLoc = frames[0].Location
+	}
 	e.emit(protocol.EventBreakpointHit, protocol.BreakpointHitPayload{
 		Breakpoint: bp.toProtocol(),
-		Goroutine:  currentGoroutineFrom(snap),
+		Goroutine:  currentGoroutineFrom(snap, currentLoc),
 		Frames:     frames,
 	})
 	e.emit(protocol.EventGoroutineSnapshot, snap)
@@ -1633,8 +1637,12 @@ func (e *engine) emitPaused(stop StopEvent) {
 	if e.dw != nil {
 		loc = e.dw.locationForPC(stop.PC)
 	}
+	currentLoc := loc
+	if len(frames) > 0 {
+		currentLoc = frames[0].Location
+	}
 	e.emit(protocol.EventPaused, protocol.PausedPayload{
-		Goroutine: currentGoroutineFrom(snap),
+		Goroutine: currentGoroutineFrom(snap, currentLoc),
 		Location:  loc,
 		Frames:    frames,
 	})

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -1612,12 +1612,15 @@ func (e *engine) emitStepped(stop StopEvent) {
 	if e.dw != nil {
 		loc = e.dw.locationForPC(stop.PC)
 	}
-	// Steps are high-frequency and must stay cheap: embed a synthetic goroutine
-	// for the stopped thread rather than scanning runtime.allgs. The rich
-	// snapshot is streamed only on breakpoint/pause/entry stops, protecting the
-	// fragile single-step/step-over path from extra per-step memory reads.
+	currentLoc := loc
+	if len(frames) > 0 {
+		currentLoc = frames[0].Location
+	}
+	// Steps are high-frequency and must stay cheap: identify the stopped
+	// goroutine through bounded register/stopped-M reads without scanning allgs.
+	// The rich snapshot remains limited to breakpoint/pause/entry stops.
 	e.emit(protocol.EventStepped, protocol.SteppedPayload{
-		Goroutine: e.syntheticGoroutine(stop.PC),
+		Goroutine: e.targetedCurrentGoroutine(currentLoc),
 		Location:  loc,
 		Frames:    frames,
 	})

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -1439,28 +1439,18 @@ func (e *engine) collectFrames(tid int) ([]protocol.Frame, error) {
 	if e.dw == nil {
 		return nil, nil
 	}
-	frames, _, _, err := e.collectFramesAndRegisters(tid)
-	return frames, err
-}
-
-func (e *engine) collectFramesAndRegisters(
-	tid int,
-) ([]protocol.Frame, int, Registers, error) {
 	if tid == 0 {
 		threads, err := e.backend.Threads()
 		if err != nil || len(threads) == 0 {
-			return nil, 0, Registers{}, fmt.Errorf("StackFrames: no threads")
+			return nil, fmt.Errorf("StackFrames: no threads")
 		}
 		tid = threads[0]
 	}
 	regs, err := e.backend.GetRegisters(tid)
 	if err != nil {
-		return nil, tid, Registers{}, fmt.Errorf("StackFrames: %w", err)
+		return nil, fmt.Errorf("StackFrames: %w", err)
 	}
-	if e.dw == nil {
-		return nil, tid, regs, nil
-	}
-	return e.dw.FramesForStack(e.walkStack(regs)), tid, regs, nil
+	return e.dw.FramesForStack(e.walkStack(regs)), nil
 }
 
 func (e *engine) walkStack(regs Registers) []uint64 {
@@ -1617,7 +1607,7 @@ func (e *engine) emitStepped(stop StopEvent) {
 	// Completing a step suspends for a self-stop, which cancels any pending
 	// Pause the same way a breakpoint hit does (see emitBreakpointHit).
 	e.manualStopPending = false
-	frames, tid, regs, regsErr := e.collectFramesAndRegisters(stop.TID)
+	frames, _ := e.collectFrames(stop.TID)
 	loc := protocol.Location{}
 	if e.dw != nil {
 		loc = e.dw.locationForPC(stop.PC)
@@ -1626,15 +1616,12 @@ func (e *engine) emitStepped(stop StopEvent) {
 	if len(frames) > 0 {
 		currentLoc = frames[0].Location
 	}
-	current := unknownGoroutine(currentLoc)
-	if regsErr == nil {
-		current = e.targetedCurrentGoroutine(currentLoc, tid, regs)
-	}
-	// Steps are high-frequency and must stay cheap: identify the stopped
-	// goroutine through bounded register/stopped-M reads without scanning allgs.
-	// The rich snapshot remains limited to breakpoint/pause/entry stops.
+	// Steps are high-frequency and must not inspect runtime collections. Frames
+	// still come from the stopped TID, while identity stays honestly unknown
+	// until a breakpoint, pause, entry, or explicit snapshot performs the rich
+	// bounded walk.
 	e.emit(protocol.EventStepped, protocol.SteppedPayload{
-		Goroutine: current,
+		Goroutine: unknownGoroutine(currentLoc),
 		Location:  loc,
 		Frames:    frames,
 	})

--- a/internal/debugger/engine_test.go
+++ b/internal/debugger/engine_test.go
@@ -37,6 +37,7 @@ type fakeBackend struct {
 	continueCalls    int
 	singleStepCalls  []int
 	stopProcessCalls int
+	getRegisterCalls int
 	readCalls        []uint64
 	writeCalls       []uint64
 	writtenAt        map[uint64][]byte
@@ -277,6 +278,7 @@ func (f *fakeBackend) writeCountFor(addr uint64) int {
 }
 
 func (f *fakeBackend) GetRegisters(tid int) (debugger.Registers, error) {
+	f.getRegisterCalls++
 	if f.getRegistersErr != nil {
 		err := f.getRegistersErr
 		f.getRegistersErr = nil

--- a/internal/debugger/engine_test.go
+++ b/internal/debugger/engine_test.go
@@ -987,7 +987,8 @@ var _ = Describe("Engine", func() {
 
 			var p protocol.SteppedPayload
 			Expect(protocol.DecodeEventPayload(evt, &p)).To(Succeed())
-			Expect(p.Goroutine.Status).To(Equal("waiting"))
+			Expect(p.Goroutine.ID).To(BeZero())
+			Expect(p.Goroutine.Status).To(Equal("unknown"))
 		})
 
 		It("puts the engine back into stateSuspended after the step", func() {
@@ -1215,7 +1216,8 @@ var _ = Describe("Engine", func() {
 			gs, err := d.Goroutines()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(gs).To(HaveLen(1))
-			Expect(gs[0].Status).To(Equal("waiting"))
+			Expect(gs[0].ID).To(BeZero())
+			Expect(gs[0].Status).To(Equal("unknown"))
 		})
 	})
 
@@ -1224,12 +1226,13 @@ var _ = Describe("Engine", func() {
 			debugger.ExportedForceSuspended(d)
 		})
 
-		It("returns one goroutine with status 'waiting'", func() {
+		It("returns one synthetic unknown goroutine", func() {
 			gs, err := d.Goroutines()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(gs).To(HaveLen(1))
-			Expect(gs[0].ID).To(Equal(1))
-			Expect(gs[0].Status).To(Equal("waiting"))
+			Expect(gs[0].ID).To(BeZero())
+			Expect(gs[0].Status).To(Equal("unknown"))
+			Expect(gs[0].Current).To(BeTrue())
 		})
 	})
 

--- a/internal/debugger/engine_test.go
+++ b/internal/debugger/engine_test.go
@@ -27,6 +27,7 @@ type fakeBackend struct {
 	memMu        sync.RWMutex
 	mem          map[uint64]byte
 	readFailures map[uint64]int
+	readCount    map[uint64]int
 	regs         map[int]debugger.Registers
 	tids         []int
 
@@ -71,6 +72,7 @@ func newFakeBackend() *fakeBackend {
 	return &fakeBackend{
 		mem:          make(map[uint64]byte),
 		readFailures: make(map[uint64]int),
+		readCount:    make(map[uint64]int),
 		regs:         map[int]debugger.Registers{1: {}},
 		tids:         []int{1},
 		stopCh:       make(chan debugger.StopEvent, 8),
@@ -227,6 +229,7 @@ func (f *fakeBackend) SingleStep(tid int) error {
 }
 
 func (f *fakeBackend) ReadMemory(addr uint64, dst []byte) error {
+	f.readCount[addr]++
 	if err := f.faultFor("read", addr); err != nil {
 		return err
 	}

--- a/internal/debugger/export_test.go
+++ b/internal/debugger/export_test.go
@@ -138,7 +138,7 @@ func ExportedThreadWalkResult(d Debugger) ExportedWalkResult {
 	e := d.(*engine)
 	var out ExportedWalkResult
 	if err := e.dispatch(func() error {
-		_, pc := e.liveRegisters()
+		_, pc, _ := e.liveRegisters()
 		result := e.readThreads(0, pc)
 		out = ExportedWalkResult{
 			Count:    len(result.Items),
@@ -156,8 +156,8 @@ func ExportedGoroutineWalkResult(d Debugger) ExportedWalkResult {
 	e := d.(*engine)
 	var out ExportedWalkResult
 	if err := e.dispatch(func() error {
-		sp, pc := e.liveRegisters()
-		result := e.buildGoroutineList(sp, pc)
+		sp, pc, currentGptr := e.liveRegisters()
+		result := e.buildGoroutineList(sp, pc, currentGptr)
 		out = ExportedWalkResult{
 			Count:    len(result.Items),
 			Complete: result.Complete,
@@ -449,7 +449,7 @@ func ExportedSnapshotFrom(d Debugger, gs []protocol.Goroutine, trackLifecycle bo
 	e := d.(*engine)
 	var snap protocol.GoroutineSnapshotPayload
 	if err := e.dispatch(func() error {
-		current, live := snapshotGoroutineState(gs)
+		live, current := snapshotGoroutineIDs(gs, 0)
 		snap = e.snapshotFrom(gs, nil, current, live, trackLifecycle)
 		return nil
 	}); err != nil {

--- a/internal/debugger/export_test.go
+++ b/internal/debugger/export_test.go
@@ -14,6 +14,7 @@ type ExportedGoRuntimeLayout struct {
 	Allm  uint64
 
 	GStack        uint64
+	GM            uint64
 	GAtomicstatus uint64
 	GGoid         uint64
 	GParentGoid   uint64
@@ -88,6 +89,7 @@ func ExportedGoRuntimeLayoutFor(d Debugger) ExportedGoRuntimeLayout {
 			Allm:  allm,
 
 			GStack:        uint64(l.gStack),
+			GM:            uint64(l.gM),
 			GAtomicstatus: uint64(l.gAtomicstatus),
 			GGoid:         uint64(l.gGoid),
 			GParentGoid:   uint64(l.gParentGoid),

--- a/internal/debugger/export_test.go
+++ b/internal/debugger/export_test.go
@@ -131,14 +131,14 @@ func ExportedGoroutineSnapshotQuery(d Debugger) protocol.GoroutineSnapshotPayloa
 }
 
 func ExportedCurrentGoroutineFrom(snap protocol.GoroutineSnapshotPayload) protocol.Goroutine {
-	return currentGoroutineFrom(snap)
+	return currentGoroutineFrom(snap, protocol.Location{})
 }
 
 func ExportedThreadWalkResult(d Debugger) ExportedWalkResult {
 	e := d.(*engine)
 	var out ExportedWalkResult
 	if err := e.dispatch(func() error {
-		_, pc, _ := e.liveRegisters()
+		_, _, pc, _ := e.liveRegisters()
 		result := e.readThreads(0, pc)
 		out = ExportedWalkResult{
 			Count:    len(result.Items),
@@ -156,8 +156,8 @@ func ExportedGoroutineWalkResult(d Debugger) ExportedWalkResult {
 	e := d.(*engine)
 	var out ExportedWalkResult
 	if err := e.dispatch(func() error {
-		sp, pc, currentGptr := e.liveRegisters()
-		result := e.buildGoroutineList(sp, pc, currentGptr)
+		tid, sp, pc, currentGptr := e.liveRegisters()
+		result := e.buildGoroutineList(sp, pc, currentGptr, tid)
 		out = ExportedWalkResult{
 			Count:    len(result.Items),
 			Complete: result.Complete,

--- a/internal/debugger/goroutine_pointer_amd64.go
+++ b/internal/debugger/goroutine_pointer_amd64.go
@@ -1,0 +1,10 @@
+//go:build amd64
+
+package debugger
+
+// FS_BASE is not a stable current-g address under external linking because the
+// ELF TLS slot can move. The shared reader resolves linux current-g through
+// runtime.allm instead.
+func (e *engine) archCurrentGoroutinePointer(regs Registers) (uint64, bool) {
+	return 0, false
+}

--- a/internal/debugger/goroutine_pointer_amd64.go
+++ b/internal/debugger/goroutine_pointer_amd64.go
@@ -8,3 +8,11 @@ package debugger
 func (e *engine) archCurrentGoroutinePointer(regs Registers) (uint64, bool) {
 	return 0, false
 }
+
+// Linux reports kernel TIDs in both ptrace stops and runtime.m.procid.
+func (e *engine) archRuntimeMProcID(tid int) (uint64, bool) {
+	if tid <= 0 {
+		return 0, false
+	}
+	return uint64(tid), true
+}

--- a/internal/debugger/goroutine_pointer_amd64_test.go
+++ b/internal/debugger/goroutine_pointer_amd64_test.go
@@ -1,0 +1,12 @@
+//go:build amd64
+
+package debugger
+
+import "testing"
+
+func TestArchCurrentGoroutinePointerAMD64(t *testing.T) {
+	got, ok := (&engine{}).archCurrentGoroutinePointer(Registers{TLS: 0x2000})
+	if ok || got != 0 {
+		t.Fatalf("current g pointer = 0x%x, %t; want unavailable so allm resolves it", got, ok)
+	}
+}

--- a/internal/debugger/goroutine_pointer_amd64_test.go
+++ b/internal/debugger/goroutine_pointer_amd64_test.go
@@ -10,3 +10,13 @@ func TestArchCurrentGoroutinePointerAMD64(t *testing.T) {
 		t.Fatalf("current g pointer = 0x%x, %t; want unavailable so allm resolves it", got, ok)
 	}
 }
+
+func TestArchRuntimeMProcIDAMD64(t *testing.T) {
+	got, ok := (&engine{}).archRuntimeMProcID(42)
+	if !ok || got != 42 {
+		t.Fatalf("runtime m procid = %d, %t; want 42, true", got, ok)
+	}
+	if got, ok := (&engine{}).archRuntimeMProcID(0); ok || got != 0 {
+		t.Fatalf("zero TID procid = %d, %t; want unavailable", got, ok)
+	}
+}

--- a/internal/debugger/goroutine_pointer_arm64.go
+++ b/internal/debugger/goroutine_pointer_arm64.go
@@ -1,0 +1,8 @@
+//go:build arm64
+
+package debugger
+
+// Go reserves X28 for the current *g on arm64.
+func (e *engine) archCurrentGoroutinePointer(regs Registers) (uint64, bool) {
+	return regs.TLS, regs.TLS != 0
+}

--- a/internal/debugger/goroutine_pointer_arm64.go
+++ b/internal/debugger/goroutine_pointer_arm64.go
@@ -6,3 +6,9 @@ package debugger
 func (e *engine) archCurrentGoroutinePointer(regs Registers) (uint64, bool) {
 	return regs.TLS, regs.TLS != 0
 }
+
+// Darwin stops identify a Mach thread port, while runtime.m.procid stores
+// pthread_self. X28 provides the stopped g directly instead.
+func (e *engine) archRuntimeMProcID(int) (uint64, bool) {
+	return 0, false
+}

--- a/internal/debugger/goroutine_pointer_arm64_test.go
+++ b/internal/debugger/goroutine_pointer_arm64_test.go
@@ -1,0 +1,13 @@
+//go:build arm64
+
+package debugger
+
+import "testing"
+
+func TestArchCurrentGoroutinePointerArm64(t *testing.T) {
+	const gptr = uint64(0x12345678)
+	got, ok := (&engine{}).archCurrentGoroutinePointer(Registers{TLS: gptr})
+	if !ok || got != gptr {
+		t.Fatalf("current g pointer = 0x%x, %t; want 0x%x, true", got, ok, gptr)
+	}
+}

--- a/internal/debugger/goroutine_pointer_arm64_test.go
+++ b/internal/debugger/goroutine_pointer_arm64_test.go
@@ -11,3 +11,10 @@ func TestArchCurrentGoroutinePointerArm64(t *testing.T) {
 		t.Fatalf("current g pointer = 0x%x, %t; want 0x%x, true", got, ok, gptr)
 	}
 }
+
+func TestArchRuntimeMProcIDArm64(t *testing.T) {
+	got, ok := (&engine{}).archRuntimeMProcID(42)
+	if ok || got != 0 {
+		t.Fatalf("runtime m procid = %d, %t; want unavailable for Mach thread ports", got, ok)
+	}
+}

--- a/internal/debugger/goroutines.go
+++ b/internal/debugger/goroutines.go
@@ -37,9 +37,6 @@ const (
 	// maxCurrentThreadScan bounds the targeted continuation past the rich allm
 	// prefix. It reads only enough fields to find the stopped M or current g.
 	maxCurrentThreadScan = 2048
-	// maxCurrentIdentityBytes bounds the single bulk read used by regular steps.
-	// Runtime g fields are compact; unusual layouts fall back to individual reads.
-	maxCurrentIdentityBytes = 4096
 	// maxGoStringLen caps a wait-reason string read from tracee memory.
 	maxGoStringLen = 256
 
@@ -274,19 +271,6 @@ type goroutineHeader struct {
 	status uint32
 }
 
-type currentGoroutineFields struct {
-	header goroutineHeader
-	lo     uint64
-	hi     uint64
-}
-
-type currentGoroutineDetail uint8
-
-const (
-	currentGoroutineRich currentGoroutineDetail = iota
-	currentGoroutineIdentity
-)
-
 // readGoroutine reads one runtime.g at gptr. Include is false for intentional
 // freelist/dead entries; Complete is false only when membership or current-
 // identity data is unreadable. liveSP/livePC identify the currently-stopped
@@ -371,78 +355,6 @@ func (e *engine) readGoroutineHeader(l *goLayout, gptr uint64) (goroutineHeader,
 
 func (h goroutineHeader) included() bool {
 	return h.goid > 0 && h.status != gStatusDead
-}
-
-func (e *engine) readCurrentGoroutineFields(
-	l *goLayout,
-	gptr uint64,
-	includeStack bool,
-) (currentGoroutineFields, bool) {
-	type identityField struct {
-		offset uint64
-		size   uint64
-	}
-	offsets := []identityField{
-		{offset: uint64(l.gAtomicstatus), size: 4},
-		{offset: uint64(l.gGoid), size: 8},
-	}
-	if includeStack {
-		offsets = append(offsets,
-			identityField{offset: uint64(l.gStack) + uint64(l.stackLo), size: 8},
-			identityField{offset: uint64(l.gStack) + uint64(l.stackHi), size: 8},
-		)
-	}
-	start := offsets[0].offset
-	end := uint64(0)
-	for _, field := range offsets {
-		if field.offset < start {
-			start = field.offset
-		}
-		if field.offset > ^uint64(0)-field.size {
-			return e.readCurrentGoroutineFieldsIndividually(l, gptr, includeStack)
-		}
-		if fieldEnd := field.offset + field.size; fieldEnd > end {
-			end = fieldEnd
-		}
-	}
-	if end < start || end-start > maxCurrentIdentityBytes ||
-		gptr > ^uint64(0)-start {
-		return e.readCurrentGoroutineFieldsIndividually(l, gptr, includeStack)
-	}
-	raw := make([]byte, end-start)
-	if err := e.backend.ReadMemory(gptr+start, raw); err != nil {
-		return currentGoroutineFields{}, false
-	}
-	at := func(offset uint64) []byte {
-		return raw[offset-start:]
-	}
-	fields := currentGoroutineFields{
-		header: goroutineHeader{
-			goid:   int64(binary.LittleEndian.Uint64(at(offsets[1].offset))),
-			status: binary.LittleEndian.Uint32(at(offsets[0].offset)) &^ gScanBit,
-		},
-	}
-	if includeStack {
-		fields.lo = binary.LittleEndian.Uint64(at(offsets[2].offset))
-		fields.hi = binary.LittleEndian.Uint64(at(offsets[3].offset))
-	}
-	return fields, true
-}
-
-func (e *engine) readCurrentGoroutineFieldsIndividually(
-	l *goLayout,
-	gptr uint64,
-	includeStack bool,
-) (currentGoroutineFields, bool) {
-	header, ok := e.readGoroutineHeader(l, gptr)
-	if !ok {
-		return currentGoroutineFields{}, false
-	}
-	if !includeStack {
-		return currentGoroutineFields{header: header}, true
-	}
-	lo, hi, ok := e.readGoroutineStackBounds(l, gptr)
-	return currentGoroutineFields{header: header, lo: lo, hi: hi}, ok
 }
 
 func (e *engine) readGoroutineStackBounds(l *goLayout, gptr uint64) (lo, hi uint64, ok bool) {
@@ -540,8 +452,9 @@ func allgsEntryAddress(ptr, index uint64) (uint64, bool) {
 
 // buildGoroutineList enumerates runtime.allgs. Complete is false when the
 // runtime can't be read (no DWARF, bad layout, unreadable membership or
-// current-identity data, or no live goroutines yet). Clipped is independent:
-// the rich walk reached its safety ceiling but every visited entry was readable.
+// required rooted current-identity data, or no live goroutines yet). An invalid
+// architecture register hint is only a miss. Clipped is independent: the rich
+// walk reached its safety ceiling but every visited entry was readable.
 func (e *engine) buildGoroutineList(
 	liveSP, livePC, currentGptr uint64,
 	stopTID int,
@@ -642,7 +555,7 @@ func (e *engine) resolveCurrentGoroutineAnchor(
 	stopTID int,
 ) currentGoroutineResult {
 	current := e.resolveTargetedCurrentGoroutine(
-		l, liveSP, livePC, currentGptr, stopTID, currentGoroutineRich,
+		l, liveSP, livePC, currentGptr, stopTID,
 	)
 	if !current.Complete || current.Found {
 		return current
@@ -661,18 +574,15 @@ func (e *engine) resolveTargetedCurrentGoroutine(
 	l *goLayout,
 	liveSP, livePC, currentGptr uint64,
 	stopTID int,
-	detail currentGoroutineDetail,
 ) currentGoroutineResult {
 	if currentGptr != 0 {
-		current := e.currentGoroutineFromRegister(
-			l, currentGptr, liveSP, livePC, detail,
-		)
-		if !current.Complete || current.Found {
+		current := e.currentGoroutineFromRegister(l, currentGptr, liveSP, livePC)
+		if current.Found {
 			return current
 		}
 	}
 	if procid, ok := e.archRuntimeMProcID(stopTID); ok {
-		current := e.findCurrentGoroutineByProcID(l, procid, livePC, detail)
+		current := e.findCurrentGoroutineByProcID(l, procid, livePC)
 		if !current.Complete || current.Found {
 			return current
 		}
@@ -683,19 +593,18 @@ func (e *engine) resolveTargetedCurrentGoroutine(
 func (e *engine) currentGoroutineFromRegister(
 	l *goLayout,
 	gptr, liveSP, livePC uint64,
-	detail currentGoroutineDetail,
 ) currentGoroutineResult {
-	fields, ok := e.readCurrentGoroutineFields(l, gptr, true)
+	// X28 is an ABI hint, not a runtime root: cgo, pre-runtime code, or a
+	// non-Go thread can leave a nonzero value that is unreadable or stale.
+	// Rejecting that hint must not discard an otherwise complete rich walk.
+	header, ok := e.readGoroutineHeader(l, gptr)
 	if !ok {
-		return currentGoroutineResult{}
+		return currentGoroutineResult{Complete: true}
 	}
-	if fields.header.goid > 0 {
-		if detail == currentGoroutineIdentity {
-			return currentGoroutineIdentityFromFields(liveSP, true, fields)
-		}
+	if header.goid > 0 {
 		result := e.readGoroutine(l, gptr, liveSP, livePC)
 		if !result.Complete {
-			return currentGoroutineResult{}
+			return currentGoroutineResult{Complete: true}
 		}
 		if result.Include && result.Item.Current {
 			return currentGoroutineResult{
@@ -706,24 +615,28 @@ func (e *engine) currentGoroutineFromRegister(
 		}
 		return currentGoroutineResult{Complete: true}
 	}
-	if fields.header.goid != 0 {
+	if header.goid != 0 {
 		return currentGoroutineResult{Complete: true}
 	}
 	mptr, ok := e.readU64(gptr + uint64(l.gM))
 	if !ok {
-		return currentGoroutineResult{}
+		return currentGoroutineResult{Complete: true}
 	}
 	if mptr == 0 {
 		return currentGoroutineResult{Complete: true}
 	}
 	schedulerG, complete := e.isSchedulerG(l, mptr, gptr)
 	if !complete {
-		return currentGoroutineResult{}
+		return currentGoroutineResult{Complete: true}
 	}
 	if !schedulerG {
 		return currentGoroutineResult{Complete: true}
 	}
-	return e.readCurrentGoroutineFromM(l, mptr, livePC, detail)
+	current := e.readCurrentGoroutineFromM(l, mptr, livePC)
+	if !current.Complete {
+		return currentGoroutineResult{Complete: true}
+	}
+	return current
 }
 
 func (e *engine) isSchedulerG(l *goLayout, mptr, gptr uint64) (bool, bool) {
@@ -751,7 +664,6 @@ func (e *engine) isSchedulerG(l *goLayout, mptr, gptr uint64) (bool, bool) {
 func (e *engine) readCurrentGoroutineFromM(
 	l *goLayout,
 	mptr, livePC uint64,
-	detail currentGoroutineDetail,
 ) currentGoroutineResult {
 	gptr, ok := e.readU64(mptr + uint64(l.mCurg))
 	if !ok {
@@ -767,9 +679,6 @@ func (e *engine) readCurrentGoroutineFromM(
 	if owner != mptr {
 		return currentGoroutineResult{Complete: true}
 	}
-	if detail == currentGoroutineIdentity {
-		return e.readCurrentGoroutineIdentity(l, gptr, 0, false)
-	}
 	result := e.readGoroutine(l, gptr, 0, 0)
 	if !result.Complete {
 		return currentGoroutineResult{}
@@ -782,42 +691,6 @@ func (e *engine) readCurrentGoroutineFromM(
 	current.CurrentLoc = e.locForPC(livePC)
 	return currentGoroutineResult{
 		Item:     current,
-		Found:    true,
-		Complete: true,
-	}
-}
-
-func (e *engine) readCurrentGoroutineIdentity(
-	l *goLayout,
-	gptr, liveSP uint64,
-	requireStack bool,
-) currentGoroutineResult {
-	fields, ok := e.readCurrentGoroutineFields(l, gptr, requireStack)
-	if !ok {
-		return currentGoroutineResult{}
-	}
-	return currentGoroutineIdentityFromFields(liveSP, requireStack, fields)
-}
-
-func currentGoroutineIdentityFromFields(
-	liveSP uint64,
-	requireStack bool,
-	fields currentGoroutineFields,
-) currentGoroutineResult {
-	if !fields.header.included() {
-		return currentGoroutineResult{Complete: true}
-	}
-	if requireStack {
-		if !stackContainsSP(fields.lo, fields.hi, liveSP) {
-			return currentGoroutineResult{Complete: true}
-		}
-	}
-	return currentGoroutineResult{
-		Item: protocol.Goroutine{
-			ID:      int(fields.header.goid),
-			Status:  goStatusString(fields.header.status),
-			Current: true,
-		},
 		Found:    true,
 		Complete: true,
 	}
@@ -872,7 +745,6 @@ func (e *engine) findCurrentGoroutine(
 func (e *engine) findCurrentGoroutineByProcID(
 	l *goLayout,
 	procid, livePC uint64,
-	detail currentGoroutineDetail,
 ) currentGoroutineResult {
 	if e.dw == nil {
 		return currentGoroutineResult{Complete: true}
@@ -888,13 +760,12 @@ func (e *engine) findCurrentGoroutineByProcID(
 	if mptr == 0 {
 		return currentGoroutineResult{Complete: true}
 	}
-	return e.findCurrentGoroutineByProcIDFrom(l, mptr, procid, livePC, detail)
+	return e.findCurrentGoroutineByProcIDFrom(l, mptr, procid, livePC)
 }
 
 func (e *engine) findCurrentGoroutineByProcIDFrom(
 	l *goLayout,
 	mptr, procid, livePC uint64,
-	detail currentGoroutineDetail,
 ) currentGoroutineResult {
 	match, next, complete := e.findMByProcID(l, mptr, procid, maxThreadScan)
 	if !complete {
@@ -909,7 +780,7 @@ func (e *engine) findCurrentGoroutineByProcIDFrom(
 	if match == 0 {
 		return currentGoroutineResult{Complete: true}
 	}
-	return e.readCurrentGoroutineFromM(l, match, livePC, detail)
+	return e.readCurrentGoroutineFromM(l, match, livePC)
 }
 
 func (e *engine) findMByProcID(
@@ -970,7 +841,7 @@ func (e *engine) readThreadsFrom(
 	currentGoid int,
 	livePC uint64,
 ) threadWalkResult {
-	out := make([]protocol.Thread, 0, maxThreadScan+1)
+	out := make([]protocol.Thread, 0, 16)
 	currentFound := false
 	i := 0
 	for ; i < maxThreadScan && mptr != 0; i++ {
@@ -1086,29 +957,6 @@ func unknownGoroutine(loc protocol.Location) protocol.Goroutine {
 		CurrentLoc: loc,
 		Current:    true,
 	}
-}
-
-// targetedCurrentGoroutine identifies the stopped goroutine without walking
-// runtime.allgs. Regular steps use this bounded path to stay cheap while still
-// giving DAP a precise thread id whenever the ABI or stopped M can provide one.
-func (e *engine) targetedCurrentGoroutine(
-	fallbackLoc protocol.Location,
-	tid int,
-	regs Registers,
-) protocol.Goroutine {
-	l, ok := e.getGoLayout()
-	if !ok {
-		return unknownGoroutine(fallbackLoc)
-	}
-	currentGptr, _ := e.archCurrentGoroutinePointer(regs)
-	current := e.resolveTargetedCurrentGoroutine(
-		l, regs.SP, regs.PC, currentGptr, tid, currentGoroutineIdentity,
-	)
-	if !current.Complete || !current.Found {
-		return unknownGoroutine(fallbackLoc)
-	}
-	current.Item.CurrentLoc = fallbackLoc
-	return current.Item
 }
 
 // syntheticGoroutine represents an unresolved stopped goroutine without

--- a/internal/debugger/goroutines.go
+++ b/internal/debugger/goroutines.go
@@ -446,76 +446,95 @@ func (e *engine) buildGoroutineListFrom(
 	ptr, length, liveSP, livePC, currentGptr uint64,
 ) goroutineWalkResult {
 	richLength := min(length, uint64(maxGoroutineScan))
+	rich, currentFound := e.readRichGoroutines(l, ptr, richLength, liveSP, livePC)
+	if !rich.Complete || len(rich.Items) == 0 {
+		return goroutineWalkResult{}
+	}
 
-	out := make([]protocol.Goroutine, 0, int(richLength)+1)
+	current := currentGoroutineResult{Complete: true}
+	if !currentFound {
+		current = e.resolveCurrentGoroutineAnchor(
+			l, ptr, richLength, length, liveSP, livePC, currentGptr,
+		)
+		if !current.Complete {
+			return goroutineWalkResult{}
+		}
+	}
+
+	anchorID := 0
+	if current.Found {
+		rich.Items = append(rich.Items, protocol.Goroutine{})
+		copy(rich.Items[1:], rich.Items)
+		rich.Items[0] = current.Item
+		anchorID = current.Item.ID
+	}
+	return goroutineWalkResult{
+		Items:    rich.Items,
+		Complete: true,
+		Clipped:  length > richLength,
+		AnchorID: anchorID,
+	}
+}
+
+func (e *engine) readRichGoroutines(
+	l *goLayout,
+	ptr, length, liveSP, livePC uint64,
+) (goroutineWalkResult, bool) {
+	out := make([]protocol.Goroutine, 0, int(length)+1)
 	currentFound := false
-	for i := uint64(0); i < richLength; i++ {
+	for i := uint64(0); i < length; i++ {
 		entryAddr, ok := allgsEntryAddress(ptr, i)
 		if !ok {
-			return goroutineWalkResult{}
+			return goroutineWalkResult{}, false
 		}
 		gptr, ok := e.readU64(entryAddr)
 		if !ok {
-			return goroutineWalkResult{}
+			return goroutineWalkResult{}, false
 		}
 		if gptr == 0 {
 			continue
 		}
 		result := e.readGoroutine(l, gptr, liveSP, livePC)
 		if !result.Complete {
-			return goroutineWalkResult{}
+			return goroutineWalkResult{}, false
 		}
 		if result.Include {
 			out = append(out, result.Item)
 			currentFound = currentFound || result.Item.Current
 		}
 	}
-	if len(out) == 0 {
-		return goroutineWalkResult{}
-	}
+	return goroutineWalkResult{Items: out, Complete: true}, currentFound
+}
 
-	current := currentGoroutineResult{Complete: true}
-	if !currentFound && currentGptr != 0 {
+func (e *engine) resolveCurrentGoroutineAnchor(
+	l *goLayout,
+	ptr, richLength, length, liveSP, livePC, currentGptr uint64,
+) currentGoroutineResult {
+	if currentGptr != 0 {
 		result := e.readGoroutine(l, currentGptr, liveSP, livePC)
 		if !result.Complete {
-			return goroutineWalkResult{}
+			return currentGoroutineResult{}
 		}
 		if result.Include && result.Item.Current {
-			current = currentGoroutineResult{
+			return currentGoroutineResult{
 				Item:     result.Item,
 				Found:    true,
 				Complete: true,
 			}
 		}
 	}
-	if !currentFound && !current.Found && liveSP != 0 {
-		current = e.findCurrentGoroutineFromThreads(l, liveSP, livePC)
-		if !current.Complete {
-			return goroutineWalkResult{}
-		}
+	if liveSP == 0 {
+		return currentGoroutineResult{Complete: true}
 	}
-	if !currentFound && !current.Found && liveSP != 0 && richLength < length {
-		fallbackEnd := min(length, richLength+uint64(maxGoroutineScan))
-		current = e.findCurrentGoroutine(
-			l, ptr, richLength, fallbackEnd, liveSP, livePC,
-		)
-		if !current.Complete {
-			return goroutineWalkResult{}
-		}
+	current := e.findCurrentGoroutineFromThreads(l, liveSP, livePC)
+	if !current.Complete || current.Found {
+		return current
 	}
-	anchorID := 0
-	if current.Found {
-		out = append(out, protocol.Goroutine{})
-		copy(out[1:], out)
-		out[0] = current.Item
-		anchorID = current.Item.ID
+	if richLength >= length {
+		return currentGoroutineResult{Complete: true}
 	}
-	return goroutineWalkResult{
-		Items:    out,
-		Complete: true,
-		Clipped:  length > richLength,
-		AnchorID: anchorID,
-	}
+	fallbackEnd := min(length, richLength+uint64(maxGoroutineScan))
+	return e.findCurrentGoroutine(l, ptr, richLength, fallbackEnd, liveSP, livePC)
 }
 
 // findCurrentGoroutine is the bounded fallback when the architecture-specific

--- a/internal/debugger/goroutines.go
+++ b/internal/debugger/goroutines.go
@@ -29,8 +29,8 @@ import (
 //     so it is prevented instead, by the read ordering in allgsMetadata.
 
 const (
-	// maxGoroutineScan bounds the runtime.allgs walk so a corrupt slice header
-	// or a pathological target can't make one snapshot read unboundedly.
+	// maxGoroutineScan bounds both the rich runtime.allgs prefix and the cheap
+	// fallback anchor scan so corrupt metadata can't make a snapshot unbounded.
 	maxGoroutineScan = 8192
 	// maxThreadScan bounds the runtime.allm linked-list walk likewise.
 	maxThreadScan = 2048
@@ -242,12 +242,19 @@ type goroutineWalkResult struct {
 	Items    []protocol.Goroutine
 	Complete bool
 	Clipped  bool
+	AnchorID int
 }
 
 type threadWalkResult struct {
 	Items    []protocol.Thread
 	Complete bool
 	Clipped  bool
+}
+
+type currentGoroutineResult struct {
+	Item     protocol.Goroutine
+	Found    bool
+	Complete bool
 }
 
 // readGoroutine reads one runtime.g at gptr. Include is false for intentional
@@ -299,7 +306,7 @@ func (e *engine) readGoroutine(l *goLayout, gptr, liveSP, livePC uint64) gorouti
 		}
 	}
 
-	current := liveSP != 0 && liveSP >= lo && liveSP < hi
+	current := stackContainsSP(lo, hi, liveSP)
 	g.Current = current
 
 	if mptr, ok := e.readU64(gptr + uint64(l.gM)); ok && mptr != 0 {
@@ -321,6 +328,16 @@ func (e *engine) readGoroutine(l *goLayout, gptr, liveSP, livePC uint64) gorouti
 		Include:  true,
 		Complete: true,
 	}
+}
+
+func (e *engine) readGoroutineStackBounds(l *goLayout, gptr uint64) (lo, hi uint64, ok bool) {
+	lo, okLo := e.readU64(gptr + uint64(l.gStack) + uint64(l.stackLo))
+	hi, okHi := e.readU64(gptr + uint64(l.gStack) + uint64(l.stackHi))
+	return lo, hi, okLo && okHi
+}
+
+func stackContainsSP(lo, hi, sp uint64) bool {
+	return sp != 0 && sp >= lo && sp < hi
 }
 
 func (e *engine) readI64(addr uint64) (int64, bool) {
@@ -398,11 +415,21 @@ func (e *engine) allgsMetadata() (ptr, length uint64, ok bool) {
 	return ptr, length, true
 }
 
+func allgsEntryAddress(ptr, index uint64) (uint64, bool) {
+	const pointerSize = uint64(8)
+	if index > (^uint64(0)-ptr)/pointerSize {
+		return 0, false
+	}
+	return ptr + index*pointerSize, true
+}
+
 // buildGoroutineList enumerates runtime.allgs. Complete is false when the
-// runtime can't be read (no DWARF, bad layout, unreadable membership data, or
-// no live goroutines yet). Clipped is independent: the walk reached its safety
-// ceiling but every visited entry was readable.
-func (e *engine) buildGoroutineList(liveSP, livePC uint64) goroutineWalkResult {
+// runtime can't be read (no DWARF, bad layout, unreadable membership or
+// current-identity data, or no live goroutines yet). Clipped is independent:
+// the rich walk reached its safety ceiling but every visited entry was readable.
+func (e *engine) buildGoroutineList(
+	liveSP, livePC, currentGptr uint64,
+) goroutineWalkResult {
 	l, ok := e.getGoLayout()
 	if !ok {
 		return goroutineWalkResult{}
@@ -411,14 +438,23 @@ func (e *engine) buildGoroutineList(liveSP, livePC uint64) goroutineWalkResult {
 	if !ok || ptr == 0 || length == 0 {
 		return goroutineWalkResult{}
 	}
-	clipped := length > maxGoroutineScan
-	if length > maxGoroutineScan {
-		length = maxGoroutineScan
-	}
+	return e.buildGoroutineListFrom(l, ptr, length, liveSP, livePC, currentGptr)
+}
 
-	out := make([]protocol.Goroutine, 0, length)
-	for i := uint64(0); i < length; i++ {
-		gptr, ok := e.readU64(ptr + i*8)
+func (e *engine) buildGoroutineListFrom(
+	l *goLayout,
+	ptr, length, liveSP, livePC, currentGptr uint64,
+) goroutineWalkResult {
+	richLength := min(length, uint64(maxGoroutineScan))
+
+	out := make([]protocol.Goroutine, 0, int(richLength)+1)
+	currentFound := false
+	for i := uint64(0); i < richLength; i++ {
+		entryAddr, ok := allgsEntryAddress(ptr, i)
+		if !ok {
+			return goroutineWalkResult{}
+		}
+		gptr, ok := e.readU64(entryAddr)
 		if !ok {
 			return goroutineWalkResult{}
 		}
@@ -431,16 +467,172 @@ func (e *engine) buildGoroutineList(liveSP, livePC uint64) goroutineWalkResult {
 		}
 		if result.Include {
 			out = append(out, result.Item)
+			currentFound = currentFound || result.Item.Current
 		}
 	}
 	if len(out) == 0 {
 		return goroutineWalkResult{}
 	}
+
+	current := currentGoroutineResult{Complete: true}
+	if !currentFound && currentGptr != 0 {
+		result := e.readGoroutine(l, currentGptr, liveSP, livePC)
+		if !result.Complete {
+			return goroutineWalkResult{}
+		}
+		if result.Include && result.Item.Current {
+			current = currentGoroutineResult{
+				Item:     result.Item,
+				Found:    true,
+				Complete: true,
+			}
+		}
+	}
+	if !currentFound && !current.Found && liveSP != 0 {
+		current = e.findCurrentGoroutineFromThreads(l, liveSP, livePC)
+		if !current.Complete {
+			return goroutineWalkResult{}
+		}
+	}
+	if !currentFound && !current.Found && liveSP != 0 && richLength < length {
+		fallbackEnd := min(length, richLength+uint64(maxGoroutineScan))
+		current = e.findCurrentGoroutine(
+			l, ptr, richLength, fallbackEnd, liveSP, livePC,
+		)
+		if !current.Complete {
+			return goroutineWalkResult{}
+		}
+	}
+	anchorID := 0
+	if current.Found {
+		out = append(out, protocol.Goroutine{})
+		copy(out[1:], out)
+		out[0] = current.Item
+		anchorID = current.Item.ID
+	}
 	return goroutineWalkResult{
 		Items:    out,
 		Complete: true,
-		Clipped:  clipped,
+		Clipped:  length > richLength,
+		AnchorID: anchorID,
 	}
+}
+
+// findCurrentGoroutine is the bounded fallback when the architecture-specific
+// current-g pointer is unavailable. It reads only each pointer and stack bounds
+// until SP containment identifies the anchor, then pays the full decode cost
+// once. An unreadable pointer ends the pass because allgs is contiguous.
+func (e *engine) findCurrentGoroutine(
+	l *goLayout,
+	ptr, start, length, liveSP, livePC uint64,
+) currentGoroutineResult {
+	for i := start; i < length; i++ {
+		entryAddr, ok := allgsEntryAddress(ptr, i)
+		if !ok {
+			return currentGoroutineResult{}
+		}
+		gptr, ok := e.readU64(entryAddr)
+		if !ok {
+			return currentGoroutineResult{}
+		}
+		if gptr == 0 {
+			continue
+		}
+		lo, hi, ok := e.readGoroutineStackBounds(l, gptr)
+		if !ok {
+			return currentGoroutineResult{}
+		}
+		if !stackContainsSP(lo, hi, liveSP) {
+			continue
+		}
+		result := e.readGoroutine(l, gptr, liveSP, livePC)
+		if !result.Complete {
+			return currentGoroutineResult{}
+		}
+		if result.Include && result.Item.Current {
+			return currentGoroutineResult{
+				Item:     result.Item,
+				Found:    true,
+				Complete: true,
+			}
+		}
+		return currentGoroutineResult{Complete: true}
+	}
+	return currentGoroutineResult{Complete: true}
+}
+
+// findCurrentGoroutineFromThreads resolves the running g through runtime.allm.
+// Unlike linux FS-relative TLS, m.curg is stable across internal and external
+// linking. SP containment still decides whether the candidate is authoritative.
+func (e *engine) findCurrentGoroutineFromThreads(
+	l *goLayout,
+	liveSP, livePC uint64,
+) currentGoroutineResult {
+	if e.dw == nil {
+		return currentGoroutineResult{Complete: true}
+	}
+	base, ok := e.dw.runtimeVarAddr("runtime.allm")
+	if !ok {
+		return currentGoroutineResult{Complete: true}
+	}
+	mptr, ok := e.readU64(base)
+	if !ok {
+		return currentGoroutineResult{}
+	}
+	if mptr == 0 {
+		return currentGoroutineResult{Complete: true}
+	}
+	return e.findCurrentGoroutineInThreadList(l, mptr, liveSP, livePC)
+}
+
+func (e *engine) findCurrentGoroutineInThreadList(
+	l *goLayout,
+	mptr, liveSP, livePC uint64,
+) currentGoroutineResult {
+	for i := 0; i < maxThreadScan && mptr != 0; i++ {
+		curg, ok := e.readU64(mptr + uint64(l.mCurg))
+		if !ok {
+			return currentGoroutineResult{}
+		}
+		if curg != 0 {
+			lo, hi, ok := e.readGoroutineStackBounds(l, curg)
+			if !ok {
+				return currentGoroutineResult{}
+			}
+			if stackContainsSP(lo, hi, liveSP) {
+				result := e.readGoroutine(l, curg, liveSP, livePC)
+				if !result.Complete {
+					return currentGoroutineResult{}
+				}
+				if result.Include && result.Item.Current {
+					return currentGoroutineResult{
+						Item:     result.Item,
+						Found:    true,
+						Complete: true,
+					}
+				}
+				return currentGoroutineResult{Complete: true}
+			}
+		}
+		next, ok := e.readU64(mptr + uint64(l.mAlllink))
+		if !ok {
+			return currentGoroutineResult{}
+		}
+		mptr = next
+	}
+	return currentGoroutineResult{Complete: true}
+}
+
+func (e *engine) allmHead() (uint64, bool) {
+	if e.dw == nil {
+		return 0, false
+	}
+	base, ok := e.dw.runtimeVarAddr("runtime.allm")
+	if !ok {
+		return 0, false
+	}
+	mptr, ok := e.readU64(base)
+	return mptr, ok && mptr != 0
 }
 
 // readThreads walks runtime.allm and reports every OS thread (M). currentGoid
@@ -454,11 +646,7 @@ func (e *engine) readThreads(currentGoid int, livePC uint64) threadWalkResult {
 	if !ok {
 		return threadWalkResult{}
 	}
-	base, ok := e.dw.runtimeVarAddr("runtime.allm")
-	if !ok {
-		return threadWalkResult{}
-	}
-	mptr, ok := e.readU64(base) // runtime.allm is a *m; read the head pointer
+	mptr, ok := e.allmHead()
 	if !ok {
 		return threadWalkResult{}
 	}
@@ -502,18 +690,20 @@ func (e *engine) readThreads(currentGoid int, livePC uint64) threadWalkResult {
 	}
 }
 
-// liveRegisters reads the currently-stopped thread's SP and PC (used to locate
-// the current goroutine and to give it a live location). Zeroes on failure.
-func (e *engine) liveRegisters() (sp, pc uint64) {
+// liveRegisters reads the currently-stopped thread's SP, PC, and Go ABI
+// current-g pointer. The pointer is only a candidate: readGoroutine validates it
+// against SP containment before it can become the snapshot anchor.
+func (e *engine) liveRegisters() (sp, pc, currentGptr uint64) {
 	tid, err := e.activeTID()
 	if err != nil {
-		return 0, 0
+		return 0, 0, 0
 	}
 	regs, err := e.backend.GetRegisters(tid)
 	if err != nil {
-		return 0, 0
+		return 0, 0, 0
 	}
-	return regs.SP, regs.PC
+	currentGptr, _ = e.archCurrentGoroutinePointer(regs)
+	return regs.SP, regs.PC, currentGptr
 }
 
 // syntheticGoroutine is the legacy fallback: a single goroutine standing in for
@@ -542,8 +732,8 @@ func (e *engine) degradedSnapshot(livePC uint64) protocol.GoroutineSnapshotPaylo
 // synthetic goroutine when the runtime can't be read. This backs the on-demand
 // Goroutines() query and the DAP threads list.
 func (e *engine) readGoroutines() ([]protocol.Goroutine, error) {
-	sp, pc := e.liveRegisters()
-	result := e.buildGoroutineList(sp, pc)
+	sp, pc, currentGptr := e.liveRegisters()
+	result := e.buildGoroutineList(sp, pc, currentGptr)
 	if result.Complete {
 		return result.Items, nil
 	}
@@ -569,9 +759,9 @@ func (e *engine) goroutineSnapshotQuery() protocol.GoroutineSnapshotPayload {
 }
 
 func (e *engine) buildSnapshot(trackLifecycle bool) protocol.GoroutineSnapshotPayload {
-	sp, pc := e.liveRegisters()
+	sp, pc, currentGptr := e.liveRegisters()
 
-	goroutines := e.buildGoroutineList(sp, pc)
+	goroutines := e.buildGoroutineList(sp, pc, currentGptr)
 	if !goroutines.Complete {
 		// Degraded snapshot: still report where we're stopped, but don't touch
 		// the remembered live set — an empty read (e.g. at the entry stop before
@@ -579,7 +769,7 @@ func (e *engine) buildSnapshot(trackLifecycle bool) protocol.GoroutineSnapshotPa
 		return e.degradedSnapshot(pc)
 	}
 
-	current, live := snapshotGoroutineState(goroutines.Items)
+	live, current := snapshotGoroutineIDs(goroutines.Items, goroutines.AnchorID)
 	threads := e.readThreads(current, pc)
 	if !threads.Complete {
 		return e.degradedSnapshot(pc)
@@ -608,22 +798,30 @@ func (e *engine) snapshotFrom(
 	return snap
 }
 
-func snapshotGoroutineState(gs []protocol.Goroutine) (int, map[int]struct{}) {
-	var current int
-	live := make(map[int]struct{}, len(gs))
+// snapshotGoroutineIDs keeps lifecycle deltas tied to the stable rich prefix.
+// A beyond-cap current anchor is present for stop identity but excluded from the
+// baseline; otherwise switching between live tail goroutines would fabricate
+// created/exited deltas for goroutines that merely fell outside the next scan.
+func snapshotGoroutineIDs(
+	gs []protocol.Goroutine,
+	anchorID int,
+) (live map[int]struct{}, current int) {
+	live = make(map[int]struct{}, len(gs))
 	for _, g := range gs {
-		live[g.ID] = struct{}{}
+		if g.ID != anchorID {
+			live[g.ID] = struct{}{}
+		}
 		if g.Current {
 			current = g.ID
 		}
 	}
-	return current, live
+	return live, current
 }
 
 // diffGoids compares the current live goid set against the previous automatic
-// snapshot's and returns the created (new) and exited (gone) goids, then adopts
-// the new set. Returns nil slices on the first snapshot so a fresh session
-// doesn't report every existing goroutine as "created". Only reached from the
+// and returns the created (new) and exited (gone) goids, then adopts the new
+// set. Returns nil slices on the first snapshot so a fresh session doesn't
+// report every existing goroutine as "created". Only reached from the
 // automatic stop path — see goroutineSnapshotQuery.
 func (e *engine) diffGoids(live map[int]struct{}) (created, exited []int) {
 	if e.prevGoids != nil {

--- a/internal/debugger/goroutines.go
+++ b/internal/debugger/goroutines.go
@@ -21,7 +21,7 @@ import (
 // and they need two distinct defences:
 //
 //   - A required read FAILS or an entry is retired mid-walk. Handled by
-//     degrading: an incomplete walk falls back to the legacy single-synthetic
+//     degrading: an incomplete walk falls back to a synthetic unknown
 //     goroutine rather than being mistaken for a lifecycle change.
 //   - Every read SUCCEEDS but the values are mutually inconsistent, because
 //     they were taken from different generations of a table that was
@@ -34,6 +34,9 @@ const (
 	maxGoroutineScan = 8192
 	// maxThreadScan bounds the runtime.allm linked-list walk likewise.
 	maxThreadScan = 2048
+	// maxCurrentThreadScan bounds the targeted continuation past the rich allm
+	// prefix. It reads only enough fields to find the stopped M or current g.
+	maxCurrentThreadScan = 2048
 	// maxGoStringLen caps a wait-reason string read from tracee memory.
 	maxGoStringLen = 256
 
@@ -62,11 +65,15 @@ type goLayout struct {
 
 	bufPC int64 // gobuf.pc, relative to gSched
 
-	mProcid   int64
-	mCurg     int64
-	mID       int64
-	mAlllink  int64
-	mSpinning int64
+	mProcid    int64
+	mG0        int64
+	mG0OK      bool
+	mGsignal   int64
+	mGsignalOK bool
+	mCurg      int64
+	mID        int64
+	mAlllink   int64
+	mSpinning  int64
 
 	// waitReasonStrings array, for turning g.waitreason into a human string.
 	wrBase   uint64
@@ -103,6 +110,8 @@ func resolveGoLayout(dw *dwarfReader) goLayout {
 	l.bufPC = req("runtime.gobuf", "pc")
 
 	l.mProcid = req("runtime.m", "procid")
+	l.mG0, l.mG0OK = dw.structMemberOffset("runtime.m", "g0")
+	l.mGsignal, l.mGsignalOK = dw.structMemberOffset("runtime.m", "gsignal")
 	l.mCurg = req("runtime.m", "curg")
 	l.mID = req("runtime.m", "id")
 	l.mAlllink = req("runtime.m", "alllink")
@@ -429,6 +438,7 @@ func allgsEntryAddress(ptr, index uint64) (uint64, bool) {
 // the rich walk reached its safety ceiling but every visited entry was readable.
 func (e *engine) buildGoroutineList(
 	liveSP, livePC, currentGptr uint64,
+	stopTID int,
 ) goroutineWalkResult {
 	l, ok := e.getGoLayout()
 	if !ok {
@@ -438,12 +448,13 @@ func (e *engine) buildGoroutineList(
 	if !ok || ptr == 0 || length == 0 {
 		return goroutineWalkResult{}
 	}
-	return e.buildGoroutineListFrom(l, ptr, length, liveSP, livePC, currentGptr)
+	return e.buildGoroutineListFrom(l, ptr, length, liveSP, livePC, currentGptr, stopTID)
 }
 
 func (e *engine) buildGoroutineListFrom(
 	l *goLayout,
 	ptr, length, liveSP, livePC, currentGptr uint64,
+	stopTID int,
 ) goroutineWalkResult {
 	richLength := min(length, uint64(maxGoroutineScan))
 	rich, currentFound := e.readRichGoroutines(l, ptr, richLength, liveSP, livePC)
@@ -454,7 +465,7 @@ func (e *engine) buildGoroutineListFrom(
 	current := currentGoroutineResult{Complete: true}
 	if !currentFound {
 		current = e.resolveCurrentGoroutineAnchor(
-			l, ptr, richLength, length, liveSP, livePC, currentGptr,
+			l, ptr, richLength, length, liveSP, livePC, currentGptr, stopTID,
 		)
 		if !current.Complete {
 			return goroutineWalkResult{}
@@ -463,10 +474,7 @@ func (e *engine) buildGoroutineListFrom(
 
 	anchorID := 0
 	if current.Found {
-		rich.Items = append(rich.Items, protocol.Goroutine{})
-		copy(rich.Items[1:], rich.Items)
-		rich.Items[0] = current.Item
-		anchorID = current.Item.ID
+		rich.Items, anchorID = installCurrentGoroutine(rich.Items, current.Item)
 	}
 	return goroutineWalkResult{
 		Items:    rich.Items,
@@ -474,6 +482,22 @@ func (e *engine) buildGoroutineListFrom(
 		Clipped:  length > richLength,
 		AnchorID: anchorID,
 	}
+}
+
+func installCurrentGoroutine(
+	gs []protocol.Goroutine,
+	current protocol.Goroutine,
+) ([]protocol.Goroutine, int) {
+	for i := range gs {
+		if gs[i].ID == current.ID {
+			gs[i] = current
+			return gs, 0
+		}
+	}
+	gs = append(gs, protocol.Goroutine{})
+	copy(gs[1:], gs)
+	gs[0] = current
+	return gs, current.ID
 }
 
 func (e *engine) readRichGoroutines(
@@ -509,9 +533,40 @@ func (e *engine) readRichGoroutines(
 func (e *engine) resolveCurrentGoroutineAnchor(
 	l *goLayout,
 	ptr, richLength, length, liveSP, livePC, currentGptr uint64,
+	stopTID int,
 ) currentGoroutineResult {
 	if currentGptr != 0 {
-		result := e.readGoroutine(l, currentGptr, liveSP, livePC)
+		current := e.currentGoroutineFromRegister(l, currentGptr, liveSP, livePC)
+		if !current.Complete || current.Found {
+			return current
+		}
+	}
+	if procid, ok := e.archRuntimeMProcID(stopTID); ok {
+		current := e.findCurrentGoroutineByProcID(l, procid, livePC)
+		if !current.Complete || current.Found {
+			return current
+		}
+	}
+	if liveSP == 0 {
+		return currentGoroutineResult{Complete: true}
+	}
+	if richLength >= length {
+		return currentGoroutineResult{Complete: true}
+	}
+	fallbackEnd := min(length, richLength+uint64(maxGoroutineScan))
+	return e.findCurrentGoroutine(l, ptr, richLength, fallbackEnd, liveSP, livePC)
+}
+
+func (e *engine) currentGoroutineFromRegister(
+	l *goLayout,
+	gptr, liveSP, livePC uint64,
+) currentGoroutineResult {
+	goid, ok := e.readI64(gptr + uint64(l.gGoid))
+	if !ok {
+		return currentGoroutineResult{}
+	}
+	if goid > 0 {
+		result := e.readGoroutine(l, gptr, liveSP, livePC)
 		if !result.Complete {
 			return currentGoroutineResult{}
 		}
@@ -522,19 +577,83 @@ func (e *engine) resolveCurrentGoroutineAnchor(
 				Complete: true,
 			}
 		}
-	}
-	if liveSP == 0 {
 		return currentGoroutineResult{Complete: true}
 	}
-	current := e.findCurrentGoroutineFromThreads(l, liveSP, livePC)
-	if !current.Complete || current.Found {
-		return current
-	}
-	if richLength >= length {
+	if goid != 0 {
 		return currentGoroutineResult{Complete: true}
 	}
-	fallbackEnd := min(length, richLength+uint64(maxGoroutineScan))
-	return e.findCurrentGoroutine(l, ptr, richLength, fallbackEnd, liveSP, livePC)
+	mptr, ok := e.readU64(gptr + uint64(l.gM))
+	if !ok {
+		return currentGoroutineResult{}
+	}
+	if mptr == 0 {
+		return currentGoroutineResult{Complete: true}
+	}
+	schedulerG, complete := e.isSchedulerG(l, mptr, gptr)
+	if !complete {
+		return currentGoroutineResult{}
+	}
+	if !schedulerG {
+		return currentGoroutineResult{Complete: true}
+	}
+	return e.readCurrentGoroutineFromM(l, mptr, livePC)
+}
+
+func (e *engine) isSchedulerG(l *goLayout, mptr, gptr uint64) (bool, bool) {
+	if l.mG0OK {
+		g0, ok := e.readU64(mptr + uint64(l.mG0))
+		if !ok {
+			return false, false
+		}
+		if g0 == gptr {
+			return true, true
+		}
+	}
+	if l.mGsignalOK {
+		gsignal, ok := e.readU64(mptr + uint64(l.mGsignal))
+		if !ok {
+			return false, false
+		}
+		if gsignal == gptr {
+			return true, true
+		}
+	}
+	return false, true
+}
+
+func (e *engine) readCurrentGoroutineFromM(
+	l *goLayout,
+	mptr, livePC uint64,
+) currentGoroutineResult {
+	gptr, ok := e.readU64(mptr + uint64(l.mCurg))
+	if !ok {
+		return currentGoroutineResult{}
+	}
+	if gptr == 0 {
+		return currentGoroutineResult{Complete: true}
+	}
+	owner, ok := e.readU64(gptr + uint64(l.gM))
+	if !ok {
+		return currentGoroutineResult{}
+	}
+	if owner != mptr {
+		return currentGoroutineResult{Complete: true}
+	}
+	result := e.readGoroutine(l, gptr, 0, 0)
+	if !result.Complete {
+		return currentGoroutineResult{}
+	}
+	if !result.Include {
+		return currentGoroutineResult{Complete: true}
+	}
+	current := result.Item
+	current.Current = true
+	current.CurrentLoc = e.locForPC(livePC)
+	return currentGoroutineResult{
+		Item:     current,
+		Found:    true,
+		Complete: true,
+	}
 }
 
 // findCurrentGoroutine is the bounded fallback when the architecture-specific
@@ -580,12 +699,12 @@ func (e *engine) findCurrentGoroutine(
 	return currentGoroutineResult{Complete: true}
 }
 
-// findCurrentGoroutineFromThreads resolves the running g through runtime.allm.
-// Unlike linux FS-relative TLS, m.curg is stable across internal and external
-// linking. SP containment still decides whether the candidate is authoritative.
-func (e *engine) findCurrentGoroutineFromThreads(
+// findCurrentGoroutineByProcID resolves the stopped Linux M exactly, then uses
+// m.curg even when the stop occurred on g0 and SP is outside the user g's stack.
+// The second window is targeted-only so the rich thread list remains capped.
+func (e *engine) findCurrentGoroutineByProcID(
 	l *goLayout,
-	liveSP, livePC uint64,
+	procid, livePC uint64,
 ) currentGoroutineResult {
 	if e.dw == nil {
 		return currentGoroutineResult{Complete: true}
@@ -601,45 +720,49 @@ func (e *engine) findCurrentGoroutineFromThreads(
 	if mptr == 0 {
 		return currentGoroutineResult{Complete: true}
 	}
-	return e.findCurrentGoroutineInThreadList(l, mptr, liveSP, livePC)
+	return e.findCurrentGoroutineByProcIDFrom(l, mptr, procid, livePC)
 }
 
-func (e *engine) findCurrentGoroutineInThreadList(
+func (e *engine) findCurrentGoroutineByProcIDFrom(
 	l *goLayout,
-	mptr, liveSP, livePC uint64,
+	mptr, procid, livePC uint64,
 ) currentGoroutineResult {
-	for i := 0; i < maxThreadScan && mptr != 0; i++ {
-		curg, ok := e.readU64(mptr + uint64(l.mCurg))
-		if !ok {
+	match, next, complete := e.findMByProcID(l, mptr, procid, maxThreadScan)
+	if !complete {
+		return currentGoroutineResult{}
+	}
+	if match == 0 && next != 0 {
+		match, _, complete = e.findMByProcID(l, next, procid, maxCurrentThreadScan)
+		if !complete {
 			return currentGoroutineResult{}
 		}
-		if curg != 0 {
-			lo, hi, ok := e.readGoroutineStackBounds(l, curg)
-			if !ok {
-				return currentGoroutineResult{}
-			}
-			if stackContainsSP(lo, hi, liveSP) {
-				result := e.readGoroutine(l, curg, liveSP, livePC)
-				if !result.Complete {
-					return currentGoroutineResult{}
-				}
-				if result.Include && result.Item.Current {
-					return currentGoroutineResult{
-						Item:     result.Item,
-						Found:    true,
-						Complete: true,
-					}
-				}
-				return currentGoroutineResult{Complete: true}
-			}
+	}
+	if match == 0 {
+		return currentGoroutineResult{Complete: true}
+	}
+	return e.readCurrentGoroutineFromM(l, match, livePC)
+}
+
+func (e *engine) findMByProcID(
+	l *goLayout,
+	mptr, procid uint64,
+	limit int,
+) (match, next uint64, complete bool) {
+	for i := 0; i < limit && mptr != 0; i++ {
+		candidate, ok := e.readU64(mptr + uint64(l.mProcid))
+		if !ok {
+			return 0, 0, false
+		}
+		if candidate == procid {
+			return mptr, 0, true
 		}
 		next, ok := e.readU64(mptr + uint64(l.mAlllink))
 		if !ok {
-			return currentGoroutineResult{}
+			return 0, 0, false
 		}
 		mptr = next
 	}
-	return currentGoroutineResult{Complete: true}
+	return 0, mptr, true
 }
 
 func (e *engine) allmHead() (uint64, bool) {
@@ -669,31 +792,21 @@ func (e *engine) readThreads(currentGoid int, livePC uint64) threadWalkResult {
 	if !ok {
 		return threadWalkResult{}
 	}
+	return e.readThreadsFrom(l, mptr, currentGoid, livePC)
+}
 
-	var out []protocol.Thread
+func (e *engine) readThreadsFrom(
+	l *goLayout,
+	mptr uint64,
+	currentGoid int,
+	livePC uint64,
+) threadWalkResult {
+	out := make([]protocol.Thread, 0, maxThreadScan+1)
+	currentFound := false
 	i := 0
 	for ; i < maxThreadScan && mptr != 0; i++ {
-		t := protocol.Thread{}
-		if procid, ok := e.readU64(mptr + uint64(l.mProcid)); ok {
-			t.ID = int(procid)
-		}
-		if id, ok := e.readI64(mptr + uint64(l.mID)); ok {
-			t.MID = int(id)
-		}
-		if sp, ok := e.readU8(mptr + uint64(l.mSpinning)); ok {
-			t.Spinning = sp != 0
-		}
-		if curg, ok := e.readU64(mptr + uint64(l.mCurg)); ok && curg != 0 {
-			if goid, ok := e.readI64(curg + uint64(l.gGoid)); ok && goid > 0 {
-				t.GoID = int(goid)
-				if int(goid) == currentGoid {
-					t.Current = true
-					t.CurrentLoc = e.locForPC(livePC)
-				} else if schedPC, ok := e.readU64(curg + uint64(l.gSched) + uint64(l.bufPC)); ok {
-					t.CurrentLoc = e.locForPC(schedPC)
-				}
-			}
-		}
+		t := e.readThread(l, mptr, currentGoid, livePC)
+		currentFound = currentFound || t.Current
 		out = append(out, t)
 
 		next, ok := e.readU64(mptr + uint64(l.mAlllink))
@@ -702,40 +815,114 @@ func (e *engine) readThreads(currentGoid int, livePC uint64) threadWalkResult {
 		}
 		mptr = next
 	}
+	clipped := i == maxThreadScan && mptr != 0
+	if currentGoid > 0 && !currentFound && mptr != 0 {
+		currentM, complete := e.findMByCurrentGoid(l, mptr, currentGoid, maxCurrentThreadScan)
+		if !complete {
+			return threadWalkResult{}
+		}
+		if currentM != 0 {
+			current := e.readThread(l, currentM, currentGoid, livePC)
+			if !current.Current {
+				return threadWalkResult{}
+			}
+			out = append(out, current)
+		}
+	}
 	return threadWalkResult{
 		Items:    out,
 		Complete: true,
-		Clipped:  i == maxThreadScan && mptr != 0,
+		Clipped:  clipped,
 	}
 }
 
-// liveRegisters reads the currently-stopped thread's SP, PC, and Go ABI
+func (e *engine) readThread(
+	l *goLayout,
+	mptr uint64,
+	currentGoid int,
+	livePC uint64,
+) protocol.Thread {
+	t := protocol.Thread{}
+	if procid, ok := e.readU64(mptr + uint64(l.mProcid)); ok {
+		t.ID = int(procid)
+	}
+	if id, ok := e.readI64(mptr + uint64(l.mID)); ok {
+		t.MID = int(id)
+	}
+	if sp, ok := e.readU8(mptr + uint64(l.mSpinning)); ok {
+		t.Spinning = sp != 0
+	}
+	if curg, ok := e.readU64(mptr + uint64(l.mCurg)); ok && curg != 0 {
+		if goid, ok := e.readI64(curg + uint64(l.gGoid)); ok && goid > 0 {
+			t.GoID = int(goid)
+			if int(goid) == currentGoid {
+				t.Current = true
+				t.CurrentLoc = e.locForPC(livePC)
+			} else if schedPC, ok := e.readU64(curg + uint64(l.gSched) + uint64(l.bufPC)); ok {
+				t.CurrentLoc = e.locForPC(schedPC)
+			}
+		}
+	}
+	return t
+}
+
+func (e *engine) findMByCurrentGoid(
+	l *goLayout,
+	mptr uint64,
+	currentGoid, limit int,
+) (uint64, bool) {
+	for i := 0; i < limit && mptr != 0; i++ {
+		curg, ok := e.readU64(mptr + uint64(l.mCurg))
+		if !ok {
+			return 0, false
+		}
+		if curg != 0 {
+			goid, ok := e.readI64(curg + uint64(l.gGoid))
+			if !ok {
+				return 0, false
+			}
+			if int(goid) == currentGoid {
+				return mptr, true
+			}
+		}
+		next, ok := e.readU64(mptr + uint64(l.mAlllink))
+		if !ok {
+			return 0, false
+		}
+		mptr = next
+	}
+	return 0, true
+}
+
+// liveRegisters reads the currently-stopped thread's TID, SP, PC, and Go ABI
 // current-g pointer. The pointer is only a candidate: readGoroutine validates it
-// against SP containment before it can become the snapshot anchor.
-func (e *engine) liveRegisters() (sp, pc, currentGptr uint64) {
+// against SP containment or resolves its M's curg before it becomes the anchor.
+// TID survives a register-read failure so Linux can still resolve m.curg.
+func (e *engine) liveRegisters() (tid int, sp, pc, currentGptr uint64) {
 	tid, err := e.activeTID()
 	if err != nil {
-		return 0, 0, 0
+		return 0, 0, 0, 0
 	}
 	regs, err := e.backend.GetRegisters(tid)
 	if err != nil {
-		return 0, 0, 0
+		return tid, 0, 0, 0
 	}
 	currentGptr, _ = e.archCurrentGoroutinePointer(regs)
-	return regs.SP, regs.PC, currentGptr
+	return tid, regs.SP, regs.PC, currentGptr
 }
 
-// syntheticGoroutine is the legacy fallback: a single goroutine standing in for
-// the stopped thread's location when the runtime can't be introspected. It
-// preserves behavior for stripped binaries, attach-without-DWARF, and the
-// pre-runtime-init entry stop (and keeps the fakeBackend unit tests green).
-func (e *engine) syntheticGoroutine(livePC uint64) protocol.Goroutine {
+func unknownGoroutine(loc protocol.Location) protocol.Goroutine {
 	return protocol.Goroutine{
-		ID:         1,
-		Status:     "waiting",
-		CurrentLoc: e.locForPC(livePC),
+		Status:     "unknown",
+		CurrentLoc: loc,
 		Current:    true,
 	}
+}
+
+// syntheticGoroutine represents an unresolved stopped goroutine without
+// borrowing a real goid. DAP may assign its own transport-only thread handle.
+func (e *engine) syntheticGoroutine(livePC uint64) protocol.Goroutine {
+	return unknownGoroutine(e.locForPC(livePC))
 }
 
 // degradedSnapshot is the single construction point for an incomplete runtime
@@ -751,8 +938,8 @@ func (e *engine) degradedSnapshot(livePC uint64) protocol.GoroutineSnapshotPaylo
 // synthetic goroutine when the runtime can't be read. This backs the on-demand
 // Goroutines() query and the DAP threads list.
 func (e *engine) readGoroutines() ([]protocol.Goroutine, error) {
-	sp, pc, currentGptr := e.liveRegisters()
-	result := e.buildGoroutineList(sp, pc, currentGptr)
+	tid, sp, pc, currentGptr := e.liveRegisters()
+	result := e.buildGoroutineList(sp, pc, currentGptr, tid)
 	if result.Complete {
 		return result.Items, nil
 	}
@@ -778,9 +965,9 @@ func (e *engine) goroutineSnapshotQuery() protocol.GoroutineSnapshotPayload {
 }
 
 func (e *engine) buildSnapshot(trackLifecycle bool) protocol.GoroutineSnapshotPayload {
-	sp, pc, currentGptr := e.liveRegisters()
+	tid, sp, pc, currentGptr := e.liveRegisters()
 
-	goroutines := e.buildGoroutineList(sp, pc, currentGptr)
+	goroutines := e.buildGoroutineList(sp, pc, currentGptr, tid)
 	if !goroutines.Complete {
 		// Degraded snapshot: still report where we're stopped, but don't touch
 		// the remembered live set — an empty read (e.g. at the entry stop before
@@ -862,14 +1049,25 @@ func (e *engine) diffGoids(live map[int]struct{}) (created, exited []int) {
 }
 
 // currentGoroutineFrom returns the goroutine marked Current in a snapshot, used
-// as the single Goroutine embedded in a stop event. Unknown is safer than
-// attributing the stop to the first unrelated goroutine when a capped scan has
-// not yet found the stopped goroutine.
-func currentGoroutineFrom(snap protocol.GoroutineSnapshotPayload) protocol.Goroutine {
+// as the single Goroutine embedded in a stop event. An unresolved snapshot must
+// never substitute another real goroutine merely because it appears first.
+func currentGoroutineFrom(
+	snap protocol.GoroutineSnapshotPayload,
+	fallbackLoc protocol.Location,
+) protocol.Goroutine {
 	for _, g := range snap.Goroutines {
 		if g.Current {
+			if g.ID == 0 {
+				if fallbackLoc == (protocol.Location{}) {
+					fallbackLoc = g.CurrentLoc
+				}
+				return unknownGoroutine(fallbackLoc)
+			}
+			if fallbackLoc != (protocol.Location{}) {
+				g.CurrentLoc = fallbackLoc
+			}
 			return g
 		}
 	}
-	return protocol.Goroutine{}
+	return unknownGoroutine(fallbackLoc)
 }

--- a/internal/debugger/goroutines.go
+++ b/internal/debugger/goroutines.go
@@ -266,22 +266,28 @@ type currentGoroutineResult struct {
 	Complete bool
 }
 
+type goroutineHeader struct {
+	goid   int64
+	status uint32
+}
+
+type currentGoroutineDetail uint8
+
+const (
+	currentGoroutineRich currentGoroutineDetail = iota
+	currentGoroutineIdentity
+)
+
 // readGoroutine reads one runtime.g at gptr. Include is false for intentional
 // freelist/dead entries; Complete is false only when membership or current-
 // identity data is unreadable. liveSP/livePC identify the currently-stopped
 // thread so the goroutine running there is marked Current and gets its live PC.
 func (e *engine) readGoroutine(l *goLayout, gptr, liveSP, livePC uint64) goroutineReadResult {
-	rawStatus, ok := e.readU32(gptr + uint64(l.gAtomicstatus))
+	header, ok := e.readGoroutineHeader(l, gptr)
 	if !ok {
 		return goroutineReadResult{}
 	}
-	status := rawStatus &^ gScanBit
-
-	goid, ok := e.readI64(gptr + uint64(l.gGoid))
-	if !ok {
-		return goroutineReadResult{}
-	}
-	if goid <= 0 || status == gStatusDead {
+	if !header.included() {
 		// Freelist / dead slots carry goid 0 or a stale id; a UI wants only the
 		// live set. Their departure is reported via the exited delta.
 		return goroutineReadResult{Complete: true}
@@ -297,8 +303,8 @@ func (e *engine) readGoroutine(l *goLayout, gptr, liveSP, livePC uint64) gorouti
 	}
 
 	g := protocol.Goroutine{
-		ID:     int(goid),
-		Status: goStatusString(status),
+		ID:     int(header.goid),
+		Status: goStatusString(header.status),
 	}
 	if parent, ok := e.readI64(gptr + uint64(l.gParentGoid)); ok && parent > 0 {
 		g.ParentID = int(parent)
@@ -309,7 +315,7 @@ func (e *engine) readGoroutine(l *goLayout, gptr, liveSP, livePC uint64) gorouti
 	if gopc, ok := e.readU64(gptr + uint64(l.gGopc)); ok {
 		g.CreatedLoc = e.locForPC(gopc)
 	}
-	if status == 4 { // waiting
+	if header.status == 4 { // waiting
 		if wr, ok := e.readU8(gptr + uint64(l.gWaitreason)); ok {
 			g.WaitReason = e.waitReasonString(l, wr)
 		}
@@ -337,6 +343,25 @@ func (e *engine) readGoroutine(l *goLayout, gptr, liveSP, livePC uint64) gorouti
 		Include:  true,
 		Complete: true,
 	}
+}
+
+func (e *engine) readGoroutineHeader(l *goLayout, gptr uint64) (goroutineHeader, bool) {
+	rawStatus, ok := e.readU32(gptr + uint64(l.gAtomicstatus))
+	if !ok {
+		return goroutineHeader{}, false
+	}
+	goid, ok := e.readI64(gptr + uint64(l.gGoid))
+	if !ok {
+		return goroutineHeader{}, false
+	}
+	return goroutineHeader{
+		goid:   goid,
+		status: rawStatus &^ gScanBit,
+	}, true
+}
+
+func (h goroutineHeader) included() bool {
+	return h.goid > 0 && h.status != gStatusDead
 }
 
 func (e *engine) readGoroutineStackBounds(l *goLayout, gptr uint64) (lo, hi uint64, ok bool) {
@@ -535,17 +560,11 @@ func (e *engine) resolveCurrentGoroutineAnchor(
 	ptr, richLength, length, liveSP, livePC, currentGptr uint64,
 	stopTID int,
 ) currentGoroutineResult {
-	if currentGptr != 0 {
-		current := e.currentGoroutineFromRegister(l, currentGptr, liveSP, livePC)
-		if !current.Complete || current.Found {
-			return current
-		}
-	}
-	if procid, ok := e.archRuntimeMProcID(stopTID); ok {
-		current := e.findCurrentGoroutineByProcID(l, procid, livePC)
-		if !current.Complete || current.Found {
-			return current
-		}
+	current := e.resolveTargetedCurrentGoroutine(
+		l, liveSP, livePC, currentGptr, stopTID, currentGoroutineRich,
+	)
+	if !current.Complete || current.Found {
+		return current
 	}
 	if liveSP == 0 {
 		return currentGoroutineResult{Complete: true}
@@ -557,15 +576,42 @@ func (e *engine) resolveCurrentGoroutineAnchor(
 	return e.findCurrentGoroutine(l, ptr, richLength, fallbackEnd, liveSP, livePC)
 }
 
+func (e *engine) resolveTargetedCurrentGoroutine(
+	l *goLayout,
+	liveSP, livePC, currentGptr uint64,
+	stopTID int,
+	detail currentGoroutineDetail,
+) currentGoroutineResult {
+	if currentGptr != 0 {
+		current := e.currentGoroutineFromRegister(
+			l, currentGptr, liveSP, livePC, detail,
+		)
+		if !current.Complete || current.Found {
+			return current
+		}
+	}
+	if procid, ok := e.archRuntimeMProcID(stopTID); ok {
+		current := e.findCurrentGoroutineByProcID(l, procid, livePC, detail)
+		if !current.Complete || current.Found {
+			return current
+		}
+	}
+	return currentGoroutineResult{Complete: true}
+}
+
 func (e *engine) currentGoroutineFromRegister(
 	l *goLayout,
 	gptr, liveSP, livePC uint64,
+	detail currentGoroutineDetail,
 ) currentGoroutineResult {
-	goid, ok := e.readI64(gptr + uint64(l.gGoid))
+	header, ok := e.readGoroutineHeader(l, gptr)
 	if !ok {
 		return currentGoroutineResult{}
 	}
-	if goid > 0 {
+	if header.goid > 0 {
+		if detail == currentGoroutineIdentity {
+			return e.currentGoroutineIdentityFromHeader(l, gptr, liveSP, true, header)
+		}
 		result := e.readGoroutine(l, gptr, liveSP, livePC)
 		if !result.Complete {
 			return currentGoroutineResult{}
@@ -579,7 +625,7 @@ func (e *engine) currentGoroutineFromRegister(
 		}
 		return currentGoroutineResult{Complete: true}
 	}
-	if goid != 0 {
+	if header.goid != 0 {
 		return currentGoroutineResult{Complete: true}
 	}
 	mptr, ok := e.readU64(gptr + uint64(l.gM))
@@ -596,7 +642,7 @@ func (e *engine) currentGoroutineFromRegister(
 	if !schedulerG {
 		return currentGoroutineResult{Complete: true}
 	}
-	return e.readCurrentGoroutineFromM(l, mptr, livePC)
+	return e.readCurrentGoroutineFromM(l, mptr, livePC, detail)
 }
 
 func (e *engine) isSchedulerG(l *goLayout, mptr, gptr uint64) (bool, bool) {
@@ -624,6 +670,7 @@ func (e *engine) isSchedulerG(l *goLayout, mptr, gptr uint64) (bool, bool) {
 func (e *engine) readCurrentGoroutineFromM(
 	l *goLayout,
 	mptr, livePC uint64,
+	detail currentGoroutineDetail,
 ) currentGoroutineResult {
 	gptr, ok := e.readU64(mptr + uint64(l.mCurg))
 	if !ok {
@@ -639,6 +686,9 @@ func (e *engine) readCurrentGoroutineFromM(
 	if owner != mptr {
 		return currentGoroutineResult{Complete: true}
 	}
+	if detail == currentGoroutineIdentity {
+		return e.readCurrentGoroutineIdentity(l, gptr, 0, false)
+	}
 	result := e.readGoroutine(l, gptr, 0, 0)
 	if !result.Complete {
 		return currentGoroutineResult{}
@@ -651,6 +701,47 @@ func (e *engine) readCurrentGoroutineFromM(
 	current.CurrentLoc = e.locForPC(livePC)
 	return currentGoroutineResult{
 		Item:     current,
+		Found:    true,
+		Complete: true,
+	}
+}
+
+func (e *engine) readCurrentGoroutineIdentity(
+	l *goLayout,
+	gptr, liveSP uint64,
+	requireStack bool,
+) currentGoroutineResult {
+	header, ok := e.readGoroutineHeader(l, gptr)
+	if !ok {
+		return currentGoroutineResult{}
+	}
+	return e.currentGoroutineIdentityFromHeader(l, gptr, liveSP, requireStack, header)
+}
+
+func (e *engine) currentGoroutineIdentityFromHeader(
+	l *goLayout,
+	gptr, liveSP uint64,
+	requireStack bool,
+	header goroutineHeader,
+) currentGoroutineResult {
+	if !header.included() {
+		return currentGoroutineResult{Complete: true}
+	}
+	if requireStack {
+		lo, hi, ok := e.readGoroutineStackBounds(l, gptr)
+		if !ok {
+			return currentGoroutineResult{}
+		}
+		if !stackContainsSP(lo, hi, liveSP) {
+			return currentGoroutineResult{Complete: true}
+		}
+	}
+	return currentGoroutineResult{
+		Item: protocol.Goroutine{
+			ID:      int(header.goid),
+			Status:  goStatusString(header.status),
+			Current: true,
+		},
 		Found:    true,
 		Complete: true,
 	}
@@ -705,6 +796,7 @@ func (e *engine) findCurrentGoroutine(
 func (e *engine) findCurrentGoroutineByProcID(
 	l *goLayout,
 	procid, livePC uint64,
+	detail currentGoroutineDetail,
 ) currentGoroutineResult {
 	if e.dw == nil {
 		return currentGoroutineResult{Complete: true}
@@ -720,12 +812,13 @@ func (e *engine) findCurrentGoroutineByProcID(
 	if mptr == 0 {
 		return currentGoroutineResult{Complete: true}
 	}
-	return e.findCurrentGoroutineByProcIDFrom(l, mptr, procid, livePC)
+	return e.findCurrentGoroutineByProcIDFrom(l, mptr, procid, livePC, detail)
 }
 
 func (e *engine) findCurrentGoroutineByProcIDFrom(
 	l *goLayout,
 	mptr, procid, livePC uint64,
+	detail currentGoroutineDetail,
 ) currentGoroutineResult {
 	match, next, complete := e.findMByProcID(l, mptr, procid, maxThreadScan)
 	if !complete {
@@ -740,7 +833,7 @@ func (e *engine) findCurrentGoroutineByProcIDFrom(
 	if match == 0 {
 		return currentGoroutineResult{Complete: true}
 	}
-	return e.readCurrentGoroutineFromM(l, match, livePC)
+	return e.readCurrentGoroutineFromM(l, match, livePC, detail)
 }
 
 func (e *engine) findMByProcID(
@@ -917,6 +1010,27 @@ func unknownGoroutine(loc protocol.Location) protocol.Goroutine {
 		CurrentLoc: loc,
 		Current:    true,
 	}
+}
+
+// targetedCurrentGoroutine identifies the stopped goroutine without walking
+// runtime.allgs. Regular steps use this bounded path to stay cheap while still
+// giving DAP a precise thread id whenever the ABI or stopped M can provide one.
+func (e *engine) targetedCurrentGoroutine(
+	fallbackLoc protocol.Location,
+) protocol.Goroutine {
+	l, ok := e.getGoLayout()
+	if !ok {
+		return unknownGoroutine(fallbackLoc)
+	}
+	tid, sp, pc, currentGptr := e.liveRegisters()
+	current := e.resolveTargetedCurrentGoroutine(
+		l, sp, pc, currentGptr, tid, currentGoroutineIdentity,
+	)
+	if !current.Complete || !current.Found {
+		return unknownGoroutine(fallbackLoc)
+	}
+	current.Item.CurrentLoc = fallbackLoc
+	return current.Item
 }
 
 // syntheticGoroutine represents an unresolved stopped goroutine without

--- a/internal/debugger/goroutines.go
+++ b/internal/debugger/goroutines.go
@@ -37,6 +37,9 @@ const (
 	// maxCurrentThreadScan bounds the targeted continuation past the rich allm
 	// prefix. It reads only enough fields to find the stopped M or current g.
 	maxCurrentThreadScan = 2048
+	// maxCurrentIdentityBytes bounds the single bulk read used by regular steps.
+	// Runtime g fields are compact; unusual layouts fall back to individual reads.
+	maxCurrentIdentityBytes = 4096
 	// maxGoStringLen caps a wait-reason string read from tracee memory.
 	maxGoStringLen = 256
 
@@ -271,6 +274,12 @@ type goroutineHeader struct {
 	status uint32
 }
 
+type currentGoroutineFields struct {
+	header goroutineHeader
+	lo     uint64
+	hi     uint64
+}
+
 type currentGoroutineDetail uint8
 
 const (
@@ -362,6 +371,78 @@ func (e *engine) readGoroutineHeader(l *goLayout, gptr uint64) (goroutineHeader,
 
 func (h goroutineHeader) included() bool {
 	return h.goid > 0 && h.status != gStatusDead
+}
+
+func (e *engine) readCurrentGoroutineFields(
+	l *goLayout,
+	gptr uint64,
+	includeStack bool,
+) (currentGoroutineFields, bool) {
+	type identityField struct {
+		offset uint64
+		size   uint64
+	}
+	offsets := []identityField{
+		{offset: uint64(l.gAtomicstatus), size: 4},
+		{offset: uint64(l.gGoid), size: 8},
+	}
+	if includeStack {
+		offsets = append(offsets,
+			identityField{offset: uint64(l.gStack) + uint64(l.stackLo), size: 8},
+			identityField{offset: uint64(l.gStack) + uint64(l.stackHi), size: 8},
+		)
+	}
+	start := offsets[0].offset
+	end := uint64(0)
+	for _, field := range offsets {
+		if field.offset < start {
+			start = field.offset
+		}
+		if field.offset > ^uint64(0)-field.size {
+			return e.readCurrentGoroutineFieldsIndividually(l, gptr, includeStack)
+		}
+		if fieldEnd := field.offset + field.size; fieldEnd > end {
+			end = fieldEnd
+		}
+	}
+	if end < start || end-start > maxCurrentIdentityBytes ||
+		gptr > ^uint64(0)-start {
+		return e.readCurrentGoroutineFieldsIndividually(l, gptr, includeStack)
+	}
+	raw := make([]byte, end-start)
+	if err := e.backend.ReadMemory(gptr+start, raw); err != nil {
+		return currentGoroutineFields{}, false
+	}
+	at := func(offset uint64) []byte {
+		return raw[offset-start:]
+	}
+	fields := currentGoroutineFields{
+		header: goroutineHeader{
+			goid:   int64(binary.LittleEndian.Uint64(at(offsets[1].offset))),
+			status: binary.LittleEndian.Uint32(at(offsets[0].offset)) &^ gScanBit,
+		},
+	}
+	if includeStack {
+		fields.lo = binary.LittleEndian.Uint64(at(offsets[2].offset))
+		fields.hi = binary.LittleEndian.Uint64(at(offsets[3].offset))
+	}
+	return fields, true
+}
+
+func (e *engine) readCurrentGoroutineFieldsIndividually(
+	l *goLayout,
+	gptr uint64,
+	includeStack bool,
+) (currentGoroutineFields, bool) {
+	header, ok := e.readGoroutineHeader(l, gptr)
+	if !ok {
+		return currentGoroutineFields{}, false
+	}
+	if !includeStack {
+		return currentGoroutineFields{header: header}, true
+	}
+	lo, hi, ok := e.readGoroutineStackBounds(l, gptr)
+	return currentGoroutineFields{header: header, lo: lo, hi: hi}, ok
 }
 
 func (e *engine) readGoroutineStackBounds(l *goLayout, gptr uint64) (lo, hi uint64, ok bool) {
@@ -604,13 +685,13 @@ func (e *engine) currentGoroutineFromRegister(
 	gptr, liveSP, livePC uint64,
 	detail currentGoroutineDetail,
 ) currentGoroutineResult {
-	header, ok := e.readGoroutineHeader(l, gptr)
+	fields, ok := e.readCurrentGoroutineFields(l, gptr, true)
 	if !ok {
 		return currentGoroutineResult{}
 	}
-	if header.goid > 0 {
+	if fields.header.goid > 0 {
 		if detail == currentGoroutineIdentity {
-			return e.currentGoroutineIdentityFromHeader(l, gptr, liveSP, true, header)
+			return currentGoroutineIdentityFromFields(liveSP, true, fields)
 		}
 		result := e.readGoroutine(l, gptr, liveSP, livePC)
 		if !result.Complete {
@@ -625,7 +706,7 @@ func (e *engine) currentGoroutineFromRegister(
 		}
 		return currentGoroutineResult{Complete: true}
 	}
-	if header.goid != 0 {
+	if fields.header.goid != 0 {
 		return currentGoroutineResult{Complete: true}
 	}
 	mptr, ok := e.readU64(gptr + uint64(l.gM))
@@ -711,35 +792,30 @@ func (e *engine) readCurrentGoroutineIdentity(
 	gptr, liveSP uint64,
 	requireStack bool,
 ) currentGoroutineResult {
-	header, ok := e.readGoroutineHeader(l, gptr)
+	fields, ok := e.readCurrentGoroutineFields(l, gptr, requireStack)
 	if !ok {
 		return currentGoroutineResult{}
 	}
-	return e.currentGoroutineIdentityFromHeader(l, gptr, liveSP, requireStack, header)
+	return currentGoroutineIdentityFromFields(liveSP, requireStack, fields)
 }
 
-func (e *engine) currentGoroutineIdentityFromHeader(
-	l *goLayout,
-	gptr, liveSP uint64,
+func currentGoroutineIdentityFromFields(
+	liveSP uint64,
 	requireStack bool,
-	header goroutineHeader,
+	fields currentGoroutineFields,
 ) currentGoroutineResult {
-	if !header.included() {
+	if !fields.header.included() {
 		return currentGoroutineResult{Complete: true}
 	}
 	if requireStack {
-		lo, hi, ok := e.readGoroutineStackBounds(l, gptr)
-		if !ok {
-			return currentGoroutineResult{}
-		}
-		if !stackContainsSP(lo, hi, liveSP) {
+		if !stackContainsSP(fields.lo, fields.hi, liveSP) {
 			return currentGoroutineResult{Complete: true}
 		}
 	}
 	return currentGoroutineResult{
 		Item: protocol.Goroutine{
-			ID:      int(header.goid),
-			Status:  goStatusString(header.status),
+			ID:      int(fields.header.goid),
+			Status:  goStatusString(fields.header.status),
 			Current: true,
 		},
 		Found:    true,
@@ -1017,14 +1093,16 @@ func unknownGoroutine(loc protocol.Location) protocol.Goroutine {
 // giving DAP a precise thread id whenever the ABI or stopped M can provide one.
 func (e *engine) targetedCurrentGoroutine(
 	fallbackLoc protocol.Location,
+	tid int,
+	regs Registers,
 ) protocol.Goroutine {
 	l, ok := e.getGoLayout()
 	if !ok {
 		return unknownGoroutine(fallbackLoc)
 	}
-	tid, sp, pc, currentGptr := e.liveRegisters()
+	currentGptr, _ := e.archCurrentGoroutinePointer(regs)
 	current := e.resolveTargetedCurrentGoroutine(
-		l, sp, pc, currentGptr, tid, currentGoroutineIdentity,
+		l, regs.SP, regs.PC, currentGptr, tid, currentGoroutineIdentity,
 	)
 	if !current.Complete || !current.Found {
 		return unknownGoroutine(fallbackLoc)

--- a/internal/debugger/goroutines_internal_test.go
+++ b/internal/debugger/goroutines_internal_test.go
@@ -161,6 +161,11 @@ func TestBuildGoroutineListAnchorsCurrentBeyondRichScan(t *testing.T) {
 	if anchorID != got[0].ID {
 		t.Fatalf("anchor id = %d, want %d", anchorID, got[0].ID)
 	}
+	for i := 0; i < maxGoroutineScan; i++ {
+		if got[i+1].ID != i+1 {
+			t.Fatalf("rich goroutine %d has id %d, want preserved prefix id %d", i, got[i+1].ID, i+1)
+		}
+	}
 
 	currentCount := 0
 	for _, g := range got {
@@ -285,6 +290,66 @@ func TestBuildGoroutineListUsesMCurgForSchedulerStop(t *testing.T) {
 	}
 }
 
+func TestUnresolvedCurrentIdentityNeverFallsBackToGoroutineOne(t *testing.T) {
+	const (
+		allgsPtr = uint64(0x1000)
+		realG    = uint64(0x200000)
+		systemG  = uint64(0x300000)
+		mptr     = uint64(0x400000)
+		systemSP = uint64(0xa0000008)
+	)
+	fallback := protocol.Location{File: "runtime.go", Line: 42, Function: "runtime.schedule"}
+
+	for _, tc := range []struct {
+		name        string
+		liveSP      uint64
+		currentGptr uint64
+		seed        func(*goroutineMemoryBackend, *goLayout)
+	}{
+		{
+			name: "no live registers",
+		},
+		{
+			name:        "unresolved g0",
+			liveSP:      systemSP,
+			currentGptr: systemG,
+			seed: func(backend *goroutineMemoryBackend, layout *goLayout) {
+				seedTestGoroutine(backend, layout, systemG, 0, systemSP-8, systemSP+0xff8)
+				backend.seedU64(systemG+uint64(layout.gM), mptr)
+				seedTestM(backend, layout, mptr, 77, 0, 0)
+				backend.seedU64(mptr+uint64(layout.mG0), systemG)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			layout := goroutineTestLayout()
+			backend := newGoroutineMemoryBackend()
+			backend.seedU64(allgsPtr, realG)
+			seedTestGoroutine(backend, layout, realG, 1, 0x1000, 0x2000)
+			if tc.seed != nil {
+				tc.seed(backend, layout)
+			}
+
+			e := &engine{backend: backend}
+			result := e.buildGoroutineListFrom(
+				layout, allgsPtr, 1, tc.liveSP, 0x1234, tc.currentGptr, 0,
+			)
+			if !result.Complete || len(result.Items) != 1 ||
+				result.Items[0].ID != 1 || result.Items[0].Current {
+				t.Fatalf("goroutine walk = %+v, want complete real list with unknown current", result)
+			}
+
+			current := currentGoroutineFrom(protocol.GoroutineSnapshotPayload{
+				Goroutines: result.Items,
+			}, fallback)
+			if current.ID != 0 || current.Status != "unknown" ||
+				!current.Current || current.CurrentLoc != fallback {
+				t.Fatalf("current goroutine = %+v, want honest unknown identity", current)
+			}
+		})
+	}
+}
+
 func TestCurrentGoroutineFromRegisterRejectsUnrelatedPositiveGoID(t *testing.T) {
 	const (
 		mptr      = uint64(0x400000)
@@ -300,9 +365,45 @@ func TestCurrentGoroutineFromRegisterRejectsUnrelatedPositiveGoID(t *testing.T) 
 	seedTestM(backend, layout, mptr, 77, currentG, 0)
 
 	e := &engine{backend: backend}
-	result := e.currentGoroutineFromRegister(layout, candidate, 0xdeadbeef, 0x1234)
+	result := e.currentGoroutineFromRegister(
+		layout, candidate, 0xdeadbeef, 0x1234, currentGoroutineRich,
+	)
 	if !result.Complete || result.Found {
 		t.Fatalf("current goroutine = %+v; want complete rejection of stale positive-goid candidate", result)
+	}
+}
+
+func TestCurrentGoroutineIdentityReadsOnlyRequiredFields(t *testing.T) {
+	const (
+		gptr   = uint64(0x200000)
+		liveSP = uint64(0x8008)
+	)
+	layout := goroutineTestLayout()
+	backend := newGoroutineMemoryBackend()
+	seedTestGoroutine(backend, layout, gptr, 42, 0x8000, 0x9000)
+
+	e := &engine{backend: backend}
+	result := e.currentGoroutineFromRegister(
+		layout, gptr, liveSP, 0x1234, currentGoroutineIdentity,
+	)
+	if !result.Complete || !result.Found ||
+		result.Item.ID != 42 || !result.Item.Current {
+		t.Fatalf("current identity = %+v, want current g42", result)
+	}
+
+	required := []uint64{
+		gptr + uint64(layout.gAtomicstatus),
+		gptr + uint64(layout.gGoid),
+		gptr + uint64(layout.gStack) + uint64(layout.stackLo),
+		gptr + uint64(layout.gStack) + uint64(layout.stackHi),
+	}
+	if len(backend.reads) != len(required) {
+		t.Fatalf("read addresses = %#v, want only %d required identity fields", backend.reads, len(required))
+	}
+	for _, addr := range required {
+		if backend.reads[addr] != 1 {
+			t.Fatalf("reads at %#x = %d, want 1", addr, backend.reads[addr])
+		}
 	}
 }
 
@@ -334,7 +435,9 @@ func TestFindCurrentGoroutineByProcIDContinuesPastRichThreadCap(t *testing.T) {
 	}
 
 	e := &engine{backend: backend}
-	result := e.findCurrentGoroutineByProcIDFrom(layout, mBase, targetID, 0x1234)
+	result := e.findCurrentGoroutineByProcIDFrom(
+		layout, mBase, targetID, 0x1234, currentGoroutineRich,
+	)
 	if !result.Complete || !result.Found ||
 		!result.Item.Current || result.Item.ID != 99 || result.Item.ThreadID != int(targetID) {
 		t.Fatalf("current goroutine = %+v; want id 99 on stopped thread %d", result, targetID)
@@ -359,7 +462,9 @@ func TestFindCurrentGoroutineByProcIDBoundsTargetedContinuation(t *testing.T) {
 	}
 
 	e := &engine{backend: backend}
-	result := e.findCurrentGoroutineByProcIDFrom(layout, mBase, ^uint64(0), 0x1234)
+	result := e.findCurrentGoroutineByProcIDFrom(
+		layout, mBase, ^uint64(0), 0x1234, currentGoroutineRich,
+	)
 	if !result.Complete || result.Found {
 		t.Fatalf("current goroutine = %+v; want complete bounded miss", result)
 	}

--- a/internal/debugger/goroutines_internal_test.go
+++ b/internal/debugger/goroutines_internal_test.go
@@ -2,15 +2,17 @@ package debugger
 
 import (
 	"encoding/binary"
+	"errors"
 	"testing"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
 
 type goroutineMemoryBackend struct {
-	mem   map[uint64]byte
-	regs  Registers
-	reads map[uint64]int
+	mem    map[uint64]byte
+	regs   Registers
+	regErr error
+	reads  map[uint64]int
 }
 
 func newGoroutineMemoryBackend() *goroutineMemoryBackend {
@@ -35,6 +37,13 @@ func goroutineTestLayout() *goLayout {
 		gParentGoid:   56,
 		gGopc:         64,
 		gStartpc:      72,
+		mProcid:       0,
+		mID:           8,
+		mSpinning:     16,
+		mG0:           24,
+		mG0OK:         true,
+		mGsignal:      32,
+		mGsignalOK:    true,
 		mCurg:         80,
 		mAlllink:      88,
 	}
@@ -52,6 +61,17 @@ func seedTestGoroutine(
 	backend.seedU64(gptr+uint64(layout.gGoid), goid)
 	backend.seedU64(gptr+uint64(layout.gStack)+uint64(layout.stackLo), stackLo)
 	backend.seedU64(gptr+uint64(layout.gStack)+uint64(layout.stackHi), stackHi)
+}
+
+func seedTestM(
+	backend *goroutineMemoryBackend,
+	layout *goLayout,
+	mptr, procid, curg, next uint64,
+) {
+	backend.seedU64(mptr+uint64(layout.mProcid), procid)
+	backend.seedU64(mptr+uint64(layout.mID), procid)
+	backend.seedU64(mptr+uint64(layout.mCurg), curg)
+	backend.seedU64(mptr+uint64(layout.mAlllink), next)
 }
 
 func (b *goroutineMemoryBackend) seedU64(addr, value uint64) {
@@ -91,7 +111,7 @@ func (b *goroutineMemoryBackend) WriteMemory(addr uint64, src []byte) error {
 }
 
 func (b *goroutineMemoryBackend) GetRegisters(int) (Registers, error) {
-	return b.regs, nil
+	return b.regs, b.regErr
 }
 
 func (b *goroutineMemoryBackend) SetRegisters(_ int, regs Registers) error {
@@ -127,7 +147,7 @@ func TestBuildGoroutineListAnchorsCurrentBeyondRichScan(t *testing.T) {
 
 	liveSP := stack + currentIndex*gStride + 8
 	e := &engine{backend: backend}
-	result := e.buildGoroutineListFrom(layout, allgsPtr, length, liveSP, 0x1234, 0)
+	result := e.buildGoroutineListFrom(layout, allgsPtr, length, liveSP, 0x1234, 0, 0)
 	got, anchorID := result.Items, result.AnchorID
 	if !result.Complete {
 		t.Fatal("buildGoroutineListFrom degraded instead of returning the rich prefix plus current anchor")
@@ -174,7 +194,7 @@ func TestBuildGoroutineListUsesDirectCurrentPointerBeyondFallback(t *testing.T) 
 	length := uint64(maxGoroutineScan*3 + 1)
 	e := &engine{backend: backend}
 	result := e.buildGoroutineListFrom(
-		layout, allgsPtr, length, stackLo+8, 0x1234, currentG,
+		layout, allgsPtr, length, stackLo+8, 0x1234, currentG, 0,
 	)
 	got, anchorID := result.Items, result.AnchorID
 	if !result.Complete || len(got) != 2 {
@@ -202,7 +222,7 @@ func TestBuildGoroutineListBoundsFallbackTail(t *testing.T) {
 	length := uint64(maxGoroutineScan*3 + 1)
 	e := &engine{backend: backend}
 	result := e.buildGoroutineListFrom(
-		layout, allgsPtr, length, 0xdeadbeef, 0x1234, 0,
+		layout, allgsPtr, length, 0xdeadbeef, 0x1234, 0, 0,
 	)
 	got, anchorID := result.Items, result.AnchorID
 	if !result.Complete || len(got) != 1 || anchorID != 0 {
@@ -221,27 +241,206 @@ func TestBuildGoroutineListBoundsFallbackTail(t *testing.T) {
 	}
 }
 
-func TestFindCurrentGoroutineFromThreadList(t *testing.T) {
+func TestBuildGoroutineListUsesMCurgForSchedulerStop(t *testing.T) {
 	const (
-		firstM   = uint64(0x400000)
-		secondM  = uint64(0x400100)
-		firstG   = uint64(0x500000)
+		allgsPtr = uint64(0x1000)
+		mptr     = uint64(0x400000)
+		systemG  = uint64(0x500000)
 		currentG = uint64(0x500100)
-		stackLo  = uint64(0xa0000000)
+		systemSP = uint64(0xa0000008)
+	)
+	layout := goroutineTestLayout()
+	for _, tc := range []struct {
+		name   string
+		offset int64
+	}{
+		{name: "g0", offset: layout.mG0},
+		{name: "gsignal", offset: layout.mGsignal},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := newGoroutineMemoryBackend()
+			backend.seedU64(allgsPtr, currentG)
+			seedTestGoroutine(backend, layout, systemG, 0, systemSP-8, systemSP+0xff8)
+			seedTestGoroutine(backend, layout, currentG, 99, 0xb0000000, 0xb0001000)
+			backend.seedU64(systemG+uint64(layout.gM), mptr)
+			backend.seedU64(currentG+uint64(layout.gM), mptr)
+			seedTestM(backend, layout, mptr, 77, currentG, 0)
+			backend.seedU64(mptr+uint64(tc.offset), systemG)
+
+			e := &engine{backend: backend}
+			result := e.buildGoroutineListFrom(
+				layout, allgsPtr, 1, systemSP, 0x1234, systemG, 0,
+			)
+			got, anchorID := result.Items, result.AnchorID
+			if !result.Complete || len(got) != 1 || !got[0].Current || got[0].ID != 99 {
+				t.Fatalf("goroutines = %+v, complete = %t; want current m.curg id 99", got, result.Complete)
+			}
+			if anchorID != 0 {
+				t.Fatalf("anchor id = %d, want 0 because m.curg was already in the rich prefix", anchorID)
+			}
+			if got[0].ThreadID != 77 {
+				t.Fatalf("current thread id = %d, want 77", got[0].ThreadID)
+			}
+		})
+	}
+}
+
+func TestCurrentGoroutineFromRegisterRejectsUnrelatedPositiveGoID(t *testing.T) {
+	const (
+		mptr      = uint64(0x400000)
+		candidate = uint64(0x500000)
+		currentG  = uint64(0x500100)
 	)
 	layout := goroutineTestLayout()
 	backend := newGoroutineMemoryBackend()
-	backend.seedU64(firstM+uint64(layout.mCurg), firstG)
-	backend.seedU64(firstM+uint64(layout.mAlllink), secondM)
-	backend.seedU64(secondM+uint64(layout.mCurg), currentG)
-	backend.seedU64(secondM+uint64(layout.mAlllink), 0)
-	seedTestGoroutine(backend, layout, firstG, 1, 0x1000, 0x2000)
-	seedTestGoroutine(backend, layout, currentG, 99, stackLo, stackLo+0x1000)
+	seedTestGoroutine(backend, layout, candidate, 88, 0xa0000000, 0xa0001000)
+	seedTestGoroutine(backend, layout, currentG, 99, 0xb0000000, 0xb0001000)
+	backend.seedU64(candidate+uint64(layout.gM), mptr)
+	backend.seedU64(currentG+uint64(layout.gM), mptr)
+	seedTestM(backend, layout, mptr, 77, currentG, 0)
 
 	e := &engine{backend: backend}
-	result := e.findCurrentGoroutineInThreadList(layout, firstM, stackLo+8, 0x1234)
-	if !result.Complete || !result.Found || !result.Item.Current || result.Item.ID != 99 {
-		t.Fatalf("current goroutine = %+v; want current id 99", result)
+	result := e.currentGoroutineFromRegister(layout, candidate, 0xdeadbeef, 0x1234)
+	if !result.Complete || result.Found {
+		t.Fatalf("current goroutine = %+v; want complete rejection of stale positive-goid candidate", result)
+	}
+}
+
+func TestFindCurrentGoroutineByProcIDContinuesPastRichThreadCap(t *testing.T) {
+	const (
+		mBase    = uint64(0x400000)
+		mStride  = uint64(0x100)
+		currentG = uint64(0x900000)
+		targetID = uint64(777777)
+	)
+	layout := goroutineTestLayout()
+	backend := newGoroutineMemoryBackend()
+	count := maxThreadScan + 2
+	for i := 0; i < count; i++ {
+		mptr := mBase + uint64(i)*mStride
+		next := uint64(0)
+		if i+1 < count {
+			next = mptr + mStride
+		}
+		procid := uint64(1000 + i)
+		curg := uint64(0)
+		if i == count-1 {
+			procid = targetID
+			curg = currentG
+			seedTestGoroutine(backend, layout, currentG, 99, 0xb0000000, 0xb0001000)
+			backend.seedU64(currentG+uint64(layout.gM), mptr)
+		}
+		seedTestM(backend, layout, mptr, procid, curg, next)
+	}
+
+	e := &engine{backend: backend}
+	result := e.findCurrentGoroutineByProcIDFrom(layout, mBase, targetID, 0x1234)
+	if !result.Complete || !result.Found ||
+		!result.Item.Current || result.Item.ID != 99 || result.Item.ThreadID != int(targetID) {
+		t.Fatalf("current goroutine = %+v; want id 99 on stopped thread %d", result, targetID)
+	}
+}
+
+func TestFindCurrentGoroutineByProcIDBoundsTargetedContinuation(t *testing.T) {
+	const (
+		mBase   = uint64(0x400000)
+		mStride = uint64(0x100)
+	)
+	layout := goroutineTestLayout()
+	backend := newGoroutineMemoryBackend()
+	count := maxThreadScan + maxCurrentThreadScan + 1
+	for i := 0; i < count; i++ {
+		mptr := mBase + uint64(i)*mStride
+		next := uint64(0)
+		if i+1 < count {
+			next = mptr + mStride
+		}
+		seedTestM(backend, layout, mptr, uint64(1000+i), 0, next)
+	}
+
+	e := &engine{backend: backend}
+	result := e.findCurrentGoroutineByProcIDFrom(layout, mBase, ^uint64(0), 0x1234)
+	if !result.Complete || result.Found {
+		t.Fatalf("current goroutine = %+v; want complete bounded miss", result)
+	}
+	firstUnscanned := mBase + uint64(maxThreadScan+maxCurrentThreadScan)*mStride
+	if reads := backend.reads[firstUnscanned+uint64(layout.mProcid)]; reads != 0 {
+		t.Fatalf("first procid beyond targeted budget reads = %d, want 0", reads)
+	}
+
+	backend.reads = make(map[uint64]int)
+	threads := e.readThreadsFrom(layout, mBase, 99, 0x1234)
+	if !threads.Complete || len(threads.Items) != maxThreadScan {
+		t.Fatalf("threads = %+v, want only the bounded rich prefix", threads)
+	}
+	if reads := backend.reads[firstUnscanned+uint64(layout.mCurg)]; reads != 0 {
+		t.Fatalf("first curg beyond targeted budget reads = %d, want 0", reads)
+	}
+}
+
+func TestReadThreadsAnchorsCurrentBeyondRichThreadCap(t *testing.T) {
+	const (
+		mBase    = uint64(0x400000)
+		mStride  = uint64(0x100)
+		currentG = uint64(0x900000)
+	)
+	layout := goroutineTestLayout()
+	backend := newGoroutineMemoryBackend()
+	count := maxThreadScan + 2
+	for i := 0; i < count; i++ {
+		mptr := mBase + uint64(i)*mStride
+		next := uint64(0)
+		if i+1 < count {
+			next = mptr + mStride
+		}
+		curg := uint64(0)
+		if i == count-1 {
+			curg = currentG
+			seedTestGoroutine(backend, layout, currentG, 99, 0xb0000000, 0xb0001000)
+		}
+		seedTestM(backend, layout, mptr, uint64(1000+i), curg, next)
+	}
+
+	e := &engine{backend: backend}
+	result := e.readThreadsFrom(layout, mBase, 99, 0x1234)
+	got := result.Items
+	if !result.Complete {
+		t.Fatal("readThreadsFrom degraded instead of returning the rich prefix plus current anchor")
+	}
+	if len(got) != maxThreadScan+1 {
+		t.Fatalf("threads = %d, want rich prefix plus one current anchor", len(got))
+	}
+	current := 0
+	for _, thread := range got {
+		if thread.Current {
+			current++
+			if thread.GoID != 99 {
+				t.Fatalf("current thread = %+v, want goid 99", thread)
+			}
+		}
+	}
+	if current != 1 {
+		t.Fatalf("current threads = %d, want 1", current)
+	}
+}
+
+func TestCurrentGoroutineFromReturnsUnknownInsteadOfFirstRealGoroutine(t *testing.T) {
+	fallback := protocol.Location{File: "runtime.go", Line: 42, Function: "runtime.schedule"}
+	for _, snap := range []protocol.GoroutineSnapshotPayload{
+		{Goroutines: []protocol.Goroutine{{ID: 1}, {ID: 2}}},
+		{Goroutines: []protocol.Goroutine{{Status: "unknown", Current: true}}},
+	} {
+		got := currentGoroutineFrom(snap, fallback)
+		if got.ID != 0 || got.Status != "unknown" || !got.Current || got.CurrentLoc != fallback {
+			t.Fatalf("fallback goroutine = %+v, want current synthetic unknown at %+v", got, fallback)
+		}
+	}
+
+	got := currentGoroutineFrom(protocol.GoroutineSnapshotPayload{
+		Goroutines: []protocol.Goroutine{{ID: 99, Status: "running", Current: true}},
+	}, fallback)
+	if got.ID != 99 || got.CurrentLoc != fallback {
+		t.Fatalf("identified current goroutine = %+v, want frame location %+v", got, fallback)
 	}
 }
 
@@ -273,10 +472,24 @@ func TestDegradedGoroutineSnapshotPreservesPreviousLiveSet(t *testing.T) {
 	}
 
 	snapshot := e.goroutineSnapshot()
-	if len(snapshot.Goroutines) != 1 || !snapshot.Goroutines[0].Current {
-		t.Fatalf("degraded snapshot goroutines = %+v, want one current synthetic goroutine", snapshot.Goroutines)
+	if len(snapshot.Goroutines) != 1 ||
+		snapshot.Goroutines[0].ID != 0 ||
+		snapshot.Goroutines[0].Status != "unknown" ||
+		!snapshot.Goroutines[0].Current {
+		t.Fatalf("degraded snapshot goroutines = %+v, want one current unknown goroutine", snapshot.Goroutines)
 	}
 	if _, ok := e.prevGoids[42]; !ok || len(e.prevGoids) != 1 {
 		t.Fatalf("prevGoids = %v, want unchanged {42}", e.prevGoids)
+	}
+}
+
+func TestLiveRegistersPreservesStoppedTIDOnReadFailure(t *testing.T) {
+	backend := newGoroutineMemoryBackend()
+	backend.regErr = errors.New("registers unavailable")
+	e := &engine{backend: backend, curTID: 77}
+
+	tid, sp, pc, gptr := e.liveRegisters()
+	if tid != 77 || sp != 0 || pc != 0 || gptr != 0 {
+		t.Fatalf("live registers = tid:%d sp:%x pc:%x g:%x, want tid 77 with unknown registers", tid, sp, pc, gptr)
 	}
 }

--- a/internal/debugger/goroutines_internal_test.go
+++ b/internal/debugger/goroutines_internal_test.go
@@ -147,7 +147,7 @@ func TestBuildGoroutineListAnchorsCurrentBeyondRichScan(t *testing.T) {
 	layout := goroutineTestLayout()
 
 	backend := newGoroutineMemoryBackend()
-	length := uint64(maxGoroutineScan + 1)
+	length := uint64(maxGoroutineScan + 4)
 	currentIndex := length - 1
 	for i := uint64(0); i < length; i++ {
 		gptr := gBase + i*gStride

--- a/internal/debugger/goroutines_internal_test.go
+++ b/internal/debugger/goroutines_internal_test.go
@@ -20,6 +20,40 @@ func newGoroutineMemoryBackend() *goroutineMemoryBackend {
 	}
 }
 
+func goroutineTestLayout() *goLayout {
+	return &goLayout{
+		valid:         true,
+		gAtomicstatus: 0,
+		gGoid:         8,
+		gStack:        16,
+		stackLo:       0,
+		stackHi:       8,
+		gM:            32,
+		gSched:        40,
+		bufPC:         0,
+		gWaitreason:   48,
+		gParentGoid:   56,
+		gGopc:         64,
+		gStartpc:      72,
+		mCurg:         80,
+		mAlllink:      88,
+	}
+}
+
+func seedTestGoroutine(
+	backend *goroutineMemoryBackend,
+	layout *goLayout,
+	gptr uint64,
+	goid uint64,
+	stackLo uint64,
+	stackHi uint64,
+) {
+	backend.seedU32(gptr+uint64(layout.gAtomicstatus), 2)
+	backend.seedU64(gptr+uint64(layout.gGoid), goid)
+	backend.seedU64(gptr+uint64(layout.gStack)+uint64(layout.stackLo), stackLo)
+	backend.seedU64(gptr+uint64(layout.gStack)+uint64(layout.stackHi), stackHi)
+}
+
 func (b *goroutineMemoryBackend) seedU64(addr, value uint64) {
 	var raw [8]byte
 	binary.LittleEndian.PutUint64(raw[:], value)
@@ -80,21 +114,7 @@ func TestBuildGoroutineListAnchorsCurrentBeyondRichScan(t *testing.T) {
 		gStride  = uint64(0x100)
 		stack    = uint64(0x80000000)
 	)
-	layout := &goLayout{
-		valid:         true,
-		gAtomicstatus: 0,
-		gGoid:         8,
-		gStack:        16,
-		stackLo:       0,
-		stackHi:       8,
-		gM:            32,
-		gSched:        40,
-		bufPC:         0,
-		gWaitreason:   48,
-		gParentGoid:   56,
-		gGopc:         64,
-		gStartpc:      72,
-	}
+	layout := goroutineTestLayout()
 
 	backend := newGoroutineMemoryBackend()
 	length := uint64(maxGoroutineScan + 4)
@@ -102,10 +122,7 @@ func TestBuildGoroutineListAnchorsCurrentBeyondRichScan(t *testing.T) {
 	for i := uint64(0); i < length; i++ {
 		gptr := gBase + i*gStride
 		backend.seedU64(allgsPtr+i*8, gptr)
-		backend.seedU32(gptr+uint64(layout.gAtomicstatus), 2)
-		backend.seedU64(gptr+uint64(layout.gGoid), i+1)
-		backend.seedU64(gptr+uint64(layout.gStack)+uint64(layout.stackLo), stack+i*gStride)
-		backend.seedU64(gptr+uint64(layout.gStack)+uint64(layout.stackHi), stack+(i+1)*gStride)
+		seedTestGoroutine(backend, layout, gptr, i+1, stack+i*gStride, stack+(i+1)*gStride)
 	}
 
 	liveSP := stack + currentIndex*gStride + 8
@@ -148,31 +165,11 @@ func TestBuildGoroutineListUsesDirectCurrentPointerBeyondFallback(t *testing.T) 
 		currentG = uint64(0x300000)
 		stackLo  = uint64(0x90000000)
 	)
-	layout := &goLayout{
-		valid:         true,
-		gAtomicstatus: 0,
-		gGoid:         8,
-		gStack:        16,
-		stackLo:       0,
-		stackHi:       8,
-		gM:            32,
-		gSched:        40,
-		bufPC:         0,
-		gWaitreason:   48,
-		gParentGoid:   56,
-		gGopc:         64,
-		gStartpc:      72,
-	}
+	layout := goroutineTestLayout()
 	backend := newGoroutineMemoryBackend()
 	backend.seedU64(allgsPtr, prefixG)
-	backend.seedU32(prefixG+uint64(layout.gAtomicstatus), 2)
-	backend.seedU64(prefixG+uint64(layout.gGoid), 1)
-	backend.seedU64(prefixG+uint64(layout.gStack)+uint64(layout.stackLo), 0x1000)
-	backend.seedU64(prefixG+uint64(layout.gStack)+uint64(layout.stackHi), 0x2000)
-	backend.seedU32(currentG+uint64(layout.gAtomicstatus), 2)
-	backend.seedU64(currentG+uint64(layout.gGoid), 99)
-	backend.seedU64(currentG+uint64(layout.gStack)+uint64(layout.stackLo), stackLo)
-	backend.seedU64(currentG+uint64(layout.gStack)+uint64(layout.stackHi), stackLo+0x1000)
+	seedTestGoroutine(backend, layout, prefixG, 1, 0x1000, 0x2000)
+	seedTestGoroutine(backend, layout, currentG, 99, stackLo, stackLo+0x1000)
 
 	length := uint64(maxGoroutineScan*3 + 1)
 	e := &engine{backend: backend}
@@ -197,27 +194,10 @@ func TestBuildGoroutineListBoundsFallbackTail(t *testing.T) {
 		allgsPtr = uint64(0x1000)
 		prefixG  = uint64(0x200000)
 	)
-	layout := &goLayout{
-		valid:         true,
-		gAtomicstatus: 0,
-		gGoid:         8,
-		gStack:        16,
-		stackLo:       0,
-		stackHi:       8,
-		gM:            32,
-		gSched:        40,
-		bufPC:         0,
-		gWaitreason:   48,
-		gParentGoid:   56,
-		gGopc:         64,
-		gStartpc:      72,
-	}
+	layout := goroutineTestLayout()
 	backend := newGoroutineMemoryBackend()
 	backend.seedU64(allgsPtr, prefixG)
-	backend.seedU32(prefixG+uint64(layout.gAtomicstatus), 2)
-	backend.seedU64(prefixG+uint64(layout.gGoid), 1)
-	backend.seedU64(prefixG+uint64(layout.gStack)+uint64(layout.stackLo), 0x1000)
-	backend.seedU64(prefixG+uint64(layout.gStack)+uint64(layout.stackHi), 0x2000)
+	seedTestGoroutine(backend, layout, prefixG, 1, 0x1000, 0x2000)
 
 	length := uint64(maxGoroutineScan*3 + 1)
 	e := &engine{backend: backend}
@@ -249,36 +229,14 @@ func TestFindCurrentGoroutineFromThreadList(t *testing.T) {
 		currentG = uint64(0x500100)
 		stackLo  = uint64(0xa0000000)
 	)
-	layout := &goLayout{
-		valid:         true,
-		gAtomicstatus: 0,
-		gGoid:         8,
-		gStack:        16,
-		stackLo:       0,
-		stackHi:       8,
-		gM:            32,
-		gSched:        40,
-		bufPC:         0,
-		gWaitreason:   48,
-		gParentGoid:   56,
-		gGopc:         64,
-		gStartpc:      72,
-		mCurg:         0,
-		mAlllink:      8,
-	}
+	layout := goroutineTestLayout()
 	backend := newGoroutineMemoryBackend()
 	backend.seedU64(firstM+uint64(layout.mCurg), firstG)
 	backend.seedU64(firstM+uint64(layout.mAlllink), secondM)
 	backend.seedU64(secondM+uint64(layout.mCurg), currentG)
 	backend.seedU64(secondM+uint64(layout.mAlllink), 0)
-	backend.seedU32(firstG+uint64(layout.gAtomicstatus), 2)
-	backend.seedU64(firstG+uint64(layout.gGoid), 1)
-	backend.seedU64(firstG+uint64(layout.gStack)+uint64(layout.stackLo), 0x1000)
-	backend.seedU64(firstG+uint64(layout.gStack)+uint64(layout.stackHi), 0x2000)
-	backend.seedU32(currentG+uint64(layout.gAtomicstatus), 2)
-	backend.seedU64(currentG+uint64(layout.gGoid), 99)
-	backend.seedU64(currentG+uint64(layout.gStack)+uint64(layout.stackLo), stackLo)
-	backend.seedU64(currentG+uint64(layout.gStack)+uint64(layout.stackHi), stackLo+0x1000)
+	seedTestGoroutine(backend, layout, firstG, 1, 0x1000, 0x2000)
+	seedTestGoroutine(backend, layout, currentG, 99, stackLo, stackLo+0x1000)
 
 	e := &engine{backend: backend}
 	result := e.findCurrentGoroutineInThreadList(layout, firstM, stackLo+8, 0x1234)

--- a/internal/debugger/goroutines_internal_test.go
+++ b/internal/debugger/goroutines_internal_test.go
@@ -391,19 +391,30 @@ func TestCurrentGoroutineIdentityReadsOnlyRequiredFields(t *testing.T) {
 		t.Fatalf("current identity = %+v, want current g42", result)
 	}
 
-	required := []uint64{
-		gptr + uint64(layout.gAtomicstatus),
-		gptr + uint64(layout.gGoid),
-		gptr + uint64(layout.gStack) + uint64(layout.stackLo),
-		gptr + uint64(layout.gStack) + uint64(layout.stackHi),
+	if len(backend.reads) != 1 || backend.reads[gptr] != 1 {
+		t.Fatalf("read addresses = %#v, want one bounded bulk identity read at %#x", backend.reads, gptr)
 	}
-	if len(backend.reads) != len(required) {
-		t.Fatalf("read addresses = %#v, want only %d required identity fields", backend.reads, len(required))
+}
+
+func TestCurrentGoroutineIdentityWideLayoutKeepsReadsBounded(t *testing.T) {
+	const (
+		gptr   = uint64(0x200000)
+		liveSP = uint64(0x8008)
+	)
+	layout := goroutineTestLayout()
+	layout.gGoid = maxCurrentIdentityBytes * 2
+	backend := newGoroutineMemoryBackend()
+	seedTestGoroutine(backend, layout, gptr, 42, 0x8000, 0x9000)
+
+	e := &engine{backend: backend}
+	result := e.currentGoroutineFromRegister(
+		layout, gptr, liveSP, 0x1234, currentGoroutineIdentity,
+	)
+	if !result.Complete || !result.Found || result.Item.ID != 42 {
+		t.Fatalf("current identity = %+v, want current g42", result)
 	}
-	for _, addr := range required {
-		if backend.reads[addr] != 1 {
-			t.Fatalf("reads at %#x = %d, want 1", addr, backend.reads[addr])
-		}
+	if len(backend.reads) != 4 {
+		t.Fatalf("read addresses = %#v, want four bounded field reads", backend.reads)
 	}
 }
 

--- a/internal/debugger/goroutines_internal_test.go
+++ b/internal/debugger/goroutines_internal_test.go
@@ -1,0 +1,324 @@
+package debugger
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+type goroutineMemoryBackend struct {
+	mem   map[uint64]byte
+	regs  Registers
+	reads map[uint64]int
+}
+
+func newGoroutineMemoryBackend() *goroutineMemoryBackend {
+	return &goroutineMemoryBackend{
+		mem:   make(map[uint64]byte),
+		reads: make(map[uint64]int),
+	}
+}
+
+func (b *goroutineMemoryBackend) seedU64(addr, value uint64) {
+	var raw [8]byte
+	binary.LittleEndian.PutUint64(raw[:], value)
+	for i, v := range raw {
+		b.mem[addr+uint64(i)] = v
+	}
+}
+
+func (b *goroutineMemoryBackend) seedU32(addr uint64, value uint32) {
+	var raw [4]byte
+	binary.LittleEndian.PutUint32(raw[:], value)
+	for i, v := range raw {
+		b.mem[addr+uint64(i)] = v
+	}
+}
+
+func (b *goroutineMemoryBackend) ContinueProcess() error { return nil }
+func (b *goroutineMemoryBackend) SingleStep(int) error   { return nil }
+func (b *goroutineMemoryBackend) StopProcess() error     { return nil }
+func (b *goroutineMemoryBackend) PauseSignal() int       { return 0 }
+
+func (b *goroutineMemoryBackend) ReadMemory(addr uint64, dst []byte) error {
+	b.reads[addr]++
+	for i := range dst {
+		dst[i] = b.mem[addr+uint64(i)]
+	}
+	return nil
+}
+
+func (b *goroutineMemoryBackend) WriteMemory(addr uint64, src []byte) error {
+	for i, v := range src {
+		b.mem[addr+uint64(i)] = v
+	}
+	return nil
+}
+
+func (b *goroutineMemoryBackend) GetRegisters(int) (Registers, error) {
+	return b.regs, nil
+}
+
+func (b *goroutineMemoryBackend) SetRegisters(_ int, regs Registers) error {
+	b.regs = regs
+	return nil
+}
+
+func (b *goroutineMemoryBackend) Threads() ([]int, error) {
+	return []int{1}, nil
+}
+
+func (b *goroutineMemoryBackend) Wait() (StopEvent, error) {
+	return StopEvent{}, ErrProcessExited
+}
+
+func TestBuildGoroutineListAnchorsCurrentBeyondRichScan(t *testing.T) {
+	const (
+		allgsPtr = uint64(0x1000)
+		gBase    = uint64(0x200000)
+		gStride  = uint64(0x100)
+		stack    = uint64(0x80000000)
+	)
+	layout := &goLayout{
+		valid:         true,
+		gAtomicstatus: 0,
+		gGoid:         8,
+		gStack:        16,
+		stackLo:       0,
+		stackHi:       8,
+		gM:            32,
+		gSched:        40,
+		bufPC:         0,
+		gWaitreason:   48,
+		gParentGoid:   56,
+		gGopc:         64,
+		gStartpc:      72,
+	}
+
+	backend := newGoroutineMemoryBackend()
+	length := uint64(maxGoroutineScan + 4)
+	currentIndex := length - 1
+	for i := uint64(0); i < length; i++ {
+		gptr := gBase + i*gStride
+		backend.seedU64(allgsPtr+i*8, gptr)
+		backend.seedU32(gptr+uint64(layout.gAtomicstatus), 2)
+		backend.seedU64(gptr+uint64(layout.gGoid), i+1)
+		backend.seedU64(gptr+uint64(layout.gStack)+uint64(layout.stackLo), stack+i*gStride)
+		backend.seedU64(gptr+uint64(layout.gStack)+uint64(layout.stackHi), stack+(i+1)*gStride)
+	}
+
+	liveSP := stack + currentIndex*gStride + 8
+	e := &engine{backend: backend}
+	result := e.buildGoroutineListFrom(layout, allgsPtr, length, liveSP, 0x1234, 0)
+	got, anchorID := result.Items, result.AnchorID
+	if !result.Complete {
+		t.Fatal("buildGoroutineListFrom degraded instead of returning the rich prefix plus current anchor")
+	}
+	if want := maxGoroutineScan + 1; len(got) != want {
+		t.Fatalf("len(goroutines) = %d, want %d", len(got), want)
+	}
+	if !got[0].Current || got[0].ID != int(currentIndex+1) {
+		t.Fatalf("first goroutine = %+v, want current anchor id %d", got[0], currentIndex+1)
+	}
+	if anchorID != got[0].ID {
+		t.Fatalf("anchor id = %d, want %d", anchorID, got[0].ID)
+	}
+
+	currentCount := 0
+	for _, g := range got {
+		if g.Current {
+			currentCount++
+		}
+	}
+	if currentCount != 1 {
+		t.Fatalf("current goroutines = %d, want 1", currentCount)
+	}
+
+	unmatchedTail := gBase + uint64(maxGoroutineScan+1)*gStride
+	if reads := backend.reads[unmatchedTail+uint64(layout.gGoid)]; reads != 0 {
+		t.Fatalf("unmatched tail goid reads = %d, want 0; tail scan must read stack bounds only", reads)
+	}
+}
+
+func TestBuildGoroutineListUsesDirectCurrentPointerBeyondFallback(t *testing.T) {
+	const (
+		allgsPtr = uint64(0x1000)
+		prefixG  = uint64(0x200000)
+		currentG = uint64(0x300000)
+		stackLo  = uint64(0x90000000)
+	)
+	layout := &goLayout{
+		valid:         true,
+		gAtomicstatus: 0,
+		gGoid:         8,
+		gStack:        16,
+		stackLo:       0,
+		stackHi:       8,
+		gM:            32,
+		gSched:        40,
+		bufPC:         0,
+		gWaitreason:   48,
+		gParentGoid:   56,
+		gGopc:         64,
+		gStartpc:      72,
+	}
+	backend := newGoroutineMemoryBackend()
+	backend.seedU64(allgsPtr, prefixG)
+	backend.seedU32(prefixG+uint64(layout.gAtomicstatus), 2)
+	backend.seedU64(prefixG+uint64(layout.gGoid), 1)
+	backend.seedU64(prefixG+uint64(layout.gStack)+uint64(layout.stackLo), 0x1000)
+	backend.seedU64(prefixG+uint64(layout.gStack)+uint64(layout.stackHi), 0x2000)
+	backend.seedU32(currentG+uint64(layout.gAtomicstatus), 2)
+	backend.seedU64(currentG+uint64(layout.gGoid), 99)
+	backend.seedU64(currentG+uint64(layout.gStack)+uint64(layout.stackLo), stackLo)
+	backend.seedU64(currentG+uint64(layout.gStack)+uint64(layout.stackHi), stackLo+0x1000)
+
+	length := uint64(maxGoroutineScan*3 + 1)
+	e := &engine{backend: backend}
+	result := e.buildGoroutineListFrom(
+		layout, allgsPtr, length, stackLo+8, 0x1234, currentG,
+	)
+	got, anchorID := result.Items, result.AnchorID
+	if !result.Complete || len(got) != 2 {
+		t.Fatalf("goroutines = %+v, complete = %t; want rich entry plus direct anchor", got, result.Complete)
+	}
+	if !got[0].Current || got[0].ID != 99 || anchorID != 99 {
+		t.Fatalf("anchor = %+v, anchor id = %d; want current id 99", got[0], anchorID)
+	}
+	firstTailEntry := allgsPtr + uint64(maxGoroutineScan)*8
+	if reads := backend.reads[firstTailEntry]; reads != 0 {
+		t.Fatalf("tail pointer reads = %d, want 0 when direct current pointer resolves", reads)
+	}
+}
+
+func TestBuildGoroutineListBoundsFallbackTail(t *testing.T) {
+	const (
+		allgsPtr = uint64(0x1000)
+		prefixG  = uint64(0x200000)
+	)
+	layout := &goLayout{
+		valid:         true,
+		gAtomicstatus: 0,
+		gGoid:         8,
+		gStack:        16,
+		stackLo:       0,
+		stackHi:       8,
+		gM:            32,
+		gSched:        40,
+		bufPC:         0,
+		gWaitreason:   48,
+		gParentGoid:   56,
+		gGopc:         64,
+		gStartpc:      72,
+	}
+	backend := newGoroutineMemoryBackend()
+	backend.seedU64(allgsPtr, prefixG)
+	backend.seedU32(prefixG+uint64(layout.gAtomicstatus), 2)
+	backend.seedU64(prefixG+uint64(layout.gGoid), 1)
+	backend.seedU64(prefixG+uint64(layout.gStack)+uint64(layout.stackLo), 0x1000)
+	backend.seedU64(prefixG+uint64(layout.gStack)+uint64(layout.stackHi), 0x2000)
+
+	length := uint64(maxGoroutineScan*3 + 1)
+	e := &engine{backend: backend}
+	result := e.buildGoroutineListFrom(
+		layout, allgsPtr, length, 0xdeadbeef, 0x1234, 0,
+	)
+	got, anchorID := result.Items, result.AnchorID
+	if !result.Complete || len(got) != 1 || anchorID != 0 {
+		t.Fatalf(
+			"goroutines = %+v, anchor id = %d, complete = %t; want bounded rich result",
+			got, anchorID, result.Complete,
+		)
+	}
+	lastFallbackEntry := allgsPtr + uint64(maxGoroutineScan*2-1)*8
+	if reads := backend.reads[lastFallbackEntry]; reads != 1 {
+		t.Fatalf("last fallback pointer reads = %d, want 1", reads)
+	}
+	firstUnscannedEntry := allgsPtr + uint64(maxGoroutineScan*2)*8
+	if reads := backend.reads[firstUnscannedEntry]; reads != 0 {
+		t.Fatalf("first pointer beyond fallback budget reads = %d, want 0", reads)
+	}
+}
+
+func TestFindCurrentGoroutineFromThreadList(t *testing.T) {
+	const (
+		firstM   = uint64(0x400000)
+		secondM  = uint64(0x400100)
+		firstG   = uint64(0x500000)
+		currentG = uint64(0x500100)
+		stackLo  = uint64(0xa0000000)
+	)
+	layout := &goLayout{
+		valid:         true,
+		gAtomicstatus: 0,
+		gGoid:         8,
+		gStack:        16,
+		stackLo:       0,
+		stackHi:       8,
+		gM:            32,
+		gSched:        40,
+		bufPC:         0,
+		gWaitreason:   48,
+		gParentGoid:   56,
+		gGopc:         64,
+		gStartpc:      72,
+		mCurg:         0,
+		mAlllink:      8,
+	}
+	backend := newGoroutineMemoryBackend()
+	backend.seedU64(firstM+uint64(layout.mCurg), firstG)
+	backend.seedU64(firstM+uint64(layout.mAlllink), secondM)
+	backend.seedU64(secondM+uint64(layout.mCurg), currentG)
+	backend.seedU64(secondM+uint64(layout.mAlllink), 0)
+	backend.seedU32(firstG+uint64(layout.gAtomicstatus), 2)
+	backend.seedU64(firstG+uint64(layout.gGoid), 1)
+	backend.seedU64(firstG+uint64(layout.gStack)+uint64(layout.stackLo), 0x1000)
+	backend.seedU64(firstG+uint64(layout.gStack)+uint64(layout.stackHi), 0x2000)
+	backend.seedU32(currentG+uint64(layout.gAtomicstatus), 2)
+	backend.seedU64(currentG+uint64(layout.gGoid), 99)
+	backend.seedU64(currentG+uint64(layout.gStack)+uint64(layout.stackLo), stackLo)
+	backend.seedU64(currentG+uint64(layout.gStack)+uint64(layout.stackHi), stackLo+0x1000)
+
+	e := &engine{backend: backend}
+	result := e.findCurrentGoroutineInThreadList(layout, firstM, stackLo+8, 0x1234)
+	if !result.Complete || !result.Found || !result.Item.Current || result.Item.ID != 99 {
+		t.Fatalf("current goroutine = %+v; want current id 99", result)
+	}
+}
+
+func TestSnapshotGoroutineIDsExcludesTailAnchorFromLifecycleSet(t *testing.T) {
+	gs := []protocol.Goroutine{
+		{ID: 99, Current: true},
+		{ID: 1},
+		{ID: 2},
+	}
+	live, current := snapshotGoroutineIDs(gs, 99)
+	if current != 99 {
+		t.Fatalf("current id = %d, want 99", current)
+	}
+	if len(live) != 2 {
+		t.Fatalf("lifecycle set = %v, want only rich ids 1 and 2", live)
+	}
+	if _, ok := live[99]; ok {
+		t.Fatalf("lifecycle set = %v, must exclude tail anchor", live)
+	}
+}
+
+func TestDegradedGoroutineSnapshotPreservesPreviousLiveSet(t *testing.T) {
+	backend := newGoroutineMemoryBackend()
+	backend.regs = Registers{SP: 0x1000, PC: 0x2000}
+	e := &engine{
+		backend:   backend,
+		curTID:    1,
+		prevGoids: map[int]struct{}{42: {}},
+	}
+
+	snapshot := e.goroutineSnapshot()
+	if len(snapshot.Goroutines) != 1 || !snapshot.Goroutines[0].Current {
+		t.Fatalf("degraded snapshot goroutines = %+v, want one current synthetic goroutine", snapshot.Goroutines)
+	}
+	if _, ok := e.prevGoids[42]; !ok || len(e.prevGoids) != 1 {
+		t.Fatalf("prevGoids = %v, want unchanged {42}", e.prevGoids)
+	}
+}

--- a/internal/debugger/goroutines_internal_test.go
+++ b/internal/debugger/goroutines_internal_test.go
@@ -13,12 +13,14 @@ type goroutineMemoryBackend struct {
 	regs   Registers
 	regErr error
 	reads  map[uint64]int
+	fails  map[uint64]int
 }
 
 func newGoroutineMemoryBackend() *goroutineMemoryBackend {
 	return &goroutineMemoryBackend{
 		mem:   make(map[uint64]byte),
 		reads: make(map[uint64]int),
+		fails: make(map[uint64]int),
 	}
 }
 
@@ -97,10 +99,18 @@ func (b *goroutineMemoryBackend) PauseSignal() int       { return 0 }
 
 func (b *goroutineMemoryBackend) ReadMemory(addr uint64, dst []byte) error {
 	b.reads[addr]++
+	if b.fails[addr] > 0 {
+		b.fails[addr]--
+		return errors.New("injected read failure")
+	}
 	for i := range dst {
 		dst[i] = b.mem[addr+uint64(i)]
 	}
 	return nil
+}
+
+func (b *goroutineMemoryBackend) failNextReadAt(addr uint64) {
+	b.fails[addr]++
 }
 
 func (b *goroutineMemoryBackend) WriteMemory(addr uint64, src []byte) error {
@@ -137,7 +147,7 @@ func TestBuildGoroutineListAnchorsCurrentBeyondRichScan(t *testing.T) {
 	layout := goroutineTestLayout()
 
 	backend := newGoroutineMemoryBackend()
-	length := uint64(maxGoroutineScan + 4)
+	length := uint64(maxGoroutineScan + 1)
 	currentIndex := length - 1
 	for i := uint64(0); i < length; i++ {
 		gptr := gBase + i*gStride
@@ -366,55 +376,112 @@ func TestCurrentGoroutineFromRegisterRejectsUnrelatedPositiveGoID(t *testing.T) 
 
 	e := &engine{backend: backend}
 	result := e.currentGoroutineFromRegister(
-		layout, candidate, 0xdeadbeef, 0x1234, currentGoroutineRich,
+		layout, candidate, 0xdeadbeef, 0x1234,
 	)
 	if !result.Complete || result.Found {
 		t.Fatalf("current goroutine = %+v; want complete rejection of stale positive-goid candidate", result)
 	}
 }
 
-func TestCurrentGoroutineIdentityReadsOnlyRequiredFields(t *testing.T) {
+func TestBuildGoroutineListTreatsSpeculativeRegisterHintFailuresAsMisses(t *testing.T) {
 	const (
-		gptr   = uint64(0x200000)
-		liveSP = uint64(0x8008)
+		allgsPtr  = uint64(0x1000)
+		realG     = uint64(0x200000)
+		candidate = uint64(0x300000)
+		mptr      = uint64(0x400000)
 	)
-	layout := goroutineTestLayout()
-	backend := newGoroutineMemoryBackend()
-	seedTestGoroutine(backend, layout, gptr, 42, 0x8000, 0x9000)
+	for _, tc := range []struct {
+		name string
+		seed func(*goroutineMemoryBackend, *goLayout)
+		fail func(*goroutineMemoryBackend, *goLayout) uint64
+	}{
+		{
+			name: "invalid positive goid",
+			seed: func(backend *goroutineMemoryBackend, layout *goLayout) {
+				seedTestGoroutine(backend, layout, candidate, 88, 0xa0000000, 0xa0001000)
+			},
+		},
+		{
+			name: "unreadable candidate header",
+			fail: func(_ *goroutineMemoryBackend, layout *goLayout) uint64 {
+				return candidate + uint64(layout.gAtomicstatus)
+			},
+		},
+		{
+			name: "unreadable candidate m",
+			seed: func(backend *goroutineMemoryBackend, layout *goLayout) {
+				seedTestGoroutine(backend, layout, candidate, 0, 0xa0000000, 0xa0001000)
+			},
+			fail: func(_ *goroutineMemoryBackend, layout *goLayout) uint64 {
+				return candidate + uint64(layout.gM)
+			},
+		},
+		{
+			name: "unreadable m.g0",
+			seed: func(backend *goroutineMemoryBackend, layout *goLayout) {
+				seedTestGoroutine(backend, layout, candidate, 0, 0xa0000000, 0xa0001000)
+				backend.seedU64(candidate+uint64(layout.gM), mptr)
+			},
+			fail: func(_ *goroutineMemoryBackend, layout *goLayout) uint64 {
+				return mptr + uint64(layout.mG0)
+			},
+		},
+		{
+			name: "unreadable m.gsignal",
+			seed: func(backend *goroutineMemoryBackend, layout *goLayout) {
+				seedTestGoroutine(backend, layout, candidate, 0, 0xa0000000, 0xa0001000)
+				backend.seedU64(candidate+uint64(layout.gM), mptr)
+				backend.seedU64(mptr+uint64(layout.mG0), 0)
+			},
+			fail: func(_ *goroutineMemoryBackend, layout *goLayout) uint64 {
+				return mptr + uint64(layout.mGsignal)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			layout := goroutineTestLayout()
+			backend := newGoroutineMemoryBackend()
+			backend.seedU64(allgsPtr, realG)
+			seedTestGoroutine(backend, layout, realG, 1, 0x1000, 0x2000)
+			if tc.seed != nil {
+				tc.seed(backend, layout)
+			}
+			var failAddr uint64
+			if tc.fail != nil {
+				failAddr = tc.fail(backend, layout)
+				backend.failNextReadAt(failAddr)
+			}
 
-	e := &engine{backend: backend}
-	result := e.currentGoroutineFromRegister(
-		layout, gptr, liveSP, 0x1234, currentGoroutineIdentity,
-	)
-	if !result.Complete || !result.Found ||
-		result.Item.ID != 42 || !result.Item.Current {
-		t.Fatalf("current identity = %+v, want current g42", result)
-	}
-
-	if len(backend.reads) != 1 || backend.reads[gptr] != 1 {
-		t.Fatalf("read addresses = %#v, want one bounded bulk identity read at %#x", backend.reads, gptr)
-	}
-}
-
-func TestCurrentGoroutineIdentityWideLayoutKeepsReadsBounded(t *testing.T) {
-	const (
-		gptr   = uint64(0x200000)
-		liveSP = uint64(0x8008)
-	)
-	layout := goroutineTestLayout()
-	layout.gGoid = maxCurrentIdentityBytes * 2
-	backend := newGoroutineMemoryBackend()
-	seedTestGoroutine(backend, layout, gptr, 42, 0x8000, 0x9000)
-
-	e := &engine{backend: backend}
-	result := e.currentGoroutineFromRegister(
-		layout, gptr, liveSP, 0x1234, currentGoroutineIdentity,
-	)
-	if !result.Complete || !result.Found || result.Item.ID != 42 {
-		t.Fatalf("current identity = %+v, want current g42", result)
-	}
-	if len(backend.reads) != 4 {
-		t.Fatalf("read addresses = %#v, want four bounded field reads", backend.reads)
+			e := &engine{backend: backend}
+			hint := e.currentGoroutineFromRegister(
+				layout, candidate, 0xdeadbeef, 0x1234,
+			)
+			if !hint.Complete || hint.Found {
+				t.Fatalf("register hint = %+v, want complete miss", hint)
+			}
+			if failAddr != 0 {
+				backend.failNextReadAt(failAddr)
+			}
+			result := e.buildGoroutineListFrom(
+				layout, allgsPtr, 1, 0xdeadbeef, 0x1234, candidate, 0,
+			)
+			if !result.Complete || result.AnchorID != 0 ||
+				len(result.Items) != 1 || result.Items[0].ID != 1 ||
+				result.Items[0].Current {
+				t.Fatalf("goroutine walk = %+v, want complete rich set with unknown current", result)
+			}
+			_, current := snapshotGoroutineIDs(result.Items, result.AnchorID)
+			if current != 0 {
+				t.Fatalf("snapshot current = %d, want honest unknown identity", current)
+			}
+			selected := currentGoroutineFrom(
+				protocol.GoroutineSnapshotPayload{Goroutines: result.Items},
+				protocol.Location{},
+			)
+			if selected.ID != 0 || selected.Status != "unknown" || !selected.Current {
+				t.Fatalf("selected current = %+v, want synthetic unknown", selected)
+			}
+		})
 	}
 }
 
@@ -447,7 +514,7 @@ func TestFindCurrentGoroutineByProcIDContinuesPastRichThreadCap(t *testing.T) {
 
 	e := &engine{backend: backend}
 	result := e.findCurrentGoroutineByProcIDFrom(
-		layout, mBase, targetID, 0x1234, currentGoroutineRich,
+		layout, mBase, targetID, 0x1234,
 	)
 	if !result.Complete || !result.Found ||
 		!result.Item.Current || result.Item.ID != 99 || result.Item.ThreadID != int(targetID) {
@@ -474,7 +541,7 @@ func TestFindCurrentGoroutineByProcIDBoundsTargetedContinuation(t *testing.T) {
 
 	e := &engine{backend: backend}
 	result := e.findCurrentGoroutineByProcIDFrom(
-		layout, mBase, ^uint64(0), 0x1234, currentGoroutineRich,
+		layout, mBase, ^uint64(0), 0x1234,
 	)
 	if !result.Complete || result.Found {
 		t.Fatalf("current goroutine = %+v; want complete bounded miss", result)

--- a/internal/debugger/goroutines_test.go
+++ b/internal/debugger/goroutines_test.go
@@ -409,8 +409,8 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 			SP:  0x8800,
 			TLS: fixture.g[1],
 		})
-
 		Expect(d.StepInto()).To(Succeed())
+		fb.getRegisterCalls = 0
 		fb.pushStop(debugger.StopEvent{
 			Reason: debugger.StopSingleStep,
 			TID:    1,
@@ -423,6 +423,7 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 		Expect(protocol.DecodeEventPayload(event, &stepped)).To(Succeed())
 		Expect(stepped.Goroutine.ID).To(Equal(102))
 		Expect(stepped.Goroutine.Current).To(BeTrue())
+		Expect(fb.getRegisterCalls).To(Equal(1))
 	})
 
 	It("retains a complete goroutine set when current identity is unknown", func() {

--- a/internal/debugger/goroutines_test.go
+++ b/internal/debugger/goroutines_test.go
@@ -321,7 +321,7 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 		clipped := debugger.ExportedGoroutineWalkResult(d)
 
 		Expect(clipped).To(Equal(debugger.ExportedWalkResult{
-			Count:    debugger.ExportedMaxGoroutineScan(),
+			Count:    debugger.ExportedMaxGoroutineScan() + 1,
 			Complete: true,
 			Clipped:  true,
 		}))

--- a/internal/debugger/goroutines_test.go
+++ b/internal/debugger/goroutines_test.go
@@ -122,7 +122,7 @@ func expectDegradedSnapshotPreservesBaseline(degraded, recovered protocol.Gorout
 		observeSnapshot(degraded),
 		observeSnapshot(recovered),
 	}).To(Equal([]snapshotObservation{
-		{Goroutines: []int{1}, Selected: 1},
+		{Goroutines: []int{0}},
 		{
 			Goroutines: []int{101, 102},
 			Threads:    2,
@@ -273,7 +273,7 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 
 			gs, err := d.Goroutines()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(goroutineIDs(gs)).To(Equal([]int{1}))
+			Expect(goroutineIDs(gs)).To(Equal([]int{0}))
 			Expect(gs[0].Current).To(BeTrue())
 		},
 		Entry("for an unreadable allgs slot", func() uint64 {
@@ -321,7 +321,7 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 		clipped := debugger.ExportedGoroutineWalkResult(d)
 
 		Expect(clipped).To(Equal(debugger.ExportedWalkResult{
-			Count:    debugger.ExportedMaxGoroutineScan() + 1,
+			Count:    debugger.ExportedMaxGoroutineScan(),
 			Complete: true,
 			Clipped:  true,
 		}))
@@ -343,6 +343,9 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 			Goroutines: []protocol.Goroutine{{ID: 101}, {ID: 102}},
 		})
 
-		Expect(current).To(Equal(protocol.Goroutine{}))
+		Expect(current).To(Equal(protocol.Goroutine{
+			Status:  "unknown",
+			Current: true,
+		}))
 	})
 })

--- a/internal/debugger/goroutines_test.go
+++ b/internal/debugger/goroutines_test.go
@@ -377,6 +377,10 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 		Expect(currentThreads).To(Equal(1))
 
 		seedU32(fb, fixture.g[2]+fixture.layout.GAtomicstatus, 6)
+		// The first failure rejects the speculative register hint; the second
+		// proves the same required stack bound still degrades when the rooted
+		// allgs tail walk reaches it.
+		fb.failNextReadAt(tailCurrent + fixture.layout.GStack + fixture.layout.StackLo)
 		fb.failNextReadAt(tailCurrent + fixture.layout.GStack + fixture.layout.StackLo)
 
 		degraded := debugger.ExportedGoroutineSnapshot(d)
@@ -402,7 +406,7 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 		Expect(currentThreads).To(Equal(1))
 	})
 
-	It("resolves regular step identity without a rich allgs walk", func() {
+	It("keeps regular step identity synthetic without reading runtime lists", func() {
 		seedU64(fb, fixture.m[1]+fixture.layout.MProcid, 1)
 		fb.seedRegs(debugger.Registers{
 			PC:  0x1234,
@@ -411,6 +415,7 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 		})
 		Expect(d.StepInto()).To(Succeed())
 		fb.getRegisterCalls = 0
+		fb.readCount = make(map[uint64]int)
 		fb.pushStop(debugger.StopEvent{
 			Reason: debugger.StopSingleStep,
 			TID:    1,
@@ -421,8 +426,17 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 		Expect(event.Kind).To(Equal(protocol.EventStepped))
 		var stepped protocol.SteppedPayload
 		Expect(protocol.DecodeEventPayload(event, &stepped)).To(Succeed())
-		Expect(stepped.Goroutine.ID).To(Equal(102))
+		Expect(stepped.Goroutine.ID).To(BeZero())
+		Expect(stepped.Goroutine.Status).To(Equal("unknown"))
 		Expect(stepped.Goroutine.Current).To(BeTrue())
+		Expect(fb.readCount[fixture.layout.Allgs]).To(BeZero(),
+			"regular steps must not read the runtime.allgs root")
+		Expect(fb.readCount[fixture.layout.Allm]).To(BeZero(),
+			"regular steps must not read the runtime.allm root")
+		Expect(fb.readCount[allgsArrayAddr]).To(BeZero(),
+			"regular steps must not walk runtime.allgs")
+		Expect(fb.readCount[mBaseAddr+fixture.layout.MProcid]).To(BeZero(),
+			"regular steps must not walk runtime.allm")
 		Expect(fb.getRegisterCalls).To(Equal(1))
 	})
 

--- a/internal/debugger/goroutines_test.go
+++ b/internal/debugger/goroutines_test.go
@@ -84,6 +84,8 @@ func seedGoroutineMemory(fb *fakeBackend, d debugger.Debugger) goroutineMemoryFi
 	seedU64(fb, fixture.m[1]+layout.MProcid, 22)
 	seedU64(fb, fixture.m[1]+layout.MCurg, fixture.g[1])
 	seedU64(fb, fixture.m[1]+layout.MAlllink, 0)
+	seedU64(fb, fixture.g[0]+layout.GM, fixture.m[0])
+	seedU64(fb, fixture.g[1]+layout.GM, fixture.m[1])
 	fb.seedRegs(debugger.Registers{SP: 0x8800})
 
 	return fixture
@@ -325,6 +327,102 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 			Complete: true,
 			Clipped:  true,
 		}))
+	})
+
+	It("preserves lifecycle state when a beyond-cap current anchor read is incomplete", func() {
+		const (
+			largeAllgsAddr = uint64(0x2000000)
+			tailStackLo    = uint64(0xb0000000)
+		)
+		richCount := debugger.ExportedMaxGoroutineScan()
+		tailCurrent := fixture.g[4]
+
+		seedU64(fb, fixture.layout.Allgs, largeAllgsAddr)
+		seedU64(fb, fixture.layout.Allgs+8, uint64(richCount+1))
+		for i := 0; i < richCount; i++ {
+			gptr := fixture.g[i%3]
+			seedU64(fb, largeAllgsAddr+uint64(i)*8, gptr)
+		}
+		seedU32(fb, tailCurrent+fixture.layout.GAtomicstatus, 4)
+		seedU64(fb, tailCurrent+fixture.layout.GGoid, 104)
+		seedU64(fb, tailCurrent+fixture.layout.GStack+fixture.layout.StackLo, tailStackLo)
+		seedU64(fb, tailCurrent+fixture.layout.GStack+fixture.layout.StackHi, tailStackLo+0x1000)
+		seedU64(fb, tailCurrent+fixture.layout.GM, fixture.m[1])
+		seedU64(fb, fixture.m[1]+fixture.layout.MProcid, 1)
+		seedU64(fb, fixture.m[1]+fixture.layout.MCurg, tailCurrent)
+		seedU64(fb, largeAllgsAddr+uint64(richCount)*8, tailCurrent)
+		fb.seedRegs(debugger.Registers{SP: tailStackLo + 8, TLS: tailCurrent})
+
+		baseline := debugger.ExportedGoroutineSnapshot(d)
+		Expect(baseline.Current).To(Equal(104))
+		Expect(baseline.Goroutines).To(HaveLen(richCount + 1))
+		Expect(baseline.Goroutines[0].ID).To(Equal(104))
+		Expect(baseline.Goroutines[0].Current).To(BeTrue())
+		Expect(baseline.Created).To(BeNil())
+		Expect(baseline.Exited).To(BeNil())
+		currentGoroutines := 0
+		for _, goroutine := range baseline.Goroutines {
+			if goroutine.Current {
+				currentGoroutines++
+			}
+		}
+		Expect(currentGoroutines).To(Equal(1))
+		currentThreads := 0
+		for _, thread := range baseline.Threads {
+			if thread.Current {
+				currentThreads++
+				Expect(thread.GoID).To(Equal(104))
+			}
+		}
+		Expect(currentThreads).To(Equal(1))
+
+		seedU32(fb, fixture.g[2]+fixture.layout.GAtomicstatus, 6)
+		fb.failNextReadAt(tailCurrent + fixture.layout.GStack + fixture.layout.StackLo)
+
+		degraded := debugger.ExportedGoroutineSnapshot(d)
+		recovered := debugger.ExportedGoroutineSnapshot(d)
+
+		Expect(degraded.Goroutines).To(Equal([]protocol.Goroutine{{
+			Status:  "unknown",
+			Current: true,
+		}}))
+		Expect(degraded.Created).To(BeNil())
+		Expect(degraded.Exited).To(BeNil())
+		Expect(recovered.Current).To(Equal(104))
+		Expect(recovered.Created).To(BeNil())
+		Expect(recovered.Exited).To(Equal([]int{103}))
+
+		currentThreads = 0
+		for _, thread := range recovered.Threads {
+			if thread.Current {
+				currentThreads++
+				Expect(thread.GoID).To(Equal(104))
+			}
+		}
+		Expect(currentThreads).To(Equal(1))
+	})
+
+	It("resolves regular step identity without a rich allgs walk", func() {
+		seedU64(fb, fixture.m[1]+fixture.layout.MProcid, 1)
+		fb.seedRegs(debugger.Registers{
+			PC:  0x1234,
+			SP:  0x8800,
+			TLS: fixture.g[1],
+		})
+
+		Expect(d.StepInto()).To(Succeed())
+		fb.pushStop(debugger.StopEvent{
+			Reason: debugger.StopSingleStep,
+			TID:    1,
+			PC:     0x1234,
+		})
+
+		event := mustNextEvent(d)
+		Expect(event.Kind).To(Equal(protocol.EventStepped))
+		var stepped protocol.SteppedPayload
+		Expect(protocol.DecodeEventPayload(event, &stepped)).To(Succeed())
+		Expect(stepped.Goroutine.ID).To(Equal(102))
+		Expect(stepped.Goroutine.Current).To(BeTrue())
 	})
 
 	It("retains a complete goroutine set when current identity is unknown", func() {

--- a/internal/debugger/goroutines_test.go
+++ b/internal/debugger/goroutines_test.go
@@ -2,6 +2,7 @@ package debugger_test
 
 import (
 	"encoding/binary"
+	"runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -377,11 +378,13 @@ var _ = Describe("goroutine snapshot partial reads", func() {
 		Expect(currentThreads).To(Equal(1))
 
 		seedU32(fb, fixture.g[2]+fixture.layout.GAtomicstatus, 6)
-		// The first failure rejects the speculative register hint; the second
-		// proves the same required stack bound still degrades when the rooted
-		// allgs tail walk reaches it.
+		// arm64 first rejects X28 as a speculative hint, then reaches the rooted
+		// allgs tail. Linux has no register candidate: its exact stopped-M lookup
+		// is already rooted, so one unreadable bound must degrade immediately.
 		fb.failNextReadAt(tailCurrent + fixture.layout.GStack + fixture.layout.StackLo)
-		fb.failNextReadAt(tailCurrent + fixture.layout.GStack + fixture.layout.StackLo)
+		if runtime.GOARCH == "arm64" {
+			fb.failNextReadAt(tailCurrent + fixture.layout.GStack + fixture.layout.StackLo)
+		}
 
 		degraded := debugger.ExportedGoroutineSnapshot(d)
 		recovered := debugger.ExportedGoroutineSnapshot(d)

--- a/internal/debugger/registers.go
+++ b/internal/debugger/registers.go
@@ -3,10 +3,10 @@ package debugger
 // Registers is the architecture-independent register snapshot the engine uses.
 //
 //	amd64:  PC=RIP   SP=RSP   BP=RBP   TLS=FS_BASE
-//	arm64:  PC=PC    SP=SP    BP=X29   TLS=X28
+//	arm64:  PC=PC    SP=SP    BP=X29   TLS=X28 (current *g)
 type Registers struct {
 	PC  uint64
 	SP  uint64
 	BP  uint64
-	TLS uint64 // goroutine pointer base (Go-specific)
+	TLS uint64
 }

--- a/justfile
+++ b/justfile
@@ -134,16 +134,21 @@ integration:
 # async-interrupt, `stepping` (StepInto/StepOut), `inspect` (StackFrames/Locals/
 # Goroutines), `breakpoints` (ClearBreakpoint), `kill` (kill-while-running),
 # `exit` (real exit code), `signals` (linux signal forwarding + Pause control),
-# `attach` (attach by PID to a running process), `restart`, and `fullstack`
-# transport, all under -race.
+# `overlap` (foreign-thread stops during single-step), `attach` (attach by PID
+# to a running process),
+# `concurrency`, `current-goroutine` (small control; heavy over-cap proof is
+# opt-in via BINGO_E2E_CURRENT_GOROUTINES), `restart`, and `fullstack` transport,
+# all under -race.
 e2e-linux:
 	go test -tags e2e -race -count=1 -v -timeout 600s ./test/integration
 
 # Run the debugger E2E acceptance tests on darwin/arm64 (native pure-Mach
 # exception-port backend). Runs every label (no filter): `basic`, `stepping`,
 # `breakpoints`, `churn`, `kill`, `exit`, `attach`, `pause`, `inspect`,
-# `restart`, `fullstack`, and the darwin-only `hygiene` (Mach port-right leak),
-# matching linux. The step-off-an-armed-trap specs and kill-while-running, once
+# `concurrency`, `current-goroutine` (small control; heavy over-cap proof is
+# opt-in via BINGO_E2E_CURRENT_GOROUTINES), `restart`, `fullstack`, and the
+# darwin-only `hygiene` (Mach port-right leak), matching linux. The
+# step-off-an-armed-trap specs and kill-while-running, once
 # linux-only under the old wait4 model, are reliable on darwin under the
 # Mach-exception rearchitecture (#92) — per-thread exception delivery, a
 # target-side I-cache flush on breakpoint writes, and a wait4-free kill (see the

--- a/pkg/protocol/payload.go
+++ b/pkg/protocol/payload.go
@@ -43,15 +43,15 @@ type Frame struct {
 // one that ran its `go` statement) and lifecycle state. IDs are the runtime's
 // goid (fits Go int on both supported 64-bit platforms).
 type Goroutine struct {
-	ID         int      `json:"id"`                   // goid
+	ID         int      `json:"id"`                   // goid; 0 for a synthetic unknown goroutine
 	ParentID   int      `json:"parentId,omitempty"`   // parent goroutine's goid; 0 for the root
-	Status     string   `json:"status"`               // scheduler status: "running" | "runnable" | "waiting" | "syscall" | "dead" | ...
+	Status     string   `json:"status"`               // scheduler status, or "unknown" for a synthetic fallback
 	WaitReason string   `json:"waitReason,omitempty"` // why a waiting goroutine is blocked (e.g. "chan receive")
 	CurrentLoc Location `json:"currentLoc"`           // where the goroutine is now (live PC if running, scheduled PC if parked)
 	StartLoc   Location `json:"startLoc,omitempty"`   // the goroutine's entry function (startpc)
 	CreatedLoc Location `json:"createdLoc,omitempty"` // the `go` statement that spawned it (gopc)
 	ThreadID   int      `json:"threadId,omitempty"`   // OS thread (m.procid) currently running it; 0 if not running
-	Current    bool     `json:"current,omitempty"`    // true for the goroutine the debugger is stopped in
+	Current    bool     `json:"current,omitempty"`    // true for the stopped goroutine or its unknown synthetic stand-in
 }
 
 // Thread is one OS thread (a runtime M) in the tracee. It complements the

--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 )
 
-const Version = "1.2"
+const Version = "1.3"
 
 // VersionError reports that a peer used a wire version other than Version.
 type VersionError struct {

--- a/pkg/protocol/protocol_test.go
+++ b/pkg/protocol/protocol_test.go
@@ -353,6 +353,25 @@ var _ = Describe("Event", func() {
 				},
 			),
 
+			Entry("GoroutineSnapshot with unknown current goroutine",
+				protocol.EventGoroutineSnapshot,
+				protocol.GoroutineSnapshotPayload{
+					Goroutines: []protocol.Goroutine{{
+						Status:  "unknown",
+						Current: true,
+					}},
+				},
+				func(e protocol.Event) {
+					var p protocol.GoroutineSnapshotPayload
+					Expect(protocol.DecodeEventPayload(e, &p)).To(Succeed())
+					Expect(p.Goroutines).To(HaveLen(1))
+					Expect(p.Goroutines[0].ID).To(BeZero())
+					Expect(p.Goroutines[0].Status).To(Equal("unknown"))
+					Expect(p.Goroutines[0].Current).To(BeTrue())
+					Expect(p.Current).To(BeZero())
+				},
+			),
+
 			Entry("Error with command",
 				protocol.EventError,
 				protocol.ErrorPayload{Command: protocol.CmdSetBreakpoint, Message: "address not found"},

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -433,6 +433,9 @@ import (
 )
 
 var sink int
+var releases []chan struct{}
+var ready = make(chan struct{})
+var assignment int
 
 //go:noinline
 func breakpointWorker(index int) {
@@ -440,27 +443,28 @@ func breakpointWorker(index int) {
 	select {}
 }
 
-func worker(index int, release <-chan struct{}, ready chan<- struct{}) {
+func worker() {
+	index := assignment
 	ready <- struct{}{}
-	<-release
+	<-releases[index]
 	breakpointWorker(index)
 }
 
+func spawnWorker() { go worker() } // SPAWN_CURRENT
+
 func main() {
 	go func() {
-		time.Sleep(180 * time.Second)
+		time.Sleep(10 * time.Minute)
 		os.Exit(0)
 	}()
 	runtime.GOMAXPROCS(4)
 
 	const goroutines = %d
-	releases := make([]chan struct{}, goroutines)
-	ready := make(chan struct{}, goroutines)
+	releases = make([]chan struct{}, goroutines)
 	for i := range releases {
 		releases[i] = make(chan struct{})
-		go worker(i, releases[i], ready)
-	}
-	for range goroutines {
+		assignment = i
+		spawnWorker()
 		<-ready
 	}
 
@@ -1215,6 +1219,7 @@ func assertCurrentGoroutineScan(count int) {
 	}
 	src := fmt.Sprintf(currentGoroutineTargetTemplate, count, releaseIndex)
 	line := markerLine(src, "// BP_CURRENT")
+	spawnLine := markerLine(src, "// SPAWN_CURRENT")
 	bin := buildTarget(fmt.Sprintf("current_goroutine_%d_target", count), src)
 
 	h := newE2EHarness(bin)
@@ -1241,15 +1246,19 @@ func assertCurrentGoroutineScan(count int) {
 	Expect(json.Unmarshal(evt.Payload, &snap)).To(Succeed(), "decode GoroutineSnapshot")
 
 	currentGoroutines := 0
+	var snapshotCurrent protocol.Goroutine
 	for _, g := range snap.Goroutines {
 		if g.Current {
 			currentGoroutines++
+			snapshotCurrent = g
 		}
 	}
 	currentThreads := 0
+	var snapshotThread protocol.Thread
 	for _, thread := range snap.Threads {
 		if thread.Current {
 			currentThreads++
+			snapshotThread = thread
 		}
 	}
 	GinkgoWriter.Printf(
@@ -1260,12 +1269,30 @@ func assertCurrentGoroutineScan(count int) {
 	)
 
 	Expect(hit.Goroutine.Current).To(BeTrue(), "BreakpointHit must identify the stopped goroutine")
+	Expect(hit.Goroutine.ID).To(BeNumerically(">", 0),
+		"BreakpointHit must carry a real nonzero goroutine id")
 	Expect(hit.Goroutine.CurrentLoc).To(Equal(hit.Frames[0].Location),
 		"BreakpointHit goroutine location must match the real stopped thread's innermost frame")
+	Expect(hit.Goroutine.StartLoc.Function).To(Equal("main.worker"),
+		"current goroutine start location must independently resolve the argumentless worker")
+	Expect(hit.Goroutine.CreatedLoc.Function).To(Equal("main.spawnWorker"),
+		"current goroutine creation location must resolve the spawning function")
+	Expect(hit.Goroutine.CreatedLoc.Line).To(Equal(spawnLine),
+		"current goroutine creation location must resolve the marked go statement")
+	Expect(snap.Current).To(BeNumerically(">", 0),
+		"snapshot Current must never pass vacuously as zero")
 	Expect(snap.Current).To(Equal(hit.Goroutine.ID),
 		"snapshot Current must identify the goroutine embedded in BreakpointHit")
 	Expect(currentGoroutines).To(Equal(1), "exactly one snapshot goroutine is current")
 	Expect(currentThreads).To(Equal(1), "exactly one runtime thread is current")
+	Expect(snapshotCurrent.ID).To(Equal(snap.Current),
+		"the uniquely marked snapshot goroutine must match snapshot Current")
+	Expect(snapshotCurrent.StartLoc.Function).To(Equal("main.worker"),
+		"snapshot current anchor must retain independently decoded start metadata")
+	Expect(snapshotCurrent.CreatedLoc.Line).To(Equal(spawnLine),
+		"snapshot current anchor must retain independently decoded creation metadata")
+	Expect(snapshotThread.GoID).To(Equal(snap.Current),
+		"the uniquely current runtime thread must run snapshot Current")
 	if count > richScanLimit {
 		Expect(snap.Goroutines).To(HaveLen(richScanLimit+1),
 			"heavy proof must append one current anchor beyond the full rich prefix")

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -20,6 +20,7 @@
 //
 //	BINGO_E2E_ITERS        (default 25)   basic continue+stepover iterations
 //	BINGO_E2E_CHURN_ITERS  (default 200)  churn iterations and target watchdog budget
+//	BINGO_E2E_CURRENT_GOROUTINES           opt-in over-cap current-g proof size
 //	BINGO_E2E_DEBUG        (unset)        route engine debug logs + every event to stderr
 
 package integration
@@ -422,6 +423,51 @@ func declareBaselineOwnershipSpec() {
 			"the automatic snapshot still owns the delta the query observed but must not consume")
 	})
 }
+
+const currentGoroutineTargetTemplate = `package main
+
+import (
+	"os"
+	"runtime"
+	"time"
+)
+
+var sink int
+
+//go:noinline
+func breakpointWorker(index int) {
+	sink = index // BP_CURRENT
+	select {}
+}
+
+func worker(index int, release <-chan struct{}, ready chan<- struct{}) {
+	ready <- struct{}{}
+	<-release
+	breakpointWorker(index)
+}
+
+func main() {
+	go func() {
+		time.Sleep(180 * time.Second)
+		os.Exit(0)
+	}()
+	runtime.GOMAXPROCS(4)
+
+	const goroutines = %d
+	releases := make([]chan struct{}, goroutines)
+	ready := make(chan struct{}, goroutines)
+	for i := range releases {
+		releases[i] = make(chan struct{})
+		go worker(i, releases[i], ready)
+	}
+	for range goroutines {
+		<-ready
+	}
+
+	close(releases[%d])
+	select {}
+}
+`
 
 // declareBasicStepOverSpec adds the continue+step-over acceptance spec to the
 // enclosing Ginkgo container. It is the correctness gate: set a breakpoint on a
@@ -1138,6 +1184,87 @@ func declareConcurrencySpec() {
 		Expect(findByStart(exited.Goroutines, "main.leaf")).To(BeNil(),
 			"leaf gone from the live set")
 	})
+}
+
+func declareCurrentGoroutineScanSpec() {
+	Describe("current goroutine discovery", Label("current-goroutine"), func() {
+		It("keeps the stopped goroutine coherent for a small target", func() {
+			assertCurrentGoroutineScan(64)
+		})
+
+		It("keeps the stopped goroutine coherent beyond the rich scan cap", func() {
+			count := envInt("BINGO_E2E_CURRENT_GOROUTINES", 0)
+			if count == 0 {
+				Skip("set BINGO_E2E_CURRENT_GOROUTINES to at least 20000 to run the heavy native proof")
+			}
+			Expect(count).To(BeNumerically(">=", 20_000),
+				"heavy proof must place its released tail worker beyond both bounded allgs windows")
+			assertCurrentGoroutineScan(count)
+		})
+	})
+}
+
+func assertCurrentGoroutineScan(count int) {
+	GinkgoHelper()
+	Expect(count).To(BeNumerically(">", 0), "target count must be positive")
+
+	releaseIndex := count - 1
+	if count > 1024 {
+		releaseIndex = count - 1024
+	}
+	src := fmt.Sprintf(currentGoroutineTargetTemplate, count, releaseIndex)
+	line := markerLine(src, "// BP_CURRENT")
+	bin := buildTarget(fmt.Sprintf("current_goroutine_%d_target", count), src)
+
+	h := newE2EHarness(bin)
+	h.waitFor(15*time.Second, protocol.EventStepped)
+
+	_, err := h.d.SetBreakpoint(filepath.Base(bin)+".go", line)
+	Expect(err).NotTo(HaveOccurred(), "SetBreakpoint on current-goroutine worker")
+	Expect(h.d.Continue()).To(Succeed(), "Continue to current-goroutine worker")
+
+	stopTimeout := 30 * time.Second
+	if count > 8192 {
+		stopTimeout = 8 * time.Minute
+	}
+	evt := h.waitFor(stopTimeout,
+		protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+	Expect(evt.Kind).To(Equal(protocol.EventBreakpointHit),
+		"expected BreakpointHit, got %s: %s", evt.Kind, evt.Payload)
+	var hit protocol.BreakpointHitPayload
+	Expect(json.Unmarshal(evt.Payload, &hit)).To(Succeed(), "decode BreakpointHit")
+	Expect(hit.Frames).NotTo(BeEmpty(), "BreakpointHit carries the stopped thread's frames")
+
+	evt = h.waitFor(stopTimeout, protocol.EventGoroutineSnapshot)
+	var snap protocol.GoroutineSnapshotPayload
+	Expect(json.Unmarshal(evt.Payload, &snap)).To(Succeed(), "decode GoroutineSnapshot")
+
+	currentGoroutines := 0
+	for _, g := range snap.Goroutines {
+		if g.Current {
+			currentGoroutines++
+		}
+	}
+	currentThreads := 0
+	for _, thread := range snap.Threads {
+		if thread.Current {
+			currentThreads++
+		}
+	}
+	GinkgoWriter.Printf(
+		"current-goroutine proof: live=%d delivered=%d hit={id:%d current:%t loc:%+v} frame0=%+v snapshot={current:%d marked:%d} currentThreads=%d\n",
+		count, len(snap.Goroutines), hit.Goroutine.ID, hit.Goroutine.Current,
+		hit.Goroutine.CurrentLoc, hit.Frames[0].Location, snap.Current,
+		currentGoroutines, currentThreads,
+	)
+
+	Expect(hit.Goroutine.Current).To(BeTrue(), "BreakpointHit must identify the stopped goroutine")
+	Expect(hit.Goroutine.CurrentLoc).To(Equal(hit.Frames[0].Location),
+		"BreakpointHit goroutine location must match the real stopped thread's innermost frame")
+	Expect(snap.Current).To(Equal(hit.Goroutine.ID),
+		"snapshot Current must identify the goroutine embedded in BreakpointHit")
+	Expect(currentGoroutines).To(Equal(1), "exactly one snapshot goroutine is current")
+	Expect(currentThreads).To(Equal(1), "exactly one runtime thread is current")
 }
 
 // findByStart returns the first goroutine whose start function matches fn, or

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -1273,6 +1273,10 @@ func assertCurrentGoroutineScan(count int) {
 		"BreakpointHit must carry a real nonzero goroutine id")
 	Expect(hit.Goroutine.CurrentLoc).To(Equal(hit.Frames[0].Location),
 		"BreakpointHit goroutine location must match the real stopped thread's innermost frame")
+	Expect(hit.Frames[0].Location.Function).To(Equal("main.breakpointWorker"),
+		"the real stopped TID must independently resolve the breakpoint frame")
+	Expect(hit.Frames[0].Location.Line).To(Equal(line),
+		"the real stopped TID must resolve the marked breakpoint line")
 	Expect(hit.Goroutine.StartLoc.Function).To(Equal("main.worker"),
 		"current goroutine start location must independently resolve the argumentless worker")
 	Expect(hit.Goroutine.CreatedLoc.Function).To(Equal("main.spawnWorker"),
@@ -1291,6 +1295,8 @@ func assertCurrentGoroutineScan(count int) {
 		"snapshot current anchor must retain independently decoded start metadata")
 	Expect(snapshotCurrent.CreatedLoc.Line).To(Equal(spawnLine),
 		"snapshot current anchor must retain independently decoded creation metadata")
+	Expect(snapshotCurrent.CurrentLoc).To(Equal(hit.Frames[0].Location),
+		"snapshot current location must independently agree with the stopped frame")
 	Expect(snapshotThread.GoID).To(Equal(snap.Current),
 		"the uniquely current runtime thread must run snapshot Current")
 	if count > richScanLimit {

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -1207,6 +1207,7 @@ func declareCurrentGoroutineScanSpec() {
 func assertCurrentGoroutineScan(count int) {
 	GinkgoHelper()
 	Expect(count).To(BeNumerically(">", 0), "target count must be positive")
+	const richScanLimit = 8192
 
 	releaseIndex := count - 1
 	if count > 1024 {
@@ -1224,7 +1225,7 @@ func assertCurrentGoroutineScan(count int) {
 	Expect(h.d.Continue()).To(Succeed(), "Continue to current-goroutine worker")
 
 	stopTimeout := 30 * time.Second
-	if count > 8192 {
+	if count > richScanLimit {
 		stopTimeout = 8 * time.Minute
 	}
 	evt := h.waitFor(stopTimeout,
@@ -1265,6 +1266,12 @@ func assertCurrentGoroutineScan(count int) {
 		"snapshot Current must identify the goroutine embedded in BreakpointHit")
 	Expect(currentGoroutines).To(Equal(1), "exactly one snapshot goroutine is current")
 	Expect(currentThreads).To(Equal(1), "exactly one runtime thread is current")
+	if count > richScanLimit {
+		Expect(snap.Goroutines).To(HaveLen(richScanLimit+1),
+			"heavy proof must append one current anchor beyond the full rich prefix")
+		Expect(snap.Goroutines[0].ID).To(Equal(hit.Goroutine.ID),
+			"beyond-prefix current anchor must lead the bounded snapshot")
+	}
 }
 
 // findByStart returns the first goroutine whose start function matches fn, or

--- a/test/integration/debugger_e2e_darwin_arm64_test.go
+++ b/test/integration/debugger_e2e_darwin_arm64_test.go
@@ -58,6 +58,7 @@ var _ = Describe("Darwin arm64 debugger backend (Mach exceptions) E2E", Label("d
 	declareAttachSpec()
 	declareConcurrencySpec()
 	declareBaselineOwnershipSpec()
+	declareCurrentGoroutineScanSpec()
 	declareFullStackSpec()
 	declareRestartSpec()
 	declareDAPSpec()

--- a/test/integration/debugger_e2e_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_linux_amd64_test.go
@@ -38,6 +38,7 @@ var _ = Describe("Linux amd64 debugger backend (ptrace) E2E", Label("linux"), fu
 	declareAttachSpec()
 	declareConcurrencySpec()
 	declareBaselineOwnershipSpec()
+	declareCurrentGoroutineScanSpec()
 	declareFullStackSpec()
 	declareRestartSpec()
 	declareDAPSpec()


### PR DESCRIPTION
Fixes #218.

> [!IMPORTANT]
> This draft is restacked directly onto exact `origin/main` `dd0f76f76687810feecc021942ba0e131d3c8370`.
>
> #219 and #238 are now landed on `main`; their old prerequisite commits (`2c0db98`, `1d06913`, `e8f2ea3`, `030ebe43`) are **not** replayed. This PR still does not absorb #196's lower-bound/total reporting semantics.

Related, not duplicate: #194/#196 concern payload packing/reporting after inspection. This bug loses stopped-goroutine identity inside inspection before packing.

## Restack composition

- Recorded canonical lease: `2c2eba3a9bf422c66a6923f8682cb9b297be4ec1`
- Exact new base: `dd0f76f76687810feecc021942ba0e131d3c8370`
- Exact published head: `6edb45c750377e64d5be03a9c96e42ff8f223517`
- The layer remains exactly 10 linear commits with the same subjects and identical 47-file name/status set.
- Range-diff maps every accepted commit 1:1 and in order:

| Accepted | Restacked | Subject |
| --- | --- | --- |
| `e84284a` | `e681dbd` | fix(debugger): preserve current goroutine beyond scan cap |
| `e7e819b` | `d7d3f86` | refactor(debugger): simplify current goroutine scan |
| `ce006d4` | `cf3f1e4` | fix(debugger): report unknown goroutine identity |
| `f1300a1` | `164b3df` | fix(debugger): preserve targeted stop identity |
| `439c144` | `ca9bef4` | perf(debugger): bound stepped identity overhead |
| `bbd0221` | `2187081` | test(debugger): prove current anchor exceeds cap |
| `3a02471` | `45ef483` | fix(debugger): address current scan review blockers |
| `99c5e05` | `ed69ace` | fix(dap): bound unknown-stop stack requests |
| `cfcc8c2` | `05603ef` | fix(dap): serve threadless stopped stacks |
| `2c2eba3` | `6edb45c` | fix(dapcli): preserve unknown stopped thread |

Stable patch IDs are identical for commits 2, 6, 9, and 10. The six adapted IDs are the deliberate landed-main compositions: #192 automatic-vs-query lifecycle ownership, #238 coherent metadata, later DAP disconnect/session-state invariants, existing debugger test instrumentation, and the permanent Linux overlap workflow gate. The normalized range-diff adds only that landed-main context around the accepted hunks.

All four old prerequisite commits are absent from the new range. `allgsMetadata` retains main's coherent length-before-pointer implementation and tests. No backend/process/waitpark/pending-signal/trap control file changed.

## Problem

The rich `runtime.allgs` walk was capped at 8,192 before SP containment identified the stopped goroutine. If the stopped `g` lay beyond that prefix, no goroutine/thread was current, snapshot `Current` stayed zero, and the old fallback embedded the first unrelated goroutine in `BreakpointHit`/`Paused`. DAP then named that unrelated goid while frames still came from the real stopped TID.

The fallback was also unsafe for zero registers and scheduler-stack/g0 stops: unknown identity could become g1.

## Fix

- Keep rich `allgs` output capped at 8,192 while resolving stopped identity independently within strict bounds.
- Preserve #238's coherent metadata contract: prefer `runtime.allglen`/`runtime.allgptr`, read length before pointer, and keep the same order for the raw-header fallback.
- On arm64, treat X28 only as a speculative hint; validate user-g SP containment or validated g0/gsignal → `m.curg` ownership.
- On linux/amd64, match the exact stopped TID to `runtime.m.procid` across the 2,048-M rich window plus one targeted-only 2,048-M continuation.
- Run one final stack-only `allgs` pass over at most 8,192 additional entries.
- Fully decode one resolved current anchor. Replace it in place when already rich; otherwise prepend it and exclude that display-only anchor from lifecycle baselines.
- Preserve main's automatic-vs-query lifecycle ownership: only automatic complete snapshots adopt `prevGoids`; queries remain read-only, and incomplete walks never mutate the baseline.
- Keep thread output at 2,048 rich entries plus at most one exact current-M anchor.
- Preserve #219's complete/clipped/degraded semantics and honest partial-read failure behavior.
- Represent unresolved identity as ID 0/status `unknown`; never select the first real goroutine.
- Keep regular step emission cheap and synthetic-unknown while frames still come from the real stopped TID.
- DAP omits optional `stopped.threadId` for unknown identity, exposes one stack target for the first unknown-stop `threads` response, and refuses stopped stacks for positive non-current IDs. `cmd/dapcli` preserves thread 0.
- Raise VS Code observer bounds to producer maxima: 8,193 goroutines, 2,049 threads, and an 8 MiB envelope.
- Permanently gate the small current-goroutine control in both native workflows; retain the opt-in 20,000-goroutine proof.
- Bump wire protocol to 1.3 and extension package version to 0.3.2, with source/package/docs/tests aligned.

## Exact-head validation

Published head `6edb45c750377e64d5be03a9c96e42ff8f223517`:

- `gofmt`, `goimports`, and diff checks: clean.
- Targeted tagged `-race` suites for debugger, DAP, dapcli, and protocol: pass.
- Uncached full `go test -tags bingonative -race -count=1 ./...`: pass.
- Tagged repository vet and e2e-tagged vet: pass.
- Linux-context `golangci-lint`: 0 issues.
- Linux/amd64 server and e2e test binary cross-builds: valid x86-64 ELF; backend control diff is empty.
- `just vscode-check`: pass.
- Reproducible VS Code package validation: pass; binary SHA-256 `8569378eebf29ab839453356de54bb5e07381f7b2cfea073f7c5bcc01cbb8378`, VSIX SHA-256 `9aeca9e1b1d46ae08470272b8b8188fda6b433af3131e63e0876d9a0580adf6a`.
- Signed native Darwin DAP + current-goroutine control: 6 passed; only the intentional heavy opt-in case skipped.
- Signed native Darwin opt-in `BINGO_E2E_CURRENT_GOROUTINES=20000`: 2/2 passed.
- Full exact-head `just e2e-darwin`: 24 passed, 0 failed, 1 intentional heavy opt-in skip. The normal count is now 24 rather than the older 23 because main's landed #192 lifecycle-baseline ownership spec is also present and passing.
- Independent code-review and rubber-duck passes: no high-confidence findings.

## Residual bounds / behavior

All lookup remains bounded: rich goroutines 8,192 plus at most one anchor; stack-only fallback stops after index 16,384; exact Linux M lookup stops after 4,096 Ms; threads are 2,048 plus at most one anchor. If every bounded path misses, identity remains unknown rather than guessed. A beyond-prefix display anchor is excluded from lifecycle deltas. DAP cannot unwind arbitrary non-current goroutines yet, and unknown-step first-thread responses intentionally expose one stack target rather than thousands. The observer accepts at most 8 MiB; #196 owns lower-bound/total reporting.

One accepted non-blocking, self-healing DAP edge remains documented: after a resolved stop, a transient degraded `Goroutines` response can advertise transport ID 1 while stack serving still tracks the prior real goid, yielding an empty stack until the next stop. This pure restack does not expand that accepted scope.