### PR TITLE
fix(debugger): route Linux waits by tracee owner

### DIFF
--- a/.github/workflows/debugger-e2e.yml
+++ b/.github/workflows/debugger-e2e.yml
@@ -119,9 +119,9 @@ jobs:
       - name: E2E current goroutine (bounded scan control)
         run: go test -tags e2e -race -count=1 -v -timeout 300s ./test/integration -ginkgo.label-filter=current-goroutine
 
-      # linux-only: Wait4(-1, WALL) is what lets a foreign thread's stop arrive
-      # mid-single-step (issue #199). The darwin receive loop parks stragglers
-      # itself, so the linux park queue has no counterpart to exercise there.
+      # linux-only: the routed any-thread status stream can deliver a foreign
+      # thread's stop mid-single-step (issue #199). The darwin receive loop
+      # parks stragglers itself, so the linux park queue has no counterpart.
       - name: E2E overlap (foreign-thread stop during a single-step)
         run: go test -tags e2e -race -count=1 -v -timeout 1800s ./test/integration -ginkgo.label-filter=overlap
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,11 +367,12 @@ anything in [internal/debugger/](internal/debugger/).
    ptrace is thread-bound on Linux, so the linux backend goes further: it owns
    a **dedicated tracer thread** (`tracerThread`) and funnels *every* ptrace
    control op through `execPtrace`, because they must issue from the exact
-   thread that forked/attached the tracee. `wait4` is the one exception — legal
-   from any thread of the tracer process, so `Wait` runs it directly off the
-   tracer thread. On Darwin there is no ptrace: the Mach calls run on the
-   engine-loop thread itself (Mach ports are task-wide). Mirrors Delve's
-   `execPtraceFunc`.
+   thread that forked/attached the tracee. Linux wait-status collection is the
+   one exception: `wait4` is not thread-bound, so the process-global
+   `linuxWaitBroker` owns it and routes exact-TID statuses to the backend that
+   registered them. The broker performs no ptrace control operations. On Darwin
+   there is no ptrace: the Mach calls run on the engine-loop thread itself (Mach
+   ports are task-wide). Mirrors Delve's `execPtraceFunc`.
 
 2. **`waitLoop` is a one-shot, locked goroutine.** Every time the process is
    resumed, a fresh `waitLoop` goroutine is started. It calls `Backend.Wait()`
@@ -383,12 +384,19 @@ anything in [internal/debugger/](internal/debugger/).
    arrives, the loop sets `stateExited`, calls `drainCmds` (answers queued
    commands with `ErrProcessExited` so blocked dispatchers unblock), then
    returns. The `defer` closes `done` (signals waitLoop to abandon pending
-   sends) and then `events` (signals hub no more events coming).
+   sends) and then `events` (signals hub no more events coming). On Linux,
+   closing the backend's wait owner drops consumer-facing queued stops but does
+   not unregister live TIDs: the process-global broker keeps exact ownership
+   until it reaps each final status. This is what lets a running Kill return
+   promptly without leaking zombies or leaving a stale waiter able to steal a
+   later session's initial stop.
 
 4. **`Kill` is idempotent and races-safe.** It checks `done` first (fast
    path), then dispatches a closure that injects a synthetic `StopExited`
    into `stopCh`. The main loop sees that, exits cleanly. Multiple concurrent
-   `Kill` callers share one teardown.
+   `Kill` callers share one teardown. A backend cleanup error is returned to the
+   caller but does not cancel that exit transition: teardown must still close
+   `done`, `events`, the tracer thread, and the Linux wait consumer.
 
 5. **`dispatch` is the only public-method pattern.** Send `engineCmd{fn,err}`
    on `cmdCh`, wait on `err`. If the loop has exited (`e.done` closed),
@@ -607,8 +615,9 @@ ptrace-stopped exactly where it is and is delivered from a FIFO queue on a later
 `Wait`, once the step has completed and the engine has reinstalled the trap it
 stepped off.
 
