### PR TITLE
fix(debugger): close attach cleanup ownership races

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2147,16 +2147,19 @@ cause event and receive a stale welcome that DAP would treat as authoritative.
 
 ## Hub debugger ownership — shutdown is a linearization point
 
-`internal/hub.Hub` guards both `dbg` and `closing` with `dbgMu`. A factory-created
-debugger is not owned by the hub until `installDebugger` accepts it under that
-lock. Shutdown takes the same lock, marks ownership closed, and removes the
-currently installed debugger atomically; it calls `Kill` only after releasing
-the lock. If shutdown wins, installation is rejected and the command path must
-discard the candidate debugger itself, then return without changing session
-state or broadcasting. If installation wins, shutdown removes and tears down
-that debugger. This covers both the initial Launch/Attach factory gap and
-Restart's longer constructor/relaunch gap, so no live tracee can appear after
-the hub and session have already exited.
+`internal/hub.Hub` guards both `dbg` and `closing` with `dbgMu`. Before invoking
+the debugger factory, the command path registers a candidate cleanup obligation
+under that lock. The obligation ends only when `installDebuggerCandidate`
+atomically transfers the candidate into `dbg`, or when candidate disposal
+actually succeeds. Shutdown takes the same lock, closes candidate admission,
+and removes the currently installed debugger atomically; it calls `Kill` only
+after releasing the lock, then waits for every pre-admitted candidate obligation.
+If shutdown wins, installation is rejected and the command path discards the
+candidate debugger itself without changing session state or broadcasting. If
+installation wins, shutdown removes and tears down that debugger. This covers
+the initial Launch/Attach factory gap, retained cleanup after a failed start, and
+Restart's longer constructor/relaunch gap, so no live tracee or cleanup owner can
+outlive hub/session completion.
 
 Never hold `dbgMu` across a `Debugger` method or socket I/O. Run-loop reads take
 a short snapshot via `currentDebugger`; teardown paths detach ownership under
