### PR TITLE
fix(debugger): preserve cleared breakpoints after owner death

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,10 +367,13 @@ invalidates matching `lastBP` / `lastBPTID`; the live PC was rewound when the
 trap stop arrived, so the next resume can continue directly from the original
 instruction. During an in-flight step-off the entry is intentionally absent
 from the table and its original bytes are already restored: `ClearBreakpoint`
-matches the retained entry by ID, marks it disabled, and succeeds. Completion
-then skips `reinstall` but still performs the saved `bpResumeAction`. Failed
-restoration leaves the entry enabled and all pending state intact. `clearAll`
-applies the same invalidation/cancellation rules for Kill.
+matches the retained entry by ID, records its restored bytes, marks it disabled,
+and succeeds. Completion then skips `reinstall` but still performs the saved
+`bpResumeAction`. Recording the bytes keeps an already-queued same-address
+sibling hit classifiable after owner death: it is rewound and resumed silently,
+never reported or reinstalled. Failed restoration leaves the entry enabled and
+all pending state intact. `clearAll` applies the same
+invalidation/cancellation rules for Kill.
 
 If `bps.reinstall` ever fails after a single-step, **suspend instead of
 resuming**. Running without the trap is a runaway process; reporting the
@@ -382,16 +385,19 @@ stepped thread's own `StopSingleStep` puts a lifted trap back, and neither
 backend surfaces a foreign breakpoint while that thread can still produce one
 (linux holds it in the wait-side queue, darwin re-faults it). So the only way
 this combination occurs is that the stepped thread died mid-step — at which
