### PR TITLE
test(debugger): warm DWARF before timed stop specs

### DIFF
--- a/internal/debugger/e2e_snapshot_warmup.go
+++ b/internal/debugger/e2e_snapshot_warmup.go
@@ -1,0 +1,44 @@
+//go:build e2e
+
+package debugger
+
+import "fmt"
+
+type SnapshotDWARFWarmupState struct {
+	FunctionIndexEntries int
+	GoLayoutCached       bool
+	RuntimeSymbols       map[string]uint64
+}
+
+// WarmSnapshotDWARFForE2E keeps image-only initialization outside native
+// acceptance deadlines; tracee-memory reads still run on the real stop path.
+func WarmSnapshotDWARFForE2E(d Debugger) (SnapshotDWARFWarmupState, error) {
+	e, ok := d.(*engine)
+	if !ok {
+		return SnapshotDWARFWarmupState{}, fmt.Errorf("unsupported debugger type %T", d)
+	}
+
+	state := SnapshotDWARFWarmupState{
+		RuntimeSymbols: make(map[string]uint64),
+	}
+	err := e.dispatch(func() error {
+		if e.dw == nil {
+			return fmt.Errorf("no DWARF info")
+		}
+		e.dw.funcIndexOnce.Do(e.dw.buildFuncIndex)
+		_, state.GoLayoutCached = e.getGoLayout()
+		for name, addr := range e.dw.runtimeVarAddrs(
+			"runtime.allglen",
+			"runtime.allgptr",
+			"runtime.allgs",
+		) {
+			state.RuntimeSymbols[name] = addr
+		}
+		if addr, found := e.dw.runtimeVarAddr("runtime.allm"); found {
+			state.RuntimeSymbols["runtime.allm"] = addr
+		}
+		state.FunctionIndexEntries = len(e.dw.funcIndex)
+		return nil
+	})
+	return state, err
+}

