### PR TITLE
fix(protocol): deprecate unproduced panic event

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,12 +136,20 @@ Two envelope types: `Event` (server → client) and `Command` (client → server
 Both versioned; both carry `Kind` + raw-JSON `Payload`. Decode with
 `DecodeEventPayload` / `DecodeCommandPayload` after switching on `Kind`.
 
+`EventPanic` and `PanicPayload` are deprecated source-compatibility tombstones.
+The server has never emitted them: a Go language panic currently terminates the
+tracee and surfaces as `EventProcessExited` (normally exit code 2), not as a
+suspending exception stop. Detecting `runtime.gopanic` before termination would
+require separate runtime-aware debugger support. Keep the exported names until a
+deliberate breaking protocol/API version change, but do not add them to
+suspending-event routing, client capability claims, or state transitions.
+
 ### Suspend/resume protocol
 
 The hub blocks after broadcasting any of these "suspending" events until a
 "resuming" command arrives (or the 30-min safety timeout fires):
 
-- Suspending events: `BreakpointHit`, `Panic`, `Stepped`, `Paused`
+- Suspending events: `BreakpointHit`, `Stepped`, `Paused`
 - Resuming commands: `Continue`, `StepOver`, `StepInto`, `StepOut`
 
 While suspended, **non-resuming** commands (`SetBreakpoint`, `Locals`, …) are
@@ -200,7 +208,7 @@ session could never be resumed again.
 `SessionState` ∈ {`idle`, `running`, `suspended`, `exited`}.
 
 ```
-            Launch / Attach       BreakpointHit / Panic / Stepped / Paused
+            Launch / Attach       BreakpointHit / Stepped / Paused
    idle ────────────────────> running <────────────────────────────────── suspended
     ▲                            │                Continue / Step*
     │                            │
@@ -1064,7 +1072,7 @@ session.
 
 `EventStepped`(entry)=handshake signal; `EventStepped`(step)→`stopped`
 reason=step; `EventBreakpointHit`→`stopped` reason=breakpoint;
-`EventPanic`→reason=exception; `EventPaused`→reason=pause;
+`EventPaused`→reason=pause;
 `EventProcessExited`→`exited`(code)+`terminated`; `EventOutput`→`output`;
 `EventRestarted`→delayed `restart` response; `EventEvaluate`→`evaluate` response
 (correlated via `evalQ`, NOT a stop — see below); `EventSessionState`→ignored on

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -284,12 +284,6 @@ func printEvent(evt protocol.Event) {
 				p.Breakpoint.ID, p.Breakpoint.Location.File, p.Breakpoint.Location.Line)
 		}
 
-	case protocol.EventPanic:
-		var p protocol.PanicPayload
-		if protocol.DecodeEventPayload(evt, &p) == nil {
-			fmt.Printf("\n  [panic] %s\nbingo> ", p.Message)
-		}
-
 	case protocol.EventOutput:
 		var p protocol.OutputPayload
 		if protocol.DecodeEventPayload(evt, &p) == nil {

--- a/cmd/wsmon/main.go
+++ b/cmd/wsmon/main.go
@@ -173,13 +173,6 @@ func describeEvent(evt protocol.Event) (string, bool) {
 		}
 		return fmt.Sprintf("exited code=%d%s", p.ExitCode, reason), true
 
-	case protocol.EventPanic:
-		var p protocol.PanicPayload
-		if protocol.DecodeEventPayload(evt, &p) != nil {
-			return "", false
-		}
-		return fmt.Sprintf("Panic %q at %s", oneLine(p.Message), locString(p.Goroutine.CurrentLoc)), true
-
 	case protocol.EventOutput:
 		var p protocol.OutputPayload
 		if protocol.DecodeEventPayload(evt, &p) != nil {

--- a/editors/vscode/src/observer.ts
+++ b/editors/vscode/src/observer.ts
@@ -275,9 +275,6 @@ export class TelemetryObserver {
       case "Stepped":
         this.#update({ lastStop: describeStop("Stepped", payload) });
         break;
-      case "Panic":
-        this.#update({ lastStop: `Panic: ${payloadText(payload.message, "")}` });
-        break;
       case "Continued":
         this.#update({ sessionState: "running", lastStop: "Continued" });
         break;

--- a/editors/vscode/src/telemetry.ts
+++ b/editors/vscode/src/telemetry.ts
@@ -12,7 +12,6 @@ const utf8 = new TextDecoder("utf-8", { fatal: true });
 
 const eventKinds = new Set([
   "BreakpointHit",
-  "Panic",
   "Stepped",
   "Paused",
   "Output",

--- a/editors/vscode/test/telemetry.test.ts
+++ b/editors/vscode/test/telemetry.test.ts
@@ -33,6 +33,13 @@ describe("telemetry codec", () => {
     assert.deepEqual(decoded.snapshot?.threads, []);
   });
 
+  it("rejects the deprecated Panic compatibility tombstone", () => {
+    assert.throws(
+      () => decodeEvent(envelope(1, "Panic", { message: "boom" })),
+      /unknown telemetry event kind/,
+    );
+  });
+
   it("rejects malformed, incompatible, oversized, and hostile payloads", () => {
     assert.throws(() => decodeEvent("{"), /valid JSON/);
     assert.throws(

--- a/internal/dap/events.go
+++ b/internal/dap/events.go
@@ -10,7 +10,7 @@ import (
 // zero or more DAP messages. Runs on the hub write-pump goroutine.
 func (h *Handler) translateEvent(evt protocol.Event) {
 	switch evt.Kind {
-	case protocol.EventStepped, protocol.EventBreakpointHit, protocol.EventPaused, protocol.EventPanic:
+	case protocol.EventStepped, protocol.EventBreakpointHit, protocol.EventPaused:
 		h.onStop(evt)
 	case protocol.EventContinued:
 		h.onContinued()
@@ -103,10 +103,6 @@ func stopGoroutine(evt protocol.Event) protocol.Goroutine {
 		return p.Goroutine
 	case protocol.EventPaused:
 		var p protocol.PausedPayload
-		_ = protocol.DecodeEventPayload(evt, &p)
-		return p.Goroutine
-	case protocol.EventPanic:
-		var p protocol.PanicPayload
 		_ = protocol.DecodeEventPayload(evt, &p)
 		return p.Goroutine
 	}

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -654,6 +654,18 @@ func TestInitializeAdvertisesEvaluateForHovers(t *testing.T) {
 	}
 }
 
+func TestInitializeDoesNotAdvertiseExceptionStops(t *testing.T) {
+	hh := newHarness(t)
+	hh.sendReq("initialize", initArgs())
+	resp := recvType[*godap.InitializeResponse](hh)
+	if len(resp.Body.ExceptionBreakpointFilters) != 0 ||
+		resp.Body.SupportsExceptionOptions ||
+		resp.Body.SupportsExceptionInfoRequest ||
+		resp.Body.SupportsExceptionFilterOptions {
+		t.Errorf("exception capabilities unexpectedly advertised: %+v", resp.Body)
+	}
+}
+
 // TestVariablesExpandsNestedStruct proves a struct local returned in EventLocals
 // with Children is served with a fresh child variablesReference, and that a
 // follow-up variables request on that ref returns the cached children WITHOUT a

--- a/internal/dap/handler_test.go
+++ b/internal/dap/handler_test.go
@@ -666,6 +666,43 @@ func TestInitializeDoesNotAdvertiseExceptionStops(t *testing.T) {
 	}
 }
 
+func TestDeprecatedPanicEventIsIgnored(t *testing.T) {
+	const panicCompatibilityEvent protocol.EventKind = "Panic"
+	hh := newHarness(t)
+	hh.doHandshake(t)
+
+	hh.handler.mu.Lock()
+	suspendedBefore := hh.handler.suspended
+	hh.handler.mu.Unlock()
+	if suspendedBefore {
+		t.Fatal("handshake left handler suspended")
+	}
+
+	hh.inject(panicCompatibilityEvent, struct {
+		Message   string             `json:"message"`
+		Goroutine protocol.Goroutine `json:"goroutine"`
+		Frames    []protocol.Frame   `json:"frames"`
+	}{
+		Message:   "boom",
+		Goroutine: protocol.Goroutine{ID: 7},
+		Frames:    []protocol.Frame{},
+	})
+
+	hh.handler.mu.Lock()
+	suspendedAfter := hh.handler.suspended
+	hh.handler.mu.Unlock()
+	if suspendedAfter != suspendedBefore {
+		t.Fatalf("suspended changed from %t to %t", suspendedBefore, suspendedAfter)
+	}
+
+	_ = hh.client.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+	if _, err := hh.reader.Peek(1); err == nil {
+		t.Fatal("deprecated Panic event emitted a DAP message")
+	} else if nerr, ok := err.(net.Error); !ok || !nerr.Timeout() {
+		t.Fatalf("read after deprecated Panic event: %v", err)
+	}
+}
+
 // TestVariablesExpandsNestedStruct proves a struct local returned in EventLocals
 // with Children is served with a fresh child variablesReference, and that a
 // follow-up variables request on that ref returns the cached children WITHOUT a

--- a/internal/dap/translate.go
+++ b/internal/dap/translate.go
@@ -27,8 +27,6 @@ func stoppedReason(kind protocol.EventKind) string {
 		return "breakpoint"
 	case protocol.EventStepped:
 		return "step"
-	case protocol.EventPanic:
-		return "exception"
 	case protocol.EventPaused:
 		return "pause"
 	default:

--- a/internal/dap/translate_test.go
+++ b/internal/dap/translate_test.go
@@ -21,7 +21,6 @@ func TestStoppedReason(t *testing.T) {
 	cases := map[protocol.EventKind]string{
 		protocol.EventBreakpointHit: "breakpoint",
 		protocol.EventStepped:       "step",
-		protocol.EventPanic:         "exception",
 		protocol.EventPaused:        "pause",
 		protocol.EventProcessExited: "pause", // fallback
 	}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -25,7 +25,6 @@ var ErrHubClosed = errors.New("hub is shutting down")
 // asynchronously on demand rather than as a self-stop.
 var suspendingEvents = map[protocol.EventKind]bool{
 	protocol.EventBreakpointHit: true,
-	protocol.EventPanic:         true,
 	protocol.EventStepped:       true,
 	protocol.EventPaused:        true,
 }
@@ -271,7 +270,7 @@ func (h *Hub) handleEvent(ctx context.Context, evt protocol.Event) {
 	h.broadcast(evt)
 
 	switch evt.Kind {
-	case protocol.EventBreakpointHit, protocol.EventPanic, protocol.EventStepped, protocol.EventPaused:
+	case protocol.EventBreakpointHit, protocol.EventStepped, protocol.EventPaused:
 		h.transitionState(protocol.StateSuspended)
 	case protocol.EventProcessExited:
 		h.transitionState(protocol.StateExited)

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -562,11 +562,12 @@ var _ = Describe("Hub", func() {
 
 	Describe("deprecated Panic compatibility event", func() {
 		It("does not enter the suspend gate", func() {
+			const panicCompatibilityEvent protocol.EventKind = "Panic"
 			conn := newFakeWSConn()
 			mustAddClient(h, conn)
 
-			fd.push(protocol.MustEvent(protocol.EventPanic, 1, protocol.PanicPayload{Message: "boom"}))
-			waitForEventKind(conn, protocol.EventPanic, nil)
+			fd.push(protocol.MustEvent(panicCompatibilityEvent, 1, map[string]string{"message": "boom"}))
+			waitForEventKind(conn, panicCompatibilityEvent, nil)
 
 			Consistently(h.State, "100ms", "10ms").Should(Equal(protocol.StateRunning))
 

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -560,6 +560,22 @@ var _ = Describe("Hub", func() {
 		})
 	})
 
+	Describe("deprecated Panic compatibility event", func() {
+		It("does not enter the suspend gate", func() {
+			conn := newFakeWSConn()
+			mustAddClient(h, conn)
+
+			fd.push(protocol.MustEvent(protocol.EventPanic, 1, protocol.PanicPayload{Message: "boom"}))
+			waitForEventKind(conn, protocol.EventPanic, nil)
+
+			Consistently(h.State, "100ms", "10ms").Should(Equal(protocol.StateRunning))
+
+			conn.inject(mustCommand(protocol.CmdContinue, struct{}{}))
+			Consistently(fd.recordedCalls, "100ms", "10ms").
+				ShouldNot(ContainElement("Continue"))
+		})
+	})
+
 	Describe("Kill while running", func() {
 		It("terminates the process even with no breakpoint set (no suspend first)", func() {
 			conn := newFakeWSConn()

--- a/pkg/protocol/payload.go
+++ b/pkg/protocol/payload.go
@@ -83,6 +83,9 @@ type BreakpointHitPayload struct {
 	Frames     []Frame    `json:"frames"`
 }
 
+// PanicPayload is retained for source compatibility with EventPanic.
+//
+// Deprecated: bingo has never produced this payload.
 type PanicPayload struct {
 	Message   string    `json:"message"`
 	Goroutine Goroutine `json:"goroutine"`

--- a/pkg/protocol/protocol.go
+++ b/pkg/protocol/protocol.go
@@ -27,7 +27,6 @@ type EventKind string
 // command (Continue / Step*) arrives. See AGENTS.md → suspend/resume protocol.
 const (
 	EventBreakpointHit EventKind = "BreakpointHit"
-	EventPanic         EventKind = "Panic"
 	EventStepped       EventKind = "Stepped"
 
 	// EventPaused reports that a Pause request forcibly halted the running
@@ -75,6 +74,15 @@ const (
 	// at the new process's entry point (same as after Launch).
 	EventRestarted EventKind = "Restarted"
 )
+
+// EventPanic is retained so existing Go consumers of pkg/protocol keep
+// compiling.
+//
+// Deprecated: bingo has never emitted this event. A Go language panic currently
+// terminates the tracee and is reported as EventProcessExited, usually with exit
+// code 2. Detecting a panic before termination requires runtime-aware debugger
+// support that is not implemented.
+const EventPanic EventKind = "Panic"
 
 type CommandKind string
 

--- a/pkg/protocol/protocol_test.go
+++ b/pkg/protocol/protocol_test.go
@@ -164,7 +164,7 @@ var _ = Describe("Event", func() {
 				},
 			),
 
-			Entry("Panic",
+			Entry("deprecated Panic compatibility tombstone",
 				protocol.EventPanic,
 				protocol.PanicPayload{
 					Message:   "runtime error: index out of range",


### PR DESCRIPTION
## Summary

- retain `EventPanic` and `PanicPayload` as deprecated source-compatibility tombstones
- remove the never-reachable panic suspend/state, DAP, CLI, wsmon, and VS Code observer paths
- document the actual contract: Go panics currently terminate as `EventProcessExited` (normally exit code 2)
- pin the cleanup with hub, DAP capability, protocol, and telemetry tests

Closes #227.

## Evidence

An exhaustive producer trace found no `EventPanic` emitter in current code or accessible history. The original payload documentation nevertheless promised it when the runtime panic handler triggered.

A deterministic darwin/arm64 target containing `panic("bingo-event-panic-repro")` produced:

```text
SessionState
Stepped
SessionState
GoroutineSnapshot
SessionState
Continued
ProcessExited
exitCode=2 sawPanic=false
```

Two independent adversarial reviews confirmed this is dead/misleading protocol surface, not a duplicate of #206's Linux fatal-signal redelivery defect. Implementing a true exception stop would require separate runtime-aware debugger work; this PR does not touch `internal/debugger`.

## Validation

- `go vet -tags bingonative ./...`
- `go test -tags bingonative -race ./...`
- `just vscode-check`
- final code-review pass: no significant issues