-Why it is needed (issue #199, linux only): `Wait` uses `Wait4(-1, …, WALL)`, so
-a sibling thread's `SIGTRAP` can surface in the middle of the
+Why it is needed (issue #199, linux only): the process-global wait broker can
+deliver any status owned by this debugger, so a sibling thread's `SIGTRAP` can
+surface in the middle of the
 restore→single-step→reinstall sequence, when the stepped-over trap bytes are out
 of the tracee and its entry is out of `bps` (see
 [step-over flow](#software-breakpoint-step-over-flow)). Handing that to the
@@ -697,9 +706,10 @@ acknowledgement in rule 5 (see the locking note below):
    The held owner is preferred when both exist. A **reaped** owner
    (`ws.Exited()`/`ws.Signaled()`) cannot be held — it is already gone — so that
    shape keeps the original lazy fallback: `stepExitPending` stays set, `Wait`
-   keeps blocking in `wait4`, and the first foreign stop to arrive parks (the
-   park condition includes `stepExitPending`) and supplies the anchor. Whole
-   process death still routes through the main thread and tears down as usual.
+   keeps blocking on its broker-owned queue, and the first foreign stop to arrive
+   parks (the park condition includes `stepExitPending`) and supplies the anchor.
+   Whole process death still routes through the main thread and tears down as
+   usual.
 
    `completeStepThreadExit` returns an error because that release is a real
    ptrace op. `ESRCH`/`ENOENT` is benign — the anchor was mid-exit and simply
@@ -905,15 +915,15 @@ acknowledgement in rule 5 (see the locking note below):
     `stopCh` error branch discards the tracee explicitly before returning:
     `endThreadStep`, `bps.clearAll` (restore the original bytes **first** — that
     is what makes the release safe), then `proc.kill(backend, running:false)`.
-    For a launched tracee `reapAfterKill` loops `Wait4(-1, WALL)` and continues
-    every thread it finds stopped, which discharges the parked stops and the
-    trigger stop; for an attached one the detach is safe because the traps are
-    already gone. `running` is false because the `waitLoop` that produced the
-    failure has already delivered its result, so `killProcess` is the sole
-    reaper (#111). Only these two branches carry the marker: ordinary `wait4`
-    failures deliberately keep their pre-existing behaviour, which still leaks a
-    detach-and-resume, and closing that generic class belongs with the
-    wait-ownership work (#205/#217).
+    For a launched tracee `reapAfterKill` drains only that backend's broker
+    queue and continues every owned thread it finds stopped, which discharges
+    the parked stops and the trigger stop; for an attached one the detach is
+    safe because the traps are already gone. `running` is false because the
+    `waitLoop` that produced the failure has already delivered its result, so
+    `killProcess` is the active consumer of those routed statuses (#111). Only
+    these two branches carry the marker: an ordinary wait failure deliberately
+    keeps its pre-existing detach-and-resume behaviour; fixing that generic
+    tracee-state cleanup class is separate from status ownership.
 
     The exec case inverts one step. `ErrImageReplaced` (which wraps
     `ErrSessionInvalidated`) suppresses the restore, because writing saved bytes
@@ -965,38 +975,35 @@ distinguish safe recovery from the mid-instruction path.
   parked sibling is never resumed at all. The queue, scripted-`Wait`, engine,
   and native raw-`SYS_exit` tests separately pin the gate, exact-TID anchor,
   breakpoint ownership, and real-kernel path for both anchor shapes.
-- **Kill ownership is unchanged, and no second reaper is added.** Killing a
-  *suspended* tracee still reaps through `reapAfterKill`, which loops
-  `Wait4(-1, WALL)` and resumes whatever it finds ptrace-stopped: a parked thread
-  — or a held anchor — is ptrace-stopped like any other and is indistinguishable
-  to that loop, so the queue costs it iterations, nothing more. Killing a
-  *running* tracee still
-  leaves reaping to the in-flight `waitLoop` (#111 forbids a second `wait4`
-  reaper here, and #205 is why a process-global one is dangerous in a shared
-  server). The one honest cost: because the drain runs before `wait4`, that
-  final `waitLoop` can return a held stop instead of blocking, so it absorbs
-  fewer thread deaths than it would have, leaving a few more unreaped statuses
-  until the tracer process exits. Bounded by the live thread count, the same P3
-  class as #217's unreaped leader, and it neither hangs nor wedges teardown —
-  `declareStepOverlapKillSpec` kills mid-step with stops held and requires both
-  `Kill` and the event-stream close to complete. Do not "fix" this with a purge
-  on kill: `purge` is `Wait`-owned (rule 6) and draining before blocking is what
-  makes a same-address sibling resolve after the reinstall (rule 3).
+- **Kill status ownership stays with the process-global broker.** Before
+  SIGKILL, the Linux backend registers every TID currently visible in
+  `/proc/<pid>/task`; it repeats the scan after the signal to close the clone
+  race. Killing a *suspended* tracee then runs `reapAfterKill`, which consumes
+  only that backend's routed statuses and resumes owned ptrace stops until the
+  broker retires every registered TID. A parked thread or held anchor costs it
+  iterations, but no other debugger or unrelated child can enter the queue.
+  Killing a *running* tracee leaves the existing engine `waitLoop` as the active
+  consumer while the engine exits; when the wait owner closes, the broker
+  silently continues exact-TID reaping until every registration is terminal.
+  Never add a competing raw waiter or unregister those TIDs at close: either
+  would recreate #205 or #217. `declareStepOverlapKillSpec` still requires both
+  Kill and event-stream close to complete with stops held.
 - **The `kill` label itself never exercises the queue.** `declareKillRunningSpec`
   sets no breakpoints — it launches, `Continue`s, and `Kill`s — so the engine
   never single-steps, `beginStep` is never called, nothing is ever parked, and
   `resumeFor` returns `resumeContinue` for every absorbed stop, which is the
-  pre-change `continueIfTraceeExists` verbatim. A failure in that label is
-  therefore not attributable to the queue. The one seen (native run
+  pre-change `continueIfTraceeExists` verbatim. A failure in that label was
+  therefore not attributable to the step queue. The one seen (native run
   `31344255645`) hung in `startTracedProcess`'s `Wait4(pid)` waiting for a *new*
-  tracee's execve stop, and is the pre-existing #205 hazard: `engine.Kill`
+  tracee's execve stop and confirmed the #205 hazard: `engine.Kill`
   injects a synthetic `StopExited`, so the loop can reach `stateExited` while the
   real `waitLoop` is still blocked in the process-global `Wait4(-1, WALL)`. That
   orphan absorbs the SIGKILLed threads' deaths, loops back, blocks again with no
   statuses left, and can then collect the *next* iteration's child exec stop
   before discovering `done` is closed and exiting — which is why no second
-  `wait4` frame survives in the timeout dump. Fixing it belongs with #205/#217,
-  not here.
+  `wait4` frame survives in the timeout dump. The exact-TID broker removes every
+  process-global consumer: launch, normal Wait, suspended Kill, and post-close
+  reaping all use one owner-routed status path.
 
 **No lock on the queue, and none is needed.** `parked` is touched only inside `Wait`.
 Successive `Wait` calls run on different one-shot `waitLoop` goroutines that the
@@ -1246,11 +1253,15 @@ arrive concurrently during requeue or the re-step may interleave. Preserving
 that provenance and delivery ordering requires the broader wait-ownership work,
 not a process-global pending-signal scalar in this layer.
 
-**Composition constraint for #205:** a future process-wide wait broker may own
-the raw `wait4`, but it must route the complete `(TID, signal)` status to the
-owning session/backend and preserve FIFO order. Pending signal state stays
-per-session and per-TID; it must not move into one process-global broker slot or
-be installed before the owning backend actually delivers the stop.
+**Composition constraint with the process-global wait broker:** the broker owns
+raw Linux `wait4`, but it routes the complete `(TID, WaitStatus)` only to the
+backend that registered that exact TID. Pending signal state stays per-session
+and per-TID; it must not move into one process-global slot or be installed before
+the owning backend actually delivers the stop. Clone ownership must be
+registered from `PTRACE_GETEVENTMSG` before the parent is resumed. Registrations
+survive consumer close until a final status or exact `ECHILD` retires them, so
+TID reuse cannot hand a stale status to a new debugger. The broker's generation
+check pins that last boundary.
 
 ## Architecture-specific traps
 
@@ -1384,9 +1395,11 @@ are detected by a `mach_msg` receive loop.
   (`tracerThread` / `execPtrace`) because ptrace is thread-bound: the initial
   fork/exec, attach, and every control op (`CONT` / `SINGLESTEP` /
   `GET`·`SETREGS` / `PEEK`·`POKEDATA` / `SETOPTIONS`) must originate from the
-  one thread that became the tracer. `wait4` runs off that thread (valid from
-  any tracer thread). Splitting the wait from the control ops was the original
-  step-over hang: cross-thread `PTRACE_SINGLESTEP` failed with `ESRCH`.
+  one thread that became the tracer. Wait-status collection does not: the
+  process-global `linuxWaitBroker` owns raw `wait4`, which is process-scoped but
+  not thread-bound. Splitting ptrace control across threads was the original
+  step-over hang: cross-thread `PTRACE_SINGLESTEP` failed with `ESRCH`; moving
+  only status collection is safe because the broker never issues ptrace.
 - `startTracedProcess` enables `PTRACE_O_TRACEEXIT | PTRACE_O_TRACEEXEC |
   PTRACE_O_TRACECLONE`. Clone tracing is set at the single-threaded execve stop
   so every later Go-runtime worker thread inherits it; without it a goroutine
@@ -1394,8 +1407,22 @@ are detected by a `mach_msg` receive loop.
   its breakpoint `SIGTRAP` to the Go runtime ("fatal: trace trap") instead of
   the tracer. Each new thread's initial `SIGSTOP` is resumed **individually** —
   never a group-continue, which would let a thread parked at a breakpoint run
-  away (the "parking the thread group" hazard).
-- `Wait` uses `Wait4(-1, …, WALL)` to receive events for any thread.
+  away (the "parking the thread group" hazard). The clone TID from
+  `PTRACE_GETEVENTMSG` is registered with the same wait owner **before** the
+  parent resumes, so its initial status cannot escape routing.
+- **One process-global exact-TID wait broker owns every Linux wait syscall.**
+  Each backend creates a wait owner and registers its root PID before consuming
+  the launch/attach stop; clone TIDs join that owner before resume. The broker
+  listens for SIGCHLD, scans only registered TIDs with
+  `Wait4(tid, WNOHANG|WALL)`, and uses a one-second fallback scan for a missed or
+  coalesced notification. It never calls `Wait4(-1, ...)` and therefore cannot
+  steal another debugger's status or reap an unrelated child. One live TID has
+  one owner; monotonically increasing registration generations prevent a scan
+  result for a retired TID from reaching a later owner after TID reuse. A closed
+  owner discards routed events but keeps registrations until final
+  `Exited`/`Signaled` or exact `ECHILD`, which closes the running-Kill and
+  natural-exit zombie leaks (#205/#217). Do not add another raw wait site.
+- `Wait` consumes its owner's routed statuses for any registered tracee thread.
   `PTRACE_EVENT_*` stops are absorbed (resumed and looped) and never surface
   to the engine — with two exceptions. The **main thread's**
   `PTRACE_EVENT_EXIT` is the one exit the engine needs, and
@@ -1444,38 +1471,33 @@ are detected by a `mach_msg` receive loop.
   `stepTID` (the exact TID `SingleStep` was issued against). Only a `cause==0`
   SIGTRAP on `stepTID` is the step's completion; the same stop on any other
   thread is that thread hitting an INT3 and is reported as a breakpoint. This
-  matters because `Wait4(-1, …)` can return a sibling thread's concurrent
+  matters because the owner queue can deliver a sibling thread's concurrent
   breakpoint (or SIGURG) while a step is in flight — keying off `stepping`
   alone would misclassify it and corrupt the engine's step-over state machine.
   Correct classification is necessary but not sufficient: a correctly-labelled
   foreign breakpoint handed to the engine mid-step is still corrupting, so `Wait`
   also **parks** it until the step completes — see
   [foreign-thread stop parking](#foreign-thread-stop-parking-during-a-single-step-linux).
-- **One live tracee per process.** `Wait4(-1, …, WALL)` is scoped to the whole
-  tracer *process*, not to one tracee, so two `Debugger`s running at once in the
-  same binary steal each other's stops — observed as `PTRACE_GETREGS` `ESRCH`
-  for a foreign tid and both backends wedging in `Kill`. Nothing filters by pid,
-  and adding a filter would break the deliberate any-thread wait. Tests must
-  therefore own exactly one tracee for its whole lifetime; an e2e spec that
-  needs a differently-configured target launches it in a spec of its own, after
-  the previous `DeferCleanup` has killed the last one.
+- **Multiple live tracees per process are supported.** Their ptrace controls
+  remain isolated on separate tracer threads and their statuses are isolated by
+  wait owners. A debugger may see only TIDs it registered; an unrelated child is
+  intentionally invisible and remains reapable by its creator. The
+  multisession E2E starts concurrent debuggers and requires both later initial
+  stops and independent natural exit codes, while the Kill E2E keeps an
+  unrelated child live across suspended teardown.
 - `g` pointer for goroutine inspection lives at `FS_BASE` on amd64.
-- `killProcess` never reaps the zombie itself while the engine's `waitLoop` is
-  in flight (a *running* tracee). That waitLoop is blocked in `Wait4(-1, WALL)`
-  and is the **sole** legitimate reaper: it absorbs every thread's SIGKILL death
-  and surfaces `StopKilled`. A second reaper in `killProcess` deadlocks Kill two
-  ways (#111): it races the waitLoop for the same stops, and — because a Go
-  tracee is always multi-threaded — `Wait4(pid)` targets only the thread-group
-  leader, whose zombie stays unreapable until every sibling is reaped, which
-  `killProcess` cannot do. So `killProcess` only reaps when the tracee was
-  **suspended** at a stop (no waitLoop), via `reapAfterKill`, which loops
-  `Wait4(-1, WALL)` (any thread, never the leader's pid), resuming any
-  ptrace-stopped thread so the pending process-wide SIGKILL kills it, until
-  `ECHILD`. The engine passes `running` (state == running) down through
-  `process.kill` to drive this. (Darwin has no such race — its `waitLoop` blocks
-  on a Mach port, not `wait4`, so its `killProcess` `Wait4(pid)` is always the
-  sole reaper and ignores `running`.) Regression guard: the `kill` e2e loops the
-  launch→run→Kill cycle (`BINGO_E2E_KILL_ITERS`).
+- `killProcess` first registers the visible thread group, sends SIGKILL, then
+  registers again to close a concurrent-clone race. For a suspended tracee,
+  `reapAfterKill` drains the same owner queue and continues owned stopped
+  threads until all registrations retire. For a running tracee, the in-flight
+  engine `waitLoop` remains the only active consumer (#111); after engine
+  shutdown closes that consumer, the broker silently reaps all remaining exact
+  TIDs. There is one raw reaper in both cases, so Kill neither races another
+  waiter nor leaves final zombies. (Darwin has no broker; its Mach wait loop and
+  targeted `wait4` reaping are unchanged.) Regression guards: the `kill` E2E
+  repeats launch→run→Kill (`BINGO_E2E_KILL_ITERS`), the suspended-Kill spec keeps
+  an unrelated child alive, and natural-exit specs require `/proc/<pid>` to
+  disappear.
 - `SIGURG` re-delivery is mandatory here too. A sibling SIGURG is re-delivered
   immediately on that sibling's continue. A SIGURG on `stepTID` consumes the
   outstanding step, so `applyAbsorb` reissues the instruction step with zero
@@ -3128,6 +3150,12 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   the state field — it starts no `waitLoop`, so a stop pushed after it is never
   consumed; reach `running` through a real `Continue` when a stop must be
   delivered. Engine tests are tagged-agnostic — they avoid native code paths.
+  On linux/amd64,
+  [waitbroker_linux_amd64_test.go](internal/debugger/waitbroker_linux_amd64_test.go)
+  drives the raw-wait seam deterministically: exact owner routing, unrelated
+  child isolation, a status pending before registration, final retirement,
+  generation-safe TID reuse, closed-owner reaping, cross-session initial stops,
+  and clone registration before parent resume.
 - `internal/hub`: `fakeDebugger` + `fakeWSConn` in [hub_test.go](internal/hub/hub_test.go).
   The fake conn uses a 256-deep `incoming` buffer so `WriteMessage` never
   blocks the hub event loop.
@@ -3148,9 +3176,12 @@ side `chan error` — every debugger outcome, failures included, rides the singl
   (StepInto crosses into a callee, StepOut returns to the caller), `inspect`
   (StackFrames chain + Locals + Goroutines at a breakpoint), `breakpoints`
   (a cleared breakpoint stops firing and an in-flight step-off reserves its
-  temporarily table-less address), `kill` (Kill terminates a
-  freely-running tracee), `exit` (EventProcessExited reports the tracee's real
-  exit code), `signals` (linux-only: fatal and ordinary signal forwarding plus
+  temporarily table-less address), `kill` (Kill terminates a freely-running
+  tracee; linux additionally kills a suspended tracee while an unrelated child
+  stays live and requires the tracee to be reaped), `exit` (EventProcessExited
+  reports the tracee's real exit code; linux additionally runs concurrent
+  sessions, routes each initial/final status to its owner, and requires natural
+  exits to disappear from `/proc`), `signals` (linux-only: fatal and ordinary signal forwarding plus
   the shared Pause-suppression control), `overlap` (linux-only: a foreign thread's breakpoint stop
   surfacing while another thread single-steps off a software breakpoint —
   issue #199), `attach` (attach by PID to an already-running tracee — one the

--- a/internal/debugger/backend_linux_amd64.go
+++ b/internal/debugger/backend_linux_amd64.go
@@ -3,6 +3,7 @@
 package debugger
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -11,12 +12,16 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
 
 func newBackend() Backend {
-	return &linuxBackend{tracer: newTracerThread()}
+	return &linuxBackend{
+		tracer: newTracerThread(),
+		waits:  processLinuxWaitBroker.newOwner(),
+	}
 }
 
 // tracerThread pins a single OS thread and runs every ptrace(2) control op on
@@ -100,6 +105,7 @@ type linuxBackend struct {
 
 	pid    int
 	tracer *tracerThread
+	waits  linuxWaitSource
 
 	// Wait writes this from a waitLoop while running engine commands may read it
 	// for TID-less memory operations. Atomicity defines that snapshot; it does
@@ -163,13 +169,22 @@ func (b *linuxBackend) eventMsg(tid int) (uint, error) {
 	return msg, err
 }
 
-// waitAny blocks for the next stop from any thread of the tracee. WALL includes
-// clone()d threads.
+// waitAny receives the next status owned by this debugger. Production statuses
+// come from the process-global exact-TID broker; tests can still script the
+// serialized Wait state machine directly.
 func (b *linuxBackend) waitAny(ws *syscall.WaitStatus) (int, error) {
 	if b.waitFn != nil {
 		return b.waitFn(ws)
 	}
-	return syscall.Wait4(-1, ws, syscall.WALL, nil)
+	if b.waits == nil {
+		return 0, syscall.ECHILD
+	}
+	result, err := b.waits.next(context.Background())
+	if err != nil {
+		return 0, err
+	}
+	*ws = result.status
+	return result.tid, nil
 }
 
 // drainParked returns the next held stop if one may be surfaced now, installing
@@ -276,6 +291,9 @@ func (b *linuxBackend) leaderExitPendingForTest() bool { return b.leaderExitStas
 func (b *linuxBackend) closeTracer() {
 	b.pendingSignals.purge()
 	b.tracer.close()
+	if b.waits != nil {
+		b.waits.close()
+	}
 }
 
 const linuxPtraceOptions = syscall.PTRACE_O_TRACEEXIT |
@@ -284,14 +302,15 @@ const linuxPtraceOptions = syscall.PTRACE_O_TRACEEXIT |
 
 // startTracedProcess forks under ptrace. The child is stopped at its first
 // instruction (execve SIGTRAP) ready for the engine to set breakpoints. The
-// fork+exec, the reap of the initial execve stop and PTRACE_SETOPTIONS all run
-// on the backend's dedicated tracer thread: the forking thread becomes the
-// tracee's tracer, so every later ptrace op must originate from that same
-// thread.
-func startTracedProcess(b Backend, binaryPath string, args []string, env []string) (int, *exec.Cmd, error) {
-	tracer, ok := b.(tracerExecer)
-	if !ok {
-		return 0, nil, fmt.Errorf("startTracedProcess: backend does not support a tracer thread")
+// fork+exec and PTRACE_SETOPTIONS run on the backend's dedicated tracer thread:
+// the forking thread becomes the tracee's tracer, so every later ptrace op must
+// originate from that same thread. The initial status is consumed outside the
+// tracer closure through the process-global wait broker; blocking the tracer
+// thread on a wait would prevent every later control operation.
+func startTracedProcess(b Backend, binaryPath string, args []string, env []string) (retPID int, retCmd *exec.Cmd, retErr error) {
+	lb, ok := b.(*linuxBackend)
+	if !ok || lb.tracer == nil || lb.waits == nil {
+		return 0, nil, fmt.Errorf("startTracedProcess: backend does not support Linux wait ownership")
 	}
 
 	// codeql-suppress[go/command-injection]: The debugger intentionally launches the local binary selected by the operator.
@@ -305,54 +324,101 @@ func startTracedProcess(b Backend, binaryPath string, args []string, env []strin
 	}
 
 	var startErr error
-	tracer.execPtrace(func() {
+	lb.execPtrace(func() {
 		if err := cmd.Start(); err != nil {
 			startErr = fmt.Errorf("exec %q: %w", binaryPath, err)
-			return
-		}
-		pid := cmd.Process.Pid
-		var ws syscall.WaitStatus
-		if _, err := syscall.Wait4(pid, &ws, 0, nil); err != nil {
-			_ = cmd.Process.Kill()
-			startErr = fmt.Errorf("wait for execve stop: %w", err)
-			return
-		}
-		if !ws.Stopped() || ws.StopSignal() != syscall.SIGTRAP {
-			_ = cmd.Process.Kill()
-			startErr = fmt.Errorf("unexpected initial stop: %v", ws)
-			return
-		}
-		if err := syscall.PtraceSetOptions(pid, linuxPtraceOptions); err != nil {
-			_ = cmd.Process.Kill()
-			startErr = fmt.Errorf("PTRACE_SETOPTIONS: %w", err)
-			return
 		}
 	})
 	if startErr != nil {
 		return 0, nil, startErr
 	}
 
-	return cmd.Process.Pid, cmd, nil
+	pid := cmd.Process.Pid
+	lb.setPID(pid)
+	if err := lb.waits.register(pid); err != nil {
+		_ = cmd.Process.Kill()
+		return 0, nil, fmt.Errorf("register initial tid %d: %w", pid, err)
+	}
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		killErr := cmd.Process.Kill()
+		if errors.Is(killErr, os.ErrProcessDone) || isNoSuchProcess(killErr) {
+			killErr = nil
+		}
+		reapErr := lb.reapAfterKill()
+		lb.setPID(0)
+		if cleanupErr := errors.Join(killErr, reapErr); cleanupErr != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("discard failed launch: %w", cleanupErr))
+		}
+	}()
+
+	var ws syscall.WaitStatus
+	if _, err := lb.waitAny(&ws); err != nil {
+		return 0, nil, fmt.Errorf("wait for execve stop: %w", err)
+	}
+	if !ws.Stopped() || ws.StopSignal() != syscall.SIGTRAP {
+		return 0, nil, fmt.Errorf("unexpected initial stop: %v", ws)
+	}
+
+	lb.execPtrace(func() {
+		if err := syscall.PtraceSetOptions(pid, linuxPtraceOptions); err != nil {
+			startErr = fmt.Errorf("PTRACE_SETOPTIONS: %w", err)
+		}
+	})
+	if startErr != nil {
+		return 0, nil, startErr
+	}
+	return pid, cmd, nil
 }
 
-func attachToProcess(b Backend, pid int) error {
-	tracer, ok := b.(tracerExecer)
-	if !ok {
-		return fmt.Errorf("attachToProcess: backend does not support a tracer thread")
+func attachToProcess(b Backend, pid int) (retErr error) {
+	lb, ok := b.(*linuxBackend)
+	if !ok || lb.tracer == nil || lb.waits == nil {
+		return fmt.Errorf("attachToProcess: backend does not support Linux wait ownership")
 	}
 	var attachErr error
-	tracer.execPtrace(func() {
+	attached := false
+	lb.execPtrace(func() {
 		if err := syscall.PtraceAttach(pid); err != nil {
 			attachErr = fmt.Errorf("PTRACE_ATTACH pid %d: %w", pid, err)
 			return
 		}
-		var ws syscall.WaitStatus
-		if _, err := syscall.Wait4(pid, &ws, 0, nil); err != nil {
-			attachErr = fmt.Errorf("wait after PTRACE_ATTACH: %w", err)
-			return
-		}
+		attached = true
 	})
-	return attachErr
+	if attachErr != nil {
+		return attachErr
+	}
+	success := false
+	defer func() {
+		if attached && !success {
+			var detachErr error
+			lb.execPtrace(func() {
+				if err := syscall.PtraceDetach(pid); err != nil && !isNoSuchProcess(err) {
+					detachErr = err
+				}
+			})
+			if detachErr != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("discard failed attach: %w", detachErr))
+			}
+			lb.setPID(0)
+		}
+	}()
+
+	lb.setPID(pid)
+	if err := lb.waits.register(pid); err != nil {
+		return fmt.Errorf("register attached tid %d: %w", pid, err)
+	}
+	var ws syscall.WaitStatus
+	if _, err := lb.waitAny(&ws); err != nil {
+		return fmt.Errorf("wait after PTRACE_ATTACH: %w", err)
+	}
+	if !ws.Stopped() {
+		return fmt.Errorf("unexpected attach status: %v", ws)
+	}
+	success = true
+	return nil
 }
 
 // killProcess terminates a launched tracee (SIGKILL) or detaches from an
@@ -366,27 +432,33 @@ func killProcess(b Backend, pid int, cmd *exec.Cmd, running bool) error {
 		lb.pendingSignals.purge()
 	}
 	if cmd != nil {
+		var cleanupErr error
+		if lb, ok := b.(*linuxBackend); ok {
+			if err := lb.registerThreadGroup(); err != nil && !isNoSuchProcess(err) {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("register thread group before kill: %w", err))
+			}
+		}
 		// SIGKILL via the OS handle is not a ptrace op, so it is safe from any
 		// thread and keeps Kill responsive even if the tracer thread is busy.
 		if err := cmd.Process.Kill(); err != nil && !isAlreadyExited(err) {
-			return err
+			return errors.Join(cleanupErr, err)
 		}
-		// Reaping the zombie belongs to the waitLoop whenever one is in flight
-		// (a running tracee). It is blocked in Wait4(-1, WALL) and will absorb
-		// every thread's SIGKILL death and surface StopKilled. A second reaper
-		// here would both (a) race that waitLoop for the same stops and (b) —
-		// since a Go tracee is always multi-threaded — never make progress:
-		// Wait4(pid) targets only the thread-group leader, whose zombie is not
-		// reapable until all siblings are, and killProcess cannot reach the
-		// siblings. Either way Kill wedges (the deadlock reported in #111). So
-		// only reap here when there is NO waitLoop — the tracee was suspended at
-		// a stop, making killProcess the sole reaper.
-		if !running {
-			if lb, ok := b.(*linuxBackend); ok {
-				lb.reapAfterKill()
+		if lb, ok := b.(*linuxBackend); ok {
+			if err := lb.registerThreadGroup(); err != nil && !isNoSuchProcess(err) {
+				cleanupErr = errors.Join(cleanupErr, fmt.Errorf("register thread group after kill: %w", err))
 			}
 		}
-		return nil
+		// A running tracee already has an engine waitLoop consuming this
+		// owner's routed queue. A suspended tracee does not, so Kill drains the
+		// same queue itself until the broker retires every exact TID.
+		if !running {
+			if lb, ok := b.(*linuxBackend); ok {
+				if err := lb.reapAfterKill(); err != nil {
+					cleanupErr = errors.Join(cleanupErr, err)
+				}
+			}
+		}
+		return cleanupErr
 	}
 	// Attached (not launched): detach, don't kill — we don't own the process.
 	// PTRACE_DETACH must run on the tracer thread.
@@ -398,37 +470,71 @@ func killProcess(b Backend, pid int, cmd *exec.Cmd, running bool) error {
 	return nil
 }
 
-// reapAfterKill drains a SIGKILL'd tracee that has no waitLoop to reap it (it
-// was suspended at a ptrace stop when killed). It waits on Wait4(-1) — any
-// thread — never Wait4(pid): a Go tracee is always multi-threaded and the
-// thread-group leader's zombie stays unreapable until every sibling thread is
-// reaped, so waiting on the leader's pid alone blocks forever. A thread frozen
-// at a ptrace stop (e.g. the breakpoint we were suspended at) will not proceed
-// to death until resumed, so continue any stopped thread before waiting again;
-// the process-wide SIGKILL then kills it. Returns once ECHILD reports the whole
-// thread group gone.
-//
-// It must never run concurrently with the engine's waitLoop: two Wait4(-1)
-// callers would steal each other's stops. killProcess guarantees that by only
-// invoking it when the tracee was not running (no waitLoop in flight).
-func (b *linuxBackend) reapAfterKill() {
+// reapAfterKill drains a SIGKILL'd tracee that has no engine waitLoop. Raw wait
+// ownership remains with the broker; this consumer only resumes owned stopped
+// TIDs until the broker has retired the exact registered set.
+func (b *linuxBackend) reapAfterKill() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	for {
-		var ws syscall.WaitStatus
-		wpid, err := syscall.Wait4(-1, &ws, syscall.WALL, nil)
+		if b.waits == nil {
+			return nil
+		}
+		result, err := b.waits.next(ctx)
 		switch {
 		case err == nil:
-			if ws.Stopped() {
-				_ = b.continueWithoutPendingSignals(wpid)
+			if result.status.Stopped() {
+				if result.status.StopSignal() == syscall.SIGTRAP &&
+					result.status.TrapCause() == syscall.PTRACE_EVENT_CLONE {
+					if err := b.registerClone(result.tid); err != nil {
+						return err
+					}
+				}
+				if err := b.continueWithoutPendingSignals(result.tid); err != nil {
+					return fmt.Errorf("resume killed tid %d: %w", result.tid, err)
+				}
 			}
-			// Exited/Signaled: that thread is reaped; loop for the rest.
 		case isNoChildProcess(err):
-			return // whole thread group reaped
-		case errors.Is(err, syscall.EINTR):
-			// interrupted by a signal; retry
+			return nil
+		case errors.Is(err, context.DeadlineExceeded):
+			return fmt.Errorf("timed out reaping killed process %d", b.pid)
 		default:
-			return // unexpected wait4 error: nothing left to reap
+			return fmt.Errorf("reap killed process %d: %w", b.pid, err)
 		}
 	}
+}
+
+func (b *linuxBackend) registerClone(parentTID int) error {
+	if b.waits == nil {
+		return nil
+	}
+	childTID, err := b.eventMsg(parentTID)
+	if err != nil {
+		return fmt.Errorf("%w: read cloned tid from parent %d: %v",
+			ErrSessionInvalidated, parentTID, err)
+	}
+	if err := b.waits.register(int(childTID)); err != nil {
+		return fmt.Errorf("%w: register cloned tid %d from parent %d: %v",
+			ErrSessionInvalidated, childTID, parentTID, err)
+	}
+	return nil
+}
+
+func (b *linuxBackend) registerThreadGroup() error {
+	if b.waits == nil || b.pid == 0 {
+		return nil
+	}
+	tids, err := b.Threads()
+	if err != nil {
+		return err
+	}
+	for _, tid := range tids {
+		if err := b.waits.register(tid); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func isAlreadyExited(err error) bool {
@@ -636,11 +742,10 @@ func (b *linuxBackend) Threads() ([]int, error) {
 // consumes it on resume; keeping it per TID prevents another stop from stealing
 // or clearing the signal.
 //
-// wait4 runs on the calling (waitLoop) thread, NOT the tracer thread: waiting
-// for a tracee is legal from any thread of the tracer process, and keeping it
-// off the tracer thread lets the engine issue control ops concurrently. Every
-// ptrace CONTROL op below, however, is funnelled through b.execPtrace so it
-// executes on the one thread the kernel accepts ptrace requests from.
+// The process-global broker collects wait statuses without occupying the tracer
+// thread, so the engine can issue control ops concurrently. Every ptrace CONTROL
+// op below is funnelled through b.execPtrace and executes on the one thread the
+// kernel accepts ptrace requests from.
 //
 //nolint:gocognit,gocyclo // The wait loop is one serialized ptrace state machine.
 func (b *linuxBackend) Wait() (StopEvent, error) {
@@ -708,6 +813,10 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 
 			switch cause {
 			case syscall.PTRACE_EVENT_CLONE:
+				if err := b.registerClone(tid); err != nil {
+					b.abortStep()
+					return StopEvent{}, err
+				}
 				if err := b.absorbStop(absorbClone, tid, 0); err != nil {
 					return StopEvent{}, fmt.Errorf("resume clone parent tid %d: %w", tid, err)
 				}
@@ -743,6 +852,12 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 				// or ECHILD) and retracted if an exec proves retirement.
 				msg, msgErr := b.eventMsg(tid)
 				b.noteLeaderExit(msg, msgErr == nil)
+				if err := b.registerThreadGroup(); err != nil && !isNoSuchProcess(err) {
+					b.abortStep()
+					return StopEvent{}, fmt.Errorf(
+						"%w: register threads while retiring leader tid %d: %v",
+						ErrSessionInvalidated, tid, err)
+				}
 				// Route the resume through the ordinary dying-thread absorb.
 				// The leader can be the thread under a single step, and a bare
 				// continue there consumes that step while stepping/stepTID stay
@@ -776,8 +891,8 @@ func (b *linuxBackend) Wait() (StopEvent, error) {
 				// The exec stop is deliberately NOT resumed here — the engine's
 				// discard reaps or detaches it, along with anything parked. Nor
 				// is startup affected: the launch path consumes its own execve
-				// stop in startTracedProcess's private Wait4 BEFORE enabling
-				// PTRACE_O_TRACEEXEC, and Restart runs on a brand-new debugger.
+				// stop through the broker BEFORE enabling PTRACE_O_TRACEEXEC,
+				// and Restart runs on a brand-new debugger.
 				formerTID, _ := b.eventMsg(tid)
 				retracted := b.retractLeaderExit()
 				b.pendingSignals.purge()

--- a/internal/debugger/backend_linux_amd64_test.go
+++ b/internal/debugger/backend_linux_amd64_test.go
@@ -2035,7 +2035,7 @@ func TestLinuxWaitClearsReusedTIDStateBeforeNewThreadResume(t *testing.T) {
 // resuming on an identity it cannot even establish.
 //
 // Startup is out of reach by construction and is not tested here: the launch
-// path consumes its own execve stop in startTracedProcess's private Wait4 before
+// path consumes its own execve stop through the wait broker before
 // PTRACE_O_TRACEEXEC is enabled, and the attach path installs no options at all.
 func TestLinuxWaitAlwaysFailsOnExec(t *testing.T) {
 	const (

--- a/internal/debugger/engine.go
+++ b/internal/debugger/engine.go
@@ -266,25 +266,22 @@ func (e *engine) Kill() error {
 		if e.getState() == stateExited {
 			return nil
 		}
-		// A running tracee has an in-flight waitLoop blocked in Wait4(-1); on
-		// linux that waitLoop — not killProcess — must reap the SIGKILL death,
-		// since two concurrent wait4 callers race and wedge Kill (#111). Capture
-		// whether we're running before endThreadStep/clearAll touch anything.
+		// A running tracee has an in-flight waitLoop consuming its broker-owned
+		// status queue; a suspended one needs killProcess to drain that queue.
+		// Capture the state before endThreadStep/clearAll touch anything.
 		running := e.getState() == stateRunning
 		// Release any threads held for an in-flight atomic step-over first, so
 		// a detach (attached-process Kill) never leaves them Mach-suspended.
 		e.endThreadStep()
 		e.clearAllBreakpoints()
-		if killErr := e.proc.kill(e.backend, running); killErr != nil {
-			return killErr
-		}
+		killErr := e.proc.kill(e.backend, running)
 		e.setState(stateExited)
 		// Inject a synthetic StopExited so the loop sees stateExited and exits.
 		select {
 		case e.stopCh <- stopResult{evt: StopEvent{Reason: StopExited}}:
 		default:
 		}
-		return nil
+		return killErr
 	})
 }
 
@@ -663,8 +660,8 @@ func (e *engine) loop() {
 }
 
 func (e *engine) waitLoop() {
-	// Lock to an OS thread: wait4 has per-thread semantics on some platforms
-	// and we don't want a thread carrying unrelated ptrace state.
+	// Backends may have thread-affine wait primitives even though Linux status
+	// collection now routes through a process-global broker.
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	evt, err := e.backend.Wait()
@@ -690,7 +687,8 @@ func (e *engine) waitLoop() {
 // kernel releases its remaining threads when the tracer thread closes.
 //
 // running is false because the waitLoop that produced this failure has already
-// delivered its result, so killProcess is the sole reaper (see #111).
+// delivered its result, so killProcess is the sole active consumer of the
+// broker-routed statuses (see #111).
 func (e *engine) discardTracee(restore bool) {
 	e.endThreadStep()
 	if restore {

--- a/internal/debugger/process.go
+++ b/internal/debugger/process.go
@@ -48,8 +48,8 @@ func (p *process) attach(b Backend, pid int) error {
 
 // kill terminates the tracee. The Backend argument lets platform kill paths run
 // PTRACE_DETACH on the tracer thread; the engine's Kill path also runs
-// bps.clearAll. running reports whether a waitLoop is in flight (a running
-// tracee), which the linux backend needs to decide who reaps the zombie.
+// bps.clearAll. running reports whether a waitLoop is already consuming the
+// Linux backend's routed status queue.
 func (p *process) kill(b Backend, running bool) error {
 	if !p.live {
 		return nil

--- a/internal/debugger/sigurg_step_e2e_linux_amd64_test.go
+++ b/internal/debugger/sigurg_step_e2e_linux_amd64_test.go
@@ -114,7 +114,7 @@ func startSteppingSIGURGTracee(t *testing.T, binary string) *steppingSIGURGTrace
 func (p *steppingSIGURGTracee) cleanup() {
 	if !p.finished {
 		_ = p.cmd.Process.Kill()
-		p.backend.reapAfterKill()
+		_ = p.backend.reapAfterKill()
 	}
 	p.backend.closeTracer()
 }

--- a/internal/debugger/waitbroker_linux_amd64.go
+++ b/internal/debugger/waitbroker_linux_amd64.go
@@ -1,0 +1,311 @@
+//go:build linux && amd64
+
+package debugger
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+const linuxWaitFallbackInterval = time.Second
+
+type linuxWaitResult struct {
+	tid    int
+	status syscall.WaitStatus
+	err    error
+}
+
+type linuxWaitSource interface {
+	register(tid int) error
+	next(context.Context) (linuxWaitResult, error)
+	close()
+}
+
+type linuxWait4Func func(pid int, status *syscall.WaitStatus, options int, rusage *syscall.Rusage) (int, error)
+
+type linuxWaitRegistration struct {
+	owner      *linuxWaitOwner
+	generation uint64
+}
+
+// linuxWaitBroker is the process-wide owner of Linux wait syscalls. SIGCHLD
+// triggers exact registered-TID scans, so one debugger can never consume
+// another debugger's stop or the status of an unrelated child.
+type linuxWaitBroker struct {
+	mu             sync.Mutex
+	registrations  map[int]linuxWaitRegistration
+	nextGeneration atomic.Uint64
+	wait4          linuxWait4Func
+	wake           chan struct{}
+	sigchld        chan os.Signal
+}
+
+type linuxWaitOwner struct {
+	broker *linuxWaitBroker
+
+	mu         sync.Mutex
+	registered map[int]uint64
+	queue      []linuxWaitResult
+	closed     bool
+	notify     chan struct{}
+}
+
+var processLinuxWaitBroker = newLinuxWaitBroker(syscall.Wait4)
+
+func newLinuxWaitBroker(wait4 linuxWait4Func) *linuxWaitBroker {
+	return newLinuxWaitBrokerWithRunner(wait4, true)
+}
+
+func newLinuxWaitBrokerWithRunner(wait4 linuxWait4Func, run bool) *linuxWaitBroker {
+	b := &linuxWaitBroker{
+		registrations: make(map[int]linuxWaitRegistration),
+		wait4:         wait4,
+		wake:          make(chan struct{}, 1),
+		sigchld:       make(chan os.Signal, 1),
+	}
+	if run {
+		signal.Notify(b.sigchld, syscall.SIGCHLD)
+		go b.run()
+	}
+	return b
+}
+
+func (b *linuxWaitBroker) newOwner() *linuxWaitOwner {
+	return &linuxWaitOwner{
+		broker:     b,
+		registered: make(map[int]uint64),
+		notify:     make(chan struct{}, 1),
+	}
+}
+
+func (o *linuxWaitOwner) register(tid int) error {
+	if tid <= 0 {
+		return fmt.Errorf("invalid tid %d", tid)
+	}
+
+	b := o.broker
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if current, ok := b.registrations[tid]; ok {
+		if current.owner == o {
+			return nil
+		}
+		current.owner.mu.Lock()
+		stale := current.owner.closed
+		if stale {
+			delete(current.owner.registered, tid)
+			current.owner.signalLocked()
+		}
+		current.owner.mu.Unlock()
+		if !stale {
+			return fmt.Errorf("tid %d is already owned by another debugger", tid)
+		}
+	}
+
+	generation := b.nextGeneration.Add(1)
+	o.mu.Lock()
+	if o.closed {
+		o.mu.Unlock()
+		return fmt.Errorf("wait owner is closed")
+	}
+	o.registered[tid] = generation
+	o.signalLocked()
+	o.mu.Unlock()
+	b.registrations[tid] = linuxWaitRegistration{owner: o, generation: generation}
+	b.signal()
+	return nil
+}
+
+func (o *linuxWaitOwner) next(ctx context.Context) (linuxWaitResult, error) {
+	for {
+		o.mu.Lock()
+		switch {
+		case len(o.queue) > 0:
+			result := o.queue[0]
+			o.queue[0] = linuxWaitResult{}
+			o.queue = o.queue[1:]
+			o.mu.Unlock()
+			if result.err != nil {
+				return linuxWaitResult{}, result.err
+			}
+			return result, nil
+		case o.closed:
+			o.mu.Unlock()
+			return linuxWaitResult{}, syscall.ECHILD
+		case len(o.registered) == 0:
+			o.mu.Unlock()
+			return linuxWaitResult{}, syscall.ECHILD
+		}
+		o.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return linuxWaitResult{}, ctx.Err()
+		case <-o.notify:
+		}
+	}
+}
+
+func (o *linuxWaitOwner) close() {
+	o.mu.Lock()
+	o.closed = true
+	o.queue = nil
+	o.signalLocked()
+	o.mu.Unlock()
+	o.broker.signal()
+}
+
+func (o *linuxWaitOwner) signalLocked() {
+	select {
+	case o.notify <- struct{}{}:
+	default:
+	}
+}
+
+func (b *linuxWaitBroker) signal() {
+	select {
+	case b.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (b *linuxWaitBroker) run() {
+	timer := time.NewTimer(time.Hour)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	defer timer.Stop()
+
+	for {
+		if b.scan() {
+			continue
+		}
+
+		if b.registrationCount() == 0 {
+			<-b.wake
+			continue
+		}
+
+		timer.Reset(linuxWaitFallbackInterval)
+		select {
+		case <-b.wake:
+			if !timer.Stop() {
+				<-timer.C
+			}
+		case <-b.sigchld:
+			if !timer.Stop() {
+				<-timer.C
+			}
+		case <-timer.C:
+		}
+	}
+}
+
+func (b *linuxWaitBroker) registrationCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.registrations)
+}
+
+func (b *linuxWaitBroker) snapshot() []struct {
+	tid int
+	reg linuxWaitRegistration
+} {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	snapshot := make([]struct {
+		tid int
+		reg linuxWaitRegistration
+	}, 0, len(b.registrations))
+	for tid, reg := range b.registrations {
+		snapshot = append(snapshot, struct {
+			tid int
+			reg linuxWaitRegistration
+		}{tid: tid, reg: reg})
+	}
+	sort.Slice(snapshot, func(i, j int) bool { return snapshot[i].tid < snapshot[j].tid })
+	return snapshot
+}
+
+// scan is separated from run so deterministic tests can drive one broker pass
+// without timing against its polling goroutine.
+func (b *linuxWaitBroker) scan() bool {
+	progressed := false
+	for _, item := range b.snapshot() {
+		var status syscall.WaitStatus
+		tid, err := b.wait4(item.tid, &status, syscall.WNOHANG|syscall.WALL, nil)
+		switch {
+		case err == nil && tid == 0:
+			continue
+		case err == nil:
+			progressed = true
+			b.deliver(item.tid, item.reg, linuxWaitResult{tid: tid, status: status},
+				status.Exited() || status.Signaled())
+		case errors.Is(err, syscall.EINTR):
+			progressed = true
+		case errors.Is(err, syscall.ECHILD):
+			progressed = true
+			b.retire(item.tid, item.reg)
+		default:
+			progressed = true
+			b.deliver(item.tid, item.reg, linuxWaitResult{
+				tid: item.tid,
+				err: fmt.Errorf("wait4 tid %d: %w", item.tid, err),
+			}, true)
+		}
+	}
+	return progressed
+}
+
+func (b *linuxWaitBroker) deliver(tid int, expected linuxWaitRegistration, result linuxWaitResult, terminal bool) {
+	b.mu.Lock()
+	current, ok := b.registrations[tid]
+	if !ok || current != expected {
+		b.mu.Unlock()
+		return
+	}
+	if terminal {
+		delete(b.registrations, tid)
+	}
+
+	owner := current.owner
+	owner.mu.Lock()
+	if terminal && owner.registered[tid] == current.generation {
+		delete(owner.registered, tid)
+	}
+	if !owner.closed {
+		owner.queue = append(owner.queue, result)
+	}
+	owner.signalLocked()
+	owner.mu.Unlock()
+	b.mu.Unlock()
+}
+
+func (b *linuxWaitBroker) retire(tid int, expected linuxWaitRegistration) {
+	b.mu.Lock()
+	current, ok := b.registrations[tid]
+	if !ok || current != expected {
+		b.mu.Unlock()
+		return
+	}
+	delete(b.registrations, tid)
+
+	owner := current.owner
+	owner.mu.Lock()
+	if owner.registered[tid] == current.generation {
+		delete(owner.registered, tid)
+	}
+	owner.signalLocked()
+	owner.mu.Unlock()
+	b.mu.Unlock()
+}

--- a/internal/debugger/waitbroker_linux_amd64_test.go
+++ b/internal/debugger/waitbroker_linux_amd64_test.go
@@ -1,0 +1,319 @@
+//go:build linux && amd64
+
+package debugger
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type scriptedExactWait4 struct {
+	mu      sync.Mutex
+	pending map[int][]syscall.WaitStatus
+	calls   []int
+}
+
+func newScriptedExactWait4() *scriptedExactWait4 {
+	return &scriptedExactWait4{pending: make(map[int][]syscall.WaitStatus)}
+}
+
+func (s *scriptedExactWait4) add(tid int, statuses ...syscall.WaitStatus) {
+	s.mu.Lock()
+	s.pending[tid] = append(s.pending[tid], statuses...)
+	s.mu.Unlock()
+}
+
+func (s *scriptedExactWait4) wait4(tid int, status *syscall.WaitStatus, options int, _ *syscall.Rusage) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, tid)
+	if options != syscall.WNOHANG|syscall.WALL {
+		return 0, fmt.Errorf("options = %x", options)
+	}
+	if len(s.pending[tid]) == 0 {
+		return 0, nil
+	}
+	*status = s.pending[tid][0]
+	s.pending[tid] = s.pending[tid][1:]
+	return tid, nil
+}
+
+func nextBrokerResult(t *testing.T, owner *linuxWaitOwner) linuxWaitResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	result, err := owner.next(ctx)
+	if err != nil {
+		t.Fatalf("next() error = %v", err)
+	}
+	return result
+}
+
+func TestLinuxWaitBrokerRoutesExactTIDsWithoutConsumingUnrelatedChildren(t *testing.T) {
+	const (
+		firstTID     = 11001
+		secondTID    = 11002
+		unrelatedTID = 11003
+	)
+	wait4 := newScriptedExactWait4()
+	wait4.add(firstTID, stoppedAt(syscall.SIGTRAP, 0))
+	wait4.add(secondTID, stoppedAt(syscall.SIGUSR1, 0))
+	wait4.add(unrelatedTID, exitedWith(77))
+
+	broker := newLinuxWaitBrokerWithRunner(wait4.wait4, false)
+	first := broker.newOwner()
+	second := broker.newOwner()
+	if err := first.register(firstTID); err != nil {
+		t.Fatal(err)
+	}
+	if err := second.register(secondTID); err != nil {
+		t.Fatal(err)
+	}
+
+	if !broker.scan() {
+		t.Fatal("scan reported no progress")
+	}
+	if got := nextBrokerResult(t, first); got.tid != firstTID {
+		t.Fatalf("first owner received tid %d, want %d", got.tid, firstTID)
+	}
+	if got := nextBrokerResult(t, second); got.tid != secondTID {
+		t.Fatalf("second owner received tid %d, want %d", got.tid, secondTID)
+	}
+
+	wait4.mu.Lock()
+	calls := append([]int(nil), wait4.calls...)
+	unrelated := append([]syscall.WaitStatus(nil), wait4.pending[unrelatedTID]...)
+	wait4.mu.Unlock()
+	if !reflect.DeepEqual(calls, []int{firstTID, secondTID}) {
+		t.Fatalf("wait4 targets = %v, want only registered tids", calls)
+	}
+	if len(unrelated) != 1 || unrelated[0].ExitStatus() != 77 {
+		t.Fatalf("unrelated child status was consumed: %v", unrelated)
+	}
+}
+
+func TestLinuxWaitBrokerClaimsAStatusThatPredatesRegistration(t *testing.T) {
+	const tid = 11101
+	wait4 := newScriptedExactWait4()
+	wait4.add(tid, stoppedAt(syscall.SIGTRAP, 0))
+
+	broker := newLinuxWaitBrokerWithRunner(wait4.wait4, false)
+	owner := broker.newOwner()
+	if err := owner.register(tid); err != nil {
+		t.Fatal(err)
+	}
+	broker.scan()
+
+	result := nextBrokerResult(t, owner)
+	if result.tid != tid || !result.status.Stopped() {
+		t.Fatalf("result = %+v, want pending initial stop for tid %d", result, tid)
+	}
+}
+
+func TestLinuxWaitBrokerRetiresOnlyAfterTheFinalStatus(t *testing.T) {
+	const tid = 11201
+	wait4 := newScriptedExactWait4()
+	wait4.add(tid,
+		stoppedAt(syscall.SIGTRAP, syscall.PTRACE_EVENT_EXIT),
+		exitedWith(31),
+	)
+	broker := newLinuxWaitBrokerWithRunner(wait4.wait4, false)
+	owner := broker.newOwner()
+	if err := owner.register(tid); err != nil {
+		t.Fatal(err)
+	}
+
+	broker.scan()
+	first := nextBrokerResult(t, owner)
+	if first.status.TrapCause() != syscall.PTRACE_EVENT_EXIT {
+		t.Fatalf("first status = %v, want PTRACE_EVENT_EXIT", first.status)
+	}
+	if broker.registrationCount() != 1 {
+		t.Fatal("an event-exit stop retired the TID before its final wait status")
+	}
+
+	broker.scan()
+	final := nextBrokerResult(t, owner)
+	if !final.status.Exited() || final.status.ExitStatus() != 31 {
+		t.Fatalf("final status = %v, want exit 31", final.status)
+	}
+	if broker.registrationCount() != 0 {
+		t.Fatal("final status did not retire the TID")
+	}
+	if _, err := owner.next(context.Background()); !errors.Is(err, syscall.ECHILD) {
+		t.Fatalf("next after retirement = %v, want ECHILD", err)
+	}
+}
+
+func TestLinuxWaitBrokerRejectsLiveCrossOwnerAliasingAndAllowsReuseAfterRetirement(t *testing.T) {
+	const tid = 11301
+	wait4 := newScriptedExactWait4()
+	broker := newLinuxWaitBrokerWithRunner(wait4.wait4, false)
+	first := broker.newOwner()
+	second := broker.newOwner()
+	if err := first.register(tid); err != nil {
+		t.Fatal(err)
+	}
+	if err := second.register(tid); err == nil {
+		t.Fatal("second owner registered a live TID already owned by the first")
+	}
+
+	wait4.add(tid, exitedWith(0))
+	broker.scan()
+	_ = nextBrokerResult(t, first)
+	if err := second.register(tid); err != nil {
+		t.Fatalf("register reused tid after retirement: %v", err)
+	}
+}
+
+func TestLinuxWaitBrokerKeepsReapingAfterItsConsumerCloses(t *testing.T) {
+	const tid = 11401
+	wait4 := newScriptedExactWait4()
+	broker := newLinuxWaitBrokerWithRunner(wait4.wait4, false)
+	owner := broker.newOwner()
+	if err := owner.register(tid); err != nil {
+		t.Fatal(err)
+	}
+	owner.close()
+	wait4.add(tid, signaledBy(syscall.SIGKILL))
+	broker.scan()
+
+	if broker.registrationCount() != 0 {
+		t.Fatal("closed owner abandoned a final status instead of reaping it")
+	}
+}
+
+func TestLinuxWaitBrokerClosedOwnerCannotStealALaterInitialStop(t *testing.T) {
+	const (
+		retiringTID = 11411
+		newTID      = 11412
+	)
+	wait4 := newScriptedExactWait4()
+	broker := newLinuxWaitBrokerWithRunner(wait4.wait4, false)
+	retiring := broker.newOwner()
+	next := broker.newOwner()
+	if err := retiring.register(retiringTID); err != nil {
+		t.Fatal(err)
+	}
+	retiring.close()
+	if err := next.register(newTID); err != nil {
+		t.Fatal(err)
+	}
+	wait4.add(newTID, stoppedAt(syscall.SIGTRAP, 0))
+
+	broker.scan()
+	result := nextBrokerResult(t, next)
+	if result.tid != newTID || !result.status.Stopped() {
+		t.Fatalf("new owner result = %+v, want initial stop for tid %d", result, newTID)
+	}
+
+	wait4.mu.Lock()
+	calls := append([]int(nil), wait4.calls...)
+	wait4.mu.Unlock()
+	if !reflect.DeepEqual(calls, []int{retiringTID, newTID}) {
+		t.Fatalf("wait4 targets = %v, want exact retiring and new tids", calls)
+	}
+}
+
+type recordingWaitSource struct {
+	events  *[]string
+	results []linuxWaitResult
+}
+
+func (s *recordingWaitSource) register(tid int) error {
+	*s.events = append(*s.events, fmt.Sprintf("register %d", tid))
+	return nil
+}
+
+func (s *recordingWaitSource) next(context.Context) (linuxWaitResult, error) {
+	if len(s.results) == 0 {
+		return linuxWaitResult{}, syscall.ECHILD
+	}
+	result := s.results[0]
+	s.results = s.results[1:]
+	return result, nil
+}
+
+func (*recordingWaitSource) close() {}
+
+func TestLinuxWaitRegistersACloneBeforeResumingItsParent(t *testing.T) {
+	const (
+		parent = 11501
+		child  = 11502
+	)
+	var events []string
+	source := &recordingWaitSource{events: &events}
+	b := &linuxBackend{
+		pid:   parent,
+		waits: source,
+		eventMsgFn: func(int) (uint, error) {
+			return child, nil
+		},
+		contFn: func(tid, _ int) error {
+			events = append(events, fmt.Sprintf("continue %d", tid))
+			return nil
+		},
+	}
+	script := &scriptedWait{stops: []scriptedStop{
+		{tid: parent, status: stoppedAt(syscall.SIGTRAP, syscall.PTRACE_EVENT_CLONE)},
+		{tid: parent, status: exitedWith(0)},
+	}}
+	b.waitFn = func(status *syscall.WaitStatus) (int, error) {
+		if script.next >= len(script.stops) {
+			return 0, syscall.ECHILD
+		}
+		stop := script.stops[script.next]
+		script.next++
+		*status = stop.status
+		return stop.tid, nil
+	}
+
+	if _, err := b.Wait(); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	want := []string{"register 11502", "continue 11501"}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %v, want %v", events, want)
+	}
+}
+
+func TestLinuxSuspendedKillDrainsOwnedStopsAndRegistersLateClones(t *testing.T) {
+	const (
+		parent = 11601
+		child  = 11602
+	)
+	var events []string
+	source := &recordingWaitSource{
+		events: &events,
+		results: []linuxWaitResult{
+			{tid: parent, status: stoppedAt(syscall.SIGTRAP, syscall.PTRACE_EVENT_CLONE)},
+			{tid: child, status: signaledBy(syscall.SIGKILL)},
+			{tid: parent, status: signaledBy(syscall.SIGKILL)},
+		},
+	}
+	b := &linuxBackend{
+		pid:   parent,
+		waits: source,
+		eventMsgFn: func(int) (uint, error) {
+			return child, nil
+		},
+		contFn: func(tid, _ int) error {
+			events = append(events, fmt.Sprintf("continue %d", tid))
+			return nil
+		},
+	}
+
+	if err := b.reapAfterKill(); err != nil {
+		t.Fatalf("reapAfterKill() error = %v", err)
+	}
+	want := []string{"register 11602", "continue 11601"}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %v, want %v", events, want)
+	}
+}

--- a/internal/debugger/waitpark.go
+++ b/internal/debugger/waitpark.go
@@ -61,10 +61,10 @@ func classifyUserStop(trap, stepping bool, stepTID, tid int) (StopReason, stopDi
 }
 
 // stepQueue is the single-step bookkeeping plus the stops held back because of
-// it. A backend whose wait primitive reports stops for ANY thread (linux
-// Wait4(-1, …, WALL)) must not hand the engine a stop from a thread other than
-// the one it is stepping; those stops are queued here instead and released once
-// the step has completed.
+// it. A backend whose wait stream reports stops for ANY owned thread (linux)
+// must not hand the engine a stop from a thread other than the one it is
+// stepping; those stops are queued here instead and released once the step has
+// completed.
 //
 // It is deliberately platform-neutral and free of any backend dependency so the
 // ordering and gating rules are unit-testable without a tracee. It carries NO

--- a/test/integration/debugger_e2e_common_test.go
+++ b/test/integration/debugger_e2e_common_test.go
@@ -935,11 +935,10 @@ func declareKillRunningSpec() {
 	It("kills a running process", Label("kill"), func() {
 		bin := buildTarget("kill_target", basicTargetSrc)
 
-		// Repeat the launch→run→Kill cycle. Killing a running tracee reaps it
-		// from the engine loop while a waitLoop concurrently reaps via
-		// Wait4(-1); the losing reaper must return promptly (ECHILD) rather than
-		// wedge Kill. That is a timing race, so a single kill only catches a
-		// regression intermittently — loop to make the reap path deterministic.
+		// Repeat the launch→run→Kill cycle. A running Kill closes the engine
+		// before every terminal status necessarily arrives; the process-global
+		// broker must keep reaping that owner's exact TIDs without letting the
+		// closed session consume the next launch's initial stop.
 		iters := envInt("BINGO_E2E_KILL_ITERS", 20)
 		for i := 0; i < iters; i++ {
 			h := newE2EHarness(bin)
@@ -952,8 +951,8 @@ func declareKillRunningSpec() {
 
 			Expect(h.d.Kill()).To(Succeed(), "Kill running process (iter %d)", i)
 			// Kill tears the engine down; which signal surfaces depends on which
-			// stop wins the race inside the loop. On linux the real wait4 exit
-			// typically arrives as ErrProcessExited and the loop emits
+			// stop wins the race inside the loop. On linux the routed terminal
+			// status typically arrives as ErrProcessExited and the loop emits
 			// EventProcessExited before closing; on darwin the synthetic
 			// StopExited injected by Kill wins and the loop returns straight to
 			// its deferred close(events) with no explicit exit event (see

--- a/test/integration/debugger_e2e_linux_amd64_test.go
+++ b/test/integration/debugger_e2e_linux_amd64_test.go
@@ -56,9 +56,176 @@ var _ = Describe("Linux amd64 debugger backend (ptrace) E2E", Label("linux"), fu
 	declareStepOwnerExitSpec()
 	declareStepOwnerHoldSpec()
 	declareLeaderRetirementSpec()
+	declareLinuxWaitOwnershipSpecs()
 })
 
 const signalTargetExitOK = 43
+
+const waitOwnershipExitTargetSrc = `package main
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+func main() {
+	_ = os.WriteFile(os.Args[1], []byte(strconv.Itoa(os.Getpid())), 0o600)
+	delay, _ := strconv.Atoi(os.Args[2])
+	code, _ := strconv.Atoi(os.Args[3])
+	time.Sleep(time.Duration(delay) * time.Millisecond)
+	os.Exit(code)
+}
+`
+
+func declareLinuxWaitOwnershipSpecs() {
+	It("kills a suspended tracee without waiting on an unrelated live child",
+		Label("kill"), func() {
+			bin := buildTarget("wait_owner_unrelated", basicTargetSrc)
+			unrelated := exec.Command(bin)
+			Expect(unrelated.Start()).To(Succeed(), "start unrelated child")
+			DeferCleanup(func() {
+				_ = unrelated.Process.Kill()
+				_ = unrelated.Wait()
+			})
+
+			before := directChildPIDs()
+			d := debugger.New(nil)
+			DeferCleanup(func() {
+				done := make(chan struct{})
+				go func() {
+					_ = d.Kill()
+					close(done)
+				}()
+				select {
+				case <-done:
+				case <-time.After(5 * time.Second):
+				}
+			})
+			Expect(d.Launch(bin, nil, nil)).To(Succeed(), "launch suspended tracee")
+			awaitEvent(d.Events(), 15*time.Second, protocol.EventStepped)
+
+			added := addedPIDs(before, directChildPIDs())
+			Expect(added).To(HaveLen(1), "identify the debugger-owned child")
+			traceePID := added[0]
+
+			killDone := make(chan error, 1)
+			go func() { killDone <- d.Kill() }()
+			select {
+			case err := <-killDone:
+				Expect(err).NotTo(HaveOccurred(), "kill suspended tracee")
+			case <-time.After(15 * time.Second):
+				Fail("Kill waited on an unrelated live child")
+			}
+
+			Eventually(func() bool { return !processExists(traceePID) }, 10*time.Second, 20*time.Millisecond).
+				Should(BeTrue(), "the debugger-owned tracee must be reaped")
+			Expect(syscall.Kill(unrelated.Process.Pid, 0)).To(Succeed(),
+				"killing one debugger session must not consume or terminate an unrelated child")
+		})
+
+	It("routes concurrent initial stops and natural exits to their owning sessions",
+		Label("exit"), func() {
+			bin := buildTarget("wait_owner_exit", waitOwnershipExitTargetSrc)
+			dir := GinkgoT().TempDir()
+
+			const sessions = 4
+			type liveSession struct {
+				debugger debugger.Debugger
+				pid      int
+				exitCode int
+			}
+			live := make([]liveSession, 0, sessions)
+			DeferCleanup(func() {
+				for _, session := range live {
+					_ = session.debugger.Kill()
+				}
+			})
+
+			for i := 0; i < sessions; i++ {
+				pidFile := filepath.Join(dir, fmt.Sprintf("session-%d.pid", i))
+				exitCode := 50 + i
+				d := debugger.New(nil)
+				args := []string{pidFile, strconv.Itoa(1500 + i*250), strconv.Itoa(exitCode)}
+				Expect(d.Launch(bin, args, nil)).To(Succeed(),
+					"session %d initial stop must not be stolen by an earlier running session", i)
+				awaitEvent(d.Events(), 15*time.Second, protocol.EventStepped)
+				Expect(d.Continue()).To(Succeed(), "continue session %d", i)
+				Eventually(func() bool { return pathExists(pidFile) }, 5*time.Second, 20*time.Millisecond).
+					Should(BeTrue(), "session %d target must publish its PID", i)
+				raw, err := os.ReadFile(pidFile)
+				Expect(err).NotTo(HaveOccurred(), "read session %d PID", i)
+				pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+				Expect(err).NotTo(HaveOccurred(), "parse session %d PID", i)
+				live = append(live, liveSession{debugger: d, pid: pid, exitCode: exitCode})
+			}
+
+			for i, session := range live {
+				evt := awaitEvent(session.debugger.Events(), 20*time.Second,
+					protocol.EventProcessExited, protocol.EventError)
+				Expect(evt.Kind).To(Equal(protocol.EventProcessExited),
+					"session %d must receive its own natural exit, got %s: %s", i, evt.Kind, evt.Payload)
+				var payload protocol.ProcessExitedPayload
+				Expect(json.Unmarshal(evt.Payload, &payload)).To(Succeed(), "decode session %d exit", i)
+				Expect(payload.ExitCode).To(Equal(session.exitCode),
+					"session %d received another tracee's status", i)
+				Eventually(func() bool { return !processExists(session.pid) }, 10*time.Second, 20*time.Millisecond).
+					Should(BeTrue(), "session %d natural exit must be reaped", i)
+			}
+		})
+}
+
+func directChildPIDs() []int {
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+	var children []int
+	for _, entry := range entries {
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join("/proc", entry.Name(), "status"))
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(raw), "\n") {
+			if !strings.HasPrefix(line, "PPid:") {
+				continue
+			}
+			ppid, _ := strconv.Atoi(strings.TrimSpace(strings.TrimPrefix(line, "PPid:")))
+			if ppid == os.Getpid() {
+				children = append(children, pid)
+			}
+			break
+		}
+	}
+	return children
+}
+
+func addedPIDs(before, after []int) []int {
+	known := make(map[int]struct{}, len(before))
+	for _, pid := range before {
+		known[pid] = struct{}{}
+	}
+	var added []int
+	for _, pid := range after {
+		if _, ok := known[pid]; !ok {
+			added = append(added, pid)
+		}
+	}
+	return added
+}
+
+func processExists(pid int) bool {
+	return pathExists(filepath.Join("/proc", strconv.Itoa(pid)))
+}
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
 
 const segvSignalTargetSrc = `package main
 
@@ -1427,13 +1594,11 @@ func declareStepOverlapPauseSpec() {
 //     trap and re-adds it to the table under the same id (the documented
 //     clear-while-parked behaviour). A spinner hits it and the pause loses to a
 //     BreakpointHit.
-//  2. Launch a second tracee while the first is still alive. The linux backend
-//     waits with Wait4(-1, …, WALL), which is scoped to the whole *process*,
-//     not to one tracee: two live debuggers in this test binary steal each
-//     other's stops. Observed as PTRACE_GETREGS ESRCH for a foreign tid and
-//     BOTH harnesses wedging in Kill. That is a pre-existing property of the
-//     backend, not of the park queue, and it is why every spec here owns
-//     exactly one tracee for its whole lifetime.
+//  2. Launch a second tracee while the first is still alive. Before the
+//     process-global exact-TID wait broker, per-session Wait4(-1, …, WALL)
+//     callers stole each other's stops. Dedicated wait-ownership specs now
+//     exercise concurrent sessions; this focused control still uses one tracee
+//     so only Pause delivery can stop it.
 //
 // As its own It, Ginkgo has already run the previous spec's DeferCleanup Kill,
 // so this tracee is alone. It never sets a breakpoint, so the SIGSTOP that


### PR DESCRIPTION
## Summary

- replace every Linux process-global `Wait4(-1, WALL)` consumer with one SIGCHLD-driven broker that scans only registered exact TIDs and routes statuses to their owning debugger
- preserve ptrace control operations on each backend's dedicated tracer thread while registering launch, attach, clone, kill, and terminal statuses with generation-safe ownership
- keep closed owners registered until final reaping so running Kill and natural exits cannot leak zombies or steal a later session's initial exec stop
- add deterministic broker regressions plus native Linux E2E coverage for unrelated children, suspended/running Kill, concurrent sessions, exact exit codes, and `/proc` zombie disappearance
- update `AGENTS.md` for the new multi-session wait and teardown invariants

Fixes #205
Addresses #217

## Validation

- `go test -tags bingonative -race -count=1 ./...`
- Linux/amd64 Docker: `go test -tags bingonative -race -count=1 ./...`
- Linux/amd64 Docker: `go test -tags e2e -race -run '^$' ./test/integration`
- `go vet -tags bingonative ./...`
- `just build linux amd64`
- `just build darwin arm64`
- independent code review: no correctness findings

Native Linux ptrace E2E is covered by the PR's `kill`, `exit`, `attach`, `overlap`, and full-stack workflow jobs; it cannot execute correctly under linux/amd64 emulation because the emulator introduces a post-start `PTRACE_EVENT_EXEC` that bingo intentionally treats as session-invalidating.