@@ -2174,18 +2177,23 @@ cheap value — `newEngine` starts `go e.loop()` immediately, that loop
 tracer thread at construction. **Only `Kill` drives that loop to exit**, so a
 dropped candidate permanently strands a goroutine plus a locked OS thread per
 attempt (issue #188: repeated failed Restarts accumulated them). `handleRestart`
-therefore registers a deferred `discardDebugger` the moment the candidate
-exists and clears it at the single ownership-transfer point — immediately after
-`installDebugger` accepts it — so relaunch failure, install rejection, and any
-future early return all dispose exactly once, and a successful restart's now
-hub-owned debugger is never killed by the caller. Disposal targets the captured
-candidate by identity, so it can never kill a newer or currently installed
-debugger.
+therefore registers a deferred `discardDebuggerCandidate` the moment the
+candidate exists and clears it at the single ownership-transfer point —
+immediately after `installDebuggerCandidate` accepts it — so relaunch failure,
+install rejection, and any future early return all dispose exactly once, and a
+successful restart's now hub-owned debugger is never killed by the caller.
+Disposal targets the captured candidate by identity, so it can never kill a
+newer or currently installed debugger.
 
 `discardDebugger` is a `Hub` method because the hub is the last owner of a
 discarded debugger: a failing `Kill` is logged there (the owning top level, per
 [docs/ErrorHandling.md](docs/ErrorHandling.md)) rather than returned, so cleanup
-never replaces the original launch error the client is told about.
+never replaces the original launch error the client is told about. A retry
+goroutine for a caller-owned candidate is not detached work: its cleanup
+obligation was registered before factory construction, and shutdown cannot close
+`shutdownCh`/`Done` until that exact obligation completes. Multiple failed starts
+remain independently owned, and a concurrent successful cleanup satisfies only
+its own obligation once.
 
 **Shutdown completion is withheld while an attached detach is retryable.**
 `ErrAttachedDetachIncomplete` means the engine and tracer still own the foreign
@@ -2280,15 +2288,15 @@ Launch) still works. The replacement that failed to launch is killed by
 [Hub debugger ownership](#hub-debugger-ownership--shutdown-is-a-linearization-point).
 
 **A failed breakpoint reinstall is NOT a failed relaunch** — do not extend the
-disposal rule to it. By the time the reinstall loop runs, `installDebugger` has
-already accepted the replacement, so it is hub-owned and the tracee is running;
-a `SetBreakpoint` error is collected as a `DiscardedBreakpoint` and reported in
-`EventRestarted` (mirroring Delve), and the session stays `running`. Killing the
-replacement there would terminate a healthy process over one unresolvable
-`file:line`. Only locations that *did* resolve are carried into
-`restartBreakpoints`. Both directions are pinned by the `Restart relaunch
-failure` and `Restart breakpoint reinstall failure` specs in
-[hub_test.go](internal/hub/hub_test.go).
+disposal rule to it. By the time the reinstall loop runs,
+`installDebuggerCandidate` has already accepted the replacement, so it is
+hub-owned and the tracee is running; a `SetBreakpoint` error is collected as a
+`DiscardedBreakpoint` and reported in `EventRestarted` (mirroring Delve), and
+the session stays `running`. Killing the replacement there would terminate a
+healthy process over one unresolvable `file:line`. Only locations that *did*
+resolve are carried into `restartBreakpoints`. Both directions are pinned by
+the `Restart relaunch failure` and `Restart breakpoint reinstall failure` specs
+in [hub_test.go](internal/hub/hub_test.go).
 
 ## Breakpoint identity — hub-owned logical ids
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1508,8 +1508,13 @@ are detected by a `mach_msg` receive loop.
   `Wait4(tid, WNOHANG|WALL)`, and uses a one-second fallback scan for a missed or
   coalesced notification. It never calls `Wait4(-1, ...)` and therefore cannot
   steal another debugger's status or reap an unrelated child. One live TID has
-  one owner; monotonically increasing registration generations prevent a scan
-  result for a retired TID from reaching a later owner after TID reuse. A
+  one owner. Each exact nonblocking wait stays under the broker lock from its
+  generation check through status consumption and queue delivery; release and
+  replacement registration take that same lock. A scan snapshot that became
+  stale therefore skips the syscall instead of consuming the replacement
+  generation's stop and dropping it on delivery. Monotonically increasing
+  registration generations prevent a result for a retired TID from reaching a
+  later owner after TID reuse. A
   successful attached detach explicitly releases the exact generation and
   purges only its queued results; exact `ECHILD` retirement is routed as a
   generation-bearing result so quiesce can distinguish it from a live stop. A closed

--- a/internal/debugger/waitbroker_linux_amd64.go
+++ b/internal/debugger/waitbroker_linux_amd64.go
@@ -40,6 +40,11 @@ type linuxWaitRegistration struct {
 	generation uint64
 }
 
+type linuxWaitScan struct {
+	tid int
+	reg linuxWaitRegistration
+}
+
 // linuxWaitBroker is the process-wide owner of Linux wait syscalls. SIGCHLD
 // triggers exact registered-TID scans, so one debugger can never consume
 // another debugger's stop or the status of an unrelated child.
@@ -277,22 +282,13 @@ func (b *linuxWaitBroker) registrationCount() int {
 	return len(b.registrations)
 }
 
-func (b *linuxWaitBroker) snapshot() []struct {
-	tid int
-	reg linuxWaitRegistration
-} {
+func (b *linuxWaitBroker) snapshot() []linuxWaitScan {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	snapshot := make([]struct {
-		tid int
-		reg linuxWaitRegistration
-	}, 0, len(b.registrations))
+	snapshot := make([]linuxWaitScan, 0, len(b.registrations))
 	for tid, reg := range b.registrations {
-		snapshot = append(snapshot, struct {
-			tid int
-			reg linuxWaitRegistration
-		}{tid: tid, reg: reg})
+		snapshot = append(snapshot, linuxWaitScan{tid: tid, reg: reg})
 	}
 	sort.Slice(snapshot, func(i, j int) bool { return snapshot[i].tid < snapshot[j].tid })
 	return snapshot
@@ -303,41 +299,46 @@ func (b *linuxWaitBroker) snapshot() []struct {
 func (b *linuxWaitBroker) scan() bool {
 	progressed := false
 	for _, item := range b.snapshot() {
-		var status syscall.WaitStatus
-		tid, err := b.wait4(item.tid, &status, syscall.WNOHANG|syscall.WALL, nil)
-		switch {
-		case err == nil && tid == 0:
-			continue
-		case err == nil:
-			progressed = true
-			b.deliver(item.tid, item.reg, linuxWaitResult{
-				tid: tid, generation: item.reg.generation, status: status,
-			},
-				status.Exited() || status.Signaled())
-		case errors.Is(err, syscall.EINTR):
-			progressed = true
-		case errors.Is(err, syscall.ECHILD):
-			progressed = true
-			b.retire(item.tid, item.reg)
-		default:
-			progressed = true
-			b.deliver(item.tid, item.reg, linuxWaitResult{
-				tid:        item.tid,
-				generation: item.reg.generation,
-				err:        fmt.Errorf("wait4 tid %d: %w", item.tid, err),
-			}, true)
-		}
+		progressed = b.scanRegistration(item) || progressed
 	}
 	return progressed
 }
 
-func (b *linuxWaitBroker) deliver(tid int, expected linuxWaitRegistration, result linuxWaitResult, terminal bool) {
+func (b *linuxWaitBroker) scanRegistration(item linuxWaitScan) bool {
 	b.mu.Lock()
-	current, ok := b.registrations[tid]
-	if !ok || current != expected {
-		b.mu.Unlock()
-		return
+	defer b.mu.Unlock()
+
+	current, ok := b.registrations[item.tid]
+	if !ok || current != item.reg {
+		return false
 	}
+
+	// The exact wait is nonblocking. Keeping registration validation and status
+	// consumption in one critical section prevents detach recovery from replacing
+	// this TID's generation after validation but before wait4 consumes its stop.
+	var status syscall.WaitStatus
+	tid, err := b.wait4(item.tid, &status, syscall.WNOHANG|syscall.WALL, nil)
+	switch {
+	case err == nil && tid == 0:
+		return false
+	case err == nil:
+		b.deliverLocked(item.tid, current, linuxWaitResult{
+			tid: tid, generation: current.generation, status: status,
+		}, status.Exited() || status.Signaled())
+	case errors.Is(err, syscall.EINTR):
+	case errors.Is(err, syscall.ECHILD):
+		b.retireLocked(item.tid, current)
+	default:
+		b.deliverLocked(item.tid, current, linuxWaitResult{
+			tid:        item.tid,
+			generation: current.generation,
+			err:        fmt.Errorf("wait4 tid %d: %w", item.tid, err),
+		}, true)
+	}
+	return true
+}
+
+func (b *linuxWaitBroker) deliverLocked(tid int, current linuxWaitRegistration, result linuxWaitResult, terminal bool) {
 	if terminal {
 		delete(b.registrations, tid)
 	}
@@ -352,16 +353,19 @@ func (b *linuxWaitBroker) deliver(tid int, expected linuxWaitRegistration, resul
 	}
 	owner.signalLocked()
 	owner.mu.Unlock()
-	b.mu.Unlock()
 }
 
 func (b *linuxWaitBroker) retire(tid int, expected linuxWaitRegistration) {
 	b.mu.Lock()
+	defer b.mu.Unlock()
 	current, ok := b.registrations[tid]
 	if !ok || current != expected {
-		b.mu.Unlock()
 		return
 	}
+	b.retireLocked(tid, current)
+}
+
+func (b *linuxWaitBroker) retireLocked(tid int, current linuxWaitRegistration) {
 	delete(b.registrations, tid)
 
 	owner := current.owner
@@ -378,5 +382,4 @@ func (b *linuxWaitBroker) retire(tid int, expected linuxWaitRegistration) {
 	}
 	owner.signalLocked()
 	owner.mu.Unlock()
-	b.mu.Unlock()
 }

--- a/internal/debugger/waitbroker_linux_amd64_test.go
+++ b/internal/debugger/waitbroker_linux_amd64_test.go
@@ -258,6 +258,126 @@ func TestLinuxWaitOwnerReleaseIsGenerationCheckedAndPurgesQueuedStops(t *testing
 	}
 }
 
+func TestLinuxWaitBrokerStaleScanCannotConsumeReplacementGenerationStop(t *testing.T) {
+	const tid = 11426
+	wait4 := newScriptedExactWait4()
+	broker := newLinuxWaitBrokerWithRunner(wait4.wait4, false)
+	owner := broker.newOwner()
+	firstGeneration, err := owner.register(tid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stale := broker.snapshot()
+	if len(stale) != 1 {
+		t.Fatalf("snapshot registrations = %d, want 1", len(stale))
+	}
+	scanPaused := make(chan struct{})
+	resumeScan := make(chan struct{})
+	scanResult := make(chan bool, 1)
+	go func() {
+		close(scanPaused)
+		<-resumeScan
+		scanResult <- broker.scanRegistration(stale[0])
+	}()
+	<-scanPaused
+
+	if !owner.release(tid, firstGeneration) {
+		t.Fatal("release rejected the original registration")
+	}
+	secondGeneration, err := owner.register(tid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wait4.add(tid, stoppedAt(syscall.SIGTRAP, 0))
+	close(resumeScan)
+	if <-scanResult {
+		t.Fatal("stale scan reported progress for a replacement registration")
+	}
+
+	wait4.mu.Lock()
+	staleCalls := append([]int(nil), wait4.calls...)
+	wait4.mu.Unlock()
+	if len(staleCalls) != 0 {
+		t.Fatalf("stale scan called wait4 for replacement generation: %v", staleCalls)
+	}
+
+	if !broker.scan() {
+		t.Fatal("fresh scan reported no progress")
+	}
+	result := nextBrokerResult(t, owner)
+	if result.tid != tid || result.generation != secondGeneration || !result.status.Stopped() {
+		t.Fatalf("replacement result = %+v, want stopped tid %d generation %d",
+			result, tid, secondGeneration)
+	}
+}
+
+func TestLinuxWaitBrokerReleaseCannotCrossValidatedWait(t *testing.T) {
+	const tid = 11427
+	wait4 := newScriptedExactWait4()
+	waitEntered := make(chan struct{})
+	releaseWait := make(chan struct{})
+	var gateOnce sync.Once
+	var broker *linuxWaitBroker
+	gatedWait4 := func(pid int, status *syscall.WaitStatus, options int, rusage *syscall.Rusage) (int, error) {
+		if broker.mu.TryLock() {
+			broker.mu.Unlock()
+			t.Error("broker lock was released between generation validation and wait4")
+		}
+		gateOnce.Do(func() {
+			close(waitEntered)
+			<-releaseWait
+		})
+		return wait4.wait4(pid, status, options, rusage)
+	}
+	broker = newLinuxWaitBrokerWithRunner(gatedWait4, false)
+	owner := broker.newOwner()
+	firstGeneration, err := owner.register(tid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	scanDone := make(chan bool, 1)
+	go func() { scanDone <- broker.scan() }()
+	<-waitEntered
+
+	releaseDone := make(chan bool, 1)
+	releaseStarted := make(chan struct{})
+	go func() {
+		close(releaseStarted)
+		releaseDone <- owner.release(tid, firstGeneration)
+	}()
+	<-releaseStarted
+	select {
+	case released := <-releaseDone:
+		close(releaseWait)
+		<-scanDone
+		t.Fatalf("release completed across a validated wait4 call: %v", released)
+	case <-time.After(250 * time.Millisecond):
+	}
+	close(releaseWait)
+	if <-scanDone {
+		t.Fatal("empty validated scan reported progress")
+	}
+	if !<-releaseDone {
+		t.Fatal("release rejected the original registration after the scan completed")
+	}
+
+	secondGeneration, err := owner.register(tid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wait4.add(tid, stoppedAt(syscall.SIGTRAP, 0))
+	if !broker.scan() {
+		t.Fatal("replacement scan reported no progress")
+	}
+	result := nextBrokerResult(t, owner)
+	if result.generation != secondGeneration || !result.status.Stopped() {
+		t.Fatalf("replacement result = %+v, want generation %d stop",
+			result, secondGeneration)
+	}
+}
+
 func TestLinuxWaitBrokerReportsExactGenerationRetirement(t *testing.T) {
 	const tid = 11431
 	broker := newLinuxWaitBrokerWithRunner(newScriptedExactWait4().wait4, false)

--- a/internal/hub/export_test.go
+++ b/internal/hub/export_test.go
@@ -11,3 +11,7 @@ func ExportedSetSuspendTimeout(h *Hub, timeout time.Duration) {
 func (h *Hub) ExportedShutdownCh() <-chan struct{} {
 	return h.shutdownCh
 }
+
+func ExportedIsClosing(h *Hub) bool {
+	return h.isClosing()
+}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -61,9 +61,15 @@ type Hub struct {
 	// dbg and closing are guarded by dbgMu. Factory results and shutdown race
 	// through that lock so every debugger is owned either by the running hub or
 	// by the path responsible for discarding it.
-	dbgMu   sync.Mutex
-	dbg     debugger.Debugger
-	closing bool
+	dbgMu sync.Mutex
+	dbg   debugger.Debugger
+
+	// candidateCleanup counts factory work from before construction until the
+	// candidate is either installed or fully discarded. Add happens only under
+	// dbgMu while closing is false, so beginShutdown is the admission fence that
+	// makes Wait safe.
+	candidateCleanup sync.WaitGroup
+	closing          bool
 
 	registry *registry
 	log      *slog.Logger
@@ -218,13 +224,31 @@ func (h *Hub) currentDebugger() debugger.Debugger {
 	return h.dbg
 }
 
-func (h *Hub) installDebugger(dbg debugger.Debugger) bool {
+func (h *Hub) newDebuggerCandidate() (debugger.Debugger, bool) {
+	h.dbgMu.Lock()
+	if h.closing {
+		h.dbgMu.Unlock()
+		return nil, false
+	}
+	h.candidateCleanup.Add(1)
+	factory := h.newDebugger
+	h.dbgMu.Unlock()
+	dbg := factory()
+	if dbg == nil {
+		h.candidateCleanup.Done()
+		return nil, false
+	}
+	return dbg, true
+}
+
+func (h *Hub) installDebuggerCandidate(dbg debugger.Debugger) bool {
 	h.dbgMu.Lock()
 	defer h.dbgMu.Unlock()
 	if h.closing {
 		return false
 	}
 	h.dbg = dbg
+	h.candidateCleanup.Done()
 	return true
 }
 
@@ -254,12 +278,12 @@ func (h *Hub) beginShutdown() debugger.Debugger {
 	return dbg
 }
 
-// discardDebugger tears down a debugger this hub does not own — a candidate
-// rejected during startup, or the instance claimed by shutdown. Kill is
-// idempotent and the hub is the last owner of a discarded debugger, so its
-// failure is logged here (the owning top level, per docs/ErrorHandling.md)
-// rather than returned: every caller is already on a failure path whose
-// original cause must reach the client unchanged.
+// discardDebugger tears down a debugger that is not installed as h.dbg — a
+// tracked candidate rejected during startup, or the instance claimed by
+// shutdown. Kill is idempotent and the hub is the last owner of a discarded
+// debugger, so its failure is logged here (the owning top level, per
+// docs/ErrorHandling.md) rather than returned: every caller is already on a
+// failure path whose original cause must reach the client unchanged.
 func (h *Hub) discardDebugger(dbg debugger.Debugger, reason string) bool {
 	if dbg == nil {
 		return true
@@ -289,6 +313,17 @@ func (h *Hub) discardDebuggerUntilSuccess(dbg debugger.Debugger, reason string) 
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
+}
+
+func (h *Hub) discardDebuggerCandidate(dbg debugger.Debugger, reason string) {
+	if h.discardDebugger(dbg, reason) {
+		h.candidateCleanup.Done()
+		return
+	}
+	go func() {
+		h.discardDebuggerUntilSuccess(dbg, reason)
+		h.candidateCleanup.Done()
+	}()
 }
 
 // AddClient registers conn as a new client. Safe from any goroutine. Admission
@@ -493,9 +528,16 @@ func (h *Hub) prepareCommandDebugger(cmd protocol.Command) (dbg debugger.Debugge
 		return nil, false, false
 	}
 
-	dbg = h.newDebugger()
+	var created bool
+	dbg, created = h.newDebuggerCandidate()
+	if !created {
+		if !h.isClosing() {
+			h.broadcastError(cmd.Kind, fmt.Errorf("debugger factory returned nil"))
+		}
+		return nil, false, false
+	}
 	if h.isClosing() {
-		h.discardDebuggerUntilSuccess(dbg, "start: hub closed before startup")
+		h.discardDebuggerCandidate(dbg, "start: hub closed before startup")
 		return nil, false, false
 	}
 	// Keep the candidate caller-owned through startup. Installing it first
@@ -506,9 +548,7 @@ func (h *Hub) prepareCommandDebugger(cmd protocol.Command) (dbg debugger.Debugge
 
 func (h *Hub) transferStartedDebugger(dbg debugger.Debugger, cmd protocol.Command, startErr error) bool {
 	if startErr != nil {
-		if !h.discardDebugger(dbg, "start: startup failed") {
-			go h.discardDebuggerUntilSuccess(dbg, "start: startup failed")
-		}
+		h.discardDebuggerCandidate(dbg, "start: startup failed")
 		if h.isClosing() {
 			return false
 		}
@@ -516,8 +556,8 @@ func (h *Hub) transferStartedDebugger(dbg debugger.Debugger, cmd protocol.Comman
 		h.broadcastError(cmd.Kind, startErr)
 		return false
 	}
-	if !h.installDebugger(dbg) {
-		h.discardDebuggerUntilSuccess(dbg, "start: hub closed before install")
+	if !h.installDebuggerCandidate(dbg) {
+		h.discardDebuggerCandidate(dbg, "start: hub closed before install")
 		return false
 	}
 	return true
@@ -639,6 +679,25 @@ type restartTarget struct {
 	loc       protocol.Location
 }
 
+func (h *Hub) restartLaunchPayload(cmd protocol.Command) (protocol.LaunchPayload, error) {
+	launch := *h.lastLaunch
+	if len(cmd.Payload) == 0 {
+		return launch, nil
+	}
+
+	var override protocol.RestartPayload
+	if err := protocol.DecodeCommandPayload(cmd, &override); err != nil {
+		return protocol.LaunchPayload{}, err
+	}
+	if override.Args != nil {
+		launch.Args = override.Args
+	}
+	if override.Env != nil {
+		launch.Env = override.Env
+	}
+	return launch, nil
+}
+
 // handleRestart kills the current process (if any), relaunches the last
 // Launch'd binary, and reinstalls previously-set breakpoints at their
 // original file:line locations — addresses are re-resolved via DWARF since a
@@ -663,23 +722,12 @@ func (h *Hub) handleRestart(cmd protocol.Command) {
 		return
 	}
 
-	var override protocol.RestartPayload
-	if len(cmd.Payload) > 0 {
-		if err := protocol.DecodeCommandPayload(cmd, &override); err != nil {
-			h.broadcastError(cmd.Kind, err)
-			return
-		}
+	launch, err := h.restartLaunchPayload(cmd)
+	if err != nil {
+		h.broadcastError(cmd.Kind, err)
+		return
 	}
-
-	program := h.lastLaunch.Program
-	args := h.lastLaunch.Args
-	if override.Args != nil {
-		args = override.Args
-	}
-	env := h.lastLaunch.Env
-	if override.Env != nil {
-		env = override.Env
-	}
+	program, args, env := launch.Program, launch.Args, launch.Env
 
 	saved := h.sortedRestartTargets()
 
@@ -692,7 +740,14 @@ func (h *Hub) handleRestart(cmd protocol.Command) {
 	if h.isClosing() {
 		return
 	}
-	newDbg := h.newDebugger()
+	newDbg, created := h.newDebuggerCandidate()
+	if !created {
+		if !h.isClosing() {
+			h.broadcastError(cmd.Kind, fmt.Errorf("restart: debugger factory returned nil"))
+			h.transitionState(protocol.StateIdle)
+		}
+		return
+	}
 
 	// The replacement is caller-owned from construction until installDebugger
 	// accepts it: it is not in h.dbg, so neither shutdown's snapshot nor Run's
@@ -703,8 +758,8 @@ func (h *Hub) handleRestart(cmd protocol.Command) {
 	// clearing candidate is the single ownership-transfer point.
 	candidate := newDbg
 	defer func() {
-		if !h.discardDebugger(candidate, "restart: abandoned replacement") {
-			go h.discardDebuggerUntilSuccess(candidate, "restart: abandoned replacement")
+		if candidate != nil {
+			h.discardDebuggerCandidate(candidate, "restart: abandoned replacement")
 		}
 	}()
 
@@ -720,7 +775,7 @@ func (h *Hub) handleRestart(cmd protocol.Command) {
 		h.transitionState(protocol.StateIdle)
 		return
 	}
-	if !h.installDebugger(newDbg) {
+	if !h.installDebuggerCandidate(newDbg) {
 		return
 	}
 	candidate = nil
@@ -919,6 +974,7 @@ func (h *Hub) shutdown() {
 		h.registry.closeAll()
 		h.outboundMu.Unlock()
 		h.discardDebuggerUntilSuccess(dbg, "hub shutdown")
+		h.candidateCleanup.Wait()
 		close(h.shutdownCh)
 	})
 }

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -155,6 +155,19 @@ func (f *blockingLaunchDebugger) Launch(string, []string, []string) error {
 	return f.launchErr
 }
 
+type blockingKillDebugger struct {
+	*fakeDebugger
+	started chan struct{}
+	release <-chan struct{}
+}
+
+func (f *blockingKillDebugger) Kill() error {
+	f.record("Kill")
+	close(f.started)
+	<-f.release
+	return nil
+}
+
 // leakyLaunchDebugger models a partially started engine: Launch acquires a
 // goroutine that only a disposal Kill can release — the same shape as the real
 // engine's LockOSThread'd loop, whose sole exit is Kill driving it to
@@ -967,7 +980,7 @@ var _ = Describe("Hub", func() {
 	})
 
 	Describe("failed startup ownership retention", func() {
-		It("reports the original Attach error without blocking the Run loop on cleanup retries", func() {
+		It("keeps failed Attach cleanup owned through hub cancellation", func() {
 			fd := newFakeDebugger()
 			fd.attachErr = errors.New("attach failed")
 			fd.setKillError(fmt.Errorf("%w: retained partial attach",
@@ -976,6 +989,7 @@ var _ = Describe("Hub", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			go h.Run(ctx)
 			defer cancel()
+			defer fd.setKillError(nil)
 
 			conn := newFakeWSConn()
 			mustAddClient(h, conn)
@@ -988,7 +1002,102 @@ var _ = Describe("Hub", func() {
 			Eventually(func() int {
 				return countCalls(fd.recordedCalls(), "Kill")
 			}, "1s", "10ms").Should(BeNumerically(">=", 2))
+			cancel()
+			Consistently(h.ExportedShutdownCh(), "100ms", "10ms").ShouldNot(BeClosed())
+			Consistently(h.Done(), "100ms", "10ms").ShouldNot(BeClosed(),
+				"hub completion would discard the failed Attach cleanup owner")
+
 			fd.setKillError(nil)
+			Eventually(h.ExportedShutdownCh(), "1s", "10ms").Should(BeClosed())
+			Eventually(h.Done(), "1s", "10ms").Should(BeClosed())
+		})
+
+		It("waits for every failed startup candidate before completing shutdown", func() {
+			first := newFakeDebugger()
+			first.attachErr = errors.New("first attach failed")
+			first.setKillError(fmt.Errorf("%w: first partial attach",
+				debugger.ErrAttachedDetachIncomplete))
+			second := newFakeDebugger()
+			second.attachErr = errors.New("second attach failed")
+			second.setKillError(fmt.Errorf("%w: second partial attach",
+				debugger.ErrAttachedDetachIncomplete))
+			candidates := []debugger.Debugger{first, second}
+			h := hub.NewSession("session", func() debugger.Debugger {
+				candidate := candidates[0]
+				candidates = candidates[1:]
+				return candidate
+			}, nil)
+			ctx, cancel := context.WithCancel(context.Background())
+			go h.Run(ctx)
+			defer cancel()
+			defer first.setKillError(nil)
+			defer second.setKillError(nil)
+
+			conn := newFakeWSConn()
+			mustAddClient(h, conn)
+			for _, pid := range []int{1234, 5678} {
+				conn.inject(mustCommand(protocol.CmdAttach, protocol.AttachPayload{PID: pid}))
+				waitForEventKind(conn, protocol.EventError, nil)
+			}
+			Eventually(func() int {
+				return countCalls(first.recordedCalls(), "Kill")
+			}, "1s", "10ms").Should(BeNumerically(">=", 2))
+			Eventually(func() int {
+				return countCalls(second.recordedCalls(), "Kill")
+			}, "1s", "10ms").Should(BeNumerically(">=", 2))
+
+			cancel()
+			first.setKillError(nil)
+			Consistently(h.Done(), "150ms", "10ms").ShouldNot(BeClosed(),
+				"the second retained candidate still owns its partial attach")
+			second.setKillError(nil)
+			Eventually(h.Done(), "1s", "10ms").Should(BeClosed())
+		})
+
+		It("linearizes successful candidate cleanup with concurrent shutdown", func() {
+			releaseKill := make(chan struct{})
+			var releaseOnce sync.Once
+			release := func() { releaseOnce.Do(func() { close(releaseKill) }) }
+			DeferCleanup(release)
+			fd := &blockingKillDebugger{
+				fakeDebugger: newFakeDebugger(),
+				started:      make(chan struct{}),
+				release:      releaseKill,
+			}
+			fd.attachErr = errors.New("attach failed")
+			h := hub.NewSession("session", func() debugger.Debugger { return fd }, nil)
+			ctx, cancel := context.WithCancel(context.Background())
+			go h.Run(ctx)
+			defer cancel()
+
+			conn := newFakeWSConn()
+			mustAddClient(h, conn)
+			conn.inject(mustCommand(protocol.CmdAttach, protocol.AttachPayload{PID: 1234}))
+			Eventually(fd.started, "1s").Should(BeClosed())
+			closeFakeWS(conn)
+			Eventually(func() bool { return hub.ExportedIsClosing(h) }, "500ms").Should(BeTrue())
+			Consistently(h.ExportedShutdownCh(), "100ms", "10ms").ShouldNot(BeClosed())
+
+			release()
+			Eventually(h.Done(), "1s", "10ms").Should(BeClosed())
+			expectCallCount(fd.fakeDebugger, "Kill", 1,
+				"candidate cleanup and shutdown must share one ownership obligation")
+		})
+
+		It("does not retain a cleanup obligation for a nil factory result", func() {
+			h := hub.NewSession("session", func() debugger.Debugger { return nil }, nil)
+			ctx, cancel := context.WithCancel(context.Background())
+			go h.Run(ctx)
+			defer cancel()
+
+			conn := newFakeWSConn()
+			mustAddClient(h, conn)
+			conn.inject(mustCommand(protocol.CmdLaunch, protocol.LaunchPayload{Program: "myapp"}))
+			var payload protocol.ErrorPayload
+			waitForEventKind(conn, protocol.EventError, &payload)
+			Expect(payload.Message).To(ContainSubstring("debugger factory returned nil"))
+			cancel()
+			Eventually(h.Done(), "1s", "10ms").Should(BeClosed())
 		})
 	})
 
@@ -1968,7 +2077,8 @@ var _ = Describe("Restart relaunch failure", func() {
 		Eventually(replacement.started, "500ms").Should(BeClosed())
 
 		closeFakeWS(conn)
-		Eventually(managed.ExportedShutdownCh(), "500ms").Should(BeClosed())
+		Eventually(func() bool { return hub.ExportedIsClosing(managed) }, "500ms").Should(BeTrue())
+		Consistently(managed.ExportedShutdownCh(), "100ms").ShouldNot(BeClosed())
 		close(releaseLaunch)
 
 		Eventually(managed.Done(), "500ms").Should(BeClosed())
@@ -2075,14 +2185,20 @@ var _ = Describe("Restart breakpoint reinstall failure", func() {
 })
 
 var _ = Describe("debugger ownership during shutdown", func() {
-	It("discards a restart replacement whose Launch finishes after shutdown", func() {
+	It("retains a restart replacement whose cleanup remains incomplete after shutdown", func() {
 		old := newFakeDebugger()
 		releaseLaunch := make(chan struct{})
+		var releaseOnce sync.Once
+		release := func() { releaseOnce.Do(func() { close(releaseLaunch) }) }
+		DeferCleanup(release)
 		replacement := &blockingLaunchDebugger{
 			fakeDebugger: newFakeDebugger(),
 			started:      make(chan struct{}),
 			release:      releaseLaunch,
 		}
+		replacement.setKillError(fmt.Errorf("%w: retained restart candidate",
+			debugger.ErrAttachedDetachIncomplete))
+		defer replacement.setKillError(nil)
 		factoryCalls := 0
 		managed := hub.NewSession("session", func() debugger.Debugger {
 			factoryCalls++
@@ -2103,9 +2219,15 @@ var _ = Describe("debugger ownership during shutdown", func() {
 		Eventually(replacement.started, "500ms").Should(BeClosed())
 
 		closeFakeWS(conn)
-		Eventually(managed.ExportedShutdownCh(), "500ms").Should(BeClosed())
-		close(releaseLaunch)
+		Eventually(func() bool { return hub.ExportedIsClosing(managed) }, "500ms").Should(BeTrue())
+		Consistently(managed.ExportedShutdownCh(), "100ms").ShouldNot(BeClosed())
+		release()
 
+		Eventually(func() int {
+			return countCalls(replacement.recordedCalls(), "Kill")
+		}, "1s", "10ms").Should(BeNumerically(">=", 2))
+		Consistently(managed.ExportedShutdownCh(), "100ms", "10ms").ShouldNot(BeClosed())
+		replacement.setKillError(nil)
 		Eventually(managed.Done(), "500ms").Should(BeClosed())
 		Expect(replacement.recordedCalls()).To(ContainElements("Launch", "Kill"))
 	})
@@ -2129,7 +2251,8 @@ var _ = Describe("debugger ownership during shutdown", func() {
 		Eventually(factoryStarted, "500ms").Should(BeClosed())
 
 		closeFakeWS(conn)
-		Eventually(managed.ExportedShutdownCh(), "500ms").Should(BeClosed())
+		Eventually(func() bool { return hub.ExportedIsClosing(managed) }, "500ms").Should(BeTrue())
+		Consistently(managed.ExportedShutdownCh(), "100ms").ShouldNot(BeClosed())
 		close(releaseFactory)
 
 		Eventually(managed.Done(), "500ms").Should(BeClosed())
@@ -2157,7 +2280,8 @@ var _ = Describe("debugger ownership during shutdown", func() {
 		Eventually(candidate.started, "500ms").Should(BeClosed())
 
 		closeFakeWS(conn)
-		Eventually(managed.ExportedShutdownCh(), "500ms").Should(BeClosed())
+		Eventually(func() bool { return hub.ExportedIsClosing(managed) }, "500ms").Should(BeTrue())
+		Consistently(managed.ExportedShutdownCh(), "100ms").ShouldNot(BeClosed())
 		close(releaseLaunch)
 
 		Eventually(managed.Done(), "500ms").Should(BeClosed())

--- a/internal/server/lifecycle_test.go
+++ b/internal/server/lifecycle_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -18,6 +19,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/bingosuite/bingo/internal/dap"
+	"github.com/bingosuite/bingo/internal/debugger"
 	"github.com/bingosuite/bingo/internal/hub"
 	"github.com/bingosuite/bingo/pkg/protocol"
 )
@@ -710,4 +712,114 @@ func TestShutdownTimeoutRetainsSessionsUntilCleanupCompletes(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("Done did not close after retained cleanup completed")
 	}
+}
+
+type retainedStartupDebugger struct {
+	mu      sync.Mutex
+	events  chan protocol.Event
+	killErr error
+	kills   int
+}
+
+func newRetainedStartupDebugger() *retainedStartupDebugger {
+	return &retainedStartupDebugger{events: make(chan protocol.Event)}
+}
+
+func (*retainedStartupDebugger) Launch(string, []string, []string) error { return nil }
+func (*retainedStartupDebugger) Attach(int, string) error {
+	return errors.New("injected attach failure")
+}
+func (d *retainedStartupDebugger) Kill() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.kills++
+	return d.killErr
+}
+func (*retainedStartupDebugger) SetBreakpoint(string, int) (protocol.Breakpoint, error) {
+	return protocol.Breakpoint{}, nil
+}
+func (*retainedStartupDebugger) ClearBreakpoint(int) error { return nil }
+func (*retainedStartupDebugger) Continue() error           { return nil }
+func (*retainedStartupDebugger) StepOver() error           { return nil }
+func (*retainedStartupDebugger) StepInto() error           { return nil }
+func (*retainedStartupDebugger) StepOut() error            { return nil }
+func (*retainedStartupDebugger) Pause() error              { return nil }
+func (*retainedStartupDebugger) Locals(int) ([]protocol.Variable, error) {
+	return nil, nil
+}
+func (*retainedStartupDebugger) Evaluate(int, string) (protocol.Variable, error) {
+	return protocol.Variable{}, nil
+}
+func (*retainedStartupDebugger) StackFrames() ([]protocol.Frame, error) { return nil, nil }
+func (*retainedStartupDebugger) Goroutines() (protocol.GoroutinesPayload, error) {
+	return protocol.GoroutinesPayload{}, nil
+}
+func (*retainedStartupDebugger) GoroutineSnapshot() (protocol.GoroutineSnapshotPayload, error) {
+	return protocol.GoroutineSnapshotPayload{}, nil
+}
+func (d *retainedStartupDebugger) Events() <-chan protocol.Event { return d.events }
+
+func (d *retainedStartupDebugger) setKillError(err error) {
+	d.mu.Lock()
+	d.killErr = err
+	d.mu.Unlock()
+}
+
+func (d *retainedStartupDebugger) killCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.kills
+}
+
+func TestServerDoneWaitsForFailedStartupCleanup(t *testing.T) {
+	g := NewWithT(t)
+	srv := New("127.0.0.1:0", nil)
+	running := startConstructedServer(t, srv)
+	fd := newRetainedStartupDebugger()
+	fd.setKillError(fmt.Errorf("%w: retained partial attach",
+		debugger.ErrAttachedDetachIncomplete))
+
+	const id = "failed-startup-cleanup"
+	h := hub.NewSession(id, func() debugger.Debugger { return fd }, nil)
+	srv.sessions.mu.Lock()
+	srv.sessions.sessions[id] = &session{id: id, hub: h, createdAt: time.Now()}
+	srv.sessions.notifyLocked()
+	srv.sessions.mu.Unlock()
+	go func() {
+		h.Run(srv.ctx)
+		srv.sessions.remove(id)
+	}()
+
+	wsURL := "ws" + strings.TrimPrefix(running.url, "http") + "/ws?session=" + id
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	g.Expect(err).NotTo(HaveOccurred())
+	_, _, err = recvStateEvent(conn)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	payload, err := json.Marshal(protocol.AttachPayload{PID: 1234})
+	g.Expect(err).NotTo(HaveOccurred())
+	command, err := json.Marshal(protocol.Command{
+		Version: protocol.Version,
+		Kind:    protocol.CmdAttach,
+		Payload: payload,
+	})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(conn.WriteMessage(websocket.TextMessage, command)).To(Succeed())
+	g.Eventually(fd.killCount, time.Second, 10*time.Millisecond).Should(BeNumerically(">=", 2))
+
+	err = srv.Shutdown(20 * time.Millisecond)
+	g.Expect(err).To(MatchError(ErrShutdownIncomplete))
+	g.Consistently(h.Done(), 100*time.Millisecond, 10*time.Millisecond).ShouldNot(BeClosed())
+	g.Consistently(srv.Done(), 100*time.Millisecond, 10*time.Millisecond).ShouldNot(BeClosed())
+	g.Expect(srv.sessions.count()).To(Equal(1))
+	killsAtTimeout := fd.killCount()
+	g.Eventually(fd.killCount, time.Second, 10*time.Millisecond).
+		Should(BeNumerically(">", killsAtTimeout),
+			"failed startup cleanup must remain actively owned after Shutdown returns")
+
+	fd.setKillError(nil)
+	g.Eventually(h.Done(), time.Second, 10*time.Millisecond).Should(BeClosed())
+	g.Eventually(srv.Done(), time.Second, 10*time.Millisecond).Should(BeClosed())
+	g.Eventually(srv.sessions.count, time.Second, 10*time.Millisecond).Should(Equal(0))
+	g.Eventually(running.errCh, time.Second).Should(Receive(BeNil()))
 }


### PR DESCRIPTION
## Context

This PR fixes two independently found post-merge blockers that remained after #225. Both are latent concurrency/ownership bugs on the exact merged base `f0d8520dea76fac7306910f0e47f198e8c74ca02`; intended debugger behavior and protocol surfaces remain unchanged.

## Fixes

### Fence Linux waitbroker registration generations

`linuxWaitBroker.scan` previously snapshotted registrations, released the broker lock, and then called exact-TID `wait4`. Partial detach recovery could release and re-register the same TID with a new generation while that stale scan was in flight. The stale scan could consume the replacement generation's stop, then drop it when delivery noticed the generation mismatch, leaving later quiesce retries without the stop they needed.

Generation validation, nonblocking exact-TID `wait4(WNOHANG|WALL)`, and delivery/retirement now share one broker-lock critical section. Release/re-registration therefore linearizes entirely before the scan (which skips the stale item) or after its status has been delivered for the validated generation.

### Retain failed startup cleanup ownership through shutdown

A failed Attach could return `ErrAttachedDetachIncomplete`, start `discardDebuggerUntilSuccess` in an untracked goroutine, and leave that candidate outside `h.dbg`. Hub shutdown only waited for the installed debugger, so `Hub.Done`, session removal, and `Server.Done` could complete while the retry goroutine still owned foreign TIDs.

The hub now registers candidate cleanup obligations under `dbgMu` before factory construction. Installation atomically transfers the candidate into `h.dbg`; otherwise the obligation remains until disposal really succeeds. Shutdown closes candidate admission and waits every pre-admitted obligation before closing `shutdownCh`/`Hub.Done`. This also covers restart candidates, multiple retained candidates, construction/install races, nil factories, and concurrent successful cleanup.

## Deterministic regressions

The new tests were independently reviewed and mutation-checked:

- A stale waitbroker snapshot is paused, the TID is released/re-registered, and the stale scan is proven not to call `wait4` or consume the replacement stop.
- A second forced interleaving gates inside `wait4` after generation validation, asserts the broker lock is still held, and proves release cannot cross the syscall boundary. Reverting the fence makes this test fail.
- Failed Attach cleanup remains active across cancellation while `shutdownCh`, `Hub.Done`, session removal, and `Server.Done` stay open; clearing the injected detach failure permits orderly completion.
- Additional coverage pins multiple retained candidates, successful cleanup racing independently triggered shutdown, retryable restart-candidate cleanup, factory construction/install races, and balanced nil-factory obligations.

## Validation

- Linux/amd64 targeted waitbroker regression: `-race -count=1000`
- Linux/amd64 both forced generation-window regressions: `-race -count=100`
- Hub ownership/shutdown specs: Ginkgo `--race --repeat=25`
- Server failed-start ownership regression: `-race -count=25`
- Full Darwin/arm64: `go test -mod=readonly -tags bingonative -race ./...`
- Full Linux/amd64 container: `go test -mod=readonly -race ./...`
- `go vet -mod=readonly -tags bingonative ./...`
- Linux/amd64 cross-build: `GOFLAGS=-mod=readonly just build linux amd64`
- Linux-target `golangci-lint run ./...`: 0 issues
- `goimports` and `git diff --check`
- Native Apple Silicon: `GOFLAGS=-mod=readonly just e2e-darwin` — 24 passed, 0 failed, 1 intentional skip

## Review

- Two initial independent high-effort reviews found test non-vacuity gaps and one nil-factory cleanup-obligation edge case; all were resolved with focused regressions.
- Two fresh high-effort reviews found no production correctness issues. The final exact-diff review mutation-tested the generation fence and shutdown wait, confirming the regressions fail when either fix is reverted.
- The coordinator independently reviewed the exact `f0d8520..163869e` production diff and commissioned an additional xhigh exact-diff review; no findings.

Hosted checks on this PR provide the native Linux ptrace/full-stack, Go, CodeQL, Sonar, VS Code, and policy/gate evidence for the published SHA.