### PR TITLE
fix(cli): harden interactive session lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ follow them so reviews stay about substance, not style.
 | [cmd/bingo](cmd/bingo/) | Server entry point — flag parsing, signal handler, calls into `internal/server`. |
 | [cmd/cli](cmd/cli/) | Interactive readline client. |
 | [cmd/dapcli](cmd/dapcli/) | Interactive readline client that drives a session over DAP (mirrors `cmd/cli`'s UX). Talks to the server's `-dap-addr` listener; can create a session or `-session` join an existing one. |
+| [cmd/internal/repl](cmd/internal/repl/) | Shared interactive-client loop: readline interrupt/cancellation semantics, refresh-safe async output, and frame-index validation. |
 | [cmd/wsmon](cmd/wsmon/) | Read-only terminal telemetry observer. `-session`-joins a running session over WebSocket and live-renders the goroutine spawn tree + OS threads + created/exited lifecycle deltas from the `EventGoroutineSnapshot` stream, reporting included/total honestly and distinguishing wire omission from a clipped runtime scan. Never drives execution — the WS-observes half of the DAP-drives/WS-observes demo. |
 | [editors/vscode](editors/vscode/) | Platform-packaged TypeScript companion extension. Owns debugger type `bingo`, manages the shared server, and hosts the read-only Bingo Concurrency Activity Bar WebSocket observer. |
 | [cmd/target](cmd/target/) | Trivial target program for manual testing. |
@@ -3123,7 +3124,12 @@ the announced id from the `console` output for `state`/discovery; with `-session
 `stopOnEntry:true` so the interactive user always gets control and the tracee
 stays alive for others to join. It buffers `break`s set before launch and flushes
 them on `initialized`. Any mix of `dapcli` and `cli` clients can drive/observe
-one session concurrently.
+one session concurrently. Both clients use `cmd/internal/repl`: Ctrl-C cancels a
+non-empty edit but exits on an empty line; signals cancel connection setup and
+in-flight management requests before closing readline/transport; remote
+disconnects close readline to unblock the terminal; async events write through
+readline's redraw-aware writer; malformed/negative `locals` frame indexes are
+rejected before transport dispatch.
 
 **Option Y (rejected).** The alternative was teaching the hub about DAP directly
 (a second protocol path through `internal/hub`). Rejected: it would fork the most

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ follow them so reviews stay about substance, not style.
 | [examples/spawntree](examples/spawntree/) | Concurrency demo target: a deterministic main → supervisor → worker×N goroutine spawn tree for exercising the telemetry stream (see [docs/ConcurrencyTelemetry.md](docs/ConcurrencyTelemetry.md)). |
 | [cmd/githook](cmd/githook/) | Conventional-commits commitlint, wired via [lefthook.yml](lefthook.yml). |
 | [pkg/protocol](pkg/protocol/) | Wire types: `Event`, `Command`, payload structs, `EventKind`, `CommandKind`, `SessionState`. Single source of truth. |
-| [pkg/client](pkg/client/) | Reference Go client. WebSocket-backed. Public surface: `Client` interface + `Create` / `Join` / `ListSessions`. |
+| [pkg/client](pkg/client/) | Reference Go client. WebSocket-backed. Public surface: `Client`, `Create` / `Join` / `ListSessions`, their context-aware `*Context` variants, and the `ErrClosed` teardown sentinel. |
 | [internal/server](internal/server/) | HTTP/WebSocket entry. `Server`, `sessionStore`, `/api/sessions` and `/ws` handlers. |
 | [internal/hub](internal/hub/) | Per-session bridge between connected clients and one `Debugger`. |
 | [internal/dap](internal/dap/) | Debug Adapter Protocol translator. A `Handler` implements `hub.WSConn`, so a DAP/IDE client plugs into a hub session as just another client (ZERO hub changes). |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,10 @@ names the expected and received versions; do not broadcast `EventError` or
 increment the shared hub sequence for a peer-local compatibility failure.
 `/api/health` remains a discovery preflight, not a substitute for per-envelope
 validation. Exact enforcement of the existing contract does not itself require
-a `Version` bump.
+a `Version` bump. The Go client retains a midstream mismatch as its terminal
+error: pending and later requests plus `Close` return that `VersionError`, and
+`cmd/cli` reports it once as an abnormal session exit. Normal transport EOF
+still ends the interactive session gracefully.
 
 ### Suspend/resume protocol
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -54,11 +54,11 @@ func mainExitCode() int {
 		c, err = client.CreateContext(ctx, *addr)
 	}
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			return 0
+		code := exitCode(err)
+		if code != 0 {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		}
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		return 1
+		return code
 	}
 	if ctx.Err() != nil {
 		_ = c.Close()
@@ -598,18 +598,22 @@ func printErrUnlessCanceled(ctx context.Context, err error) {
 }
 
 func commandErrorSuppressed(ctx context.Context, err error) bool {
-	if ctx.Err() != nil ||
+	return ctx.Err() != nil ||
+		errors.Is(err, client.ErrClosed) ||
 		errors.Is(err, io.EOF) ||
 		errors.Is(err, io.ErrUnexpectedEOF) ||
-		errors.Is(err, net.ErrClosed) {
-		return true
+		errors.Is(err, io.ErrClosedPipe) ||
+		errors.Is(err, net.ErrClosed) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNABORTED) ||
+		errors.Is(err, syscall.EPIPE)
+}
+
+func exitCode(err error) int {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return 0
 	}
-	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "client closed") ||
-		strings.Contains(message, "closed network connection") ||
-		strings.Contains(message, "connection reset") ||
-		strings.Contains(message, "broken pipe") ||
-		strings.Contains(message, "websocket: close")
+	return 1
 }
 
 func printHelp() {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -507,10 +507,6 @@ func formatGoroutineList(list protocol.GoroutinesPayload) string {
 	return b.String()
 }
 
-func printGoroutine(g protocol.Goroutine) {
-	fmt.Println(formatGoroutine(g))
-}
-
 func formatGoroutine(g protocol.Goroutine) string {
 	marker := " "
 	if g.Current {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -80,10 +80,14 @@ func mainExitCode() int {
 	}
 
 	printHelp()
-	runInteractive(ctx, rl, c.Events(), c.Close, func(ctx context.Context, args []string) bool {
+	err = runInteractive(ctx, rl, c.Events(), c.Close, func(ctx context.Context, args []string) bool {
 		return dispatch(ctx, c, *addr, args)
 	})
-	return 0
+	code := exitCode(err)
+	if code != 0 {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	}
+	return code
 }
 
 type lineEditor interface {
@@ -97,7 +101,7 @@ func runInteractive(
 	events <-chan protocol.Event,
 	closeTransport func() error,
 	dispatchCommand func(context.Context, []string) bool,
-) {
+) error {
 	runCtx, cancel := context.WithCancel(ctx)
 
 	var closeEditorOnce sync.Once
@@ -105,8 +109,9 @@ func runInteractive(
 		closeEditorOnce.Do(func() { _ = editor.Close() })
 	}
 	var closeTransportOnce sync.Once
+	var closeTransportErr error
 	closeClient := func() {
-		closeTransportOnce.Do(func() { _ = closeTransport() })
+		closeTransportOnce.Do(func() { closeTransportErr = closeTransport() })
 	}
 	shutdown := func() {
 		closeClient()
@@ -133,6 +138,14 @@ func runInteractive(
 	shutdown()
 	stopShutdown()
 	<-eventDone
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if closeTransportErr == nil || transportErrorSuppressed(closeTransportErr) {
+		return nil
+	}
+	return closeTransportErr
 }
 
 //nolint:gocognit,gocyclo // The CLI keeps command routing in one switch while commands are still small.
@@ -598,8 +611,14 @@ func printErrUnlessCanceled(ctx context.Context, err error) {
 }
 
 func commandErrorSuppressed(ctx context.Context, err error) bool {
-	return ctx.Err() != nil ||
-		errors.Is(err, client.ErrClosed) ||
+	var versionErr *protocol.VersionError
+	return errors.As(err, &versionErr) ||
+		ctx.Err() != nil ||
+		transportErrorSuppressed(err)
+}
+
+func transportErrorSuppressed(err error) bool {
+	return errors.Is(err, client.ErrClosed) ||
 		errors.Is(err, io.EOF) ||
 		errors.Is(err, io.ErrUnexpectedEOF) ||
 		errors.Is(err, io.ErrClosedPipe) ||

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -4,14 +4,21 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
+	"syscall"
 
+	"github.com/bingosuite/bingo/cmd/internal/repl"
 	"github.com/bingosuite/bingo/pkg/client"
 	"github.com/bingosuite/bingo/pkg/protocol"
 	"github.com/chzyer/readline"
@@ -24,8 +31,14 @@ import (
 // error. Shared between the REPL goroutine and the event printer.
 var fullSnapshotNext atomic.Bool
 
-//nolint:gocognit,gocyclo // The CLI keeps command routing in one switch while commands are still small.
 func main() {
+	os.Exit(mainExitCode())
+}
+
+func mainExitCode() int {
+	ctx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
+
 	addr := flag.String("addr", "localhost:6060", "server address (host:port)")
 	sessionID := flag.String("session", "", "session ID to join (omit to create)")
 	flag.Parse()
@@ -35,22 +48,26 @@ func main() {
 
 	if *sessionID != "" {
 		fmt.Printf("joining session %s on %s...\n", *sessionID, *addr)
-		c, err = client.Join(*addr, *sessionID)
+		c, err = client.JoinContext(ctx, *addr, *sessionID)
 	} else {
 		fmt.Printf("creating new session on %s...\n", *addr)
-		c, err = client.Create(*addr)
+		c, err = client.CreateContext(ctx, *addr)
 	}
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return 0
+		}
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+		return 1
 	}
-	defer func() { _ = c.Close() }()
+	if ctx.Err() != nil {
+		_ = c.Close()
+		return 0
+	}
 
 	fmt.Printf("connected — session %s (state: %s)\n\n", c.SessionID(), c.State())
 
-	go eventPrinter(c.Events())
-
-	rl, err := readline.NewEx(&readline.Config{
+	rl, err := repl.NewEditor(&readline.Config{
 		Prompt:          "bingo> ",
 		HistoryFile:     os.ExpandEnv("$HOME/.bingo_history"),
 		InterruptPrompt: "^C",
@@ -58,291 +75,365 @@ func main() {
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error initializing readline: %v\n", err)
-		os.Exit(1)
+		_ = c.Close()
+		return 1
 	}
-	defer func() { _ = rl.Close() }()
 
 	printHelp()
-	for {
-		line, err := rl.Readline()
+	runInteractive(ctx, rl, c.Events(), c.Close, func(ctx context.Context, args []string) bool {
+		return dispatch(ctx, c, *addr, args)
+	})
+	return 0
+}
+
+type lineEditor interface {
+	repl.Reader
+	Close() error
+}
+
+func runInteractive(
+	ctx context.Context,
+	editor lineEditor,
+	events <-chan protocol.Event,
+	closeTransport func() error,
+	dispatchCommand func(context.Context, []string) bool,
+) {
+	runCtx, cancel := context.WithCancel(ctx)
+
+	var closeEditorOnce sync.Once
+	closeEditor := func() {
+		closeEditorOnce.Do(func() { _ = editor.Close() })
+	}
+	var closeTransportOnce sync.Once
+	closeClient := func() {
+		closeTransportOnce.Do(func() { _ = closeTransport() })
+	}
+	shutdown := func() {
+		closeClient()
+		closeEditor()
+	}
+	stopShutdown := context.AfterFunc(runCtx, shutdown)
+
+	disconnected := make(chan struct{})
+	eventDone := make(chan struct{})
+	go func() {
+		defer close(eventDone)
+		if eventPrinter(runCtx, events, editor.Stdout()) {
+			close(disconnected)
+			cancel()
+			closeEditor()
+		}
+	}()
+
+	repl.Loop(runCtx, editor, closeEditor, disconnected, func(args []string) bool {
+		return dispatchCommand(runCtx, args)
+	})
+
+	cancel()
+	shutdown()
+	stopShutdown()
+	<-eventDone
+}
+
+//nolint:gocognit,gocyclo // The CLI keeps command routing in one switch while commands are still small.
+func dispatch(ctx context.Context, c client.Client, addr string, args []string) bool {
+	switch cmd := args[0]; cmd {
+	case "sessions", "ls":
+		sessions, err := client.ListSessionsContext(ctx, addr)
 		if err != nil {
-			if err == readline.ErrInterrupt || err == io.EOF {
-				fmt.Println("bye")
-				return
-			}
-			break
+			printErrUnlessCanceled(ctx, err)
+			return false
+		}
+		if ctx.Err() != nil {
+			return false
+		}
+		if len(sessions) == 0 {
+			fmt.Println("  (no active sessions)")
+			return false
+		}
+		for _, s := range sessions {
+			fmt.Printf("  %s  state=%-10s clients=%d  created=%s\n",
+				s.ID, s.State, s.Clients, s.CreatedAt.Format("15:04:05"))
 		}
 
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
+	case "state":
+		fmt.Printf("  session=%s  state=%s\n", c.SessionID(), c.State())
+
+	case "launch":
+		if len(args) < 2 {
+			fmt.Println("  usage: launch <binary> [args...]")
+			return false
+		}
+		var launchArgs []string
+		if len(args) > 2 {
+			launchArgs = args[2:]
+		}
+		if err := c.Launch(args[1], launchArgs, nil); err != nil {
+			printErrUnlessCanceled(ctx, err)
 		}
 
-		args := strings.Fields(line)
-		cmd := args[0]
+	case "attach":
+		if len(args) < 2 {
+			fmt.Println("  usage: attach <pid> [binary-path]")
+			return false
+		}
+		pid, err := strconv.Atoi(args[1])
+		if err != nil {
+			fmt.Printf("  invalid pid: %s\n", args[1])
+			return false
+		}
+		var binPath string
+		if len(args) > 2 {
+			binPath = args[2]
+		}
+		if err := c.Attach(pid, binPath); err != nil {
+			printErrUnlessCanceled(ctx, err)
+		}
 
-		switch cmd {
+	case "kill":
+		if err := c.Kill(); err != nil {
+			printErrUnlessCanceled(ctx, err)
+		}
 
-		case "sessions", "ls":
-			sessions, err := client.ListSessions(*addr)
-			if err != nil {
-				printErr(err)
-				continue
-			}
-			if len(sessions) == 0 {
-				fmt.Println("  (no active sessions)")
-				continue
-			}
-			for _, s := range sessions {
-				fmt.Printf("  %s  state=%-10s clients=%d  created=%s\n",
-					s.ID, s.State, s.Clients, s.CreatedAt.Format("15:04:05"))
-			}
+	case "restart":
+		p, err := c.Restart(nil, nil)
+		if err != nil {
+			printErrUnlessCanceled(ctx, err)
+			return false
+		}
+		if ctx.Err() != nil {
+			return false
+		}
+		fmt.Printf("  restarted %s\n", p.Program)
+		for _, bp := range p.Breakpoints {
+			fmt.Printf("  breakpoint %d reinstalled at %s:%d\n", bp.ID, bp.Location.File, bp.Location.Line)
+		}
+		for _, d := range p.Discarded {
+			fmt.Printf("  breakpoint at %s:%d discarded: %s\n", d.Location.File, d.Location.Line, d.Reason)
+		}
 
-		case "state":
-			fmt.Printf("  session=%s  state=%s\n", c.SessionID(), c.State())
+	case "c", "continue":
+		if err := c.Continue(); err != nil {
+			printErrUnlessCanceled(ctx, err)
+		}
 
-		case "launch":
-			if len(args) < 2 {
-				fmt.Println("  usage: launch <binary> [args...]")
-				continue
-			}
-			var launchArgs []string
-			if len(args) > 2 {
-				launchArgs = args[2:]
-			}
-			if err := c.Launch(args[1], launchArgs, nil); err != nil {
-				printErr(err)
-			}
+	case "n", "next":
+		if err := c.StepOver(); err != nil {
+			printErrUnlessCanceled(ctx, err)
+		}
 
-		case "attach":
-			if len(args) < 2 {
-				fmt.Println("  usage: attach <pid> [binary-path]")
-				continue
-			}
-			pid, err := strconv.Atoi(args[1])
-			if err != nil {
-				fmt.Printf("  invalid pid: %s\n", args[1])
-				continue
-			}
-			var binPath string
-			if len(args) > 2 {
-				binPath = args[2]
-			}
-			if err := c.Attach(pid, binPath); err != nil {
-				printErr(err)
-			}
+	case "s", "step":
+		if err := c.StepInto(); err != nil {
+			printErrUnlessCanceled(ctx, err)
+		}
 
-		case "kill":
-			if err := c.Kill(); err != nil {
-				printErr(err)
-			}
+	case "out", "finish":
+		if err := c.StepOut(); err != nil {
+			printErrUnlessCanceled(ctx, err)
+		}
 
-		case "restart":
-			p, err := c.Restart(nil, nil)
-			if err != nil {
-				printErr(err)
-				continue
-			}
-			fmt.Printf("  restarted %s\n", p.Program)
-			for _, bp := range p.Breakpoints {
-				fmt.Printf("  breakpoint %d reinstalled at %s:%d\n", bp.ID, bp.Location.File, bp.Location.Line)
-			}
-			for _, d := range p.Discarded {
-				fmt.Printf("  breakpoint at %s:%d discarded: %s\n", d.Location.File, d.Location.Line, d.Reason)
-			}
+	case "p", "pause":
+		if err := c.Pause(); err != nil {
+			printErrUnlessCanceled(ctx, err)
+		}
 
-		case "c", "continue":
-			if err := c.Continue(); err != nil {
-				printErr(err)
-			}
+	case "b", "break":
+		if len(args) < 2 {
+			fmt.Println("  usage: break <file>:<line>")
+			return false
+		}
+		file, line, ok := parseFileLine(args[1])
+		if !ok {
+			fmt.Println("  usage: break <file>:<line>  (e.g. main.go:42)")
+			return false
+		}
+		bp, err := c.SetBreakpoint(file, line)
+		if err != nil {
+			printErrUnlessCanceled(ctx, err)
+			return false
+		}
+		if ctx.Err() != nil {
+			return false
+		}
+		fmt.Printf("  breakpoint %d set at %s:%d\n",
+			bp.ID, bp.Location.File, bp.Location.Line)
 
-		case "n", "next":
-			if err := c.StepOver(); err != nil {
-				printErr(err)
-			}
+	case "clear":
+		if len(args) < 2 {
+			fmt.Println("  usage: clear <breakpoint-id>")
+			return false
+		}
+		id, err := strconv.Atoi(args[1])
+		if err != nil {
+			fmt.Printf("  invalid breakpoint id: %s\n", args[1])
+			return false
+		}
+		if err := c.ClearBreakpoint(id); err != nil {
+			printErrUnlessCanceled(ctx, err)
+			return false
+		}
+		if ctx.Err() != nil {
+			return false
+		}
+		fmt.Printf("  breakpoint %d cleared\n", id)
 
-		case "s", "step":
-			if err := c.StepInto(); err != nil {
-				printErr(err)
-			}
+	case "locals":
+		showLocals(ctx, c, args[1:], os.Stdout)
 
-		case "out", "finish":
-			if err := c.StepOut(); err != nil {
-				printErr(err)
-			}
+	case "bt", "backtrace":
+		frames, err := c.StackFrames()
+		if err != nil {
+			printErrUnlessCanceled(ctx, err)
+			return false
+		}
+		if ctx.Err() != nil {
+			return false
+		}
+		for _, f := range frames {
+			fmt.Printf("  #%d  %s at %s:%d\n",
+				f.Index, f.Location.Function, f.Location.File, f.Location.Line)
+		}
 
-		case "p", "pause":
-			if err := c.Pause(); err != nil {
-				printErr(err)
-			}
+	case "goroutines", "grs":
+		grs, err := c.GoroutineList()
+		if err != nil {
+			printErrUnlessCanceled(ctx, err)
+			return false
+		}
+		if ctx.Err() != nil {
+			return false
+		}
+		fmt.Print(formatGoroutineList(grs))
 
-		case "b", "break":
-			if len(args) < 2 {
-				fmt.Println("  usage: break <file>:<line>")
-				continue
-			}
-			file, line, ok := parseFileLine(args[1])
+	case "snapshot", "snap":
+		// This is only a display arm: snapshot events are broadcasts and carry
+		// no requester identity, so whichever snapshot arrives next consumes it.
+		fullSnapshotNext.Store(true)
+		if err := c.RequestGoroutineSnapshot(); err != nil {
+			fullSnapshotNext.Store(false)
+			printErrUnlessCanceled(ctx, err)
+			return false
+		}
+
+	case "help", "h", "?":
+		printHelp()
+
+	case "quit", "q", "exit":
+		return true
+
+	default:
+		fmt.Printf("  unknown command: %s (type 'help' for usage)\n", cmd)
+	}
+	return false
+}
+
+type localsClient interface {
+	Locals(frameIndex int) ([]protocol.Variable, error)
+}
+
+func showLocals(ctx context.Context, c localsClient, args []string, out io.Writer) {
+	frame, err := repl.FrameIndex(args)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "  %s\n", err)
+		return
+	}
+	vars, err := c.Locals(frame)
+	if err != nil {
+		if !commandErrorSuppressed(ctx, err) {
+			_, _ = fmt.Fprintf(out, "  error: %v\n", err)
+		}
+		return
+	}
+	if ctx.Err() != nil {
+		return
+	}
+	if len(vars) == 0 {
+		_, _ = fmt.Fprintln(out, "  (no locals)")
+		return
+	}
+	for _, v := range vars {
+		_, _ = fmt.Fprintf(out, "  %s %s = %s\n", v.Name, v.Type, v.Value)
+	}
+}
+
+func eventPrinter(ctx context.Context, events <-chan protocol.Event, out io.Writer) bool {
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case evt, ok := <-events:
 			if !ok {
-				fmt.Println("  usage: break <file>:<line>  (e.g. main.go:42)")
-				continue
+				if ctx.Err() != nil {
+					return false
+				}
+				repl.PrintAsync(out, "disconnected")
+				return true
 			}
-			bp, err := c.SetBreakpoint(file, line)
-			if err != nil {
-				printErr(err)
-				continue
-			}
-			fmt.Printf("  breakpoint %d set at %s:%d\n",
-				bp.ID, bp.Location.File, bp.Location.Line)
-
-		case "clear":
-			if len(args) < 2 {
-				fmt.Println("  usage: clear <breakpoint-id>")
-				continue
-			}
-			id, err := strconv.Atoi(args[1])
-			if err != nil {
-				fmt.Printf("  invalid breakpoint id: %s\n", args[1])
-				continue
-			}
-			if err := c.ClearBreakpoint(id); err != nil {
-				printErr(err)
-				continue
-			}
-			fmt.Printf("  breakpoint %d cleared\n", id)
-
-		case "locals":
-			frame := 0
-			if len(args) > 1 {
-				frame, _ = strconv.Atoi(args[1])
-			}
-			vars, err := c.Locals(frame)
-			if err != nil {
-				printErr(err)
-				continue
-			}
-			if len(vars) == 0 {
-				fmt.Println("  (no locals)")
-				continue
-			}
-			for _, v := range vars {
-				fmt.Printf("  %s %s = %s\n", v.Name, v.Type, v.Value)
-			}
-
-		case "bt", "backtrace":
-			frames, err := c.StackFrames()
-			if err != nil {
-				printErr(err)
-				continue
-			}
-			for _, f := range frames {
-				fmt.Printf("  #%d  %s at %s:%d\n",
-					f.Index, f.Location.Function, f.Location.File, f.Location.Line)
-			}
-
-		case "goroutines", "grs":
-			grs, err := c.GoroutineList()
-			if err != nil {
-				printErr(err)
-				continue
-			}
-			fmt.Print(formatGoroutineList(grs))
-
-		case "snapshot", "snap":
-			// Fire-and-forget: the snapshot answers on the event stream, where
-			// automatic stop snapshots also arrive. fullSnapshotNext is a
-			// display arm only — it selects the renderer for the NEXT snapshot,
-			// whichever that turns out to be. An automatic push (or another
-			// client's requested one) can consume the arm, and any broadcast
-			// snapshot error can disarm it, so the detailed view may land on a
-			// different snapshot than the one this command asked for. No
-			// snapshot data is lost either way: every one is printed, in order,
-			// in one form or the other.
-			fullSnapshotNext.Store(true)
-			if err := c.RequestGoroutineSnapshot(); err != nil {
-				fullSnapshotNext.Store(false)
-				printErr(err)
-				continue
-			}
-
-		case "help", "h", "?":
-			printHelp()
-
-		case "quit", "q", "exit":
-			fmt.Println("bye")
-			return
-
-		default:
-			fmt.Printf("  unknown command: %s (type 'help' for usage)\n", cmd)
+			printEvent(out, evt)
 		}
 	}
 }
 
-func eventPrinter(events <-chan protocol.Event) {
-	for evt := range events {
-		printEvent(evt)
-	}
-}
-
-func printEvent(evt protocol.Event) {
+func printEvent(out io.Writer, evt protocol.Event) {
 	switch evt.Kind {
 
 	case protocol.EventSessionState:
 		var p protocol.SessionStatePayload
 		if protocol.DecodeEventPayload(evt, &p) == nil {
-			fmt.Printf("\n  [state] %s (clients: %d)\nbingo> ", p.State, p.Clients)
+			repl.PrintAsync(out, fmt.Sprintf("[state] %s (clients: %d)", p.State, p.Clients))
 		}
 
 	case protocol.EventBreakpointHit:
 		var p protocol.BreakpointHitPayload
 		if protocol.DecodeEventPayload(evt, &p) == nil {
-			fmt.Printf("\n  [hit] breakpoint %d at %s:%d\nbingo> ",
-				p.Breakpoint.ID, p.Breakpoint.Location.File, p.Breakpoint.Location.Line)
+			repl.PrintAsync(out, fmt.Sprintf("[hit] breakpoint %d at %s:%d",
+				p.Breakpoint.ID, p.Breakpoint.Location.File, p.Breakpoint.Location.Line))
 		}
 
 	case protocol.EventPanic:
 		var p protocol.PanicPayload
 		if protocol.DecodeEventPayload(evt, &p) == nil {
-			fmt.Printf("\n  [panic] %s\nbingo> ", p.Message)
+			repl.PrintAsync(out, "[panic] "+p.Message)
 		}
 
 	case protocol.EventOutput:
 		var p protocol.OutputPayload
 		if protocol.DecodeEventPayload(evt, &p) == nil {
-			fmt.Printf("\n  [%s] %s\nbingo> ", p.Stream, p.Content)
+			repl.PrintOutput(out, p.Stream, p.Content)
 		}
 
 	case protocol.EventProcessExited:
 		var p protocol.ProcessExitedPayload
 		if protocol.DecodeEventPayload(evt, &p) == nil {
-			fmt.Printf("\n  [exited] code=%d reason=%s\nbingo> ", p.ExitCode, p.Reason)
+			repl.PrintAsync(out, fmt.Sprintf("[exited] code=%d reason=%s", p.ExitCode, p.Reason))
 		}
 
 	case protocol.EventStepped:
 		var p protocol.SteppedPayload
 		if protocol.DecodeEventPayload(evt, &p) == nil {
-			fmt.Printf("\n  [stepped] %s:%d in %s\nbingo> ",
-				p.Location.File, p.Location.Line, p.Location.Function)
+			repl.PrintAsync(out, fmt.Sprintf("[stepped] %s:%d in %s",
+				p.Location.File, p.Location.Line, p.Location.Function))
 		}
 
 	case protocol.EventPaused:
 		var p protocol.PausedPayload
 		if protocol.DecodeEventPayload(evt, &p) == nil {
-			fmt.Printf("\n  [paused] %s:%d in %s\nbingo> ",
-				p.Location.File, p.Location.Line, p.Location.Function)
+			repl.PrintAsync(out, fmt.Sprintf("[paused] %s:%d in %s",
+				p.Location.File, p.Location.Line, p.Location.Function))
 		}
 
 	default:
-		printAuxEvent(evt)
+		printAuxEvent(out, evt)
 	}
 }
 
 // printAuxEvent renders the non-stop events. Split out of printEvent so neither
 // switch trips the cyclomatic-complexity linter as event kinds grow.
-func printAuxEvent(evt protocol.Event) {
+func printAuxEvent(out io.Writer, evt protocol.Event) {
 	switch evt.Kind {
 
 	case protocol.EventContinued:
-		fmt.Print("\n  [continued]\nbingo> ")
+		repl.PrintAsync(out, "[continued]")
 
 	case protocol.EventError:
 		var p protocol.ErrorPayload
@@ -353,26 +444,24 @@ func printAuxEvent(evt protocol.Event) {
 				// leaving the arm set would expand an unrelated automatic push.
 				fullSnapshotNext.Store(false)
 			}
-			fmt.Printf("\n  [error] %s: %s\nbingo> ", p.Command, p.Message)
+			repl.PrintAsync(out, fmt.Sprintf("[error] %s: %s", p.Command, p.Message))
 		}
 
 	case protocol.EventRestarted:
 		var p protocol.RestartedPayload
 		if protocol.DecodeEventPayload(evt, &p) == nil {
-			fmt.Printf("\n  [restarted] %s (%d breakpoint(s), %d discarded)\nbingo> ",
-				p.Program, len(p.Breakpoints), len(p.Discarded))
+			repl.PrintAsync(out, fmt.Sprintf("[restarted] %s (%d breakpoint(s), %d discarded)",
+				p.Program, len(p.Breakpoints), len(p.Discarded)))
 		}
 
 	case protocol.EventGoroutineSnapshot:
 		var p protocol.GoroutineSnapshotPayload
 		if protocol.DecodeEventPayload(evt, &p) == nil {
 			if fullSnapshotNext.CompareAndSwap(true, false) {
-				fmt.Println()
-				printSnapshot(p)
-				fmt.Print("bingo> ")
+				printSnapshot(out, p)
 				return
 			}
-			msg := fmt.Sprintf("\n  [goroutines] %s, %s threads, current G%d",
+			msg := fmt.Sprintf("[goroutines] %s, %s threads, current G%d",
 				countOf(len(p.Goroutines), p.Totals, totalGoroutines),
 				countOf(len(p.Threads), p.Totals, totalThreads), p.Current)
 			if len(p.Created) > 0 {
@@ -381,11 +470,11 @@ func printAuxEvent(evt protocol.Event) {
 			if len(p.Exited) > 0 {
 				msg += fmt.Sprintf(", -%v", p.Exited)
 			}
-			fmt.Print(msg + "\nbingo> ")
+			repl.PrintAsync(out, msg)
 		}
 
 	default:
-		fmt.Printf("\n  [%s] seq=%d\nbingo> ", evt.Kind, evt.Seq)
+		repl.PrintAsync(out, fmt.Sprintf("[%s] seq=%d", evt.Kind, evt.Seq))
 	}
 }
 
@@ -430,12 +519,12 @@ func formatGoroutine(g protocol.Goroutine) string {
 
 // printSnapshot renders a full concurrency snapshot: goroutines (with spawn
 // linkage), OS threads, and the created/exited lifecycle deltas.
-func printSnapshot(snap protocol.GoroutineSnapshotPayload) {
-	fmt.Printf("  goroutines: %s  threads: %s  current: G%d\n",
+func printSnapshot(out io.Writer, snap protocol.GoroutineSnapshotPayload) {
+	_, _ = fmt.Fprintf(out, "  goroutines: %s  threads: %s  current: G%d\n",
 		countOf(len(snap.Goroutines), snap.Totals, totalGoroutines),
 		countOf(len(snap.Threads), snap.Totals, totalThreads), snap.Current)
 	for _, g := range snap.Goroutines {
-		printGoroutine(g)
+		_, _ = fmt.Fprintln(out, formatGoroutine(g))
 	}
 	for _, t := range snap.Threads {
 		marker := " "
@@ -446,13 +535,13 @@ func printSnapshot(snap protocol.GoroutineSnapshotPayload) {
 		if t.Spinning {
 			spin = " spinning"
 		}
-		fmt.Printf("%s M%-4d tid=%-6d G%d%s\n", marker, t.MID, t.ID, t.GoID, spin)
+		_, _ = fmt.Fprintf(out, "%s M%-4d tid=%-6d G%d%s\n", marker, t.MID, t.ID, t.GoID, spin)
 	}
 	if len(snap.Created) > 0 {
-		fmt.Printf("  created: %v\n", snap.Created)
+		_, _ = fmt.Fprintf(out, "  created: %v\n", snap.Created)
 	}
 	if len(snap.Exited) > 0 {
-		fmt.Printf("  exited:  %v\n", snap.Exited)
+		_, _ = fmt.Fprintf(out, "  exited:  %v\n", snap.Exited)
 	}
 }
 
@@ -500,6 +589,27 @@ func parseFileLine(s string) (string, int, bool) {
 
 func printErr(err error) {
 	fmt.Printf("  error: %v\n", err)
+}
+
+func printErrUnlessCanceled(ctx context.Context, err error) {
+	if !commandErrorSuppressed(ctx, err) {
+		printErr(err)
+	}
+}
+
+func commandErrorSuppressed(ctx context.Context, err error) bool {
+	if ctx.Err() != nil ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "client closed") ||
+		strings.Contains(message, "closed network connection") ||
+		strings.Contains(message, "connection reset") ||
+		strings.Contains(message, "broken pipe") ||
+		strings.Contains(message, "websocket: close")
 }
 
 func printHelp() {

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -6,12 +6,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/bingosuite/bingo/pkg/client"
 	"github.com/bingosuite/bingo/pkg/protocol"
 	"github.com/chzyer/readline"
 )
@@ -396,14 +399,60 @@ func TestShowLocalsSuppressesCancellationError(t *testing.T) {
 	}
 }
 
-func TestCommandErrorSuppressionOnlyMatchesShutdown(t *testing.T) {
-	if !commandErrorSuppressed(context.Background(), errors.New("client closed")) {
-		t.Fatal("client closure was not suppressed")
+func TestExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "clean"},
+		{name: "canceled", err: fmt.Errorf("connect: %w", context.Canceled)},
+		{name: "failure", err: errors.New("dial failed"), want: 1},
 	}
-	if !commandErrorSuppressed(context.Background(), io.ErrUnexpectedEOF) {
-		t.Fatal("transport EOF was not suppressed")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := exitCode(tt.err); got != tt.want {
+				t.Fatalf("exitCode(%v) = %d, want %d", tt.err, got, tt.want)
+			}
+		})
 	}
-	if commandErrorSuppressed(context.Background(), errors.New("server: no active debugger")) {
-		t.Fatal("server command error was incorrectly suppressed")
+}
+
+func TestCommandErrorSuppressionUsesTypedShutdownErrors(t *testing.T) {
+	shutdownErrors := []error{
+		client.ErrClosed,
+		io.EOF,
+		io.ErrUnexpectedEOF,
+		io.ErrClosedPipe,
+		net.ErrClosed,
+		syscall.ECONNRESET,
+		syscall.ECONNABORTED,
+		syscall.EPIPE,
+	}
+	for _, err := range shutdownErrors {
+		if !commandErrorSuppressed(context.Background(), fmt.Errorf("wrapped: %w", err)) {
+			t.Errorf("typed shutdown error %v was not suppressed", err)
+		}
+	}
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if !commandErrorSuppressed(canceled, errors.New("server error")) {
+		t.Fatal("context cancellation did not suppress command output")
+	}
+}
+
+func TestCommandErrorSuppressionPreservesServerMessages(t *testing.T) {
+	for _, phrase := range []string{
+		"client closed",
+		"closed network connection",
+		"connection reset",
+		"broken pipe",
+		"websocket: close",
+	} {
+		err := errors.New("server: debuggee reported " + phrase)
+		if commandErrorSuppressed(context.Background(), err) {
+			t.Errorf("server message %q was incorrectly suppressed", phrase)
+		}
 	}
 }

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -199,21 +199,23 @@ func TestRunInteractiveStopsOnEventStreamClosure(t *testing.T) {
 	editor := newTestEditor()
 	events := make(chan protocol.Event)
 	var transportCloses atomic.Int32
-	done := make(chan struct{})
+	result := make(chan error, 1)
 	go func() {
-		runInteractive(context.Background(), editor, events, func() error {
+		result <- runInteractive(context.Background(), editor, events, func() error {
 			transportCloses.Add(1)
 			return nil
 		}, func(context.Context, []string) bool {
 			t.Error("dispatch called after disconnect")
 			return false
 		})
-		close(done)
 	}()
 
 	close(events)
 	select {
-	case <-done:
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("runInteractive error = %v, want graceful disconnect", err)
+		}
 	case <-time.After(time.Second):
 		t.Fatal("interactive session stayed blocked after event stream closure")
 	}
@@ -233,21 +235,23 @@ func TestRunInteractiveCancellationIsSilentAndClosesResources(t *testing.T) {
 	events := make(chan protocol.Event)
 	var transportCloses atomic.Int32
 	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan struct{})
+	result := make(chan error, 1)
 	go func() {
-		runInteractive(ctx, editor, events, func() error {
+		result <- runInteractive(ctx, editor, events, func() error {
 			transportCloses.Add(1)
 			return nil
 		}, func(context.Context, []string) bool {
 			t.Error("dispatch called after cancellation")
 			return false
 		})
-		close(done)
 	}()
 
 	cancel()
 	select {
-	case <-done:
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("runInteractive error = %v, want context cancellation", err)
+		}
 	case <-time.After(time.Second):
 		t.Fatal("interactive session stayed blocked after cancellation")
 	}

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -262,6 +262,31 @@ func TestRunInteractiveCancellationIsSilentAndClosesResources(t *testing.T) {
 	}
 }
 
+func TestRunInteractiveReturnsTerminalDisconnectError(t *testing.T) {
+	editor := newTestEditor()
+	events := make(chan protocol.Event)
+	close(events)
+	versionErr := &protocol.VersionError{Expected: protocol.Version, Received: "999.0"}
+
+	err := runInteractive(context.Background(), editor, events, func() error {
+		return fmt.Errorf("server event: %w", versionErr)
+	}, func(context.Context, []string) bool {
+		t.Error("dispatch called after terminal disconnect")
+		return false
+	})
+
+	var gotVersionErr *protocol.VersionError
+	if !errors.As(err, &gotVersionErr) {
+		t.Fatalf("runInteractive error = %v, want VersionError", err)
+	}
+	if got := editor.out.String(); got != "  disconnected\n" {
+		t.Fatalf("output = %q, want one disconnect notice", got)
+	}
+	if !commandErrorSuppressed(context.Background(), err) {
+		t.Fatal("terminal error should be owned by runInteractive, not a racing command")
+	}
+}
+
 func TestPrintEventSurfacesOutputWithoutHandwrittenPrompt(t *testing.T) {
 	event, err := protocol.NewEvent(protocol.EventOutput, 1, protocol.OutputPayload{
 		Stream:  "stderr",

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -1,38 +1,20 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/bingosuite/bingo/pkg/protocol"
+	"github.com/chzyer/readline"
 )
-
-// captureStdout runs fn with os.Stdout redirected and returns what it printed.
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	original := os.Stdout
-	os.Stdout = w
-	defer func() { os.Stdout = original }()
-
-	fn()
-
-	if err := w.Close(); err != nil {
-		t.Fatalf("close pipe writer: %v", err)
-	}
-	out, err := io.ReadAll(r)
-	if err != nil {
-		t.Fatalf("read pipe: %v", err)
-	}
-	return string(out)
-}
 
 func testSnapshotEvent(t *testing.T, seq uint64) protocol.Event {
 	t.Helper()
@@ -55,7 +37,9 @@ func TestFullSnapshotNextRendersOnceThenSummarises(t *testing.T) {
 	t.Cleanup(func() { fullSnapshotNext.Store(false) })
 
 	fullSnapshotNext.Store(true)
-	full := captureStdout(t, func() { printEvent(testSnapshotEvent(t, 2)) })
+	var out bytes.Buffer
+	printEvent(&out, testSnapshotEvent(t, 2))
+	full := out.String()
 	if !strings.Contains(full, "goroutines: 2 live  threads: 1 live  current: G1") {
 		t.Fatalf("requested snapshot render = %q, want the full view", full)
 	}
@@ -66,7 +50,9 @@ func TestFullSnapshotNextRendersOnceThenSummarises(t *testing.T) {
 		t.Fatal("fullSnapshotNext still armed after one snapshot")
 	}
 
-	summary := captureStdout(t, func() { printEvent(testSnapshotEvent(t, 3)) })
+	out.Reset()
+	printEvent(&out, testSnapshotEvent(t, 3))
+	summary := out.String()
 	if !strings.Contains(summary, "[goroutines] 2 live, 1 live threads, current G1") {
 		t.Fatalf("automatic snapshot render = %q, want the summary line", summary)
 	}
@@ -85,14 +71,18 @@ func TestSnapshotErrorDisarmsFullRender(t *testing.T) {
 		Command: protocol.CmdGoroutineSnapshot,
 		Message: "process not suspended",
 	})
-	if out := captureStdout(t, func() { printEvent(rejected) }); !strings.Contains(out, "process not suspended") {
-		t.Fatalf("error render = %q, want the server message", out)
+	var out bytes.Buffer
+	printEvent(&out, rejected)
+	if got := out.String(); !strings.Contains(got, "process not suspended") {
+		t.Fatalf("error render = %q, want the server message", got)
 	}
 	if fullSnapshotNext.Load() {
 		t.Fatal("fullSnapshotNext still armed after a rejected request")
 	}
 
-	summary := captureStdout(t, func() { printEvent(testSnapshotEvent(t, 3)) })
+	out.Reset()
+	printEvent(&out, testSnapshotEvent(t, 3))
+	summary := out.String()
 	if !strings.Contains(summary, "[goroutines] 2 live") {
 		t.Fatalf("automatic snapshot render = %q, want the summary line", summary)
 	}
@@ -168,6 +158,154 @@ func TestCountOf(t *testing.T) {
 	}
 }
 
+type testEditor struct {
+	lines  chan *readline.Result
+	closed chan struct{}
+	once   sync.Once
+	closes atomic.Int32
+	out    bytes.Buffer
+}
+
+func newTestEditor() *testEditor {
+	return &testEditor{
+		lines:  make(chan *readline.Result),
+		closed: make(chan struct{}),
+	}
+}
+
+func (e *testEditor) Line() *readline.Result {
+	select {
+	case line := <-e.lines:
+		return line
+	case <-e.closed:
+		return &readline.Result{Error: io.EOF}
+	}
+}
+
+func (e *testEditor) Stdout() io.Writer { return &e.out }
+
+func (e *testEditor) Close() error {
+	e.once.Do(func() {
+		e.closes.Add(1)
+		close(e.closed)
+	})
+	return nil
+}
+
+func TestRunInteractiveStopsOnEventStreamClosure(t *testing.T) {
+	editor := newTestEditor()
+	events := make(chan protocol.Event)
+	var transportCloses atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		runInteractive(context.Background(), editor, events, func() error {
+			transportCloses.Add(1)
+			return nil
+		}, func(context.Context, []string) bool {
+			t.Error("dispatch called after disconnect")
+			return false
+		})
+		close(done)
+	}()
+
+	close(events)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("interactive session stayed blocked after event stream closure")
+	}
+	if got := editor.closes.Load(); got != 1 {
+		t.Fatalf("editor close calls = %d, want 1", got)
+	}
+	if got := transportCloses.Load(); got != 1 {
+		t.Fatalf("transport close calls = %d, want 1", got)
+	}
+	if got := editor.out.String(); got != "  disconnected\n" {
+		t.Fatalf("output = %q, want one disconnect notice", got)
+	}
+}
+
+func TestRunInteractiveCancellationIsSilentAndClosesResources(t *testing.T) {
+	editor := newTestEditor()
+	events := make(chan protocol.Event)
+	var transportCloses atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		runInteractive(ctx, editor, events, func() error {
+			transportCloses.Add(1)
+			return nil
+		}, func(context.Context, []string) bool {
+			t.Error("dispatch called after cancellation")
+			return false
+		})
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("interactive session stayed blocked after cancellation")
+	}
+	if got := editor.closes.Load(); got != 1 {
+		t.Fatalf("editor close calls = %d, want 1", got)
+	}
+	if got := transportCloses.Load(); got != 1 {
+		t.Fatalf("transport close calls = %d, want 1", got)
+	}
+	if got := editor.out.String(); got != "" {
+		t.Fatalf("output = %q, want no disconnect or goodbye on cancellation", got)
+	}
+}
+
+func TestPrintEventSurfacesOutputWithoutHandwrittenPrompt(t *testing.T) {
+	event, err := protocol.NewEvent(protocol.EventOutput, 1, protocol.OutputPayload{
+		Stream:  "stderr",
+		Content: "debuggee output\n",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+
+	printEvent(&out, event)
+
+	if got := out.String(); got != "  [stderr] debuggee output\n" {
+		t.Fatalf("output = %q", got)
+	}
+	if strings.Contains(out.String(), "bingo>") {
+		t.Fatal("async output wrote a prompt instead of relying on readline redraw")
+	}
+}
+
+type recordingLocalsClient struct {
+	frames []int
+}
+
+func (c *recordingLocalsClient) Locals(frameIndex int) ([]protocol.Variable, error) {
+	c.frames = append(c.frames, frameIndex)
+	return nil, nil
+}
+
+func TestShowLocalsRejectsInvalidFramesBeforeDispatch(t *testing.T) {
+	for _, frame := range []string{"abc", "-1"} {
+		t.Run(frame, func(t *testing.T) {
+			client := &recordingLocalsClient{}
+			var out bytes.Buffer
+
+			showLocals(context.Background(), client, []string{frame}, &out)
+
+			if len(client.frames) != 0 {
+				t.Fatalf("Locals called with %v", client.frames)
+			}
+			if !strings.Contains(out.String(), "invalid frame index") {
+				t.Fatalf("output = %q", out.String())
+			}
+		})
+	}
+}
+
 // TestFormatGoroutineListStatesWhatItOmits pins the listing's honesty. The
 // goroutine list is bounded by the wire contract, so a caller that prints only
 // the delivered entries presents a packed subset — or a scan that stopped early
@@ -218,5 +356,54 @@ func TestFormatGoroutineListStatesWhatItOmits(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+type blockingLocalsClient struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (c *blockingLocalsClient) Locals(int) ([]protocol.Variable, error) {
+	close(c.started)
+	<-c.release
+	return nil, errors.New("client closed")
+}
+
+func TestShowLocalsSuppressesCancellationError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	client := &blockingLocalsClient{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	var out bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		showLocals(ctx, client, nil, &out)
+		close(done)
+	}()
+
+	<-client.started
+	cancel()
+	close(client.release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("showLocals did not return after cancellation")
+	}
+	if got := out.String(); got != "" {
+		t.Fatalf("output = %q, want silent cancellation", got)
+	}
+}
+
+func TestCommandErrorSuppressionOnlyMatchesShutdown(t *testing.T) {
+	if !commandErrorSuppressed(context.Background(), errors.New("client closed")) {
+		t.Fatal("client closure was not suppressed")
+	}
+	if !commandErrorSuppressed(context.Background(), io.ErrUnexpectedEOF) {
+		t.Fatal("transport EOF was not suppressed")
+	}
+	if commandErrorSuppressed(context.Background(), errors.New("server: no active debugger")) {
+		t.Fatal("server command error was incorrectly suppressed")
 	}
 }

--- a/cmd/dapcli/main.go
+++ b/cmd/dapcli/main.go
@@ -113,14 +113,21 @@ func mainExitCode() int {
 	sessionID := flag.String("session", "", "existing bingo session ID to join (omit to create on launch)")
 	flag.Parse()
 
-	if err := runDAPCLI(ctx, *addr, *sessionID); err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, errDAPDisconnected) {
-			return 0
-		}
+	err := runDAPCLI(ctx, *addr, *sessionID)
+	code := exitCode(err)
+	if code != 0 {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		return 1
 	}
-	return 0
+	return code
+}
+
+func exitCode(err error) int {
+	if err == nil ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, errDAPDisconnected) {
+		return 0
+	}
+	return 1
 }
 
 func runDAPCLI(ctx context.Context, addr, sessionID string) error {

--- a/cmd/dapcli/main.go
+++ b/cmd/dapcli/main.go
@@ -19,17 +19,23 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"net"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"syscall"
 	"time"
 
+	"github.com/bingosuite/bingo/cmd/internal/repl"
 	"github.com/bingosuite/bingo/internal/dapclient"
 	"github.com/bingosuite/bingo/pkg/protocol"
 	"github.com/chzyer/readline"
@@ -41,10 +47,17 @@ const (
 	replyTimeout = 15 * time.Second
 )
 
+var errDAPDisconnected = errors.New("DAP connection closed")
+
 type breakpoint struct {
 	line     int
 	id       int
 	verified bool
+}
+
+type pendingResult struct {
+	message godap.Message
+	err     error
 }
 
 // dapCLI is a minimal interactive DAP client: a demuxing read loop matches
@@ -54,10 +67,11 @@ type dapCLI struct {
 	conn   net.Conn
 	reader *bufio.Reader
 
-	// mu guards seq and pending (the response-waiter registry).
-	mu      sync.Mutex
-	seq     int
-	pending map[int]chan godap.Message
+	// mu guards seq, pending (the response-waiter registry), and terminalErr.
+	mu          sync.Mutex
+	seq         int
+	pending     map[int]chan pendingResult
+	terminalErr error
 
 	// writeMu serialises WriteProtocolMessage across the REPL goroutine, the
 	// initialized-handler goroutine, and any command handler — concurrent writes
@@ -73,31 +87,100 @@ type dapCLI struct {
 
 	// printMu serialises console output so async event prints don't interleave.
 	printMu sync.Mutex
+	out     io.Writer
+
+	closeEditor  func()
+	disconnected chan struct{}
+	readDone     chan struct{}
+	readMu       sync.Mutex
+	readErr      error
+	readClosing  bool
+
+	transportOnce  sync.Once
+	disconnectOnce sync.Once
+	intentional    atomic.Bool
 }
 
 func main() {
+	os.Exit(mainExitCode())
+}
+
+func mainExitCode() int {
+	ctx, stopSignals := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopSignals()
+
 	addr := flag.String("addr", "localhost:4711", "DAP server address (host:port)")
 	sessionID := flag.String("session", "", "existing bingo session ID to join (omit to create on launch)")
 	flag.Parse()
 
-	conn, err := net.Dial("tcp4", *addr)
+	if err := runDAPCLI(ctx, *addr, *sessionID); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, errDAPDisconnected) {
+			return 0
+		}
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func runDAPCLI(ctx context.Context, addr, sessionID string) error {
+	conn, err := (&net.Dialer{}).DialContext(ctx, "tcp4", addr)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: dial DAP %s: %v\n", *addr, err)
-		os.Exit(1)
+		return fmt.Errorf("dial DAP %s: %w", addr, err)
+	}
+	if err := ctx.Err(); err != nil {
+		_ = conn.Close()
+		return err
 	}
 
+	rl, err := repl.NewEditor(&readline.Config{
+		Prompt:          prompt,
+		HistoryFile:     os.ExpandEnv("$HOME/.bingo_dap_history"),
+		InterruptPrompt: "^C",
+		EOFPrompt:       "exit",
+	})
+	if err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("initialize readline: %w", err)
+	}
+
+	var closeEditorOnce sync.Once
+	closeEditor := func() {
+		closeEditorOnce.Do(func() { _ = rl.Close() })
+	}
 	h := &dapCLI{
-		conn:      conn,
-		reader:    bufio.NewReader(conn),
-		pending:   make(map[int]chan godap.Message),
-		bpsByFile: make(map[string][]breakpoint),
+		conn:         conn,
+		reader:       bufio.NewReader(conn),
+		pending:      make(map[int]chan pendingResult),
+		bpsByFile:    make(map[string][]breakpoint),
+		out:          rl.Stdout(),
+		closeEditor:  closeEditor,
+		disconnected: make(chan struct{}),
+		readDone:     make(chan struct{}),
 	}
-	go h.readLoop()
 
-	if *sessionID != "" {
-		fmt.Printf("joining session %s on %s over DAP...\n", *sessionID, *addr)
+	runCtx, cancel := context.WithCancel(ctx)
+	go h.readLoop()
+	stopShutdown := context.AfterFunc(runCtx, func() {
+		h.close()
+		closeEditor()
+	})
+	var finishOnce sync.Once
+	finish := func() {
+		finishOnce.Do(func() {
+			cancel()
+			h.close()
+			closeEditor()
+			stopShutdown()
+			<-h.readDone
+		})
+	}
+	defer finish()
+
+	if sessionID != "" {
+		fmt.Printf("joining session %s on %s over DAP...\n", sessionID, addr)
 	} else {
-		fmt.Printf("connecting to %s over DAP (session created on launch)...\n", *addr)
+		fmt.Printf("connecting to %s over DAP (session created on launch)...\n", addr)
 	}
 
 	// initialize handshake — block for the capabilities response.
@@ -112,52 +195,29 @@ func main() {
 			SupportsRunInTerminalRequest: false,
 		},
 	}); err != nil {
-		fmt.Fprintf(os.Stderr, "error: initialize: %v\n", err)
-		os.Exit(1)
+		if errors.Is(err, errDAPDisconnected) || runCtx.Err() != nil {
+			return nil
+		}
+		return fmt.Errorf("initialize: %w", err)
 	}
 
-	if *sessionID != "" {
+	if sessionID != "" {
 		// Join: attach carrying the session id and no pid. The response arrives
 		// after our auto-configurationDone, so fire it and let the read loop
 		// drive the rest of the handshake.
-		args, _ := json.Marshal(map[string]any{"session": *sessionID})
-		h.setSessionID(*sessionID)
+		args, _ := json.Marshal(map[string]any{"session": sessionID})
+		h.setSessionID(sessionID)
 		h.fire("attach", &godap.AttachRequest{Arguments: args})
 	}
 
-	rl, err := readline.NewEx(&readline.Config{
-		Prompt:          prompt,
-		HistoryFile:     os.ExpandEnv("$HOME/.bingo_dap_history"),
-		InterruptPrompt: "^C",
-		EOFPrompt:       "exit",
-	})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "error initializing readline: %v\n", err)
-		os.Exit(1)
-	}
-	defer func() { _ = rl.Close() }()
-
 	printHelp()
-	for {
-		line, err := rl.Readline()
-		if err != nil {
-			if err == readline.ErrInterrupt || err == io.EOF {
-				fmt.Println("bye")
-				h.close()
-				return
-			}
-			break
-		}
-
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		if h.dispatch(strings.Fields(line)) {
-			h.close()
-			return
-		}
+	repl.Loop(runCtx, rl, closeEditor, h.disconnected, h.dispatch)
+	finish()
+	readErr, intentional := h.readOutcome()
+	if ctx.Err() != nil {
+		return nil
 	}
+	return sessionEndError(readErr, intentional)
 }
 
 // dispatch runs one REPL command, returning true when the CLI should exit.
@@ -204,7 +264,7 @@ func (h *dapCLI) dispatch(args []string) bool {
 
 	case "restart":
 		if _, err := h.request("restart", &godap.RestartRequest{}); err != nil {
-			printErr(err)
+			h.printRequestError("", err)
 		} else {
 			fmt.Println("  restarted (breakpoints reinstalled)")
 		}
@@ -249,9 +309,10 @@ func (h *dapCLI) dispatch(args []string) bool {
 		h.clearBreakpoint(id)
 
 	case "locals":
-		frame := 0
-		if len(args) > 1 {
-			frame, _ = strconv.Atoi(args[1])
+		frame, err := repl.FrameIndex(args[1:])
+		if err != nil {
+			fmt.Printf("  %s\n", err)
+			return false
 		}
 		h.showLocals(frame)
 
@@ -265,7 +326,6 @@ func (h *dapCLI) dispatch(args []string) bool {
 		printHelp()
 
 	case "quit", "q", "exit":
-		fmt.Println("bye")
 		return true
 
 	default:
@@ -279,15 +339,11 @@ func (h *dapCLI) dispatch(args []string) bool {
 // readLoop demuxes responses (to waiters, by request seq) and events (printed /
 // handshake-driven) until the connection closes.
 func (h *dapCLI) readLoop() {
+	defer close(h.readDone)
 	for {
 		msg, err := readDAPMessage(h.reader)
 		if err != nil {
-			h.failPending()
-			if !isClosed(err) {
-				h.printAsync("connection closed: " + err.Error())
-			} else {
-				h.printAsync("disconnected")
-			}
+			h.endConnection(err)
 			return
 		}
 		switch m := msg.(type) {
@@ -309,7 +365,10 @@ func (h *dapCLI) onResponse(rm godap.ResponseMessage, msg godap.Message) {
 	ch := h.pending[rs.RequestSeq]
 	h.mu.Unlock()
 	if ch != nil {
-		ch <- msg
+		select {
+		case ch <- pendingResult{message: msg}:
+		default:
+		}
 		return
 	}
 	// No waiter (a fire-and-forget command): surface failures so they aren't
@@ -323,43 +382,62 @@ func (h *dapCLI) onResponse(rm godap.ResponseMessage, msg godap.Message) {
 // ack we don't surface). Errors still surface via onResponse.
 func (h *dapCLI) fire(command string, m godap.RequestMessage) {
 	h.mu.Lock()
+	if h.terminalErr != nil {
+		h.mu.Unlock()
+		return
+	}
 	h.seq++
 	seq := h.seq
 	h.mu.Unlock()
-	h.write(command, seq, m)
+	if err := h.write(command, seq, m); err != nil {
+		h.endConnection(err)
+	}
 }
 
 // request sends a request and blocks for its response (or a timeout).
 func (h *dapCLI) request(command string, m godap.RequestMessage) (godap.Message, error) {
 	h.mu.Lock()
+	if h.terminalErr != nil {
+		err := h.terminalErr
+		h.mu.Unlock()
+		return nil, err
+	}
 	h.seq++
 	seq := h.seq
-	ch := make(chan godap.Message, 1)
+	ch := make(chan pendingResult, 1)
 	h.pending[seq] = ch
 	h.mu.Unlock()
 
-	h.write(command, seq, m)
-
-	select {
-	case msg := <-ch:
+	defer func() {
 		h.mu.Lock()
 		delete(h.pending, seq)
 		h.mu.Unlock()
-		if rm, ok := msg.(godap.ResponseMessage); ok {
+	}()
+
+	if err := h.write(command, seq, m); err != nil {
+		h.endConnection(err)
+		return nil, connectionError(err)
+	}
+
+	timer := time.NewTimer(replyTimeout)
+	defer timer.Stop()
+	select {
+	case result := <-ch:
+		if result.err != nil {
+			return nil, result.err
+		}
+		if rm, ok := result.message.(godap.ResponseMessage); ok {
 			if rs := rm.GetResponse(); !rs.Success {
-				return msg, fmt.Errorf("%s", rs.Message)
+				return result.message, fmt.Errorf("%s", rs.Message)
 			}
 		}
-		return msg, nil
-	case <-time.After(replyTimeout):
-		h.mu.Lock()
-		delete(h.pending, seq)
-		h.mu.Unlock()
+		return result.message, nil
+	case <-timer.C:
 		return nil, fmt.Errorf("timeout awaiting %s response", command)
 	}
 }
 
-func (h *dapCLI) write(command string, seq int, m godap.RequestMessage) {
+func (h *dapCLI) write(command string, seq int, m godap.RequestMessage) error {
 	req := m.GetRequest()
 	req.Seq = seq
 	req.Type = "request"
@@ -367,22 +445,71 @@ func (h *dapCLI) write(command string, seq int, m godap.RequestMessage) {
 	h.writeMu.Lock()
 	err := godap.WriteProtocolMessage(h.conn, m)
 	h.writeMu.Unlock()
-	if err != nil {
-		h.printAsync(fmt.Sprintf("[error] write %s: %v", command, err))
-	}
+	return err
 }
 
 // failPending unblocks every outstanding waiter when the connection drops.
-func (h *dapCLI) failPending() {
+func (h *dapCLI) failPending(err error) {
 	h.mu.Lock()
+	if h.terminalErr == nil {
+		h.terminalErr = err
+	}
+	err = h.terminalErr
+	pending := make([]chan pendingResult, 0, len(h.pending))
 	for seq, ch := range h.pending {
-		close(ch)
+		pending = append(pending, ch)
 		delete(h.pending, seq)
 	}
 	h.mu.Unlock()
+	for _, ch := range pending {
+		select {
+		case ch <- pendingResult{err: err}:
+		default:
+		}
+	}
 }
 
-func (h *dapCLI) close() { _ = h.conn.Close() }
+func (h *dapCLI) close() {
+	h.intentional.Store(true)
+	h.failPending(errDAPDisconnected)
+	h.closeTransport()
+}
+
+func (h *dapCLI) closeTransport() {
+	h.transportOnce.Do(func() { _ = h.conn.Close() })
+}
+
+func (h *dapCLI) endConnection(err error) {
+	h.disconnectOnce.Do(func() {
+		intentional := h.intentional.Load()
+		h.readMu.Lock()
+		h.readErr = err
+		h.readClosing = intentional
+		h.readMu.Unlock()
+
+		if !intentional {
+			close(h.disconnected)
+		}
+		h.failPending(connectionError(err))
+		h.closeTransport()
+		if intentional {
+			return
+		}
+
+		if isClosed(err) {
+			h.printAsync("disconnected")
+		} else {
+			h.printAsync("connection closed: " + err.Error())
+		}
+		h.closeEditor()
+	})
+}
+
+func (h *dapCLI) readOutcome() (error, bool) {
+	h.readMu.Lock()
+	defer h.readMu.Unlock()
+	return h.readErr, h.readClosing
+}
 
 // --- event handling ------------------------------------------------------------
 
@@ -408,11 +535,7 @@ func (h *dapCLI) onEvent(em godap.EventMessage) {
 		h.printAsync("[continued]")
 	case *godap.OutputEvent:
 		h.captureSession(e.Body.Output)
-		cat := e.Body.Category
-		if cat == "" {
-			cat = "output"
-		}
-		h.printAsync(fmt.Sprintf("[%s] %s", cat, strings.TrimRight(e.Body.Output, "\n")))
+		h.printOutput(e.Body.Category, e.Body.Output)
 	case *godap.ExitedEvent:
 		h.printAsync(fmt.Sprintf("[exited] code=%d", e.Body.ExitCode))
 	case *godap.TerminatedEvent:
@@ -527,7 +650,7 @@ func (h *dapCLI) sendBreakpoints(file string, announce bool) {
 		},
 	})
 	if err != nil {
-		h.printAsync("[error] setBreakpoints: " + err.Error())
+		h.printRequestError("setBreakpoints", err)
 		return
 	}
 	resp, ok := msg.(*godap.SetBreakpointsResponse)
@@ -562,7 +685,7 @@ func (h *dapCLI) sendBreakpoints(file string, announce bool) {
 func (h *dapCLI) showThreads() {
 	msg, err := h.request("threads", &godap.ThreadsRequest{})
 	if err != nil {
-		printErr(err)
+		h.printRequestError("", err)
 		return
 	}
 	resp, ok := msg.(*godap.ThreadsResponse)
@@ -580,7 +703,7 @@ func (h *dapCLI) showStackTrace() {
 		Arguments: godap.StackTraceArguments{ThreadId: h.thread()},
 	})
 	if err != nil {
-		printErr(err)
+		h.printRequestError("", err)
 		return
 	}
 	resp, ok := msg.(*godap.StackTraceResponse)
@@ -603,7 +726,7 @@ func (h *dapCLI) showLocals(frame int) {
 		Arguments: godap.VariablesArguments{VariablesReference: frame + 1},
 	})
 	if err != nil {
-		printErr(err)
+		h.printRequestError("", err)
 		return
 	}
 	resp, ok := msg.(*godap.VariablesResponse)
@@ -636,12 +759,43 @@ func (h *dapCLI) setSessionID(id string) {
 	h.stateMu.Unlock()
 }
 
-// printAsync writes an out-of-band line (event / async result) and redraws the
-// prompt, mirroring cmd/cli's event printer.
 func (h *dapCLI) printAsync(msg string) {
 	h.printMu.Lock()
-	fmt.Printf("\n  %s\n%s", msg, prompt)
+	repl.PrintAsync(h.output(), msg)
 	h.printMu.Unlock()
+}
+
+func (h *dapCLI) printOutput(category, content string) {
+	h.printMu.Lock()
+	repl.PrintOutput(h.output(), category, content)
+	h.printMu.Unlock()
+}
+
+func (h *dapCLI) output() io.Writer {
+	if h.out != nil {
+		return h.out
+	}
+	return os.Stdout
+}
+
+func (h *dapCLI) printRequestError(command string, err error) {
+	if h.intentional.Load() || h.connectionEnded() || errors.Is(err, errDAPDisconnected) {
+		return
+	}
+	if command != "" {
+		h.printAsync(fmt.Sprintf("[error] %s: %v", command, err))
+		return
+	}
+	fmt.Printf("  error: %v\n", err)
+}
+
+func (h *dapCLI) connectionEnded() bool {
+	select {
+	case <-h.disconnected:
+		return true
+	default:
+		return false
+	}
 }
 
 func parseFileLine(s string) (string, int, bool) {
@@ -657,14 +811,27 @@ func parseFileLine(s string) (string, int, bool) {
 }
 
 func isClosed(err error) bool {
-	return err == io.EOF || errStringContains(err, "closed")
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, net.ErrClosed) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNABORTED) ||
+		errors.Is(err, syscall.EPIPE)
 }
 
-func errStringContains(err error, sub string) bool {
-	return err != nil && strings.Contains(err.Error(), sub)
+func connectionError(err error) error {
+	if isClosed(err) {
+		return errDAPDisconnected
+	}
+	return fmt.Errorf("DAP connection failed: %w", err)
 }
 
-func printErr(err error) { fmt.Printf("  error: %v\n", err) }
+func sessionEndError(err error, intentional bool) error {
+	if err == nil || intentional || isClosed(err) {
+		return nil
+	}
+	return fmt.Errorf("DAP connection ended: %w", err)
+}
 
 func printHelp() {
 	fmt.Println(`commands (Debug Adapter Protocol):

--- a/cmd/dapcli/main_test.go
+++ b/cmd/dapcli/main_test.go
@@ -3,8 +3,12 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"net"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -47,14 +51,14 @@ func TestReadLoopContinuesAfterSessionAnnouncement(t *testing.T) {
 		_ = client.Close()
 	})
 
