### PR TITLE
test(integration): make overlap signal gate deterministic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -984,16 +984,21 @@ those specs. The counter is cumulative and `atomic` because the test reads it
 from its own goroutine; draining and purging describe what is still held, not
 what was ever held, so neither rolls it back.
 
-`LinuxParkedSignalCount` splits out the held **signal** stops, and the `Pause`
-overlap spec's non-vacuity rests on it. The wait loop absorbs SIGURG, SIGCONT
-and a new thread's initial SIGSTOP before `classifyUserStop`, so a signal stop
-that reaches the queue can only be an externally-directed interrupt — in that
-target, the SIGSTOP `Pause` sends at the main thread. Since the main thread
-never traps there, it is never the stepped thread, so a held signal is direct
-evidence that the interrupt arrived *while a single-step was outstanding*. That
-spec asserts three independent things: a `Pause` was accepted (the engine was
-running, so a step really was in flight), an interrupt was held mid-step, and at
-least one `EventPaused` actually surfaced.
+`LinuxParkedSignalCount` splits out the held **signal** stops. The wait loop
+absorbs SIGURG, SIGCONT and a new thread's initial SIGSTOP before
+`classifyUserStop`, so a signal stop that reaches the queue is an
+externally-directed interrupt. The ordinary-signal overlap target exposes one
+locked signal TID and a separate locked thread stopped on a breakpoint at a raw
+`nanosleep` syscall. The harness starts a machine step over that syscall, then
+directs SIGUSR1 to the known foreign TID. The step owner blocks runtime
+preemption's SIGURG, and the target gates its SIGCONT storm until this transaction
+finishes, so the blocking syscall keeps the step open until the foreign signal
+is provably parked. After forwarding, the signaled locked thread must hit its
+own gated breakpoint under the same TID, proving the backend resumed the thread
+that actually stopped rather than merely reporting the signal. The Pause overlap
+spec uses the same counter for its directed main-thread SIGSTOP. In both cases,
+a held signal is direct evidence that the interrupt arrived *while a single-step
+was outstanding*.
 
 **The foreign-signal spec also gates the signal *number*, not just its arrival.**
 A held stop carries its signal in the `StopEvent` the wait loop builds at park
@@ -1002,9 +1007,9 @@ still advance every counter, and merely report `signal 0`. The spec therefore
 records the numbers the engine reported and requires `SIGUSR1` to be among them
 and `0` not to be — with a held **signal** stop asserted separately, since that
 is the population whose number travels through the queue. `SIGUSR1` is chosen
-because ptrace intercepts it and the engine resumes with signal 0, so the storm
-never changes the target's behaviour; its exact value is now asserted, so do not
-swap it.
+because ptrace intercepts and forwards it to the exact stopped TID, whose handler
+changes only an atomic counter in the target; its exact value is asserted, so do
+not swap it.
 
 **`LinuxStepRearmCount` is the native evidence for rule 7.** The failure that
 rule prevents is a freeze, which a test can otherwise only observe as a timeout —