-point the trap is out of the tracee, the entry is out of `byID`/`byAddr`, and
-the sole remaining reference to it is the one-slot `steppingOverBP` that the
-next resume overwrites. The reconcile runs **before** `bps.atAddr`, not after,
-so a sibling stopped at the *same* address resolves to the reinstalled
-breakpoint instead of falling through to the spurious-SIGTRAP path. Placement
-is load-bearing and pinned by mutation: moving it below the lookup fails the
-same-address spec, removing it fails both (`engine_test.go` →
-"a breakpoint stop that arrives while a step-over is in flight"). This mirrors
-the reconcile the `StopSignal` branch has always done; before it, the two
-branches disagreed and only the signal half was safe.
+point the entry is out of `byID`/`byAddr`, and the sole remaining reference to
+it is the one-slot `steppingOverBP` that the next resume overwrites. An enabled
+entry is reinstalled **before** `bps.atAddr`, not after, so a sibling stopped at
+the same address resolves to the real breakpoint instead of taking the
+spurious-SIGTRAP path. A concurrently-cleared entry is different: its original
+bytes are already authoritative and `enabled=false`, so the backstop ends the
+step without reinstalling it. Clearing is final on every completion path.
+Placement is load-bearing and pinned by mutation: moving the reconcile below
+the lookup fails the same-address spec, removing it fails both
+(`engine_test.go` → "a breakpoint stop that arrives while a step-over is in
+flight"); `engine_breakpoint_clear_test.go` separately pins the disabled path.
+This mirrors the reconcile the `StopSignal` branch has always done; before it,
+the two branches disagreed and only the signal half was safe.
 
 On **linux** that death is now caught earlier and more precisely, by the
 `StopStepThreadExited` boundary (park-queue rule 5): the backend refuses to
@@ -407,12 +413,15 @@ the boundary is the ordered handoff, the reconcile is the invariant that a
 breakpoint stop never proceeds while a lifted trap is outstanding.
 
 The engine's `StopStepThreadExited` handler therefore has a strict order:
-reinstall through the anchor, *then* acknowledge with `completeStepThreadExit`,
-which is what releases it. Both halves can fail, and both halt suspended rather
-than tearing the session down — a failed reinstall keeps `steppingOverBP` set and
-the anchor held, a failed release keeps the anchor held and the gate closed, and
-in both cases `ContinueProcess`/`SingleStep` refuse while `stepExitPending` so
-Kill/Restart is the only recovery.
+resolve the retained breakpoint entry, *then* acknowledge with
+`completeStepThreadExit`, which is what releases the anchor. Resolution means
+reinstalling an enabled entry through the anchor, or preserving the restored
+bytes of an entry cleared mid-step; the cleared path still acknowledges, because
+it has no write obligation but must open the gate. Both operations can fail and
+halt suspended rather than tearing the session down — a failed reinstall keeps
+`steppingOverBP` set and the anchor held, a failed release keeps the anchor held
+and the gate closed, and in both cases `ContinueProcess`/`SingleStep` refuse
+while `stepExitPending` so Kill/Restart is the only recovery.
 
 **Every asynchronous halt in `handleStop` must be reported with a *suspending*
 event, not a bare `EventError`.** These failures happen after the resume that
@@ -862,15 +871,18 @@ that their stops are *reported later*, after the trap is back:
   Callers already tolerate this; the `churn` spec always has.
 - Queue depth is bounded by the live thread count — a ptrace-stopped thread
   cannot stop again until it is resumed (G7) — so no cap is needed.
-- A user `ClearBreakpoint` of an address a parked stop refers to still surfaces
-  that stop as a generic SIGTRAP. One-shot engine sentinels are different: their
-  restored-byte histories are remembered, so a delayed sibling hit is rewound
-  only when current bytes match the engine's successful restore and no live
-  architecture trap spans the address. The focused engine tests pin the exact
-  `SetRegisters(tid, rewoundPC)` operation, a genuine live trap at the same
-  address, and x86's cross-boundary `CD 03`; the plain native overlap spec requires
-  `LinuxRetiredInternalBreakpointCount > 0`; an armed-ness probe alone cannot
-  distinguish safe recovery from the mid-instruction path.
+- A table-resident user `ClearBreakpoint` of an address a parked stop refers to
+still surfaces that stop as a generic SIGTRAP. An in-flight clear is different:
+its retained entry records the restored bytes before it is disabled, so an
+owner-death boundary can release a same-address sibling without resurrecting
+the breakpoint or resuming mid-instruction. One-shot engine sentinels retain
+the same kind of restored-byte history. In both cases a delayed hit is rewound
+only when current bytes match the engine's successful restore and no live
+architecture trap spans the address. The focused engine tests pin the exact
+`SetRegisters(tid, rewoundPC)` operation, a genuine live trap at the same
+address, and x86's cross-boundary `CD 03`; the plain native overlap spec requires
+`LinuxRetiredInternalBreakpointCount > 0`; an armed-ness probe alone cannot
+distinguish safe recovery from the mid-instruction path.
 - **A stepped thread that dies never releases a held stop directly.** The
   internal boundary is returned first and records the anchor TID as `traceTID`,
   so the engine's reinstall writes through a genuinely stopped thread while every

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -94,12 +94,14 @@ type engine struct {
 	stepOverFile string
 	stepOverLine int
 
-	// Linux can report a sibling's already-queued hit after a one-shot internal
-	// breakpoint has been restored and removed from bps. A stale stop is resumed
-	// only when current memory matches bytes this engine actually restored and
-	// no live architecture trap spans that address. Histories live for the
-	// engine's lifetime because wait statuses expose no safe drain point.
+	// A sibling's already-queued hit can surface after the trap that produced it
+	// has been restored and removed from bps. This includes one-shot internal
+	// sentinels and user entries cleared during an in-flight step-off. A stale
+	// stop is resumed only when current memory matches bytes this engine actually
+	// restored and no live architecture trap spans that address. The histories
+	// stay separate so the Linux internal-sentinel diagnostic remains precise.
 	retiredInternalBreakpointBytes map[uint64][][]byte
+	retiredClearedBreakpointBytes  map[uint64][][]byte
 	retiredInternalBreakpointHits  int
 
 	// manualStopPending records that a Pause request has fired the backend's
@@ -320,6 +322,11 @@ func (e *engine) clearBreakpoint(id int) error {
 		// The step-off path already restored the original instruction and
 		// transiently removed this entry from the table. Keep its metadata for
 		// the pending resume action, but make completion skip the reinstall.
+		// Its restored bytes identify any same-address sibling hit the kernel
+		// had already queued, so that stop can resume at the instruction rather
+		// than being advanced into or past it as an unowned trap.
+		e.retiredClearedBreakpointBytes = recordRetiredBreakpointBytes(
+			e.retiredClearedBreakpointBytes, e.steppingOverBP.addr, e.steppingOverBP.originalBytes)
 		e.steppingOverBP.enabled = false
 		return nil
 	}
@@ -710,26 +717,26 @@ func (e *engine) handleStop(stop StopEvent) {
 		// other way out of it, and both backends refuse to surface a foreign
 		// breakpoint while the stepped thread can still produce one (linux
 		// parks it, darwin re-faults it). So the stepped thread died, and the
-		// trap this step-over lifted is now removed from the tracee and out of
-		// the table with nothing left to put it back. Reconcile it here, before
-		// the table lookup, so that a sibling stopped at the *same* address
-		// resolves to a real breakpoint instead of taking the spurious-SIGTRAP
-		// path, and so the next resume cannot overwrite the one-slot
-		// steppingOverBP and lose the breakpoint for good.
+		// retained entry must be resolved before the table lookup. A live entry
+		// needs its lifted trap put back so a same-address sibling resolves to
+		// the real breakpoint; a cleared entry already owns restored bytes and
+		// must not be resurrected.
 		if sob := e.steppingOverBP; sob != nil {
 			e.steppingOverBP = nil
-			if rerr := e.bps.reinstall(e.backend, sob); rerr != nil {
-				e.endThreadStep()
-				e.log.Error("breakpoint reinstall failed after the stepped thread died",
-					"addr", fmt.Sprintf("0x%x", sob.addr), "err", rerr)
-				e.haltOnError(protocol.CmdNone, fmt.Errorf(
-					"reinstall breakpoint 0x%x after the stepped thread died "+
-						"(it may no longer be armed or tracked): %w", sob.addr, rerr), stop)
-				return
+			if sob.enabled {
+				if rerr := e.bps.reinstall(e.backend, sob); rerr != nil {
+					e.endThreadStep()
+					e.log.Error("breakpoint reinstall failed after the stepped thread died",
+						"addr", fmt.Sprintf("0x%x", sob.addr), "err", rerr)
+					e.haltOnError(protocol.CmdNone, fmt.Errorf(
+						"reinstall breakpoint 0x%x after the stepped thread died "+
+							"(it may no longer be armed or tracked): %w", sob.addr, rerr), stop)
+					return
+				}
+				e.log.Debug("breakpoint reinstalled after stepped-thread death",
+					"addr", fmt.Sprintf("0x%x", sob.addr))
 			}
 			e.endThreadStep()
-			e.log.Debug("breakpoint reinstalled after stepped-thread death",
-				"addr", fmt.Sprintf("0x%x", sob.addr))
 		}
 		var err error
 		stop, err = e.populateBreakpointStop(stop)
@@ -748,7 +755,7 @@ func (e *engine) handleStop(stop StopEvent) {
 			"found", bp != nil,
 			"steppingOverBP", e.steppingOverBP != nil)
 		if bp == nil {
-			if e.resumeRetiredInternalBreakpoint(stop) {
+			if e.resumeRetiredBreakpoint(stop) {
 				return
 			}
 			// Spurious SIGTRAP — a BRK we did not install (Go runtime
@@ -888,27 +895,31 @@ func (e *engine) handleStop(stop StopEvent) {
 	case StopStepThreadExited:
 		// The backend is holding a genuinely ptrace-stopped thread solely as a
 		// memory-write anchor — the dying step owner itself, or a sibling whose
-		// real stop stays queued. Reinstall through it FIRST; only the
-		// acknowledgement below releases that anchor and lets held stops drain.
+		// real stop stays queued. Resolve the breakpoint transaction FIRST:
+		// reinstall a live entry through the anchor, or preserve the restored
+		// bytes of an entry cleared mid-step. Only the acknowledgement below
+		// releases that anchor and lets held stops drain.
 		if sob := e.steppingOverBP; sob != nil {
-			if rerr := e.bps.reinstall(e.backend, sob); rerr != nil {
-				// steppingOverBP is deliberately left set: the trap is still out
-				// of the tracee and the engine still owns it, which is also what
-				// keeps the backend's gate closed so Continue/Step are refused.
-				e.setState(stateSuspended)
-				e.haltOnError(protocol.CmdNone, fmt.Errorf(
-					"reinstall breakpoint 0x%x after stepped thread exited; kill or restart to recover safely: %w",
-					sob.addr, rerr), stop)
-				return
+			if sob.enabled {
+				if rerr := e.bps.reinstall(e.backend, sob); rerr != nil {
+					// steppingOverBP is deliberately left set: the trap is still out
+					// of the tracee and the engine still owns it, which is also what
+					// keeps the backend's gate closed so Continue/Step are refused.
+					e.setState(stateSuspended)
+					e.haltOnError(protocol.CmdNone, fmt.Errorf(
+						"reinstall breakpoint 0x%x after stepped thread exited; kill or restart to recover safely: %w",
+						sob.addr, rerr), stop)
+					return
+				}
+				e.log.Debug("breakpoint reinstalled after stepped thread exited",
+					"addr", fmt.Sprintf("0x%x", sob.addr))
 			}
 			e.steppingOverBP = nil
-			e.log.Debug("breakpoint reinstalled after stepped thread exited",
-				"addr", fmt.Sprintf("0x%x", sob.addr))
 		}
 		if cerr := e.completeStepThreadExit(); cerr != nil {
-			// The reinstall succeeded but the anchor could not be released, so
-			// the gate stays closed and no waitLoop is started: resuming would
-			// leave a thread stopped that nothing will ever deliver.
+			// The breakpoint transaction is resolved but the anchor could not be
+			// released, so the gate stays closed and no waitLoop is started:
+			// resuming would leave a thread stopped that nothing will ever deliver.
 			e.setState(stateSuspended)
 			e.haltOnError(protocol.CmdNone, fmt.Errorf(
 				"reconcile the exited step owner; kill or restart to recover safely: %w",
@@ -974,29 +985,45 @@ func (e *engine) retireInternalBreakpoint(bp *breakpointEntry, stop StopEvent) b
 			fmt.Errorf("clear internal breakpoint 0x%x: %w", bp.addr, err), stop)
 		return false
 	}
-	if e.retiredInternalBreakpointBytes == nil {
-		e.retiredInternalBreakpointBytes = make(map[uint64][][]byte)
-	}
-	restored := bytes.Clone(bp.originalBytes)
-	history := e.retiredInternalBreakpointBytes[bp.addr]
-	for _, prior := range history {
-		if bytes.Equal(prior, restored) {
-			return true
-		}
-	}
-	e.retiredInternalBreakpointBytes[bp.addr] = append(history, restored)
+	e.retiredInternalBreakpointBytes = recordRetiredBreakpointBytes(
+		e.retiredInternalBreakpointBytes, bp.addr, bp.originalBytes)
 	return true
 }
 
-// resumeRetiredInternalBreakpoint handles a sibling that executed a one-shot
-// sentinel before another thread cleared it, but whose kernel stop reached the
-// engine only afterwards. On amd64 the live RIP is then one byte into the
-// restored instruction. An address match is insufficient: tracee code may later
-// place a genuine trap there, including an x86 CD 03 spanning the rewind
-// boundary, and rewinding that live trap would re-execute it forever.
-func (e *engine) resumeRetiredInternalBreakpoint(stop StopEvent) bool {
-	history, ok := e.retiredInternalBreakpointBytes[stop.PC]
-	if !ok {
+func recordRetiredBreakpointBytes(history map[uint64][][]byte, addr uint64, original []byte) map[uint64][][]byte {
+	if history == nil {
+		history = make(map[uint64][][]byte)
+	}
+	restored := bytes.Clone(original)
+	priorBytes := history[addr]
+	for _, prior := range priorBytes {
+		if bytes.Equal(prior, restored) {
+			return history
+		}
+	}
+	history[addr] = append(priorBytes, restored)
+	return history
+}
+
+func matchesRetiredBreakpointBytes(current []byte, history [][]byte) bool {
+	for _, prior := range history {
+		if bytes.Equal(current, prior) {
+			return true
+		}
+	}
+	return false
+}
+
+// resumeRetiredBreakpoint handles a sibling whose kernel stop arrives after
+// another thread removed the trap that produced it. On amd64 the live RIP is
+// then one byte into the restored instruction. An address match is insufficient:
+// tracee code may later place a genuine trap there, including an x86 CD 03
+// spanning the rewind boundary, and rewinding that live trap would re-execute it
+// forever.
+func (e *engine) resumeRetiredBreakpoint(stop StopEvent) bool {
+	internalHistory := e.retiredInternalBreakpointBytes[stop.PC]
+	clearedHistory := e.retiredClearedBreakpointBytes[stop.PC]
+	if len(internalHistory) == 0 && len(clearedHistory) == 0 {
 		return false
 	}
 
@@ -1004,7 +1031,7 @@ func (e *engine) resumeRetiredInternalBreakpoint(stop StopEvent) bool {
 	if err != nil {
 		e.setState(stateSuspended)
 		e.haltOnError(protocol.CmdNone,
-			fmt.Errorf("inspect retired internal breakpoint at 0x%x: %w", stop.PC, err), stop)
+			fmt.Errorf("inspect retired breakpoint at 0x%x: %w", stop.PC, err), stop)
 		return true
 	}
 	if liveTrap {
@@ -1014,14 +1041,8 @@ func (e *engine) resumeRetiredInternalBreakpoint(stop StopEvent) bool {
 		return true
 	}
 
-	restored := false
-	for _, prior := range history {
-		if bytes.Equal(current, prior) {
-			restored = true
-			break
-		}
-	}
-	if !restored {
+	internalMatch := matchesRetiredBreakpointBytes(current, internalHistory)
+	if !internalMatch && !matchesRetiredBreakpointBytes(current, clearedHistory) {
 		e.log.Debug("retired address no longer matches restored breakpoint bytes",
 			"tid", stop.TID, "pc", fmt.Sprintf("0x%x", stop.PC))
 		e.resumeUnownedBreakpoint(stop, stop.PC+uint64(len(archTrapInstruction())))
@@ -1032,7 +1053,7 @@ func (e *engine) resumeRetiredInternalBreakpoint(stop StopEvent) bool {
 	if err != nil {
 		e.setState(stateSuspended)
 		e.haltOnError(protocol.CmdNone,
-			fmt.Errorf("read registers for retired internal breakpoint on thread %d: %w", stop.TID, err), stop)
+			fmt.Errorf("read registers for retired breakpoint on thread %d: %w", stop.TID, err), stop)
 		return true
 	}
 	if regs.PC != stop.PC {
@@ -1040,20 +1061,22 @@ func (e *engine) resumeRetiredInternalBreakpoint(stop StopEvent) bool {
 		if err := e.backend.SetRegisters(stop.TID, regs); err != nil {
 			e.setState(stateSuspended)
 			e.haltOnError(protocol.CmdNone,
-				fmt.Errorf("rewind retired internal breakpoint on thread %d: %w", stop.TID, err), stop)
+				fmt.Errorf("rewind retired breakpoint on thread %d: %w", stop.TID, err), stop)
 			return true
 		}
 	}
 
-	e.log.Debug("resuming delayed sibling hit on retired internal breakpoint",
+	e.log.Debug("resuming delayed sibling hit on retired breakpoint",
 		"tid", stop.TID, "pc", fmt.Sprintf("0x%x", stop.PC))
 	if err := e.backend.ContinueProcess(); err != nil {
 		e.setState(stateSuspended)
 		e.haltOnError(protocol.CmdNone,
-			fmt.Errorf("continue after retired internal breakpoint on thread %d: %w", stop.TID, err), stop)
+			fmt.Errorf("continue after retired breakpoint on thread %d: %w", stop.TID, err), stop)
 		return true
 	}
-	e.retiredInternalBreakpointHits++
+	if internalMatch {
+		e.retiredInternalBreakpointHits++
+	}
 	e.setState(stateRunning)
 	go e.waitLoop()
 	return true

--- a/internal/debugger/engine_breakpoint_clear_test.go
+++ b/internal/debugger/engine_breakpoint_clear_test.go
@@ -195,6 +195,67 @@ var _ = Describe("Breakpoint clear state transitions", func() {
 		Expect(d.ClearBreakpoint(id)).To(MatchError(ContainSubstring("not found")))
 	})
 
+	It("does not resurrect a cleared breakpoint in the stepped-thread death backstop", func() {
+		const (
+			siblingAddr = bpAddr + 0x100
+			siblingTID  = 2
+		)
+		fb.seedMem(siblingAddr, original)
+		siblingID := debugger.ExportedSetBreakpointAt(d, siblingAddr)
+		parkOnBreakpoint(1)
+
+		continueAndConsumeContinued(d)
+		Expect(d.ClearBreakpoint(id)).To(Succeed())
+
+		hitPC := siblingAddr
+		if len(trap) == 1 {
+			hitPC++
+		}
+		fb.tids = []int{1, siblingTID}
+		fb.regs[siblingTID] = debugger.Registers{PC: hitPC}
+		fb.pushStop(debugger.StopEvent{
+			Reason: debugger.StopBreakpoint,
+			TID:    siblingTID,
+			PC:     siblingAddr,
+		})
+
+		evt := mustNextEvent(d)
+		Expect(evt.Kind).To(Equal(protocol.EventBreakpointHit))
+		var payload protocol.BreakpointHitPayload
+		Expect(protocol.DecodeEventPayload(evt, &payload)).To(Succeed())
+		Expect(payload.Breakpoint.ID).To(Equal(siblingID))
+		expectOriginalInstruction()
+		Expect(d.ClearBreakpoint(id)).To(MatchError(ContainSubstring("not found")))
+	})
+
+	It("rewinds a queued same-address hit after the in-flight breakpoint is cleared", func() {
+		const siblingTID = 2
+		parkOnBreakpoint(1)
+
+		continueAndConsumeContinued(d)
+		Expect(d.ClearBreakpoint(id)).To(Succeed())
+
+		hitPC := bpAddr
+		if len(trap) == 1 {
+			hitPC++
+		}
+		fb.tids = []int{1, siblingTID}
+		fb.regs[siblingTID] = debugger.Registers{PC: hitPC}
+		fb.pushStop(debugger.StopEvent{
+			Reason: debugger.StopBreakpoint,
+			TID:    siblingTID,
+			PC:     bpAddr,
+		})
+
+		waitForContinue()
+		Expect(fb.regs[siblingTID].PC).To(Equal(bpAddr),
+			"the delayed hit must execute the restored instruction rather than resume past it")
+		expectOriginalInstruction()
+		Expect(d.ClearBreakpoint(id)).To(MatchError(ContainSubstring("not found")))
+		_, ok := nextEvent(d)
+		Expect(ok).To(BeFalse(), "a delayed hit on a cleared breakpoint must remain silent")
+	})
+
 	It("makes Kill's clearAll path forget a parked breakpoint", func() {
 		parkOnBreakpoint(1)
 

--- a/internal/debugger/engine_halt_test.go
+++ b/internal/debugger/engine_halt_test.go
@@ -177,7 +177,7 @@ var _ = Describe("asynchronous halts in handleStop", func() {
 		fb.failRegisters(errInjected)
 		fb.pushStop(debugger.StopEvent{Reason: debugger.StopBreakpoint, TID: 2, PC: addr})
 
-		expectHaltReported(d, "read registers for retired internal breakpoint on thread 2")
+		expectHaltReported(d, "read registers for retired breakpoint on thread 2")
 		fb.clearFaults()
 		Expect(d.Continue()).To(Succeed(), "the session must remain resumable")
 	})
@@ -190,7 +190,7 @@ var _ = Describe("asynchronous halts in handleStop", func() {
 		fb.failReadAt(addr, errInjected)
 		fb.pushStop(debugger.StopEvent{Reason: debugger.StopBreakpoint, TID: 2, PC: addr})
 
-		expectHaltReported(d, "inspect retired internal breakpoint")
+		expectHaltReported(d, "inspect retired breakpoint")
 		fb.clearFaults()
 		Expect(d.Continue()).To(Succeed(), "the session must remain resumable")
 	})
@@ -207,7 +207,7 @@ var _ = Describe("asynchronous halts in handleStop", func() {
 		fb.failSetRegisters(errInjected)
 		fb.pushStop(debugger.StopEvent{Reason: debugger.StopBreakpoint, TID: 2, PC: addr})
 
-		expectHaltReported(d, "rewind retired internal breakpoint on thread 2")
+		expectHaltReported(d, "rewind retired breakpoint on thread 2")
 		fb.clearFaults()
 		Expect(d.Continue()).To(Succeed(), "the session must remain resumable")
 	})
@@ -221,7 +221,7 @@ var _ = Describe("asynchronous halts in handleStop", func() {
 		fb.failContinue(errInjected)
 		fb.pushStop(debugger.StopEvent{Reason: debugger.StopBreakpoint, TID: 2, PC: addr})
 
-		expectHaltReported(d, "continue after retired internal breakpoint on thread 2")
+		expectHaltReported(d, "continue after retired breakpoint on thread 2")
 		fb.clearFaults()
 		Expect(d.Continue()).To(Succeed(), "the session must remain resumable")
 	})

--- a/internal/debugger/engine_stepqueue_test.go
+++ b/internal/debugger/engine_stepqueue_test.go
@@ -356,6 +356,46 @@ var _ = Describe("Engine over the production park queue", func() {
 			"the dead step owner's breakpoint must still be tracked by id")
 	})
 
+	It("opens the owner-death gate without reinstalling a breakpoint cleared mid-step", func() {
+		idA := debugger.ExportedSetBreakpointAt(d, bpAddrA)
+
+		continueAndConsumeContinued(d)
+		qb.push(rawStop{tid: steppedTID, trap: true, pc: bpAddrA})
+		Expect(mustNextEvent(d).Kind).To(Equal(protocol.EventBreakpointHit))
+
+		continueAndConsumeContinued(d)
+		Eventually(func() []byte { return fb.peekMem(bpAddrA, len(trap)) }).
+			ShouldNot(Equal(trap), "the step-over transaction must own A's lifted trap")
+		Expect(d.ClearBreakpoint(idA)).To(Succeed())
+
+		hitPC := bpAddrA
+		if len(trap) == 1 {
+			hitPC++
+		}
+		fb.regs[siblingTID] = debugger.Registers{PC: hitPC}
+		qb.push(rawStop{tid: siblingTID, trap: true, pc: bpAddrA})
+		Eventually(qb.q.ParkedDepth).Should(Equal(1),
+			"the same-address sibling must remain held until owner reconciliation")
+
+		qb.resetOrder()
+		continuesBefore := fb.continueCount()
+		qb.push(rawStop{tid: steppedTID, death: true})
+
+		Eventually(qb.events).Should(Equal([]string{"release"}),
+			"a cleared entry needs no reinstall, but its held sibling must still drain")
+		Eventually(qb.q.StepExitPending).Should(BeFalse(),
+			"skipping the write must still open the reconciliation gate")
+		Eventually(fb.continueCount).Should(BeNumerically(">", continuesBefore),
+			"the released same-address hit must be resumed silently")
+		Expect(fb.regs[siblingTID].PC).To(Equal(bpAddrA),
+			"the released hit must execute the restored instruction rather than resume past it")
+		Expect(fb.peekMem(bpAddrA, len(trap))).NotTo(Equal(trap),
+			"the stepped-owner death path must not resurrect a cleared breakpoint")
+		Expect(d.ClearBreakpoint(idA)).To(MatchError(ContainSubstring("not found")))
+		Expect(noUserEventWithin(d, 150*time.Millisecond)).To(BeTrue(),
+			"reconciling a cleared breakpoint must not fabricate a stop")
+	})
+
 	// Reinstall failure on the held-owner path. The trap is still out of the
 	// tracee and the engine still owns it, so the anchor must NOT be released
 	// and the session must halt suspended rather than resume or die.


### PR DESCRIPTION
## P1 regression

Main `83e0be812f32c476fb03e4cd9346641728889c28` can resurrect a successfully cleared software breakpoint when the thread single-stepping off it exits. During the step-off window the entry is retained in `steppingOverBP`; `ClearBreakpoint` disables that entry because the original instruction is already restored. Both owner-death completion paths nevertheless reinstalled it unconditionally:

- the cross-platform `StopBreakpoint` death backstop
- the Linux `StopStepThreadExited` reconciliation boundary

That violates the API invariant that a successful clear is final and can make a cleared breakpoint fire again. A sibling can also have an already-queued same-address trap stop from before the clear, so simply skipping reinstall is insufficient: the delayed stop must be recognized without mistaking a genuine live trap for stale state.

## Fix

- Reinstall retained entries on owner death only while they remain enabled.
- Always complete step bookkeeping and release the Linux owner-death gate, including the cleared-entry path.
- Retain the restored instruction bytes for cleared in-flight entries so a delayed same-address stop is byte-verified, PC-rewound, and silently resumed.
- Preserve enabled-entry reinstall-before-release behavior and all asynchronous halt semantics from #202.
- Add focused fake-backend and engine-over-stepQueue regressions, and document the final clearing invariant in `AGENTS.md`.

## Provenance

This branch is exactly one commit on `83e0be812f32c476fb03e4cd9346641728889c28`. Its patch is identical to reviewed commit `4699d76ef3bce48e1283280a62fa9dca43007fb6`, which was not included when #202 merged from an intermediate head. Stable patch ID: `f1ffc3f0762e13595ee942c36b0645012644bdd0`. No old #202 stack commits are present.

## Validation

- `gofmt` and `goimports` clean
- Three focused owner-death/clear regressions under `-race`
- `go test -tags bingonative -race -count=1 ./...`
- `go vet -tags bingonative ./...`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 golangci-lint run` (0 issues)
- `just e2e-darwin` (22/22 passed)

Native Linux E2E and mutation execution require the Linux CI runners; the existing fresh-PR gates remain unchanged.