-	response := make(chan godap.Message, 1)
-	h := &dapCLI{
-		conn:      client,
-		reader:    bufio.NewReader(client),
-		pending:   map[int]chan godap.Message{7: response},
-		bpsByFile: make(map[string][]breakpoint),
-	}
+	h := newTestDAPCLI(client, io.Discard, func() {})
+	pending := make(chan pendingResult, 1)
+	h.pending[7] = pending
 	go h.readLoop()
+	t.Cleanup(func() {
+		h.close()
+		<-h.readDone
+	})
 
 	go func() {
 		writeDAPFrameTo(server, fmt.Sprintf(
@@ -73,8 +77,8 @@ func TestReadLoopContinuesAfterSessionAnnouncement(t *testing.T) {
 	}()
 
 	select {
-	case message := <-response:
-		_, ok := message.(*godap.InitializeResponse)
+	case result := <-pending:
+		_, ok := result.message.(*godap.InitializeResponse)
 		g.Expect(ok).To(BeTrue())
 	case <-time.After(time.Second):
 		t.Fatal("normal response was not delivered after custom event")
@@ -91,6 +95,214 @@ func TestSetThreadPreservesUnknownStopIdentity(t *testing.T) {
 	h.setThread(0)
 	if got := h.thread(); got != 0 {
 		t.Fatalf("thread = %d, want unknown stopped thread 0", got)
+	}
+}
+
+func TestOutputEventUsesAsyncWriter(t *testing.T) {
+	var out bytes.Buffer
+	h := &dapCLI{out: &out}
+
+	h.onEvent(&godap.OutputEvent{
+		Body: godap.OutputEventBody{
+			Category: "stderr",
+			Output:   "debuggee output\n",
+		},
+	})
+
+	if got := out.String(); got != "  [stderr] debuggee output\n" {
+		t.Fatalf("output = %q", got)
+	}
+	if strings.Contains(out.String(), prompt) {
+		t.Fatal("async output wrote a prompt instead of relying on readline redraw")
+	}
+}
+
+func TestRequestFailsWhenTransportCloses(t *testing.T) {
+	server, client := net.Pipe()
+	var out bytes.Buffer
+	var editorCloses atomic.Int32
+	h := newTestDAPCLI(client, &out, func() { editorCloses.Add(1) })
+	go h.readLoop()
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		_, _ = readDAPMessage(bufio.NewReader(server))
+		_ = server.Close()
+	}()
+
+	_, err := h.request("threads", &godap.ThreadsRequest{})
+	if !errors.Is(err, errDAPDisconnected) {
+		t.Fatalf("request error = %v, want DAP disconnect", err)
+	}
+	select {
+	case <-h.readDone:
+	case <-time.After(time.Second):
+		t.Fatal("read loop did not stop after transport EOF")
+	}
+	<-serverDone
+
+	if got := editorCloses.Load(); got != 1 {
+		t.Fatalf("editor close calls = %d, want 1", got)
+	}
+	if got := out.String(); got != "  disconnected\n" {
+		t.Fatalf("output = %q, want one disconnect notice", got)
+	}
+}
+
+func TestIntentionalCloseDoesNotReportDisconnect(t *testing.T) {
+	server, client := net.Pipe()
+	var out bytes.Buffer
+	var editorCloses atomic.Int32
+	h := newTestDAPCLI(client, &out, func() { editorCloses.Add(1) })
+	go h.readLoop()
+
+	h.close()
+	_ = server.Close()
+	select {
+	case <-h.readDone:
+	case <-time.After(time.Second):
+		t.Fatal("read loop did not stop after intentional close")
+	}
+
+	if got := editorCloses.Load(); got != 0 {
+		t.Fatalf("editor close calls = %d, want caller-owned close", got)
+	}
+	if got := out.String(); got != "" {
+		t.Fatalf("output = %q, want no disconnect notice", got)
+	}
+}
+
+func TestReadLoopDoesNotTreatProtocolErrorContainingClosedAsDisconnect(t *testing.T) {
+	server, client := net.Pipe()
+	var out bytes.Buffer
+	h := newTestDAPCLI(client, &out, func() {})
+	go h.readLoop()
+
+	writeDAPFrameTo(server, `{"seq":1,"type":"closed"}`)
+	select {
+	case <-h.readDone:
+	case <-time.After(time.Second):
+		t.Fatal("read loop did not stop after malformed DAP message")
+	}
+	_ = server.Close()
+
+	readErr, intentional := h.readOutcome()
+	if readErr == nil || intentional {
+		t.Fatalf("read outcome = (%v, %v), want unintentional protocol failure", readErr, intentional)
+	}
+	if err := sessionEndError(readErr, intentional); err == nil {
+		t.Fatal("protocol error containing closed was treated as graceful")
+	}
+	if got := out.String(); !strings.Contains(got, "connection closed:") {
+		t.Fatalf("output = %q, want protocol failure notice", got)
+	}
+}
+
+func TestSessionEndErrorClassifiesOnlyUnexpectedFailures(t *testing.T) {
+	if err := sessionEndError(io.EOF, false); err != nil {
+		t.Fatalf("EOF error = %v, want graceful end", err)
+	}
+	if err := sessionEndError(errors.New("malformed DAP frame"), true); err != nil {
+		t.Fatalf("intentional close error = %v, want graceful end", err)
+	}
+	if err := sessionEndError(errors.New("malformed DAP frame"), false); err == nil {
+		t.Fatal("unexpected protocol failure was treated as graceful")
+	}
+}
+
+func TestRequestErrorIsSuppressedAfterConnectionEnds(t *testing.T) {
+	var out bytes.Buffer
+	h := &dapCLI{
+		out:          &out,
+		disconnected: make(chan struct{}),
+	}
+	close(h.disconnected)
+
+	h.printRequestError("threads", errDAPDisconnected)
+
+	if got := out.String(); got != "" {
+		t.Fatalf("output = %q, want disconnect notice to own the error", got)
+	}
+}
+
+func TestEndConnectionPublishesStateBeforeFailingWaiters(t *testing.T) {
+	server, client := net.Pipe()
+	t.Cleanup(func() { _ = server.Close() })
+	h := newTestDAPCLI(client, io.Discard, func() {})
+	waiter := make(chan pendingResult, 1)
+	h.pending[1] = waiter
+	failure := errors.New("malformed DAP frame")
+
+	h.endConnection(failure)
+
+	result := <-waiter
+	if !h.connectionEnded() {
+		t.Fatal("pending request woke before connection state was published")
+	}
+	if result.err == nil {
+		t.Fatal("pending request did not receive the connection failure")
+	}
+	readErr, intentional := h.readOutcome()
+	if !errors.Is(readErr, failure) || intentional {
+		t.Fatalf("read outcome = (%v, %v), want original unintentional failure", readErr, intentional)
+	}
+	if err := sessionEndError(readErr, intentional); err == nil {
+		t.Fatal("unexpected write/read failure was downgraded to graceful exit")
+	}
+}
+
+func TestRequestDoesNotRegisterAfterConnectionEnds(t *testing.T) {
+	server, client := net.Pipe()
+	t.Cleanup(func() { _ = server.Close() })
+	h := newTestDAPCLI(client, io.Discard, func() {})
+	h.endConnection(io.EOF)
+
+	start := time.Now()
+	_, err := h.request("threads", &godap.ThreadsRequest{})
+	if !errors.Is(err, errDAPDisconnected) {
+		t.Fatalf("request error = %v, want DAP disconnect", err)
+	}
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Fatalf("request waited %v after terminal disconnect", elapsed)
+	}
+	h.mu.Lock()
+	seq := h.seq
+	h.mu.Unlock()
+	if seq != 0 {
+		t.Fatalf("request sequence = %d, want no registration", seq)
+	}
+}
+
+func TestDispatchRejectsInvalidFramesBeforeRequest(t *testing.T) {
+	for _, frame := range []string{"abc", "-1"} {
+		t.Run(frame, func(t *testing.T) {
+			h := &dapCLI{}
+
+			if h.dispatch([]string{"locals", frame}) {
+				t.Fatal("invalid locals command requested exit")
+			}
+
+			h.mu.Lock()
+			seq := h.seq
+			h.mu.Unlock()
+			if seq != 0 {
+				t.Fatalf("request sequence = %d, want no request", seq)
+			}
+		})
+	}
+}
+
+func newTestDAPCLI(conn net.Conn, out io.Writer, closeEditor func()) *dapCLI {
+	return &dapCLI{
+		conn:         conn,
+		reader:       bufio.NewReader(conn),
+		pending:      make(map[int]chan pendingResult),
+		bpsByFile:    make(map[string][]breakpoint),
+		out:          out,
+		closeEditor:  closeEditor,
+		disconnected: make(chan struct{}),
+		readDone:     make(chan struct{}),
 	}
 }
 

--- a/cmd/dapcli/main_test.go
+++ b/cmd/dapcli/main_test.go
@@ -3,10 +3,12 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -17,6 +19,26 @@ import (
 	godap "github.com/google/go-dap"
 	. "github.com/onsi/gomega"
 )
+
+func TestExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "clean"},
+		{name: "canceled", err: fmt.Errorf("initialize: %w", context.Canceled)},
+		{name: "disconnected", err: fmt.Errorf("request: %w", errDAPDisconnected)},
+		{name: "failure", err: errors.New("malformed DAP frame"), want: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := exitCode(tt.err); got != tt.want {
+				t.Fatalf("exitCode(%v) = %d, want %d", tt.err, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestReadDAPMessageAcceptsSessionAnnouncement(t *testing.T) {
 	g := NewWithT(t)
@@ -226,26 +248,67 @@ func TestRequestErrorIsSuppressedAfterConnectionEnds(t *testing.T) {
 	}
 }
 
-func TestEndConnectionPublishesStateBeforeFailingWaiters(t *testing.T) {
+func TestReadLoopPublishesConnectionBeforeWakingRequest(t *testing.T) {
+	oldProcs := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(oldProcs)
+
 	server, client := net.Pipe()
 	t.Cleanup(func() { _ = server.Close() })
-	h := newTestDAPCLI(client, io.Discard, func() {})
-	waiter := make(chan pendingResult, 1)
-	h.pending[1] = waiter
-	failure := errors.New("malformed DAP frame")
+	var out bytes.Buffer
+	h := newTestDAPCLI(client, &out, func() {})
+	go h.readLoop()
 
-	h.endConnection(failure)
+	requestDone := make(chan error, 1)
+	go func() {
+		_, err := h.request("threads", &godap.ThreadsRequest{})
+		h.printRequestError("threads", err)
+		requestDone <- err
+	}()
 
-	result := <-waiter
-	if !h.connectionEnded() {
-		t.Fatal("pending request woke before connection state was published")
+	if _, err := readDAPMessage(bufio.NewReader(server)); err != nil {
+		t.Fatalf("read request: %v", err)
 	}
-	if result.err == nil {
-		t.Fatal("pending request did not receive the connection failure")
+
+	h.readMu.Lock()
+	writeDAPFrameTo(server, `{"seq":1,"type":"closed"}`)
+	runtime.Gosched()
+	var requestErr error
+	wokeBeforePublication := false
+	select {
+	case requestErr = <-requestDone:
+		wokeBeforePublication = true
+	default:
+	}
+	h.readMu.Unlock()
+
+	select {
+	case <-h.readDone:
+	case <-time.After(time.Second):
+		t.Fatal("read loop did not stop after protocol failure")
+	}
+	if !wokeBeforePublication {
+		select {
+		case requestErr = <-requestDone:
+		case <-time.After(time.Second):
+			t.Fatal("request waiter did not wake after protocol failure")
+		}
+	}
+	if requestErr == nil {
+		t.Fatal("request returned nil after protocol failure")
+	}
+	if wokeBeforePublication {
+		t.Error("request waiter woke before connection state was published")
+	}
+
+	if got := strings.Count(out.String(), "connection closed:"); got != 1 {
+		t.Fatalf("connection-closed notices = %d, output %q", got, out.String())
+	}
+	if strings.Contains(out.String(), "[error] threads:") {
+		t.Fatalf("request printed a second error before disconnect publication: %q", out.String())
 	}
 	readErr, intentional := h.readOutcome()
-	if !errors.Is(readErr, failure) || intentional {
-		t.Fatalf("read outcome = (%v, %v), want original unintentional failure", readErr, intentional)
+	if readErr == nil || intentional {
+		t.Fatalf("read outcome = (%v, %v), want unintentional protocol failure", readErr, intentional)
 	}
 	if err := sessionEndError(readErr, intentional); err == nil {
 		t.Fatal("unexpected write/read failure was downgraded to graceful exit")

--- a/cmd/internal/repl/repl.go
+++ b/cmd/internal/repl/repl.go
@@ -1,0 +1,156 @@
+package repl
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/chzyer/readline"
+)
+
+// Editor makes readline cancellation safe for bingo's long-lived event loops.
+type Editor struct {
+	*readline.Instance
+
+	input     *readyInput
+	closeOnce sync.Once
+	closeErr  error
+}
+
+type readyInput struct {
+	io.ReadCloser
+	ready chan struct{}
+	once  sync.Once
+}
+
+func (i *readyInput) Read(p []byte) (int, error) {
+	i.once.Do(func() { close(i.ready) })
+	return i.ReadCloser.Read(p)
+}
+
+// NewEditor retains readline's inner cancelable input so Close can unblock it.
+func NewEditor(config *readline.Config) (*Editor, error) {
+	source := config.Stdin
+	if source == nil {
+		source = readline.Stdin
+	}
+	input := &readyInput{
+		ReadCloser: readline.NewCancelableStdin(source),
+		ready:      make(chan struct{}),
+	}
+	config.Stdin = input
+
+	instance, err := readline.NewEx(config)
+	if err != nil {
+		_ = input.Close()
+		return nil, err
+	}
+	return &Editor{Instance: instance, input: input}, nil
+}
+
+func (e *Editor) Close() error {
+	e.closeOnce.Do(func() {
+		_ = e.input.Close()
+		select {
+		case <-e.input.ready:
+		default:
+			// readline adds its terminal WaitGroup entry inside the goroutine.
+			// A canceled read is the only monotonic proof that Add has run.
+			e.Terminal.KickRead()
+			<-e.input.ready
+		}
+		e.closeErr = e.Instance.Close()
+	})
+	return e.closeErr
+}
+
+// Reader is the readline surface shared by bingo's interactive clients.
+type Reader interface {
+	Line() *readline.Result
+	Stdout() io.Writer
+}
+
+// Loop reads and dispatches commands until the user exits, the context is
+// canceled, or the remote endpoint disconnects.
+func Loop(
+	ctx context.Context,
+	reader Reader,
+	closeInput func(),
+	disconnected <-chan struct{},
+	dispatch func([]string) bool,
+) {
+	stopClose := context.AfterFunc(ctx, closeInput)
+	defer stopClose()
+
+	for {
+		result := reader.Line()
+		if ctx.Err() != nil || channelClosed(disconnected) {
+			return
+		}
+		if result.CanContinue() {
+			continue
+		}
+		if result.CanBreak() {
+			if ctx.Err() == nil && !channelClosed(disconnected) {
+				_, _ = fmt.Fprintln(reader.Stdout(), "bye")
+			}
+			return
+		}
+
+		line := strings.TrimSpace(result.Line)
+		if line == "" {
+			continue
+		}
+		if dispatch(strings.Fields(line)) {
+			_, _ = fmt.Fprintln(reader.Stdout(), "bye")
+			return
+		}
+	}
+}
+
+// FrameIndex parses the optional argument accepted by `locals [frame]`.
+func FrameIndex(args []string) (int, error) {
+	if len(args) == 0 {
+		return 0, nil
+	}
+	if len(args) > 1 {
+		return 0, fmt.Errorf("usage: locals [frame]")
+	}
+
+	frame, err := strconv.Atoi(args[0])
+	if err != nil || frame < 0 || frame == math.MaxInt {
+		return 0, fmt.Errorf("invalid frame index: %s", args[0])
+	}
+	return frame, nil
+}
+
+// PrintAsync writes one refresh-safe line through readline's output writer.
+func PrintAsync(out io.Writer, message string) {
+	_, _ = fmt.Fprintf(out, "  %s\n", message)
+}
+
+// PrintOutput renders asynchronous debuggee output consistently across clients.
+func PrintOutput(out io.Writer, category, content string) {
+	if category == "" {
+		category = "output"
+	}
+	content = strings.TrimRight(content, "\r\n")
+	if content == "" {
+		_, _ = fmt.Fprintf(out, "  [%s]\n", category)
+		return
+	}
+	_, _ = fmt.Fprintf(out, "  [%s] %s\n", category, content)
+}
+
+func channelClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/internal/repl/repl_test.go
+++ b/cmd/internal/repl/repl_test.go
@@ -51,6 +51,24 @@ func (r *testReader) close() {
 	})
 }
 
+func newPipeEditor(t *testing.T, input io.ReadCloser) *Editor {
+	t.Helper()
+	editor, err := NewEditor(&readline.Config{
+		Stdin:              input,
+		Stdout:             io.Discard,
+		Stderr:             io.Discard,
+		FuncIsTerminal:     func() bool { return false },
+		FuncMakeRaw:        func() error { return nil },
+		FuncExitRaw:        func() error { return nil },
+		FuncGetWidth:       func() int { return 80 },
+		FuncOnWidthChanged: func(func()) {},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return editor
+}
+
 func TestLoopContinuesAfterPartialInterrupt(t *testing.T) {
 	reader := newTestReader(
 		&readline.Result{Line: "locals 123", Error: readline.ErrInterrupt},
@@ -113,22 +131,28 @@ func TestLoopDoesNotDispatchLineReturnedDuringCancellation(t *testing.T) {
 	}
 }
 
+func TestLoopDoesNotDispatchQueuedInputAfterDisconnect(t *testing.T) {
+	reader := newTestReader(
+		&readline.Result{Line: "continue"},
+		&readline.Result{Error: io.EOF},
+	)
+	disconnected := make(chan struct{})
+	close(disconnected)
+
+	Loop(context.Background(), reader, reader.close, disconnected, func(args []string) bool {
+		t.Fatalf("dispatched %v after disconnect", args)
+		return false
+	})
+
+	if got := reader.out.String(); got != "" {
+		t.Fatalf("output = %q, want no goodbye after disconnect", got)
+	}
+}
+
 func TestEditorCloseUnblocksLine(t *testing.T) {
 	input, inputWriter := io.Pipe()
 	t.Cleanup(func() { _ = inputWriter.Close() })
-	editor, err := NewEditor(&readline.Config{
-		Stdin:              input,
-		Stdout:             io.Discard,
-		Stderr:             io.Discard,
-		FuncIsTerminal:     func() bool { return false },
-		FuncMakeRaw:        func() error { return nil },
-		FuncExitRaw:        func() error { return nil },
-		FuncGetWidth:       func() int { return 80 },
-		FuncOnWidthChanged: func(func()) {},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	editor := newPipeEditor(t, input)
 
 	lineDone := make(chan *readline.Result, 1)
 	go func() { lineDone <- editor.Line() }()
@@ -146,22 +170,30 @@ func TestEditorCloseUnblocksLine(t *testing.T) {
 	}
 }
 
+func TestEditorCloseBeforeLine(t *testing.T) {
+	const iterations = 50
+	for i := 0; i < iterations; i++ {
+		input, inputWriter := io.Pipe()
+		editor := newPipeEditor(t, input)
+		closeDone := make(chan error, 1)
+		go func() { closeDone <- editor.Close() }()
+
+		select {
+		case err := <-closeDone:
+			if err != nil {
+				t.Fatalf("iteration %d: Close: %v", i, err)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("iteration %d: Close blocked before any Line call", i)
+		}
+		_ = inputWriter.Close()
+	}
+}
+
 func TestEditorCloseDoesNotConsumeBufferedNextLine(t *testing.T) {
 	input, inputWriter := io.Pipe()
 	t.Cleanup(func() { _ = inputWriter.Close() })
-	editor, err := NewEditor(&readline.Config{
-		Stdin:              input,
-		Stdout:             io.Discard,
-		Stderr:             io.Discard,
-		FuncIsTerminal:     func() bool { return false },
-		FuncMakeRaw:        func() error { return nil },
-		FuncExitRaw:        func() error { return nil },
-		FuncGetWidth:       func() int { return 80 },
-		FuncOnWidthChanged: func(func()) {},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	editor := newPipeEditor(t, input)
 
 	loopDone := make(chan struct{})
 	go func() {

--- a/cmd/internal/repl/repl_test.go
+++ b/cmd/internal/repl/repl_test.go
@@ -1,0 +1,219 @@
+package repl
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"math"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/chzyer/readline"
+)
+
+type testReader struct {
+	results chan *readline.Result
+	closed  chan struct{}
+	once    sync.Once
+	closes  atomic.Int32
+	out     bytes.Buffer
+}
+
+func newTestReader(results ...*readline.Result) *testReader {
+	ch := make(chan *readline.Result, len(results))
+	for _, result := range results {
+		ch <- result
+	}
+	return &testReader{
+		results: ch,
+		closed:  make(chan struct{}),
+	}
+}
+
+func (r *testReader) Line() *readline.Result {
+	select {
+	case result := <-r.results:
+		return result
+	case <-r.closed:
+		return &readline.Result{Error: io.EOF}
+	}
+}
+
+func (r *testReader) Stdout() io.Writer { return &r.out }
+
+func (r *testReader) close() {
+	r.once.Do(func() {
+		r.closes.Add(1)
+		close(r.closed)
+	})
+}
+
+func TestLoopContinuesAfterPartialInterrupt(t *testing.T) {
+	reader := newTestReader(
+		&readline.Result{Line: "locals 123", Error: readline.ErrInterrupt},
+		&readline.Result{Line: "state"},
+		&readline.Result{Error: readline.ErrInterrupt},
+	)
+	var commands [][]string
+
+	Loop(context.Background(), reader, reader.close, make(chan struct{}), func(args []string) bool {
+		commands = append(commands, args)
+		return false
+	})
+
+	if len(commands) != 1 || len(commands[0]) != 1 || commands[0][0] != "state" {
+		t.Fatalf("commands = %#v, want only state after canceled partial input", commands)
+	}
+	if got := reader.out.String(); got != "bye\n" {
+		t.Fatalf("output = %q, want %q", got, "bye\n")
+	}
+}
+
+func TestLoopCancellationClosesBlockedInput(t *testing.T) {
+	reader := newTestReader()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		Loop(ctx, reader, reader.close, make(chan struct{}), func([]string) bool {
+			t.Error("dispatch called after cancellation")
+			return false
+		})
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("loop did not stop after cancellation")
+	}
+	if got := reader.closes.Load(); got != 1 {
+		t.Fatalf("close calls = %d, want 1", got)
+	}
+	if got := reader.out.String(); got != "" {
+		t.Fatalf("output = %q, want no goodbye for cancellation", got)
+	}
+}
+
+func TestLoopDoesNotDispatchLineReturnedDuringCancellation(t *testing.T) {
+	reader := newTestReader(&readline.Result{Line: "continue"})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	Loop(ctx, reader, reader.close, make(chan struct{}), func(args []string) bool {
+		t.Fatalf("dispatched %v after cancellation", args)
+		return false
+	})
+
+	if got := reader.out.String(); got != "" {
+		t.Fatalf("output = %q, want silent cancellation", got)
+	}
+}
+
+func TestEditorCloseUnblocksLine(t *testing.T) {
+	input, inputWriter := io.Pipe()
+	t.Cleanup(func() { _ = inputWriter.Close() })
+	editor, err := NewEditor(&readline.Config{
+		Stdin:              input,
+		Stdout:             io.Discard,
+		Stderr:             io.Discard,
+		FuncIsTerminal:     func() bool { return false },
+		FuncMakeRaw:        func() error { return nil },
+		FuncExitRaw:        func() error { return nil },
+		FuncGetWidth:       func() int { return 80 },
+		FuncOnWidthChanged: func(func()) {},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lineDone := make(chan *readline.Result, 1)
+	go func() { lineDone <- editor.Line() }()
+
+	if err := editor.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case result := <-lineDone:
+		if !result.CanBreak() {
+			t.Fatalf("Line result = %+v, want a break after Close", result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Editor.Close did not unblock Line")
+	}
+}
+
+func TestEditorCloseDoesNotConsumeBufferedNextLine(t *testing.T) {
+	input, inputWriter := io.Pipe()
+	t.Cleanup(func() { _ = inputWriter.Close() })
+	editor, err := NewEditor(&readline.Config{
+		Stdin:              input,
+		Stdout:             io.Discard,
+		Stderr:             io.Discard,
+		FuncIsTerminal:     func() bool { return false },
+		FuncMakeRaw:        func() error { return nil },
+		FuncExitRaw:        func() error { return nil },
+		FuncGetWidth:       func() int { return 80 },
+		FuncOnWidthChanged: func(func()) {},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	loopDone := make(chan struct{})
+	go func() {
+		Loop(context.Background(), editor, func() { _ = editor.Close() }, make(chan struct{}), func(args []string) bool {
+			return len(args) == 1 && args[0] == "quit"
+		})
+		close(loopDone)
+	}()
+	if _, err := inputWriter.Write([]byte("quit\n\n")); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-loopDone:
+	case <-time.After(time.Second):
+		t.Fatal("loop did not process quit")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- editor.Close() }()
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Editor.Close consumed buffered input and hung")
+	}
+}
+
+func TestFrameIndexValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    int
+		wantErr bool
+	}{
+		{name: "default", want: 0},
+		{name: "explicit", args: []string{"3"}, want: 3},
+		{name: "malformed", args: []string{"abc"}, wantErr: true},
+		{name: "negative", args: []string{"-1"}, wantErr: true},
+		{name: "reference overflow", args: []string{strconv.Itoa(math.MaxInt)}, wantErr: true},
+		{name: "extra", args: []string{"1", "2"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FrameIndex(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("FrameIndex(%v) error = %v, wantErr %v", tt.args, err, tt.wantErr)
+			}
+			if err == nil && got != tt.want {
+				t.Fatalf("FrameIndex(%v) = %d, want %d", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -103,10 +104,19 @@ type SessionInfo struct {
 
 // ListSessions queries the server's REST API for all active sessions.
 func ListSessions(addr string) ([]SessionInfo, error) {
+	return ListSessionsContext(context.Background(), addr)
+}
+
+// ListSessionsContext queries the server's REST API for all active sessions.
+func ListSessionsContext(ctx context.Context, addr string) ([]SessionInfo, error) {
 	url := fmt.Sprintf("http://%s/api/sessions", addr)
 
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil) //nolint:gosec // no auth by design
+	if err != nil {
+		return nil, fmt.Errorf("list sessions: request: %w", err)
+	}
 	httpClient := http.Client{Timeout: listSessionsTimeout}
-	resp, err := httpClient.Get(url) //nolint:gosec // no auth by design
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("list sessions: %w", err)
 	}
@@ -125,10 +135,20 @@ func ListSessions(addr string) ([]SessionInfo, error) {
 
 // Create connects to the server and creates a new debug session.
 func Create(addr string) (Client, error) {
-	return dial(addr, "create=1")
+	return CreateContext(context.Background(), addr)
+}
+
+// CreateContext connects to the server and creates a new debug session.
+func CreateContext(ctx context.Context, addr string) (Client, error) {
+	return dial(ctx, addr, "create=1")
 }
 
 // Join connects to the server and joins an existing session by UUID.
 func Join(addr, sessionID string) (Client, error) {
-	return dial(addr, fmt.Sprintf("session=%s", sessionID))
+	return JoinContext(context.Background(), addr, sessionID)
+}
+
+// JoinContext connects to the server and joins an existing session by UUID.
+func JoinContext(ctx context.Context, addr, sessionID string) (Client, error) {
+	return dial(ctx, addr, fmt.Sprintf("session=%s", sessionID))
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,6 +6,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -14,6 +15,9 @@ import (
 )
 
 const listSessionsTimeout = 5 * time.Second
+
+// ErrClosed reports that a client operation was interrupted by connection teardown.
+var ErrClosed = errors.New("client closed")
 
 // Client interacts with a bingo debug server. All methods are goroutine-safe.
 type Client interface {

--- a/pkg/client/ws.go
+++ b/pkg/client/ws.go
@@ -1,9 +1,11 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
 	"sync"
 	"time"
 
@@ -58,10 +60,31 @@ type wsClient struct {
 }
 
 // dial opens the WebSocket and waits for the server's welcome SessionState.
-func dial(addr, query string) (Client, error) {
+func dial(ctx context.Context, addr, query string) (Client, error) {
 	url := fmt.Sprintf("ws://%s/ws?%s", addr, query)
 
-	conn, _, err := websocket.DefaultDialer.Dial(url, nil)
+	dialer := *websocket.DefaultDialer
+	var stopDialCancel func() bool
+	dialer.NetDialContext = func(dialCtx context.Context, network, address string) (net.Conn, error) {
+		rawConn, err := (&net.Dialer{}).DialContext(dialCtx, network, address)
+		if err != nil {
+			return nil, err
+		}
+		// gorilla applies context deadlines to the upgrade but does not close an
+		// established socket when a deadline-free context is canceled.
+		stopDialCancel = context.AfterFunc(ctx, func() { _ = rawConn.Close() })
+		return rawConn, nil
+	}
+	conn, _, err := dialer.DialContext(ctx, url, nil)
+	if stopDialCancel != nil {
+		stopDialCancel()
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		if conn != nil {
+			_ = conn.Close()
+		}
+		return nil, fmt.Errorf("dial %s: %w", url, ctxErr)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("dial %s: %w", url, err)
 	}
@@ -81,6 +104,8 @@ func dial(addr, query string) (Client, error) {
 
 	go c.readPump()
 
+	timer := time.NewTimer(dialTimeout)
+	defer timer.Stop()
 	select {
 	case evt, ok := <-c.events:
 		if !ok {
@@ -89,11 +114,16 @@ func dial(addr, query string) (Client, error) {
 			}
 			return nil, fmt.Errorf("connection closed before receiving session state")
 		}
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("wait for session state: %w", err)
+		}
 		if evt.Kind != protocol.EventSessionState {
 			return nil, fmt.Errorf("expected SessionState event, got %s", evt.Kind)
 		}
-	case <-time.After(dialTimeout):
+	case <-timer.C:
 		return nil, fmt.Errorf("timeout waiting for session state from server")
+	case <-ctx.Done():
+		return nil, fmt.Errorf("wait for session state: %w", ctx.Err())
 	}
 
 	cleanup = false

--- a/pkg/client/ws.go
+++ b/pkg/client/ws.go
@@ -552,10 +552,15 @@ func (c *wsClient) RequestGoroutineSnapshot() error {
 	return c.send(cmd)
 }
 
-// Close disconnects from the server. Safe to call multiple times.
+// Close disconnects from the server. A terminal read failure takes precedence
+// over the socket close result so the connection owner can report its cause.
 func (c *wsClient) Close() error {
 	c.signalDone()
-	return c.conn.Close()
+	closeErr := c.conn.Close()
+	if err := c.terminalReadError(); err != nil {
+		return err
+	}
+	return closeErr
 }
 
 func (c *wsClient) signalDone() {

--- a/pkg/client/ws.go
+++ b/pkg/client/ws.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -242,17 +243,44 @@ func (c *wsClient) send(cmd protocol.Command) error {
 	if err := c.terminalReadError(); err != nil {
 		return err
 	}
+	if c.closed() {
+		return ErrClosed
+	}
 	data, err := json.Marshal(cmd)
 	if err != nil {
 		return fmt.Errorf("marshal command: %w", err)
 	}
 	c.writeMu.Lock()
+	if err := c.terminalReadError(); err != nil {
+		c.writeMu.Unlock()
+		return err
+	}
+	if c.closed() {
+		c.writeMu.Unlock()
+		return ErrClosed
+	}
 	writeErr := c.conn.WriteMessage(websocket.TextMessage, data)
 	c.writeMu.Unlock()
 	if err := c.terminalReadError(); err != nil {
 		return err
 	}
-	return writeErr
+	return c.normalizeSendError(writeErr)
+}
+
+func (c *wsClient) normalizeSendError(err error) error {
+	if errors.Is(err, websocket.ErrCloseSent) || c.closed() {
+		return ErrClosed
+	}
+	return err
+}
+
+func (c *wsClient) closed() bool {
+	select {
+	case <-c.done:
+		return true
+	default:
+		return false
+	}
 }
 
 // sendAndWait sends cmd and blocks for the matching confirmation event or an
@@ -289,7 +317,7 @@ func (c *wsClient) sendAndWait(cmd protocol.Command, wantKind protocol.EventKind
 		if err := c.terminalReadError(); err != nil {
 			return protocol.Event{}, err
 		}
-		return protocol.Event{}, fmt.Errorf("client closed")
+		return protocol.Event{}, ErrClosed
 	}
 }
 

--- a/pkg/client/ws.go
+++ b/pkg/client/ws.go
@@ -240,47 +240,42 @@ func (c *wsClient) retirePending(req *pendingReq) {
 }
 
 func (c *wsClient) send(cmd protocol.Command) error {
-	if err := c.terminalReadError(); err != nil {
+	if err := c.operationError(nil); err != nil {
 		return err
-	}
-	if c.closed() {
-		return ErrClosed
 	}
 	data, err := json.Marshal(cmd)
 	if err != nil {
 		return fmt.Errorf("marshal command: %w", err)
 	}
 	c.writeMu.Lock()
-	if err := c.terminalReadError(); err != nil {
+	if err := c.operationError(nil); err != nil {
 		c.writeMu.Unlock()
 		return err
-	}
-	if c.closed() {
-		c.writeMu.Unlock()
-		return ErrClosed
 	}
 	writeErr := c.conn.WriteMessage(websocket.TextMessage, data)
 	c.writeMu.Unlock()
-	if err := c.terminalReadError(); err != nil {
-		return err
-	}
 	return c.normalizeSendError(writeErr)
 }
 
 func (c *wsClient) normalizeSendError(err error) error {
-	if errors.Is(err, websocket.ErrCloseSent) || c.closed() {
-		return ErrClosed
-	}
-	return err
+	return c.operationError(err)
 }
 
-func (c *wsClient) closed() bool {
+func (c *wsClient) operationError(fallback error) error {
+	c.readErrMu.RLock()
+	defer c.readErrMu.RUnlock()
+	if c.readErr != nil {
+		return c.readErr
+	}
 	select {
 	case <-c.done:
-		return true
+		return ErrClosed
 	default:
-		return false
 	}
+	if errors.Is(fallback, websocket.ErrCloseSent) {
+		return ErrClosed
+	}
+	return fallback
 }
 
 // sendAndWait sends cmd and blocks for the matching confirmation event or an
@@ -314,10 +309,7 @@ func (c *wsClient) sendAndWait(cmd protocol.Command, wantKind protocol.EventKind
 		return protocol.Event{}, fmt.Errorf("timeout waiting for %s response", wantKind)
 	case <-c.done:
 		c.discardPending(req)
-		if err := c.terminalReadError(); err != nil {
-			return protocol.Event{}, err
-		}
-		return protocol.Event{}, ErrClosed
+		return protocol.Event{}, c.operationError(nil)
 	}
 }
 

--- a/pkg/client/ws_internal_test.go
+++ b/pkg/client/ws_internal_test.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestNormalizeSendError(t *testing.T) {
+	c := &wsClient{done: make(chan struct{})}
+	if err := c.normalizeSendError(websocket.ErrCloseSent); !errors.Is(err, ErrClosed) {
+		t.Fatalf("close-sent error = %v, want ErrClosed", err)
+	}
+
+	failure := errors.New("write failed")
+	if err := c.normalizeSendError(failure); !errors.Is(err, failure) {
+		t.Fatalf("open-client error = %v, want original failure", err)
+	}
+
+	close(c.done)
+	if err := c.normalizeSendError(failure); !errors.Is(err, ErrClosed) {
+		t.Fatalf("closed-client error = %v, want ErrClosed", err)
+	}
+}

--- a/pkg/client/ws_internal_test.go
+++ b/pkg/client/ws_internal_test.go
@@ -22,4 +22,12 @@ func TestNormalizeSendError(t *testing.T) {
 	if err := c.normalizeSendError(failure); !errors.Is(err, ErrClosed) {
 		t.Fatalf("closed-client error = %v, want ErrClosed", err)
 	}
+
+	terminal := errors.New("terminal protocol error")
+	c.readErrMu.Lock()
+	c.readErr = terminal
+	c.readErrMu.Unlock()
+	if err := c.normalizeSendError(failure); !errors.Is(err, terminal) {
+		t.Fatalf("terminal client error = %v, want %v", err, terminal)
+	}
 }

--- a/pkg/client/ws_test.go
+++ b/pkg/client/ws_test.go
@@ -445,6 +445,12 @@ func TestMidstreamVersionMismatchFailsPendingRequest(t *testing.T) {
 	if time.Since(start) > time.Second {
 		t.Fatal("later request waited instead of reusing the terminal version error")
 	}
+	closeErr := c.Close()
+	if closeErr == nil ||
+		!strings.Contains(closeErr.Error(), `expected "`+protocol.Version+`"`) ||
+		!strings.Contains(closeErr.Error(), `received "999.0"`) {
+		t.Fatalf("Close did not preserve the terminal version error: %v", closeErr)
+	}
 
 	select {
 	case <-handlerDone:

--- a/pkg/client/ws_test.go
+++ b/pkg/client/ws_test.go
@@ -1,6 +1,9 @@
 package client_test
 
 import (
+	"context"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,6 +16,117 @@ import (
 
 	"github.com/gorilla/websocket"
 )
+
+func TestCreateContextCancelsStalledHandshake(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			accepted <- conn
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, createErr := client.CreateContext(ctx, listener.Addr().String())
+		result <- createErr
+	}()
+
+	var conn net.Conn
+	select {
+	case conn = <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("client did not start the WebSocket handshake")
+	}
+	defer func() { _ = conn.Close() }()
+
+	cancel()
+	select {
+	case createErr := <-result:
+		if !errors.Is(createErr, context.Canceled) {
+			t.Fatalf("CreateContext error = %v, want context cancellation", createErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("CreateContext did not cancel the stalled WebSocket handshake")
+	}
+}
+
+func TestCreateContextCancelsWelcomeWait(t *testing.T) {
+	connected := make(chan struct{})
+	release := make(chan struct{})
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		close(connected)
+		<-release
+	}))
+	defer server.Close()
+	defer close(release)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, createErr := client.CreateContext(ctx, strings.TrimPrefix(server.URL, "http://"))
+		result <- createErr
+	}()
+
+	select {
+	case <-connected:
+	case <-time.After(time.Second):
+		t.Fatal("client did not complete the WebSocket handshake")
+	}
+	cancel()
+	select {
+	case createErr := <-result:
+		if !errors.Is(createErr, context.Canceled) {
+			t.Fatalf("CreateContext error = %v, want context cancellation", createErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("CreateContext did not cancel the welcome wait")
+	}
+}
+
+func TestListSessionsContextCancelsRequest(t *testing.T) {
+	started := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, listErr := client.ListSessionsContext(ctx, strings.TrimPrefix(server.URL, "http://"))
+		result <- listErr
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("list sessions request did not start")
+	}
+	cancel()
+	select {
+	case listErr := <-result:
+		if !errors.Is(listErr, context.Canceled) {
+			t.Fatalf("ListSessionsContext error = %v, want context cancellation", listErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ListSessionsContext did not cancel the request")
+	}
+}
 
 // fakeServer is a minimal WebSocket bingo server that drives the real client
 // through its actual dial → command → confirmation flow. It records every

--- a/pkg/client/ws_test.go
+++ b/pkg/client/ws_test.go
@@ -365,6 +365,17 @@ func TestCreateRejectsIncompatibleWelcomeVersion(t *testing.T) {
 	}
 }
 
+func requireVersionError(t *testing.T, context string, err error) {
+	t.Helper()
+	var versionErr *protocol.VersionError
+	if !errors.As(err, &versionErr) {
+		t.Fatalf("%s = %v, want VersionError", context, err)
+	}
+	if versionErr.Expected != protocol.Version || versionErr.Received != "999.0" {
+		t.Fatalf("%s = %v, want expected %q and received %q", context, err, protocol.Version, "999.0")
+	}
+}
+
 func TestMidstreamVersionMismatchFailsPendingRequest(t *testing.T) {
 	ts, handlerDone := newScriptedServer(t, func(conn *websocket.Conn) {
 		writeServerEvent(t, conn, protocol.MustEvent(
@@ -417,11 +428,7 @@ func TestMidstreamVersionMismatchFailsPendingRequest(t *testing.T) {
 
 	select {
 	case err := <-errCh:
-		if err == nil ||
-			!strings.Contains(err.Error(), `expected "`+protocol.Version+`"`) ||
-			!strings.Contains(err.Error(), `received "999.0"`) {
-			t.Fatalf("SetBreakpoint error does not preserve the terminal version error: %v", err)
-		}
+		requireVersionError(t, "SetBreakpoint error", err)
 	case <-time.After(2 * time.Second):
 		t.Fatal("SetBreakpoint waited instead of failing on the terminal version error")
 	}
@@ -437,20 +444,12 @@ func TestMidstreamVersionMismatchFailsPendingRequest(t *testing.T) {
 
 	start := time.Now()
 	_, err = c.SetBreakpoint("main.go", 43)
-	if err == nil ||
-		!strings.Contains(err.Error(), `expected "`+protocol.Version+`"`) ||
-		!strings.Contains(err.Error(), `received "999.0"`) {
-		t.Fatalf("later request did not preserve the terminal version error: %v", err)
-	}
+	requireVersionError(t, "later SetBreakpoint error", err)
 	if time.Since(start) > time.Second {
 		t.Fatal("later request waited instead of reusing the terminal version error")
 	}
 	closeErr := c.Close()
-	if closeErr == nil ||
-		!strings.Contains(closeErr.Error(), `expected "`+protocol.Version+`"`) ||
-		!strings.Contains(closeErr.Error(), `received "999.0"`) {
-		t.Fatalf("Close did not preserve the terminal version error: %v", closeErr)
-	}
+	requireVersionError(t, "Close error", closeErr)
 
 	select {
 	case <-handlerDone:

--- a/pkg/client/ws_test.go
+++ b/pkg/client/ws_test.go
@@ -171,8 +171,9 @@ func TestListSessionsContextCancelsRequest(t *testing.T) {
 }
 
 func TestPeerCloseNormalizesCommandErrors(t *testing.T) {
+	upgrader := websocket.Upgrader{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, err := websocket.Upgrade(w, r, nil, 0, 0)
+		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			return
 		}

--- a/pkg/client/ws_test.go
+++ b/pkg/client/ws_test.go
@@ -59,16 +59,47 @@ func TestCreateContextCancelsStalledHandshake(t *testing.T) {
 }
 
 func TestCreateContextCancelsWelcomeWait(t *testing.T) {
-	connected := make(chan struct{})
+	welcomeWaitActive := make(chan error, 1)
 	release := make(chan struct{})
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
+			welcomeWaitActive <- err
 			return
 		}
 		defer func() { _ = conn.Close() }()
-		close(connected)
+
+		pong := make(chan struct{})
+		var pongOnce sync.Once
+		conn.SetPongHandler(func(data string) error {
+			if data == "welcome-ready" {
+				pongOnce.Do(func() { close(pong) })
+			}
+			return nil
+		})
+		go func() {
+			for {
+				if _, _, err := conn.ReadMessage(); err != nil {
+					return
+				}
+			}
+		}()
+		if err := conn.WriteControl(
+			websocket.PingMessage,
+			[]byte("welcome-ready"),
+			time.Now().Add(time.Second),
+		); err != nil {
+			welcomeWaitActive <- err
+			return
+		}
+		select {
+		case <-pong:
+			welcomeWaitActive <- nil
+		case <-time.After(time.Second):
+			welcomeWaitActive <- errors.New("client read pump did not answer ping")
+			return
+		}
 		<-release
 	}))
 	defer server.Close()
@@ -82,15 +113,26 @@ func TestCreateContextCancelsWelcomeWait(t *testing.T) {
 	}()
 
 	select {
-	case <-connected:
+	case err := <-welcomeWaitActive:
+		if err != nil {
+			t.Fatal(err)
+		}
 	case <-time.After(time.Second):
-		t.Fatal("client did not complete the WebSocket handshake")
+		t.Fatal("client did not enter the post-upgrade welcome wait")
 	}
+
+	start := time.Now()
 	cancel()
 	select {
 	case createErr := <-result:
 		if !errors.Is(createErr, context.Canceled) {
 			t.Fatalf("CreateContext error = %v, want context cancellation", createErr)
+		}
+		if !strings.Contains(createErr.Error(), "wait for session state") {
+			t.Fatalf("CreateContext error = %v, want welcome-wait context", createErr)
+		}
+		if elapsed := time.Since(start); elapsed > time.Second {
+			t.Fatalf("welcome wait cancellation took %v", elapsed)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("CreateContext did not cancel the welcome wait")
@@ -125,6 +167,57 @@ func TestListSessionsContextCancelsRequest(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("ListSessionsContext did not cancel the request")
+	}
+}
+
+func TestPeerCloseNormalizesCommandErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Upgrade(w, r, nil, 0, 0)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		welcome := protocol.MustEvent(protocol.EventSessionState, 1, protocol.SessionStatePayload{
+			SessionID: "closing-session",
+			State:     protocol.StateIdle,
+			Clients:   1,
+		})
+		data, err := protocol.MarshalEvent(welcome)
+		if err != nil {
+			return
+		}
+		if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
+			return
+		}
+		_ = conn.WriteControl(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+			time.Now().Add(time.Second),
+		)
+	}))
+	defer server.Close()
+
+	c, err := client.Create(strings.TrimPrefix(server.URL, "http://"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = c.Close() }()
+
+	select {
+	case _, ok := <-c.Events():
+		if ok {
+			t.Fatal("unexpected event before peer-close completion")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("client did not observe peer close")
+	}
+
+	if err := c.Continue(); !errors.Is(err, client.ErrClosed) {
+		t.Errorf("Continue error = %v, want client.ErrClosed", err)
+	}
+	if _, err := c.SetBreakpoint("main.go", 42); !errors.Is(err, client.ErrClosed) {
+		t.Errorf("SetBreakpoint error = %v, want client.ErrClosed", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- share readline interrupt, cancellation, async redraw, and frame-index validation behavior across `cmd/cli` and `cmd/dapcli`
- cancel connection setup and in-flight management work on signals, unblock terminal reads, and treat normal transport EOF as a graceful session end
- preserve abnormal DAP protocol failures as errors while draining pending requests safely
- preserve current client reply-debt and fire-and-forget snapshot semantics, plus DAP's unknown stopped-thread identity
- add focused deterministic coverage for Ctrl-C/cancellation, output redraw, disconnect/EOF, waiter teardown, and frame validation

## Final restack

Rebased onto exact `origin/main` `30879dd5020d3810cd151a14f2f9fd7621a54b55` after the Linux wait broker and PR #197 landed.

| Accepted/prepared commit | Final commit |
| --- | --- |
| `af7c9e7` | `280e4de11286da7e70bd783bfa827859d680ea84` |
| `9257108` | `db7259ed5002f7676701bfe4adc185118845671e` |
| `68642a5` | `4e40a917e868dd84dbf7c419c0a852b55baac90a` |
| `3e6c58a` | `8033f9d52690d1454d1c61f64367d0deea8a4806` |
| `4c9b134` | `308ddd1b67a3586140d1fd67a9f66f9772caaa34` |
| `210e2b9` | `872ff68c5e21e3e782c1d1aebe5313f8a7760c98` |
| `afd718d` cleanup | `3733b0b603954cd2d1374ef7ae3c31e21250543e` |

The prepared-to-final `range-diff` is patch-equivalent for all seven commits.

## Validation

- repository-wide `goimports` check
- `go test -tags bingonative -race -count=200 ./cmd/internal/repl`
- `go test -tags bingonative -race -count=200 ./cmd/cli`
- `go test -tags bingonative -race -count=200 ./cmd/dapcli`
- `go test -tags bingonative -race -count=200 ./pkg/client`
- `go test -tags bingonative -race -count=200 ./cmd/internal/repl -run 'TestLoop|TestEditorClose'`
- `go test -tags bingonative -race -count=1 ./...`
- `go vet -tags bingonative ./...`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build ./...`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 golangci-lint run`
- `just e2e-darwin`: 24 passed, 0 failed, 1 intentionally skipped
- independent review: no high-confidence findings

Fixes #208
