### PR TITLE
fix(debugger): read allgs metadata coherently

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1705,6 +1705,36 @@ race the walk; only backends that stop the world make the reads race-free. This
 also preserves behavior for stripped binaries / attach-without-DWARF and keeps
 the `fakeBackend` engine unit tests green.
 
+**Coherent metadata reads — the half degradation can't cover.** Degradation
+answers reads that *fail*. It cannot answer reads that all *succeed* while
+being mutually inconsistent, which is the other shape of the same Linux race.
+`allgsMetadata` (`goroutines.go`) prevents that shape instead of detecting it,
+and its read **order** is the whole mechanism:
+
+- `runtime.allgadd` publishes the array pointer **before** the length. Reading
+  the pointer first can therefore pair a stale array with its larger
+  successor's length and walk past the end of the old allocation. The word
+  after a heap object is mapped, so that overrun **succeeds** — the walk
+  reports `Complete: true`, and an unrelated heap object is accepted as a
+  goroutine, fabricating a `Created` and then an `Exited` for a goroutine that
+  never existed.
+- Read the **length first, the pointer second**. This is sound only because
+  `runtime.allgs` is **append-only and never shrinks**, so a length observed
+  before a pointer always fits inside whichever array that pointer names. Do
+  not "simplify" this ordering, and do not assume a wider single read fixes it:
+  `process_vm_readv` takes no lock and is not atomic against the writer's
+  separate word stores.
+- Prefer `runtime.allglen` + `runtime.allgptr`, the runtime's own atomics,
+  which carry the documented contract ("allgptr is updated before allglen.
+  Readers should read allglen before allgptr"). The raw `runtime.allgs` header
+  is a fallback for images lacking those symbols and uses the same
+  length-before-pointer order, but its three words are ordinary
+  compiler-scheduled stores, so it is best-effort where the mirror is
+  guaranteed.
+
+Worst case under the correct order is missing a goroutine created during the
+read, which the runtime explicitly sanctions for lock-free readers. See #235.
+
 **Current goroutine = SP-containment** (platform-independent): the stopped
 thread's SP within `[g.stack.lo, g.stack.hi)`. The current *thread* is the M
 whose `curg` goid equals the current goid. A non-current goroutine's
@@ -3161,7 +3191,10 @@ through the justfile.
   (snapshot on breakpoint/pause/entry, never per-step), the degraded-snapshot
   rule (don't touch `prevGoids` on an unreadable read), and the
   automatic-snapshots-own-the-baseline rule (a `CmdGoroutineSnapshot` query
-  reports no deltas and never advances `prevGoids`).
+  reports no deltas and never advances `prevGoids`), and the
+  length-before-pointer order in `allgsMetadata` (see *Coherent metadata
+  reads*) — reordering it silently reintroduces fabricated goroutines that no
+  completeness check can catch.
 - **Breakpoint ids**: client-visible ids are the hub's session-stable logical
   ids (see
   [Breakpoint identity](#breakpoint-identity--hub-owned-logical-ids)). A new

--- a/internal/debugger/allgs_metadata_test.go
+++ b/internal/debugger/allgs_metadata_test.go
@@ -1,0 +1,639 @@
+package debugger
+
+// Regression gates for the coherent read of the goroutine table's metadata.
+//
+// A Linux ptrace stop halts only the trapping thread, so runtime.allgadd can
+// republish runtime.allgs while this walk is reading it. allgadd publishes the
+// array pointer before the length, so a reader that takes the pointer first can
+// pair a stale array with its successor's length and walk past the end of the
+// old allocation. Crucially that overrun READS SUCCESSFULLY — the word after a
+// heap object is mapped — so the walk reports Complete and the incomplete-read
+// degradation path never fires. The defect is prevented by ordering, in
+// allgsMetadata, and these tests exist to keep that ordering.
+//
+// The fixture models tracee memory with real mapping (a read that leaves every
+// mapped region fails, as process_vm_readv would) and drives the production
+// goroutineSnapshot/buildGoroutineList against DWARF-resolved runtime offsets
+// taken from a real Go binary, so nothing here depends on hardcoded layout.
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/bingosuite/bingo/pkg/protocol"
+)
+
+// Fabricated tracee addresses; arbitrary but disjoint and aligned.
+const (
+	probeAllgsHdr = uint64(0x004c0000) // runtime.allgs slice header (ptr,len,cap)
+	probeAllgLen  = uint64(0x004c0040) // runtime.allglen
+	probeAllgPtr  = uint64(0x004c0080) // runtime.allgptr
+	probeAllmHdr  = uint64(0x004c0100) // runtime.allm
+
+	// probeOldArray is the pre-growth backing array: capacity 4 (32 bytes).
+	// probeOldRegion also covers the next object in the same size-class span,
+	// which is what a read one word past the array's end actually lands on.
+	// Mapping it is the point: that read succeeds.
+	probeOldArray  = uint64(0x00800000)
+	probeOldArrCap = uint64(4)
+	probeOldRegion = uint64(64)
+
+	probeNewArray  = uint64(0x00801000)
+	probeNewArrCap = uint64(8)
+
+	probeGBase   = uint64(0x00900000)
+	probeGStride = uint64(0x400)
+	probeGCount  = 5 // goids 101..105
+
+	// probeDecoy models an unrelated live heap object that the span-neighbour
+	// word points at. Read as a runtime.g it yields a plausible positive goid
+	// and a non-dead status, i.e. a phantom goroutine.
+	probeDecoy     = uint64(0x00a00000)
+	probeDecoySize = uint64(0x400)
+
+	probeM     = uint64(0x00b00000)
+	probeMSize = uint64(0x400)
+
+	probeStackLo = uint64(0x00c00000)
+	probeStackHi = uint64(0x00c10000)
+	probeSP      = uint64(0x00c08000)
+
+	// probePhantomGoid is heap-pointer shaped, which is what the goid word of an
+	// unrelated object tends to look like. As an int64 it is positive, so the
+	// goroutine read would accept it.
+	probePhantomGoid = int64(0x00007f9ac4010018)
+)
+
+type probeRegion struct {
+	base uint64
+	data []byte
+}
+
+// probeBackend is a memory-model Backend. Unlike engine_test.go's fakeBackend
+// (whose map-backed memory can never fail) it models real mapping, which is
+// what lets these tests assert that the out-of-bounds read SUCCEEDS.
+//
+// sibling models a concurrently running tracee thread, fired after an exact
+// read index so a test can place it precisely inside the reader's sequence.
+type probeBackend struct {
+	regions []probeRegion
+
+	sibling       func(*probeBackend)
+	fireAfterRead int
+	readIdx       int
+	siblingFired  bool
+
+	reads      int
+	readErrors int
+	readAddrs  map[uint64]int
+}
+
+func (b *probeBackend) mapRegion(base, size uint64) {
+	b.regions = append(b.regions, probeRegion{base: base, data: make([]byte, size)})
+}
+
+func (b *probeBackend) find(addr uint64, n int) []byte {
+	for i := range b.regions {
+		r := &b.regions[i]
+		if addr >= r.base && addr+uint64(n) <= r.base+uint64(len(r.data)) {
+			return r.data[addr-r.base:]
+		}
+	}
+	return nil
+}
+
+func (b *probeBackend) poke64(addr, v uint64) {
+	s := b.find(addr, 8)
+	if s == nil {
+		panic(fmt.Sprintf("probe fixture: unmapped write at %#x", addr))
+	}
+	binary.LittleEndian.PutUint64(s[:8], v)
+}
+
+func (b *probeBackend) poke32(addr uint64, v uint32) {
+	s := b.find(addr, 4)
+	if s == nil {
+		panic(fmt.Sprintf("probe fixture: unmapped write at %#x", addr))
+	}
+	binary.LittleEndian.PutUint32(s[:4], v)
+}
+
+func (b *probeBackend) ReadMemory(addr uint64, dst []byte) error {
+	if len(dst) == 0 {
+		return nil
+	}
+	b.reads++
+	if b.readAddrs == nil {
+		b.readAddrs = map[uint64]int{}
+	}
+	b.readAddrs[addr]++
+
+	src := b.find(addr, len(dst))
+	if src == nil {
+		b.readErrors++
+		return fmt.Errorf("probe: unmapped read %#x len %d", addr, len(dst))
+	}
+	copy(dst, src[:len(dst)])
+
+	b.readIdx++
+	if b.fireAfterRead > 0 && !b.siblingFired && b.readIdx == b.fireAfterRead {
+		b.siblingFired = true
+		if b.sibling != nil {
+			b.sibling(b)
+		}
+	}
+	return nil
+}
+
+func (b *probeBackend) WriteMemory(addr uint64, src []byte) error {
+	dst := b.find(addr, len(src))
+	if dst == nil {
+		return fmt.Errorf("probe: unmapped write %#x", addr)
+	}
+	copy(dst, src)
+	return nil
+}
+
+func (b *probeBackend) GetRegisters(int) (Registers, error) {
+	return Registers{SP: probeSP}, nil
+}
+func (b *probeBackend) SetRegisters(int, Registers) error { return nil }
+func (b *probeBackend) Threads() ([]int, error)           { return []int{1}, nil }
+func (b *probeBackend) ContinueProcess() error            { return nil }
+func (b *probeBackend) SingleStep(int) error              { return nil }
+func (b *probeBackend) StopProcess() error                { return nil }
+func (b *probeBackend) PauseSignal() int                  { return 0 }
+func (b *probeBackend) Wait() (StopEvent, error)          { return StopEvent{}, nil }
+
+// arm schedules the sibling after read index n and clears the read counters.
+func (b *probeBackend) arm(n int) {
+	b.readIdx = 0
+	b.fireAfterRead = n
+	b.siblingFired = false
+	b.reads, b.readErrors = 0, 0
+	b.readAddrs = map[uint64]int{}
+}
+
+func gAddr(i int) uint64 { return probeGBase + uint64(i)*probeGStride }
+
+// setMetadata publishes one coherent generation to both the atomic mirror and
+// the raw slice header, so either read path sees the same table.
+func (b *probeBackend) setMetadata(ptr, length, capacity uint64) {
+	b.poke64(probeAllgsHdr+0, ptr)
+	b.poke64(probeAllgsHdr+8, length)
+	b.poke64(probeAllgsHdr+16, capacity)
+	b.poke64(probeAllgPtr, ptr)
+	b.poke64(probeAllgLen, length)
+}
+
+// siblingAllgadd replays runtime.allgadd's publication order for both the raw
+// header (cap, pointer, length — the compiler's store order) and the atomic
+// mirror (allgptr then allglen — the runtime's documented order). Pointer
+// before length in both is exactly what makes a pointer-first reader unsafe.
+func siblingAllgadd(b *probeBackend) {
+	b.poke64(probeAllgsHdr+16, probeNewArrCap)
+	b.poke64(probeAllgsHdr+0, probeNewArray)
+	b.poke64(probeAllgsHdr+8, 5)
+
+	b.poke64(probeAllgPtr, probeNewArray)
+	b.poke64(probeAllgLen, 5)
+}
+
+// newProbeBackend lays out a miniature but structurally faithful tracee heap:
+// five runtime.g structs, a full pre-growth array of capacity 4, a post-growth
+// array of capacity 8, one runtime.m, and a mapped span neighbour immediately
+// after the old array whose first word points at an unrelated live object.
+func newProbeBackend(l *goLayout) *probeBackend {
+	b := &probeBackend{}
+	b.mapRegion(probeAllgsHdr, 24)
+	b.mapRegion(probeAllgLen, 8)
+	b.mapRegion(probeAllgPtr, 8)
+	b.mapRegion(probeAllmHdr, 8)
+	b.mapRegion(probeOldArray, probeOldRegion)
+	b.mapRegion(probeNewArray, probeNewArrCap*8)
+	for i := 0; i < probeGCount; i++ {
+		b.mapRegion(gAddr(i), probeGStride)
+	}
+	b.mapRegion(probeDecoy, probeDecoySize)
+	b.mapRegion(probeM, probeMSize)
+
+	for i := 0; i < probeGCount; i++ {
+		g := gAddr(i)
+		b.poke32(g+uint64(l.gAtomicstatus), 1) // _Grunnable
+		b.poke64(g+uint64(l.gGoid), uint64(101+i))
+		b.poke64(g+uint64(l.gStartpc), 0) // zero PCs keep locForPC cheap
+		b.poke64(g+uint64(l.gGopc), 0)
+		b.poke64(g+uint64(l.gSched)+uint64(l.bufPC), 0)
+		// Only g101 owns the stack the stopped SP falls in, so exactly one
+		// goroutine is Current.
+		lo, hi := probeStackLo+uint64(i+1)*0x100000, probeStackHi+uint64(i+1)*0x100000
+		if i == 0 {
+			lo, hi = probeStackLo, probeStackHi
+		}
+		b.poke64(g+uint64(l.gStack)+uint64(l.stackLo), lo)
+		b.poke64(g+uint64(l.gStack)+uint64(l.stackHi), hi)
+	}
+
+	for i := uint64(0); i < probeOldArrCap; i++ {
+		b.poke64(probeOldArray+i*8, gAddr(int(i)))
+	}
+	// The span neighbour one word past the end of the old array.
+	b.poke64(probeOldArray+probeOldArrCap*8, probeDecoy)
+
+	for i := 0; i < probeGCount; i++ {
+		b.poke64(probeNewArray+uint64(i)*8, gAddr(i))
+	}
+
+	// The decoy read as a runtime.g: non-dead status, plausible positive goid.
+	b.poke32(probeDecoy+uint64(l.gAtomicstatus), 1)
+	b.poke64(probeDecoy+uint64(l.gGoid), uint64(probePhantomGoid))
+
+	b.poke64(probeM+uint64(l.mProcid), 7)
+	b.poke64(probeM+uint64(l.mID), 1)
+	b.poke64(probeM+uint64(l.mCurg), gAddr(0))
+	b.poke64(probeM+uint64(l.mAlllink), 0)
+	b.poke64(probeAllmHdr, probeM)
+
+	b.setMetadata(probeOldArray, 4, 4)
+	return b
+}
+
+// buildProbeTarget compiles a throwaway Go binary so the fixture resolves
+// runtime struct offsets from REAL DWARF instead of hardcoding them.
+func buildProbeTarget(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := "package main\n\nfunc main() { done := make(chan struct{}); go func() { close(done) }(); <-done }\n"
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module probetarget\n\ngo 1.25\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(dir, "probetarget")
+	cmd := exec.Command("go", "build", "-gcflags=all=-N -l", "-o", bin, ".")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build probe target: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// newProbeEngine wires the fixture to a real DWARF reader. withMirror=false
+// marks runtime.allglen/runtime.allgptr as absent (a cached zero address is how
+// runtimeVarAddr reports "resolved, not present"), which forces the raw-header
+// fallback path.
+func newProbeEngine(t *testing.T, withMirror bool) (*engine, *probeBackend) {
+	t.Helper()
+	dr, err := openDWARF(buildProbeTarget(t))
+	if err != nil {
+		t.Fatalf("openDWARF: %v", err)
+	}
+	layout := resolveGoLayout(dr)
+	if !layout.valid {
+		t.Fatal("probe: could not resolve runtime layout from DWARF")
+	}
+	b := newProbeBackend(&layout)
+	e := &engine{backend: b, dw: dr, curTID: 1}
+
+	// The fixture's addresses are absolute, so override whatever the binary's
+	// DWARF reported.
+	dr.cacheMu.Lock()
+	if dr.varAddrs == nil {
+		dr.varAddrs = map[string]uint64{}
+	}
+	dr.varAddrs["runtime.allgs"] = probeAllgsHdr
+	dr.varAddrs["runtime.allm"] = probeAllmHdr
+	if withMirror {
+		dr.varAddrs["runtime.allglen"] = probeAllgLen
+		dr.varAddrs["runtime.allgptr"] = probeAllgPtr
+	} else {
+		dr.varAddrs["runtime.allglen"] = 0
+		dr.varAddrs["runtime.allgptr"] = 0
+	}
+	dr.cacheMu.Unlock()
+	return e, b
+}
+
+func goids(gs []protocol.Goroutine) []int {
+	out := make([]int, 0, len(gs))
+	for _, g := range gs {
+		out = append(out, g.ID)
+	}
+	return out
+}
+
+func containsID(ids []int, want int) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+// assertNoFabrication fails when a snapshot reports a goroutine outside the
+// fixture's real set, or any lifecycle delta mentioning one.
+func assertNoFabrication(t *testing.T, label string, snap protocol.GoroutineSnapshotPayload) {
+	t.Helper()
+	real := map[int]bool{101: true, 102: true, 103: true, 104: true, 105: true}
+	for _, g := range snap.Goroutines {
+		if !real[g.ID] {
+			t.Fatalf("%s: fabricated goroutine %d in %v", label, g.ID, goids(snap.Goroutines))
+		}
+	}
+	for _, id := range snap.Created {
+		if !real[id] {
+			t.Fatalf("%s: fabricated Created delta %d (%v)", label, id, snap.Created)
+		}
+	}
+	for _, id := range snap.Exited {
+		if !real[id] {
+			t.Fatalf("%s: fabricated Exited delta %d (%v)", label, id, snap.Exited)
+		}
+	}
+}
+
+// runTornSchedules drives the production snapshot once per injection point,
+// firing the sibling allgadd after every read index in the reader's sequence,
+// and fails if any schedule fabricates a goroutine or lifecycle delta.
+func runTornSchedules(t *testing.T, withMirror bool, label string) {
+	t.Helper()
+	e, b := newProbeEngine(t, withMirror)
+
+	b.arm(0)
+	base := e.goroutineSnapshot()
+	if got := goids(base.Goroutines); len(got) != 4 {
+		t.Fatalf("%s baseline: want the four live goroutines, got %v", label, got)
+	}
+	total := b.reads
+
+	for k := 1; k <= total+2; k++ {
+		e.prevGoids = map[int]struct{}{101: {}, 102: {}, 103: {}, 104: {}}
+		b.setMetadata(probeOldArray, 4, 4)
+		b.sibling = siblingAllgadd
+		b.arm(k)
+
+		snap := e.goroutineSnapshot()
+		assertNoFabrication(t, fmt.Sprintf("%s schedule %d", label, k), snap)
+	}
+	t.Logf("%s: %d schedules across a %d-read sequence, no fabricated goroutine or delta",
+		label, total+2, total)
+}
+
+// TestAllgsMetadataNeverFabricatesViaMirror is the production gate. It drives
+// the real goroutineSnapshot with the runtime atomic mirror available and
+// requires that no interleaving of runtime.allgadd can fabricate a goroutine or
+// a lifecycle delta.
+func TestAllgsMetadataNeverFabricatesViaMirror(t *testing.T) {
+	runTornSchedules(t, true, "mirror")
+}
+
+// TestAllgsMetadataUsesMirrorNotFallback proves the gate above actually
+// exercises the runtime.allglen/runtime.allgptr path rather than passing
+// because it silently fell back to the raw header.
+func TestAllgsMetadataUsesMirrorNotFallback(t *testing.T) {
+	e, b := newProbeEngine(t, true)
+	b.arm(0)
+
+	_ = e.goroutineSnapshot()
+
+	if b.readAddrs[probeAllgLen] == 0 {
+		t.Fatal("runtime.allglen was never read; the mirror path was not taken")
+	}
+	if b.readAddrs[probeAllgPtr] == 0 {
+		t.Fatal("runtime.allgptr was never read; the mirror path was not taken")
+	}
+	for _, off := range []uint64{0, 8, 16} {
+		if n := b.readAddrs[probeAllgsHdr+off]; n != 0 {
+			t.Fatalf("raw runtime.allgs header +%d was read %d time(s) despite the mirror "+
+				"being available", off, n)
+		}
+	}
+	t.Logf("mirror path confirmed: allglen read %d time(s), allgptr %d time(s), raw header 0",
+		b.readAddrs[probeAllgLen], b.readAddrs[probeAllgPtr])
+}
+
+// TestAllgsMetadataNeverFabricatesViaFallback is the fallback gate: with the
+// mirror symbols absent, the raw slice header must still be read length-first
+// so no schedule pairs a stale pointer with a fresh length.
+func TestAllgsMetadataNeverFabricatesViaFallback(t *testing.T) {
+	runTornSchedules(t, false, "fallback")
+}
+
+// TestAllgsMetadataFallbackUsesRawHeader proves the fallback gate exercises the
+// raw header rather than the mirror.
+func TestAllgsMetadataFallbackUsesRawHeader(t *testing.T) {
+	e, b := newProbeEngine(t, false)
+	b.arm(0)
+
+	_ = e.goroutineSnapshot()
+
+	if b.readAddrs[probeAllgsHdr+8] == 0 {
+		t.Fatal("raw runtime.allgs length word was never read; fallback not taken")
+	}
+	if b.readAddrs[probeAllgsHdr+0] == 0 {
+		t.Fatal("raw runtime.allgs pointer word was never read; fallback not taken")
+	}
+	if n := b.readAddrs[probeAllgLen] + b.readAddrs[probeAllgPtr]; n != 0 {
+		t.Fatalf("mirror was read %d time(s) despite being unavailable", n)
+	}
+}
+
+// TestAllgsNewGoroutineSurfacesNextSnapshot pins the accepted degradation: a
+// goroutine appended during the read may be missed for exactly one snapshot
+// (the Go runtime documents this for lock-free readers), and must then appear
+// as a genuine creation rather than being lost.
+func TestAllgsNewGoroutineSurfacesNextSnapshot(t *testing.T) {
+	e, b := newProbeEngine(t, true)
+
+	b.arm(0)
+	if got := goids(e.goroutineSnapshot().Goroutines); len(got) != 4 {
+		t.Fatalf("baseline: want four goroutines, got %v", got)
+	}
+
+	b.sibling = siblingAllgadd
+	b.arm(1)
+	torn := e.goroutineSnapshot()
+	assertNoFabrication(t, "torn", torn)
+
+	b.sibling = nil
+	b.arm(0)
+	next := e.goroutineSnapshot()
+	assertNoFabrication(t, "recovery", next)
+	if !containsID(goids(next.Goroutines), 105) {
+		t.Fatalf("recovery: the appended goroutine must surface, got %v",
+			goids(next.Goroutines))
+	}
+	if !containsID(next.Created, 105) {
+		t.Fatalf("recovery: want Created=[105], got %v", next.Created)
+	}
+	t.Logf("torn snapshot=%v created=%v exited=%v; recovery snapshot=%v created=%v",
+		goids(torn.Goroutines), torn.Created, torn.Exited,
+		goids(next.Goroutines), next.Created)
+}
+
+// TestAllgsCoherentMetadataIsUnaffected is the negative control: with no
+// concurrent republication the walk reports the whole table and the ordinary
+// lifecycle delta, so the fix does not change steady-state behaviour.
+func TestAllgsCoherentMetadataIsUnaffected(t *testing.T) {
+	e, b := newProbeEngine(t, true)
+
+	b.arm(0)
+	first := e.goroutineSnapshot()
+	if got := goids(first.Goroutines); len(got) != 4 || !containsID(got, 104) {
+		t.Fatalf("baseline: got %v", got)
+	}
+
+	// The append completes fully before the reader starts.
+	siblingAllgadd(b)
+	b.sibling = nil
+	b.arm(0)
+
+	snap := e.goroutineSnapshot()
+	assertNoFabrication(t, "coherent", snap)
+	if !containsID(snap.Created, 105) {
+		t.Fatalf("coherent: want Created=[105], got %v", snap.Created)
+	}
+	if len(snap.Exited) != 0 {
+		t.Fatalf("coherent: want no exits, got %v", snap.Exited)
+	}
+	if b.readErrors != 0 {
+		t.Fatalf("coherent: want no read failures, got %d", b.readErrors)
+	}
+}
+
+// TestAllgsOutOfBoundsSlotWouldReadSuccessfully documents WHY completeness
+// checking cannot substitute for ordering: the word one past the end of the old
+// array is mapped, so reading it succeeds and produces a plausible goroutine.
+// If this ever starts failing, the fixture has stopped modelling the hazard and
+// the gates above would pass vacuously.
+func TestAllgsOutOfBoundsSlotWouldReadSuccessfully(t *testing.T) {
+	e, b := newProbeEngine(t, true)
+	layout, ok := e.getGoLayout()
+	if !ok {
+		t.Fatal("probe: layout unavailable")
+	}
+
+	b.arm(0)
+	oob, ok := e.readU64(probeOldArray + probeOldArrCap*8)
+	if !ok {
+		t.Fatal("the out-of-bounds slot read failed; the fixture no longer models a mapped " +
+			"span neighbour, so the ordering gates would pass for the wrong reason")
+	}
+	if b.readErrors != 0 {
+		t.Fatalf("want the out-of-bounds read to succeed, got %d failures", b.readErrors)
+	}
+
+	res := e.readGoroutine(layout, oob, probeSP, 0)
+	if !res.Complete || !res.Include {
+		t.Fatalf("the span neighbour must still look like a live goroutine "+
+			"(Complete=%v Include=%v)", res.Complete, res.Include)
+	}
+	if res.Item.ID != int(probePhantomGoid) {
+		t.Fatalf("want the phantom goid %d, got %d", probePhantomGoid, res.Item.ID)
+	}
+	t.Logf("hazard intact: the slot past the old array reads successfully (%d failures) and "+
+		"yields goid %d with Complete=true — invisible to any completeness check",
+		b.readErrors, res.Item.ID)
+}
+
+// TestAllgsUnpublishedMirrorFallsBackOrdered covers the third path: the mirror
+// symbols exist but the runtime has not written them yet (they are populated by
+// the first allgadd, so a pre-init stop reads zeroes). The walk must consult the
+// raw header rather than reporting an empty table, and must still read it
+// length-first so the fallback cannot fabricate either.
+func TestAllgsUnpublishedMirrorFallsBackOrdered(t *testing.T) {
+	e, b := newProbeEngine(t, true)
+
+	// Mirror resolvable but unpublished; only the raw header carries the table.
+	b.poke64(probeAllgLen, 0)
+	b.poke64(probeAllgPtr, 0)
+	b.arm(0)
+
+	base := e.goroutineSnapshot()
+	if got := goids(base.Goroutines); len(got) != 4 {
+		t.Fatalf("unpublished mirror must fall back to the header, got %v", got)
+	}
+	if b.readAddrs[probeAllgsHdr+8] == 0 || b.readAddrs[probeAllgsHdr+0] == 0 {
+		t.Fatal("raw header was not consulted after an unpublished mirror")
+	}
+
+	total := b.reads
+	for k := 1; k <= total+2; k++ {
+		e.prevGoids = map[int]struct{}{101: {}, 102: {}, 103: {}, 104: {}}
+		b.setMetadata(probeOldArray, 4, 4)
+		b.poke64(probeAllgLen, 0)
+		b.poke64(probeAllgPtr, 0)
+		// The sibling republishes the header only, matching a runtime whose
+		// atomics this image cannot see.
+		b.sibling = func(tb *probeBackend) {
+			tb.poke64(probeAllgsHdr+16, probeNewArrCap)
+			tb.poke64(probeAllgsHdr+0, probeNewArray)
+			tb.poke64(probeAllgsHdr+8, 5)
+		}
+		b.arm(k)
+
+		assertNoFabrication(t, fmt.Sprintf("unpublished-mirror schedule %d", k),
+			e.goroutineSnapshot())
+	}
+	t.Logf("unpublished mirror: %d schedules, fell back to the header with no fabrication",
+		total+2)
+}
+
+// TestRuntimeVarAddrsMatchesSingleLookups covers the one-pass symbol resolver
+// the coherent read relies on. The fixtures above pre-seed the address cache, so
+// without this the batched scan itself would go unexercised.
+//
+// It pins the two properties the batching must not break: every name resolves to
+// exactly what the single-name resolver returns, and a name that is genuinely
+// absent is cached as absent rather than being mistaken for one that the scan
+// simply stopped before reaching.
+func TestRuntimeVarAddrsMatchesSingleLookups(t *testing.T) {
+	bin := buildProbeTarget(t)
+	names := []string{"runtime.allglen", "runtime.allgptr", "runtime.allgs", "runtime.bingoNoSuchVar"}
+
+	batched, err := openDWARF(bin)
+	if err != nil {
+		t.Fatalf("openDWARF: %v", err)
+	}
+	got := batched.runtimeVarAddrs(names...)
+
+	for _, name := range names {
+		single, err := openDWARF(bin) // fresh reader: cold cache per name
+		if err != nil {
+			t.Fatalf("openDWARF: %v", err)
+		}
+		wantAddr, wantOK := single.runtimeVarAddr(name)
+
+		gotAddr, gotOK := got[name]
+		if gotOK != wantOK || gotAddr != wantAddr {
+			t.Fatalf("%s: batched (%#x, %v) != single (%#x, %v)",
+				name, gotAddr, gotOK, wantAddr, wantOK)
+		}
+	}
+	if _, present := got["runtime.bingoNoSuchVar"]; present {
+		t.Fatal("an absent name must not appear in the batched result")
+	}
+	if len(got) != 3 {
+		t.Fatalf("want the three real names resolved, got %d entries: %v", len(got), got)
+	}
+
+	// The absent name must be cached as decided, so a repeat call cannot rescan
+	// and cannot start reporting it as present.
+	batched.cacheMu.Lock()
+	cached, decided := batched.varAddrs["runtime.bingoNoSuchVar"]
+	batched.cacheMu.Unlock()
+	if !decided || cached != 0 {
+		t.Fatalf("absent name must be cached as 0, got (%#x, decided=%v)", cached, decided)
+	}
+	if second := batched.runtimeVarAddrs(names...); len(second) != len(got) {
+		t.Fatalf("repeat call changed the result: %v vs %v", second, got)
+	}
+	t.Logf("batched resolution matches single lookups for %d names; absent name cached as absent",
+		len(names))
+}

--- a/internal/debugger/dwarf.go
+++ b/internal/debugger/dwarf.go
@@ -745,6 +745,86 @@ func (r *dwarfReader) runtimeVarAddr(name string) (uint64, bool) {
 	return addr, addr != 0
 }
 
+// runtimeVarAddrs resolves several package-level variable addresses in a SINGLE
+// DWARF pass, caching each result exactly as runtimeVarAddr does. A name absent
+// from the returned map has no usable DW_OP_addr location.
+//
+// resolveVarAddr walks every DIE in the image, so looking names up one at a time
+// costs one full traversal of a Go binary's tens of thousands of entries per
+// name — on the serialized engine loop, at the first stop, where it is already
+// competing with the rest of the snapshot. Resolving a related set together
+// keeps that to one traversal that stops as soon as every requested name is
+// found. Same reasoning as funcIndex: DWARF scans on the engine loop are
+// expensive enough to notice, especially under -race.
+func (r *dwarfReader) runtimeVarAddrs(names ...string) map[string]uint64 {
+	out := make(map[string]uint64, len(names))
+	r.cacheMu.Lock()
+	defer r.cacheMu.Unlock()
+	if r.varAddrs == nil {
+		r.varAddrs = make(map[string]uint64)
+	}
+
+	missing := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if addr, cached := r.varAddrs[name]; cached {
+			if addr != 0 {
+				out[name] = addr
+			}
+			continue
+		}
+		missing[name] = struct{}{}
+	}
+	if len(missing) == 0 {
+		return out
+	}
+
+	found := r.scanVarAddrs(missing)
+	for name := range missing {
+		addr := found[name]
+		r.varAddrs[name] = addr
+		if addr != 0 {
+			out[name] = addr
+		}
+	}
+	return out
+}
+
+// scanVarAddrs performs the one-pass traversal behind runtimeVarAddrs. It keeps
+// the first match for a name, mirroring resolveVarAddr's single-name semantics,
+// and stops early once every requested name has been decided.
+func (r *dwarfReader) scanVarAddrs(want map[string]struct{}) map[string]uint64 {
+	found := make(map[string]uint64, len(want))
+	rd := r.data.Reader()
+	for len(found) < len(want) {
+		entry, err := rd.Next()
+		if err != nil || entry == nil {
+			break
+		}
+		if entry.Tag != dwarf.TagVariable {
+			// Variables live at CU top level in Go DWARF; don't descend into
+			// subprograms (their locals share the tag and would shadow globals).
+			if entry.Tag == dwarf.TagSubprogram {
+				rd.SkipChildren()
+			}
+			continue
+		}
+		name, _ := entry.Val(dwarf.AttrName).(string)
+		if _, wanted := want[name]; !wanted {
+			continue
+		}
+		if _, decided := found[name]; decided {
+			continue
+		}
+		loc, ok := entry.Val(dwarf.AttrLocation).([]byte)
+		if !ok || len(loc) < 9 || loc[0] != 0x03 { // DW_OP_addr
+			found[name] = 0
+			continue
+		}
+		found[name] = uint64(int64(binary.LittleEndian.Uint64(loc[1:9])) + r.slide)
+	}
+	return found
+}
+
 func (r *dwarfReader) resolveVarAddr(name string) uint64 {
 	rd := r.data.Reader()
 	for {

--- a/internal/debugger/goroutines.go
+++ b/internal/debugger/goroutines.go
@@ -17,9 +17,16 @@ import (
 //
 // The engine serializes the walk while the reporting thread is suspended.
 // Darwin also stops sibling threads, but Linux ptrace stops are per-thread, so
-// runtime mutations can race the walk there. Any incomplete required read
-// therefore degrades gracefully to the legacy single-synthetic goroutine rather
-// than being mistaken for a lifecycle change or erroring the stop.
+// runtime mutations can race the walk there. That race has two distinct shapes
+// and they need two distinct defences:
+//
+//   - A required read FAILS or an entry is retired mid-walk. Handled by
+//     degrading: an incomplete walk falls back to the legacy single-synthetic
+//     goroutine rather than being mistaken for a lifecycle change.
+//   - Every read SUCCEEDS but the values are mutually inconsistent, because
+//     they were taken from different generations of a table that was
+//     republished underneath us. Degradation cannot see this — nothing failed —
+//     so it is prevented instead, by the read ordering in allgsMetadata.
 
 const (
 	// maxGoroutineScan bounds the runtime.allgs walk so a corrupt slice header
@@ -321,6 +328,76 @@ func (e *engine) readI64(addr uint64) (int64, bool) {
 	return int64(v), ok
 }
 
+// allgsMetadata reads the goroutine table's array pointer and length as a
+// coherent pair.
+//
+// The read ORDER is load-bearing, and it is the opposite of the obvious one.
+// Only the trapping thread halts at a Linux ptrace stop, so sibling threads
+// keep running while this walk reads tracee memory and runtime.allgadd can
+// republish the table between our two reads. allgadd publishes the array
+// pointer BEFORE the length, so reading the pointer first can pair a stale
+// array with a length belonging to its larger successor and walk past the end
+// of the old allocation. That overrun is not detectable downstream: the word
+// after a heap object is mapped, so the read SUCCEEDS and the walk reports
+// itself Complete while carrying a goroutine that never existed.
+//
+// Reading the length FIRST is what makes the pair safe, and it is safe only
+// because runtime.allgs is append-only and never shrinks: a length observed
+// before a pointer therefore always fits inside whichever array that pointer
+// names. The worst case degrades to missing a goroutine created during the
+// read, which the runtime documents as acceptable for lock-free readers.
+//
+// runtime.allglen/runtime.allgptr are the runtime's own atomics, published for
+// exactly this purpose and carrying the documented contract ("allgptr is
+// updated before allglen. Readers should read allglen before allgptr"), so they
+// are preferred. The raw runtime.allgs header is a fallback for images without
+// those symbols; it applies the same length-before-pointer ordering, but the
+// slice header's three words are ordinary compiler-scheduled stores rather than
+// a documented contract, so the fallback is best-effort where the mirror is
+// guaranteed.
+//
+// ok is false whenever a required read fails, so callers degrade exactly as
+// they do for any other unreadable runtime data.
+func (e *engine) allgsMetadata() (ptr, length uint64, ok bool) {
+	// One DWARF pass for all three names: resolving them separately costs a
+	// full DIE traversal each, on the engine loop, at the first stop.
+	addrs := e.dw.runtimeVarAddrs("runtime.allglen", "runtime.allgptr", "runtime.allgs")
+
+	lenAddr, haveLen := addrs["runtime.allglen"]
+	ptrAddr, havePtr := addrs["runtime.allgptr"]
+	if haveLen && havePtr {
+		mlen, lenOK := e.readU64(lenAddr)
+		if !lenOK {
+			return 0, 0, false
+		}
+		mptr, ptrOK := e.readU64(ptrAddr)
+		if !ptrOK {
+			return 0, 0, false
+		}
+		// A zero pair means the runtime has not published the table through
+		// these atomics yet — they are written by the first allgadd, so a
+		// pre-init stop sees nothing here. Fall through rather than reporting
+		// an empty table, since the header is the older and more widely
+		// populated source; when it is empty too the caller degrades exactly
+		// as it always has.
+		if mptr != 0 && mlen != 0 {
+			return mptr, mlen, true
+		}
+	}
+
+	base, haveBase := addrs["runtime.allgs"]
+	if !haveBase {
+		return 0, 0, false
+	}
+	if length, ok = e.readU64(base + 8); !ok { // slice header: len @ +8, FIRST
+		return 0, 0, false
+	}
+	if ptr, ok = e.readU64(base); !ok { // slice header: array pointer @ +0
+		return 0, 0, false
+	}
+	return ptr, length, true
+}
+
 // buildGoroutineList enumerates runtime.allgs. Complete is false when the
 // runtime can't be read (no DWARF, bad layout, unreadable membership data, or
 // no live goroutines yet). Clipped is independent: the walk reached its safety
@@ -330,16 +407,8 @@ func (e *engine) buildGoroutineList(liveSP, livePC uint64) goroutineWalkResult {
 	if !ok {
 		return goroutineWalkResult{}
 	}
-	base, ok := e.dw.runtimeVarAddr("runtime.allgs")
-	if !ok {
-		return goroutineWalkResult{}
-	}
-	ptr, ok := e.readU64(base) // slice header: array pointer @ +0
-	if !ok || ptr == 0 {
-		return goroutineWalkResult{}
-	}
-	length, ok := e.readU64(base + 8) // slice header: len @ +8
-	if !ok || length == 0 {
+	ptr, length, ok := e.allgsMetadata()
+	if !ok || ptr == 0 || length == 0 {
 		return goroutineWalkResult{}
 	}
 	clipped := length > maxGoroutineScan


### PR DESCRIPTION
## Summary

`buildGoroutineList` read the `runtime.allgs` slice header as two independent reads: array pointer first, length second. Only the trapping thread halts at a Linux ptrace stop, so `runtime.allgadd` can republish the table between those reads, and it publishes the pointer before the length. A pointer-first reader can therefore pair a stale array with its larger successor's length and walk one slot past the old allocation.

That overrun is invisible to incomplete-read degradation: the word after a heap object is mapped, so the read succeeds, the walk reports `Complete: true`, and an unrelated heap object can be accepted as a goroutine. The lifecycle diff then fabricates a `Created` and, on the next snapshot, an `Exited` for a goroutine that never existed.

Fixes #235.

## What changed

`allgsMetadata` now reads the table metadata as a coherent pair:

- Prefer the runtime's atomic mirror, reading `runtime.allglen` before `runtime.allgptr`, exactly as the runtime contract requires.
- Resolve `runtime.allglen`, `runtime.allgptr`, and `runtime.allgs` efficiently in one DWARF pass and cache every result.
- Fall back to the raw `runtime.allgs` header, still reading length at `+8` before pointer at `+0`, when the mirror symbols are absent.
- Fall back when the mirror exists but is still unpublished as a zero pair.

Length-first is safe because `runtime.allgs` is append-only and never shrinks: the observed length fits whichever array pointer is observed afterward. The worst case is missing one concurrent append for one snapshot; the next automatic snapshot reports it as an ordinary creation.

The #219 `Complete`/`Clipped`, required-read, empty-metadata, and degradation behavior is unchanged. The #192 query-versus-automatic lifecycle baseline ownership is unchanged. There are no protocol or consumer changes.

## Tests

`internal/debugger/allgs_metadata_test.go` drives the real goroutine snapshot path against DWARF-resolved runtime offsets and a mapped-memory model:

- schedule sweeps inject `allgadd` after every read index for both the mirror and fallback paths;
- path-specific assertions prove the mirror and raw header are each exercised independently;
- the unpublished-zero mirror path proves ordered fallback;
- a recovery test proves an append missed by one snapshot appears as a genuine creation in the next;
- an anti-vacuity test proves the slot past the old array reads successfully and decodes as a plausible, complete goroutine.

The mirror and fallback tests independently fail if their respective read order is reversed.

## Restack

- Exact base: `ee64ab79704ae26ed19152a16e3672269076c698` (`origin/main`)
- Accepted commit: `030ebe43f2301b4af0fc142aee98dbeba5604131`
- Restacked commit: `4eb521eda9a67769a9385b71b09c9366a677ecb0`
- The three former prerequisite commits were not replayed; their accepted #219 behavior is already on `main`.

Per-file stable patch IDs are identical for the implementation and tests:

| File | Stable patch ID |
| --- | --- |
| `internal/debugger/goroutines.go` | `babab6fb908c599c4759ca3fd77fad24fa60f54d` |
| `internal/debugger/dwarf.go` | `0f84f7986ed6e9719acca406b2a9b7e0de3941a1` |
| `internal/debugger/allgs_metadata_test.go` | `80072dc67c4d20381510c09171da9728ec72decd` |

`git range-diff` shows only the intentional `AGENTS.md` conflict resolution needed to preserve both current `main`'s automatic-baseline invariant and this patch's length-before-pointer invariant.

## Validation

All commands ran on exact head `4eb521eda9a67769a9385b71b09c9366a677ecb0`:

- `go test -tags bingonative -race -run 'TestAllgs' -count=1 ./internal/debugger`
- `go test -tags bingonative -race -count=1 ./internal/debugger`
- `go test -tags bingonative -race ./... -count=1`
- `go vet -tags bingonative ./...`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 golangci-lint run`
- Linux/amd64 cross-build of all packages, `cmd/bingo`, `internal/debugger.test`, and the `e2e` integration test binary
- `just e2e-darwin`: **23/23 passed, 0 failed, 0 pending, 0 skipped**
- Independent code review: no findings
- Published exact-head CI: Go build/unit, Linux debugger E2E, Linux full-stack, Darwin compile gates, VS Code packages, CodeQL, SonarCloud, and Darwin policy tests all passed; final `Darwin E2E verified` status is successful for `4eb521e`.