--- a/internal/debugger/park_diag_linux_amd64.go
+++ b/internal/debugger/park_diag_linux_amd64.go
@@ -29,10 +29,9 @@ func LinuxParkedStopCount(d Debugger) (int, bool) {
 //
 // This is the observable that proves an asynchronous interrupt was received by
 // the backend *while a single-step was in flight*. The wait loop absorbs SIGURG,
-// SIGCONT and a new thread's initial SIGSTOP before classification, so the only
-// signal that can reach the park queue in the overlap target is the SIGSTOP that
-// Pause directs at the main thread. Returns (0, false) for a non-engine
-// Debugger.
+// SIGCONT and a new thread's initial SIGSTOP before classification. The native
+// overlap specs use this to gate both Pause's directed SIGSTOP and an ordinary
+// directed SIGUSR1. Returns (0, false) for a non-engine Debugger.
 func LinuxParkedSignalCount(d Debugger) (int, bool) {
 	e, ok := d.(*engine)
 	if !ok {

--- a/internal/debugger/waitpark.go
+++ b/internal/debugger/waitpark.go
@@ -157,8 +157,8 @@ func (q *stepQueue) parkedCount() int { return int(q.parkedTotal.Load()) }
 // asynchronous interrupt reached the backend while a step was in flight" from
 // "a sibling happened to trap". The linux wait loop absorbs SIGURG, SIGCONT and
 // a new thread's initial SIGSTOP before classification, so a parked signal stop
-// is a genuine externally-directed interrupt — in practice the SIGSTOP that
-// Pause sends at the main thread.
+// is a genuine externally-directed interrupt, either Pause's directed SIGSTOP
+// or the ordinary directed signal used by the native overlap gate.
 func (q *stepQueue) parkedSignalCount() int { return int(q.parkedSignalTotal.Load()) }
 
 // releasable pops the oldest held stop if one may be surfaced now.

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -1098,8 +1098,13 @@ type e2eHarness struct {
 // failure mode instead of wedging the whole suite.
 func newE2EHarness(bin string) *e2eHarness {
 	GinkgoHelper()
+	return newE2EHarnessArgs(bin, nil)
+}
+
+func newE2EHarnessArgs(bin string, args []string) *e2eHarness {
+	GinkgoHelper()
 	d := debugger.New(nil)
-	Expect(d.Launch(bin, nil, nil)).To(Succeed(), "Launch target")
+	Expect(d.Launch(bin, args, nil)).To(Succeed(), "Launch target")
 	DeferCleanup(func() {
 		done := make(chan struct{})
 		go func() { _ = d.Kill(); close(done) }()

--- a/test/integration/debugger_e2e_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_linux_amd64_test.go
@@ -674,11 +674,13 @@ func declareStepOverlapSpec() {
 	})
 }
 
-// overlapSignalTargetSrc adds a process-directed signal storm to the overlap
-// workload. A process-directed signal is delivered to an arbitrary thread that
-// is not blocking it, so it regularly lands on a spinner in the exact window
-// where another spinner is single-stepping off a trap — the foreign StopSignal
-// case, as opposed to the foreign SIGTRAP the plain overlap target produces.
+// overlapSignalTargetSrc adds a dedicated, locked signal thread and a raw
+// nanosleep syscall to the overlap workload. The harness directs SIGUSR1 to the
+// known signal TID after single-stepping the syscall has begun. The step thread
+// blocks runtime preemption's SIGURG, and the SIGCONT storm starts only after
+// this gate, so the syscall keeps the step open until the foreign signal stop is
+// provably parked instead of relying on a process-directed storm to win a
+// microsecond-scale race.
 //
 // SIGUSR1 is handled explicitly so forwarding it changes only an atomic counter.
 // Its exact number is asserted by the spec, so do not swap it for another
@@ -694,15 +696,22 @@ func declareStepOverlapSpec() {
 const overlapSignalTargetSrc = `package main
 
 import (
+	"fmt"
 	"os"
 	"os/signal"
 	"runtime"
 	"sync/atomic"
 	"syscall"
 	"time"
+	"unsafe"
 )
 
-var sink int64
+var (
+	sink          int64
+	signalHandled int64
+)
+
+func slowStep()
 
 func work(n int64) int64 {
 	s := int64(0)
@@ -723,27 +732,72 @@ func spin(id int64) {
 	}
 }
 
+func signalThread(ready chan<- int) {
+	runtime.LockOSThread()
+	ready <- syscall.Gettid()
+	for atomic.LoadInt64(&signalHandled) == 0 {
+		atomic.AddInt64(&sink, 1)
+	}
+	for {
+		atomic.AddInt64(&sink, 1) // SIGNAL_THREAD_RESUMED
+	}
+}
+
+func stepThread() {
+	runtime.LockOSThread()
+	mask := uint64(1) << (uint(syscall.SIGURG) - 1)
+	_, _, errno := syscall.RawSyscall6(
+		syscall.SYS_RT_SIGPROCMASK,
+		0,
+		uintptr(unsafe.Pointer(&mask)),
+		0,
+		unsafe.Sizeof(mask),
+		0,
+		0,
+	)
+	runtime.KeepAlive(&mask)
+	if errno != 0 {
+		os.Exit(96)
+	}
+	slowStep()
+	for {
+		time.Sleep(time.Second)
+	}
+}
+
 func main() {
 	go func() { time.Sleep(180 * time.Second); os.Exit(0) }()
-	runtime.GOMAXPROCS(4)
-	for i := int64(0); i < 6; i++ {
-		go spin(i)
-	}
+	runtime.GOMAXPROCS(6)
 	signals := make(chan os.Signal, 64)
 	signal.Notify(signals, syscall.SIGUSR1)
 	go func() {
 		for range signals {
+			atomic.StoreInt64(&signalHandled, 1)
 			atomic.AddInt64(&sink, 1)
 		}
 	}()
+	if len(os.Args) != 3 {
+		os.Exit(94)
+	}
+	ready := make(chan int, 1)
+	go signalThread(ready)
+	signalTID := <-ready
+	if err := os.WriteFile(os.Args[1],
+		[]byte(fmt.Sprintf("%d %d\n", os.Getpid(), signalTID)), 0600); err != nil {
+		os.Exit(95)
+	}
+	go stepThread()
 	pid := os.Getpid()
 	go func() {
 		for {
-			_ = syscall.Kill(pid, syscall.SIGUSR1)
-			time.Sleep(2 * time.Millisecond)
+			if _, err := os.Stat(os.Args[2]); err == nil {
+				break
+			}
+			time.Sleep(time.Millisecond)
 		}
-	}()
-	go func() {
+		for i := int64(0); i < 6; i++ {
+			go spin(i)
+		}
 		for {
 			_ = syscall.Kill(pid, syscall.SIGCONT)
 			time.Sleep(1 * time.Millisecond)
@@ -754,6 +808,37 @@ func main() {
 	}
 }
 `
+
+const overlapSignalTargetAsm = `#include "textflag.h"
+
+TEXT ·slowStep(SB), NOSPLIT, $16-0
+	MOVQ $5, 0(SP)
+	MOVQ $0, 8(SP)
+	MOVQ $35, AX
+	LEAQ 0(SP), DI
+	XORQ SI, SI
+	SYSCALL // OVERLAP_SIGNAL_STEP
+	RET
+`
+
+func buildOverlapSignalTarget() string {
+	GinkgoHelper()
+	dir := GinkgoT().TempDir()
+	goPath := filepath.Join(dir, "overlap_signal_target.go")
+	asmPath := filepath.Join(dir, "overlap_signal_target.s")
+	modPath := filepath.Join(dir, "go.mod")
+	Expect(os.WriteFile(goPath, []byte(overlapSignalTargetSrc), 0o600)).To(Succeed())
+	Expect(os.WriteFile(asmPath, []byte(overlapSignalTargetAsm), 0o600)).To(Succeed())
+	Expect(os.WriteFile(modPath, []byte("module overlap_signal_target\n\ngo 1.25\n"), 0o600)).To(Succeed())
+
+	binPath := filepath.Join(dir, "overlap_signal_target")
+	cmd := exec.Command("go", "build", "-gcflags=all=-N -l", "-o", binPath, ".")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	out, err := cmd.CombinedOutput()
+	Expect(err).NotTo(HaveOccurred(), "build deterministic overlap-signal target:\n%s", out)
+	return binPath
+}
 
 // overlapProbe bundles the per-stop bookkeeping the overlap specs share: the
 // liveness probe that both logical breakpoints are still tracked, and the tally
@@ -896,6 +981,92 @@ func setupOverlap(name, src string) (*overlapProbe, int, int) {
 	return newOverlapProbe(h, name+".go", []int{bpA.ID, bpB.ID}, []int{lineA, lineB}), bpA.ID, bpB.ID
 }
 
+func setupOverlapSignal() (*overlapProbe, int, int, int) {
+	GinkgoHelper()
+	syncDir := GinkgoT().TempDir()
+	syncPath := filepath.Join(syncDir, "signal-thread")
+	stormPath := filepath.Join(syncDir, "start-sigcont-storm")
+	h := newE2EHarnessArgs(buildOverlapSignalTarget(), []string{syncPath, stormPath})
+	h.waitFor(20*time.Second, protocol.EventStepped)
+
+	stepLine := markerLine(overlapSignalTargetAsm, "// OVERLAP_SIGNAL_STEP")
+	stepBP, err := h.d.SetBreakpoint("overlap_signal_target.s", stepLine)
+	Expect(err).NotTo(HaveOccurred(), "set blocking single-step breakpoint")
+	resumedLine := markerLine(overlapSignalTargetSrc, "// SIGNAL_THREAD_RESUMED")
+	resumedBP, err := h.d.SetBreakpoint("overlap_signal_target.go", resumedLine)
+	Expect(err).NotTo(HaveOccurred(), "set signal-thread liveness breakpoint")
+	parkedSignalsBefore, ok := debugger.LinuxParkedSignalCount(h.d)
+	Expect(ok).To(BeTrue(), "parked-signal hook unavailable")
+
+	Expect(h.d.Continue()).To(Succeed(), "continue to blocking single-step breakpoint")
+	evt := awaitFrom(h, 30*time.Second,
+		protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+	Expect(evt.Kind).To(Equal(protocol.EventBreakpointHit),
+		"blocking single-step breakpoint did not stop: %s", evt.Payload)
+	var hit protocol.BreakpointHitPayload
+	Expect(json.Unmarshal(evt.Payload, &hit)).To(Succeed())
+	Expect(hit.Breakpoint.ID).To(Equal(stepBP.ID))
+
+	var pid, signalTID int
+	syncData, err := os.ReadFile(syncPath)
+	Expect(err).NotTo(HaveOccurred(), "read signal-thread identity")
+	_, err = fmt.Sscanf(string(syncData), "%d %d", &pid, &signalTID)
+	Expect(err).NotTo(HaveOccurred(), "decode signal-thread identity %q", syncData)
+	Expect(pid).To(BeNumerically(">", 0))
+	Expect(signalTID).To(BeNumerically(">", 0))
+	Expect(hit.Goroutine.ThreadID).To(BeNumerically(">", 0),
+		"blocking step did not report its OS thread")
+	Expect(hit.Goroutine.Current).To(BeTrue(),
+		"blocking step fell back to a non-current goroutine")
+	Expect(hit.Goroutine.ThreadID).NotTo(Equal(signalTID),
+		"the directed signal thread must be foreign to the single-step owner")
+
+	Expect(h.d.StepInto()).To(Succeed(), "single-step blocking nanosleep syscall")
+	Expect(syscall.Tgkill(pid, signalTID, syscall.SIGUSR1)).To(Succeed(),
+		"direct SIGUSR1 to the known foreign thread")
+	evt = awaitFrom(h, 30*time.Second,
+		protocol.EventStepped, protocol.EventBreakpointHit,
+		protocol.EventProcessExited, protocol.EventError)
+	Expect(evt.Kind).To(Equal(protocol.EventStepped),
+		"the blocking syscall step did not complete after holding the foreign signal: %s", evt.Payload)
+	Expect(h.d.ClearBreakpoint(stepBP.ID)).To(Succeed(),
+		"clear blocking single-step breakpoint")
+
+	lineA := markerLine(overlapSignalTargetSrc, "// OVERLAP_A")
+	lineB := markerLine(overlapSignalTargetSrc, "// OVERLAP_B")
+	bpA, err := h.d.SetBreakpoint("overlap_signal_target.go", lineA)
+	Expect(err).NotTo(HaveOccurred(), "SetBreakpoint A")
+	bpB, err := h.d.SetBreakpoint("overlap_signal_target.go", lineB)
+	Expect(err).NotTo(HaveOccurred(), "SetBreakpoint B")
+	p := newOverlapProbe(h, "overlap_signal_target.go",
+		[]int{bpA.ID, bpB.ID}, []int{lineA, lineB})
+
+	Expect(h.d.Continue()).To(Succeed(), "release the held foreign signal")
+	evt = p.await(30*time.Second,
+		protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+	Expect(evt.Kind).To(Equal(protocol.EventBreakpointHit),
+		"the directed signal thread did not resume after SIGUSR1 forwarding: %s", evt.Payload)
+	Expect(json.Unmarshal(evt.Payload, &hit)).To(Succeed())
+	Expect(hit.Breakpoint.ID).To(Equal(resumedBP.ID),
+		"the first post-signal stop must prove the exact signaled thread resumed")
+	Expect(hit.Goroutine.Current).To(BeTrue(),
+		"signal-thread liveness stop fell back to a non-current goroutine")
+	Expect(hit.Goroutine.ThreadID).To(Equal(signalTID),
+		"the liveness breakpoint ran on TID %d, want directed signal TID %d",
+		hit.Goroutine.ThreadID, signalTID)
+	Expect(h.d.ClearBreakpoint(resumedBP.ID)).To(Succeed(),
+		"clear signal-thread liveness breakpoint")
+	Expect(os.WriteFile(stormPath, nil, 0o600)).To(Succeed(),
+		"start the hot-loop and stepped-thread SIGCONT workloads")
+	Expect(h.d.Continue()).To(Succeed(), "continue into the hot-loop overlap workload")
+	evt = p.await(30*time.Second,
+		protocol.EventBreakpointHit, protocol.EventProcessExited, protocol.EventError)
+	Expect(evt.Kind).To(Equal(protocol.EventBreakpointHit),
+		"hot-loop overlap workload did not stop: %s", evt.Payload)
+	p.record(evt, "after deterministic foreign signal", false)
+	return p, bpA.ID, bpB.ID, parkedSignalsBefore
+}
+
 // declareStepOverlapStepIntoSpec covers the machine-granularity step
 // (bpResumeStep) rather than the source-level step-over: StepInto off an armed
 // trap issues the same restore → single-step → reinstall dance, but suspends on
@@ -959,24 +1130,12 @@ func declareStepOverlapStepIntoSpec() {
 func declareStepOverlapSignalSpec() {
 	It("resumes the thread that stopped when a foreign signal lands mid-step",
 		Label("overlap"), func() {
-			p, bpA, bpB := setupOverlap("overlap_signal_target", overlapSignalTargetSrc)
-			parkedSignalsBefore, ok := debugger.LinuxParkedSignalCount(p.h.d)
-			Expect(ok).To(BeTrue(), "parked-signal hook unavailable")
+			p, bpA, bpB, parkedSignalsBefore := setupOverlapSignal()
 
 			iters := envInt("BINGO_E2E_OVERLAP_SIGNAL_ITERS", 40)
-			// Machine steps per cycle. A foreign signal is only *held* if it
-			// lands while a step is outstanding, and that window is a few tens
-			// of microseconds against a cycle time dominated by the storm
-			// itself — so the way to make the held-signal population reliable
-			// is to spend more of the run inside a step, not to storm harder
-			// (a faster storm costs a ptrace round-trip per signal and would
-			// dominate the runtime). A burst of machine steps multiplies the
-			// exposure for a per-step cost far below one cycle. Measured: 80
-			// cycles x 1 step gave 12 / 2 / 0 held signals across three native
-			// runs — the zero run is what made this necessary. 40 x 13 windows
-			// is ~6.5x the exposure at roughly the same wall time, since the
-			// halved cycle count pays for the steps: sizing is two-sided here,
-			// because every target self-exits on a 180s watchdog.
+			// Keep the machine-step burst and its existing watchdog envelope:
+			// besides the directed SIGUSR1 gate above, SIGCONT still exercises
+			// the stepped-thread re-arm path opportunistically across the run.
 			steps := envInt("BINGO_E2E_OVERLAP_SIGNAL_STEPS", 12)
 			for i := 0; i < iters; i++ {
 				where := fmt.Sprintf("cycle #%d", i)
@@ -1016,8 +1175,8 @@ func declareStepOverlapSignalSpec() {
 			Expect(p.h.d.ClearBreakpoint(bpA)).To(Succeed(), "ClearBreakpoint A after the run")
 			Expect(p.h.d.ClearBreakpoint(bpB)).To(Succeed(), "ClearBreakpoint B after the run")
 
-			// Non-vacuity: the signal storm must have reached the debugger,
-			// otherwise this ran as a plain overlap spec.
+			// Non-vacuity: the directed setup gate must have reached the
+			// debugger, otherwise this ran as a plain overlap spec.
 			Expect(p.signalOutputs).To(BeNumerically(">", 0),
 				"no signal stops were reported — the foreign-signal path was never exercised")
 
@@ -1052,8 +1211,8 @@ func declareStepOverlapSignalSpec() {
 			parkedSignals, ok := debugger.LinuxParkedSignalCount(p.h.d)
 			Expect(ok).To(BeTrue(), "parked-signal hook unavailable")
 			Expect(parkedSignals).To(BeNumerically(">", parkedSignalsBefore),
-				"no signal stop was ever held back across %d cycles x %d steps: "+
-					"the queued signal path was not exercised", iters, steps)
+				"the deterministic setup gate did not hold a signal stop behind "+
+					"its in-flight single-step")
 			// Liveness: threads are still making progress at the end of the
 			// run. A thread resumed while another was left stopped would drop
 			// out permanently, since every spinner is LockOSThread'd.


### PR DESCRIPTION
## Summary
- replace the probabilistic process-wide SIGUSR1 storm with a directed SIGUSR1 to a known locked foreign thread while a separate locked thread is single-stepping a blocked raw `nanosleep`
- gate competing SIGCONT/workers until the directed signal is parked, then prove the exact signaled TID resumes at a dedicated breakpoint
- retain exact signal-number, parked-signal, breakpoint integrity, late-progress, watchdog, and step-rearm coverage
- update the documented native regression-gate invariants

## Root cause
The target started six hot breakpoint workers before the signal goroutine. Under the failing hosted-runner schedule, ptrace repeatedly stopped those workers before the process-wide SIGUSR1 storm became runnable, so both attempts of run 31634568937 completed the full ~112s spec with zero signal stops. Increasing probabilistic exposure could not make that gate deterministic.

## Deterministic proof
Exact head `85719e28bacfe6a595b8d26aed59233d8d4f0e58` passed the native Linux ptrace job in run 31642225913. The overlap report recorded:
- signal stops: 1
- parked signal stops: 1
- signal values: `map[10:1]` (SIGUSR1, no signal 0)
- parked stops: 31
- step re-arms: 7
- goroutines observed: 6; still active in final quarter: 5
- all 9 overlap specs passed

The setup is mutation-sensitive: `StepInto` synchronously arms PTRACE_SINGLESTEP on a SIGURG-masked thread blocked in raw `nanosleep`; only then does the harness `tgkill` SIGUSR1 to a different known TID. The test requires the parked-signal counter to advance, the queued signal number to remain SIGUSR1, and that same locked TID to hit a post-forwarding breakpoint.

## Validation
- `go test -tags bingonative -race ./internal/debugger ./test/integration`
- `go vet -tags bingonative ./...`
- Linux/amd64 cross-build and test-binary compilation with `GOOS=linux GOARCH=amd64 CGO_ENABLED=0`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 golangci-lint run`
- `just e2e-darwin`: 22/22 passed on Apple Silicon at exact head
- exact-head native Linux ptrace, Linux full-stack, Darwin compile, Go, CodeQL, VS Code packaging, and Darwin policy/status checks all passed
- independent code review and rubber-duck review completed; all findings addressed

## Merge safety
Test/harness and invariant-documentation changes only; no production control-path semantics changed. The existing 40×12 overlap workload, 180s target watchdog, breakpoint integrity assertions, late-progress gate, and SIGCONT re-arm coverage remain intact. Draft only; do not merge as part of this task.