--- a/internal/debugger/engine_curtid_test.go
+++ b/internal/debugger/engine_curtid_test.go
@@ -107,6 +107,15 @@ var _ = Describe("current-thread inspection", func() {
 		d = debugger.NewWithBackend(fb, nil)
 		debugger.ExportedLoadDWARF(d, bin)
 
+		cold := debugger.ExportedDWARFInspectionCacheState(d)
+		Expect(cold.FunctionIndexEntries).To(BeZero())
+		Expect(cold.GoLayoutCached).To(BeFalse())
+		for _, name := range snapshotRuntimeSymbols {
+			Expect(cold.RuntimeSymbols[name].Cached).To(BeFalse(),
+				"%s must start cold so this spec proves the warmup", name)
+		}
+		debugger.ExportedWarmDWARFInspection(d)
+
 		pcAlpha, err = debugger.ExportedPCForFileLine(d, fileName, inspectMarkerLine("alpha-marker"))
 		Expect(err).NotTo(HaveOccurred())
 		pcBeta, err = debugger.ExportedPCForFileLine(d, fileName, inspectMarkerLine("beta-marker"))
@@ -130,6 +139,19 @@ var _ = Describe("current-thread inspection", func() {
 	// stopOnThread2 drives a breakpoint stop on TID 2, leaving the engine
 	// suspended with curTID==2 (thread 2 in beta) while threads[0]==1 is alpha.
 	stopOnThread2 := func() {
+		warm := debugger.ExportedDWARFInspectionCacheState(d)
+		Expect(warm.FunctionIndexEntries).To(BeNumerically(">", 0),
+			"function index must be warm before the timed stop")
+		Expect(warm.GoLayoutCached).To(BeTrue(),
+			"runtime layout must be resolved before the timed stop")
+		for _, name := range snapshotRuntimeSymbols {
+			symbol := warm.RuntimeSymbols[name]
+			Expect(symbol.Cached).To(BeTrue(),
+				"%s must be cached before the timed stop", name)
+			Expect(symbol.Address).NotTo(BeZero(),
+				"%s must resolve in the current Go runtime", name)
+		}
+
 		debugger.ExportedForceSuspended(d)
 		debugger.ExportedSetBreakpointAt(d, pcBeta)
 		continueAndConsumeContinued(d)
@@ -187,3 +209,10 @@ var _ = Describe("current-thread inspection", func() {
 			"after a step, StackFrames should follow curTID (2), got %q", frames[0].Location.Function)
 	})
 })
+
+var snapshotRuntimeSymbols = []string{
+	"runtime.allglen",
+	"runtime.allgptr",
+	"runtime.allgs",
+	"runtime.allm",
+}

--- a/internal/debugger/export_test.go
+++ b/internal/debugger/export_test.go
@@ -53,6 +53,67 @@ func ExportedLoadDWARF(d Debugger, binaryPath string) {
 	}
 }
 
+type ExportedDWARFInspectionState struct {
+	FunctionIndexEntries int
+	GoLayoutCached       bool
+	RuntimeSymbols       map[string]ExportedRuntimeSymbolState
+}
+
+type ExportedRuntimeSymbolState struct {
+	Cached  bool
+	Address uint64
+}
+
+// ExportedWarmDWARFInspection moves image-only lazy scans outside tests' timed
+// stop window while preserving the engine-loop ownership used in production.
+func ExportedWarmDWARFInspection(d Debugger) {
+	e := d.(*engine)
+	if err := e.dispatch(func() error {
+		if e.dw == nil {
+			return fmt.Errorf("no DWARF loaded")
+		}
+		e.dw.funcIndexOnce.Do(e.dw.buildFuncIndex)
+		_, _ = e.getGoLayout()
+		_ = e.dw.runtimeVarAddrs("runtime.allglen", "runtime.allgptr", "runtime.allgs")
+		_, _ = e.dw.runtimeVarAddr("runtime.allm")
+		return nil
+	}); err != nil {
+		panic("ExportedWarmDWARFInspection: " + err.Error())
+	}
+}
+
+func ExportedDWARFInspectionCacheState(d Debugger) ExportedDWARFInspectionState {
+	e := d.(*engine)
+	state := ExportedDWARFInspectionState{
+		RuntimeSymbols: make(map[string]ExportedRuntimeSymbolState),
+	}
+	if err := e.dispatch(func() error {
+		if e.dw == nil {
+			return fmt.Errorf("no DWARF loaded")
+		}
+		state.FunctionIndexEntries = len(e.dw.funcIndex)
+		state.GoLayoutCached = e.goLayout != nil && e.goLayout.valid
+		e.dw.cacheMu.Lock()
+		for _, name := range []string{
+			"runtime.allglen",
+			"runtime.allgptr",
+			"runtime.allgs",
+			"runtime.allm",
+		} {
+			addr, cached := e.dw.varAddrs[name]
+			state.RuntimeSymbols[name] = ExportedRuntimeSymbolState{
+				Cached:  cached,
+				Address: addr,
+			}
+		}
+		e.dw.cacheMu.Unlock()
+		return nil
+	}); err != nil {
+		panic("ExportedDWARFInspectionCacheState: " + err.Error())
+	}
+	return state
+}
+
 // ExportedPCForFileLine resolves file:line to a runtime PC via the loaded DWARF.
 func ExportedPCForFileLine(d Debugger, file string, line int) (uint64, error) {
 	e := d.(*engine)

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -1242,6 +1242,12 @@ func assertCurrentGoroutineScan(count int) {
 	GinkgoHelper()
 	Expect(count).To(BeNumerically(">", 0), "target count must be positive")
 	const richScanLimit = 8192
+	snapshotRuntimeSymbols := []string{
+		"runtime.allglen",
+		"runtime.allgptr",
+		"runtime.allgs",
+		"runtime.allm",
+	}
 
 	releaseIndex := count - 1
 	if count > 1024 {
@@ -1255,7 +1261,18 @@ func assertCurrentGoroutineScan(count int) {
 	h := newE2EHarness(bin)
 	h.waitFor(15*time.Second, protocol.EventStepped)
 
-	_, err := h.d.SetBreakpoint(filepath.Base(bin)+".go", line)
+	warm, err := debugger.WarmSnapshotDWARFForE2E(h.d)
+	Expect(err).NotTo(HaveOccurred(), "warm image-only snapshot DWARF")
+	Expect(warm.FunctionIndexEntries).To(BeNumerically(">", 0),
+		"function index must be warm before the timed stop")
+	Expect(warm.GoLayoutCached).To(BeTrue(),
+		"runtime layout must be resolved before the timed stop")
+	for _, name := range snapshotRuntimeSymbols {
+		Expect(warm.RuntimeSymbols[name]).NotTo(BeZero(),
+			"%s must be resolved before the timed stop", name)
+	}
+
+	_, err = h.d.SetBreakpoint(filepath.Base(bin)+".go", line)
 	Expect(err).NotTo(HaveOccurred(), "SetBreakpoint on current-goroutine worker")
 	Expect(h.d.Continue()).To(Succeed(), "Continue to current-goroutine worker")
 
@@ -1330,8 +1347,12 @@ func assertCurrentGoroutineScan(count int) {
 	Expect(snapshotThread.GoID).To(Equal(snap.Current),
 		"the uniquely current runtime thread must run snapshot Current")
 	if count > richScanLimit {
-		Expect(snap.Goroutines).To(HaveLen(richScanLimit+1),
-			"heavy proof must append one current anchor beyond the full rich prefix")
+		Expect(snap.Totals).NotTo(BeNil(),
+			"the packed heavy snapshot must report omitted goroutines")
+		Expect(snap.Totals.Goroutines).To(BeNumerically(">=", richScanLimit+1),
+			"the full scan must include the rich prefix plus the current anchor")
+		Expect(snap.Totals.Goroutines).To(BeNumerically(">", len(snap.Goroutines)),
+			"the byte-bounded payload must report its omitted tail")
 		Expect(snap.Goroutines[0].ID).To(Equal(hit.Goroutine.ID),
 			"beyond-prefix current anchor must lead the bounded snapshot")
 	}


### PR DESCRIPTION
## Summary
- warm each test engine's lazy DWARF function index, runtime layout, and every runtime global used by the current goroutine snapshot path before timed stops:
  - `runtime.allglen`
  - `runtime.allgptr`
  - `runtime.allgs`
  - `runtime.allm`
- assert those caches start cold and are valid/nonzero immediately before the timed stop, so a removed or partial warmup fails deterministically
- keep tracee-memory reads and stopped-thread/runtime identity checks on the real stop path; production debugger behavior and the shared 500 ms timeout are unchanged
- make the 20,000-goroutine proof honor protocol 1.4 packing: require truthful `Totals` plus the beyond-prefix current anchor instead of an impossible pre-packing list length

## Exact provenance
- historical PR head: `27abc68ecc42a9d3f32a488b78043afc7db3d364`
- previously approved adapted commit: `a3fa252fbfaac6a747de176060d1acccb80f954a`
- exact final base: `9a2f232ff59add2d3c3dc8902dd52a9e412f0637`
- final PR head: `8353dfb19ab6f1b262e9df237fba7bbc918c8569`
- `8353dfb^` is exactly `9a2f232`; stable patch-id is unchanged (`a4aba0ebabf1e2c4e3b9e9524910e21980b97253`), and `git range-diff` reports the patch unchanged

## Reproduction and mutation proof
- the cold current-main test line reproduced the original first-use 500 ms timeout on repeat attempt 2
- removing `runtime.allgptr` from the unit warmup makes all four focused specs fail before the timed stop
- removing function-index warmup makes all four focused specs fail before the timed stop
- removing `runtime.allgptr` from the native E2E warmup makes the signed small-target proof fail before the timed stop
- under four CPU-burning workers, 11 repeated exact-head suites passed (44/44 focused current-thread specs)

## Exact-head validation
- `go test -tags bingonative -race -count=1 ./internal/debugger`
- `go vet -tags bingonative ./...`
- `just build darwin arm64`
- `just e2e-darwin`: 24 passed, 0 failed, 1 opt-in heavy spec skipped (262.348 s)
- signed 20,000-goroutine proof: 1 passed (287.246 s)
- independent final code review: no significant findings

The heavy proof verifies the current goroutine is retained as the first packed anchor, agrees with the real stopped frame and current runtime thread, preserves start/creation metadata, and reports `Totals.Goroutines >= 8193` with a delivered count below the truthful total when the 2 MiB event budget omits the tail.

Fixes #240.
