### PR TITLE
feat(neovim): add nvim-dap companion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ test/coverage.out
 /editors/vscode/bin/
 /editors/vscode/dist/
 /editors/vscode/*.vsix
+
+# Neovim companion native server
+/editors/neovim/bin/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ follow them so reviews stay about substance, not style.
 | [cmd/dapcli](cmd/dapcli/) | Interactive readline client that drives a session over DAP (mirrors `cmd/cli`'s UX). Talks to the server's `-dap-addr` listener; can create a session or `-session` join an existing one. |
 | [cmd/wsmon](cmd/wsmon/) | Read-only terminal telemetry observer. `-session`-joins a running session over WebSocket and live-renders the goroutine spawn tree + OS threads + created/exited lifecycle deltas from the `EventGoroutineSnapshot` stream. Never drives execution — the WS-observes half of the DAP-drives/WS-observes demo. |
 | [editors/vscode](editors/vscode/) | Platform-packaged TypeScript companion extension. Owns debugger type `bingo`, manages the shared server, and hosts the read-only Bingo Concurrency Activity Bar WebSocket observer. |
+| [editors/neovim](editors/neovim/) | Lua companion for `nvim-dap`. Mirrors managed server discovery/start, drives launch/attach/join over DAP, and exposes the announced session ID for a separate WebSocket observer. |
 | [cmd/target](cmd/target/) | Trivial target program for manual testing. |
 | [examples/level1-loop](examples/level1-loop/) … [examples/level5-workflow](examples/level5-workflow/) | Progressive debugger targets, selected by the root VS Code launch picker and built together with `just build-examples` (see [examples/README.md](examples/README.md)). |
 | [examples/spawntree](examples/spawntree/) | Concurrency demo target: a deterministic main → supervisor → worker×N goroutine spawn tree for exercising the telemetry stream (see [docs/ConcurrencyTelemetry.md](docs/ConcurrencyTelemetry.md)). |
@@ -2116,6 +2117,24 @@ Code's raw launch/attach arguments; Go's JSON decoder ignores those unknown
 fields, so they never enter the bingo command payload. Do not add them to the
 wire protocol or `launchConfig`.
 
+**Neovim companion — the same managed transport through `nvim-dap`.**
+[editors/neovim](editors/neovim/) registers a function-form `dap.adapters.bingo`
+that asynchronously resolves to the existing TCP listener; it does not
+implement another adapter or invoke Delve. `auto` mode mirrors the VS Code
+health contract and spawn safety: exact service/management/wire/session-event
+compatibility, loopback-only start, detached argv-based spawn, endpoint-level
+coalescing, persistent logs, and server-owned idle teardown. `connectOnly`
+bypasses health and spawn. The prepared native binary is generated under
+`editors/neovim/bin/` by `just neovim-prepare` and is never committed; runtime
+falls back to `PATH` or explicit `server.binary`.
+
+The plugin listens on nvim-dap's literal
+`event_bingo/session/v1` listener key, validates the strict two-field payload,
+and emits `User BingoSession`; `Session.on_close` owns cleanup across terminate,
+disconnect, and transport failure. DAP remains drive-only. The plugin does not
+reimplement RFC 6455 in Lua: concurrency telemetry stays on the WebSocket side
+and uses `cmd/wsmon` until a bounded native observer exists.
+
 **VS Code connect-or-start invariants.** Default `serverMode:"auto"` is local
 only: management `127.0.0.1:6060`, DAP `127.0.0.1:4711`, readiness 5s, managed
 idle grace 30s. It health-checks before spawning and requires
@@ -2702,6 +2721,10 @@ translator keeps DAP entirely outside the hub — a strictly additive package.
   dedicated [vscode-extension.yml](.github/workflows/vscode-extension.yml)
   workflow lints, typechecks, tests, bundles, and builds the local VSIX without
   changing the Go CI jobs.
+- Neovim: [editors/neovim](editors/neovim/) keeps configuration, health-contract,
+  HTTP framing, adapter registration, and session-event validation independent
+  of a real `nvim-dap` install and runs them in headless Neovim with
+  `just neovim-check`; the same recipe parses every Lua source file.
 
 ## Error handling
 
@@ -3090,6 +3113,8 @@ just vscode-package                        # writes verified dist/bingo-<platfor
 just vscode-install                        # explicitly installs/updates bingosuite.bingo
 npm --prefix editors/vscode run test:integration # pinned Electron activation/view/custom-event test
 npm --prefix editors/vscode run e2e:packaged     # real native packaged DAP + graphical telemetry path
+just neovim-prepare                        # stage the host-native server for the Lua companion
+just neovim-check                          # parse and test the Neovim companion
 just e2e-linux                             # native linux/amd64 ptrace E2E (all labels)
 just e2e-darwin                            # native darwin/arm64 Mach-exception E2E (codesigned; all labels)
 # Filter to one label, e.g. only the correctness gate (package path must come

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ BinGo is a standalone visual concurrency debugger for Go that helps you:
 
 - Visualize and understand goroutines, channels, and synchronization behavior
 - Capture detailed runtime events and turn them into clear, interactive visualizations
-- Use in a terminal UI or inside editors like VS Code or Vim
+- Use in a terminal UI or inside editors like VS Code or Neovim
 - Track goroutine lifecycles
 - Inspect channels and mutexes
 - Replay timelines of concurrent execution
@@ -36,7 +36,7 @@ Builds on other GOOS/GOARCH combinations will fail with `undefined: newBackend` 
 ## Debug Adapter Protocol (DAP)
 
 BinGo speaks the [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/)
-alongside its native WebSocket protocol, so a standard IDE (VS Code, neovim) can
+alongside its native WebSocket protocol, so a standard IDE (VS Code, Neovim) can
 drive a debug session over a TCP socket while BinGo's own visual clients observe
 — and optionally also drive — the **same** session in parallel.
 
@@ -49,8 +49,8 @@ bingo -addr 127.0.0.1:6060 -dap-addr 127.0.0.1:4711
 ```
 
 `just server` starts both listeners with the defaults above; use `just server-ws`
-for a WebSocket-only run (DAP disabled). The VS Code companion can instead
-connect-or-start automatically.
+for a WebSocket-only run (DAP disabled). The VS Code and Neovim companions can
+instead connect-or-start automatically.
 
 ### Server discovery and managed lifetime
 
@@ -171,6 +171,31 @@ automatically follows the exact DAP-created session over WebSocket—no session
 ID copy is needed. It visualizes the goroutine spawn tree, OS threads, current
 goroutine, source locations, and bounded created/exited timeline while keeping
 all run control in VS Code's Debug UI.
+
+### Neovim companion
+
+Prepare the platform-native server and add `editors/neovim` to Neovim's runtime
+path with `nvim-dap` installed:
+
+```sh
+just neovim-prepare
+```
+
+```lua
+require("bingo").setup()
+```
+
+The companion registers a function-form `nvim-dap` adapter with managed local
+`auto` mode and remote/custom `connectOnly` mode. It provides
+`:BingoLaunch`, `:BingoAttach`, and `:BingoJoin` commands while normal
+`nvim-dap` commands drive breakpoints, stepping, stack frames, variables, and
+evaluate requests.
+
+The validated `bingo/session/v1` event is available through `:BingoSession` and
+`require("bingo").session_id()` so `cmd/wsmon` can observe the same managed
+session over WebSocket. See the
+[Neovim companion guide](editors/neovim/README.md) for installation,
+configuration, lifecycle, and remote-use details.
 
 Other DAP clients can point at `127.0.0.1:4711`. The DAP client creates a
 managed session on `launch`/`attach`; WebSocket observers join that same session

--- a/docs/ConcurrencyTelemetry.md
+++ b/docs/ConcurrencyTelemetry.md
@@ -2,8 +2,8 @@
 
 bingo speaks two protocols against **one** debug session at the same time:
 
-- **DAP** (`-dap-addr`) — an IDE (VS Code) or `cmd/dapcli` *drives* the session:
-  breakpoints, stepping, continue/pause, stack/variables. This is the
+- **DAP** (`-dap-addr`) — an IDE (VS Code or Neovim) or `cmd/dapcli` *drives*
+  the session: breakpoints, stepping, continue/pause, stack/variables. This is the
   least-common-denominator debug loop.
 - **WebSocket** (`-addr`) — any number of clients *observe* (and can also drive)
   the same session. The richer concurrency telemetry — the goroutine spawn tree,
@@ -14,10 +14,14 @@ The VS Code 0.3.1 extension wires both together automatically: DAP drives while
 the **Bingo Concurrency** Activity Bar view observes the exact session over
 WebSocket. `cmd/wsmon` remains the terminal observer for non-VS Code workflows.
 
+The Neovim companion drives the same DAP workflow through `nvim-dap`, captures
+the managed-session announcement, and pairs with `cmd/wsmon` for read-only
+telemetry.
+
 ```
-             drives (DAP :4711)                observes (WS :6060)
-  VS Code  ─────────────────────►  bingo server  ◄─────────────────  Concurrency view
-  / dapcli                          (one session)                    / cmd/wsmon
+                 drives (DAP :4711)                observes (WS :6060)
+  VS Code / Neovim ─────────────►  bingo server  ◄─────────────────  Concurrency view
+  / dapcli                           (one session)                    / cmd/wsmon
                                           │                            threads,
                                           ▼                            lifecycle)
                                     spawntree tracee
@@ -46,6 +50,10 @@ architecture behind this.
   it neither invokes nor validates `dlv`, and it does not replace the Go
   extension's `"go"` type. To update, rerun `just vscode-install`; uninstall with
   `code --uninstall-extension bingosuite.bingo`.
+
+- For Neovim: Neovim 0.11.7 or newer plus `nvim-dap`. Run
+  `just neovim-prepare`, add `editors/neovim` to the runtime path, and call
+  `require("bingo").setup()`. See the [Neovim guide](../editors/neovim/README.md).
 
 ## 1. Demo targets
 
@@ -107,7 +115,23 @@ path in **bingo Server** rather than killing a potentially shared process.
 > `binaryPath` attaches to an OS process instead; the extension README has the
 > full shape.
 
-## 3. Drive with cmd/dapcli (DAP, no IDE)
+## 3. Drive with Neovim (DAP, automatic server)
+
+1. Run `just neovim-prepare` and configure the companion as described in
+   [editors/neovim/README.md](../editors/neovim/README.md).
+2. Open a Go source file and run `:BingoLaunch ./build/examples/level5-workflow`.
+   The adapter health-checks the loopback management endpoint, reuses or starts
+   a compatible detached server, and connects `nvim-dap`.
+3. Use normal `nvim-dap` breakpoint and continue mappings. The plugin validates
+   `bingo/session/v1`; `:BingoSession` shows the ID.
+4. Run `go run ./cmd/wsmon -session <session-id>` in another terminal for the
+   goroutine tree, OS threads, and lifecycle deltas.
+
+`:BingoAttach <pid> [binary]` attaches to an OS process, while
+`:BingoJoin <session-id>` joins an existing managed session without relaunching
+or resuming it. Remote endpoints use `server.mode = "connectOnly"`.
+
+## 4. Drive with cmd/dapcli (DAP, no IDE)
 
 Equivalent driver in a terminal requires a manual server:
 
@@ -124,7 +148,7 @@ c                             # continue → hits the breakpoint
 `dapcli` prints the session id it created (also on the server console). Continue
 again to churn rounds; each stop pushes a fresh telemetry snapshot to observers.
 
-## 4. Terminal fallback with cmd/wsmon
+## 5. Terminal fallback with cmd/wsmon
 
 In another terminal, join the **same session id** read-only and watch it update:
 

--- a/editors/neovim/README.md
+++ b/editors/neovim/README.md
@@ -1,0 +1,138 @@
+# bingo for Neovim
+
+The Neovim companion registers bingo as a TCP adapter for
+[`nvim-dap`](https://github.com/mfussenegger/nvim-dap). `nvim-dap` owns the
+standard debug UI and drives launch, attach, breakpoints, stepping, stack frames,
+variables, and evaluate requests. bingo remains a separate server and never
+invokes Delve.
+
+## Requirements
+
+- Neovim 0.11.7 or newer;
+- `mfussenegger/nvim-dap`;
+- Apple Silicon macOS or x86-64 Linux;
+- a bingo server prepared with `just neovim-prepare`, available as `bingo` on
+  `PATH`, or configured explicitly.
+
+## Install from this repository
+
+Prepare the platform-native server:
+
+```sh
+just neovim-prepare
+```
+
+Add `editors/neovim` to Neovim's runtime path with your plugin manager. For a
+local checkout with `lazy.nvim`:
+
+```lua
+{
+  dir = "/absolute/path/to/bingo/editors/neovim",
+  dependencies = { "mfussenegger/nvim-dap" },
+  config = function()
+    require("bingo").setup()
+  end,
+}
+```
+
+The generated `editors/neovim/bin/bingo` is platform-specific and ignored by
+Git. If the plugin directory is installed separately, put a compatible `bingo`
+binary on `PATH` or pass `server.binary`.
+
+## Managed connect-or-start
+
+The default `auto` mode mirrors the VS Code companion:
+
+1. probe `http://127.0.0.1:6060/api/health`;
+2. reuse a compatible bingo server with DAP on `127.0.0.1:4711`;
+3. start the prepared or configured binary only when the management connection
+   is refused;
+4. wait up to five seconds for compatible health;
+5. connect `nvim-dap` to the shared DAP listener.
+
+The spawned server is detached and receives a 30-second server-owned idle grace.
+The plugin never kills it. Logs default to
+`stdpath("state") .. "/bingo/server.log"`.
+
+```lua
+require("bingo").setup({
+  server = {
+    mode = "auto",
+    binary = "/absolute/path/to/bingo", -- optional
+    management_host = "127.0.0.1",
+    management_port = 6060,
+    dap_host = "127.0.0.1",
+    dap_port = 4711,
+    ready_timeout_ms = 5000,
+    idle_timeout_ms = 30000,
+    log_path = nil,
+  },
+  configurations = true,
+  notify_session = true,
+})
+```
+
+`setup()` adds three Go configurations to `dap.configurations.go`: launch a
+binary, attach to a PID, and join a managed session. Set `configurations = false`
+to register only the adapter.
+
+## Drive a session
+
+Use `:DapContinue` and the rest of your normal `nvim-dap` mappings, or start
+through the companion commands:
+
+```vim
+:BingoLaunch /absolute/path/to/program
+:BingoAttach 1234 /absolute/path/to/program
+:BingoJoin session-id
+:BingoSession
+```
+
+`BingoAttach` accepts an optional binary path, but DWARF-backed source
+breakpoints, stack frames, and locals require it. Joining does not relaunch,
+reattach, or automatically resume the shared session.
+
+The adapter's `bingo/session/v1` event is validated and retained. `:BingoSession`
+shows the active ID, `require("bingo").session_id()` returns it, and the plugin
+emits `User BingoSession` with `event.data.session_id` for other Neovim plugins.
+
+## Remote and custom endpoints
+
+Autostart is loopback-only. Connect to an externally managed or forwarded server
+without probing or spawning:
+
+```lua
+require("bingo").setup({
+  server = {
+    mode = "connectOnly",
+    dap_host = "debug.internal",
+    dap_port = 14711,
+  },
+})
+```
+
+Each `nvim-dap` configuration may override the same camel-case lifecycle fields
+as VS Code: `serverMode`, `managementHost`, `managementPort`, `dapHost`,
+`dapPort`, `serverReadyTimeoutMs`, and `managedIdleTimeoutMs`.
+
+## Concurrency telemetry
+
+DAP drives the debug loop. bingo's richer goroutine spawn hierarchy remains on
+the WebSocket stream, so observe the announced session from another terminal:
+
+```sh
+go run ./cmd/wsmon -session <session-id>
+```
+
+The observer is read-only and can coexist with Neovim and other DAP or WebSocket
+clients on the same session.
+
+## Development
+
+```sh
+just neovim-check
+```
+
+The headless-Neovim check parses every Lua file and runs the dependency-free
+configuration, adapter-registration, health-contract, HTTP, and session-event
+tests.

--- a/editors/neovim/lua/bingo/config.lua
+++ b/editors/neovim/lua/bingo/config.lua
@@ -1,0 +1,219 @@
+local M = {}
+
+M.defaults = {
+  configurations = true,
+  notify_session = true,
+  log = nil,
+  server = {
+    mode = "auto",
+    management_host = "127.0.0.1",
+    management_port = 6060,
+    dap_host = "127.0.0.1",
+    dap_port = 4711,
+    ready_timeout_ms = 5000,
+    idle_timeout_ms = 30000,
+    binary = nil,
+    log_path = nil,
+  },
+}
+
+local function fail(message)
+  error("bingo: " .. message, 0)
+end
+
+local function copy(value)
+  if type(value) ~= "table" then
+    return value
+  end
+  local result = {}
+  for key, item in pairs(value) do
+    result[key] = copy(item)
+  end
+  return result
+end
+
+local function boolean(value, fallback, name)
+  if value == nil then
+    return fallback
+  end
+  if type(value) ~= "boolean" then
+    fail(name .. " must be a boolean")
+  end
+  return value
+end
+
+local function string_value(value, fallback, name)
+  if value == nil then
+    return fallback
+  end
+  if type(value) ~= "string" or value:match("^%s*$") then
+    fail(name .. " must be a non-empty string")
+  end
+  return value
+end
+
+local function integer(value, fallback, name, minimum, maximum)
+  if value == nil then
+    return fallback
+  end
+  if type(value) ~= "number" or value % 1 ~= 0 or value < minimum or value > maximum then
+    fail(
+      string.format(
+        "%s must be an integer between %d and %d",
+        name,
+        minimum,
+        maximum
+      )
+    )
+  end
+  return value
+end
+
+local function mode(value, fallback)
+  value = value == nil and fallback or value
+  if value ~= "auto" and value ~= "connectOnly" then
+    fail('server mode must be "auto" or "connectOnly"')
+  end
+  return value
+end
+
+function M.normalize(options)
+  options = options or {}
+  if type(options) ~= "table" then
+    fail("setup options must be a table")
+  end
+  local server = options.server or {}
+  if type(server) ~= "table" then
+    fail("server options must be a table")
+  end
+
+  local defaults = M.defaults
+  local result = copy(defaults)
+  result.configurations = boolean(
+    options.configurations,
+    defaults.configurations,
+    "configurations"
+  )
+  result.notify_session = boolean(
+    options.notify_session,
+    defaults.notify_session,
+    "notify_session"
+  )
+  if options.log ~= nil and type(options.log) ~= "function" then
+    fail("log must be a function")
+  end
+  result.log = options.log
+
+  result.server.mode = mode(server.mode, defaults.server.mode)
+  result.server.management_host = string_value(
+    server.management_host,
+    defaults.server.management_host,
+    "server.management_host"
+  )
+  result.server.management_port = integer(
+    server.management_port,
+    defaults.server.management_port,
+    "server.management_port",
+    1,
+    65535
+  )
+  result.server.dap_host = string_value(
+    server.dap_host,
+    defaults.server.dap_host,
+    "server.dap_host"
+  )
+  result.server.dap_port = integer(
+    server.dap_port,
+    defaults.server.dap_port,
+    "server.dap_port",
+    1,
+    65535
+  )
+  result.server.ready_timeout_ms = integer(
+    server.ready_timeout_ms,
+    defaults.server.ready_timeout_ms,
+    "server.ready_timeout_ms",
+    100,
+    120000
+  )
+  result.server.idle_timeout_ms = integer(
+    server.idle_timeout_ms,
+    defaults.server.idle_timeout_ms,
+    "server.idle_timeout_ms",
+    1,
+    86400000
+  )
+  result.server.binary = string_value(
+    server.binary,
+    defaults.server.binary,
+    "server.binary"
+  )
+  result.server.log_path = string_value(
+    server.log_path,
+    defaults.server.log_path,
+    "server.log_path"
+  )
+  return result
+end
+
+local function debug_string(debug_config, key, fallback)
+  local value = debug_config[key]
+  return string_value(value, fallback, key)
+end
+
+local function debug_integer(debug_config, key, fallback, minimum, maximum)
+  return integer(debug_config[key], fallback, key, minimum, maximum)
+end
+
+function M.resolve(debug_config, options)
+  if type(debug_config) ~= "table" then
+    fail("debug configuration must be a table")
+  end
+  options = options or M.normalize()
+  local server = options.server
+  local resolved_mode = mode(debug_config.serverMode, server.mode)
+
+  return {
+    mode = resolved_mode,
+    management = {
+      host = debug_string(
+        debug_config,
+        "managementHost",
+        server.management_host
+      ),
+      port = debug_integer(
+        debug_config,
+        "managementPort",
+        server.management_port,
+        1,
+        65535
+      ),
+    },
+    dap = {
+      host = debug_string(debug_config, "dapHost", server.dap_host),
+      port = debug_integer(debug_config, "dapPort", server.dap_port, 1, 65535),
+    },
+    ready_timeout_ms = debug_integer(
+      debug_config,
+      "serverReadyTimeoutMs",
+      server.ready_timeout_ms,
+      100,
+      120000
+    ),
+    idle_timeout_ms = debug_integer(
+      debug_config,
+      "managedIdleTimeoutMs",
+      server.idle_timeout_ms,
+      1,
+      86400000
+    ),
+    binary = server.binary,
+    log_path = server.log_path,
+  }
+end
+
+function M.endpoint(endpoint)
+  return string.format("%s:%d", endpoint.host, endpoint.port)
+end
+
+return M

--- a/editors/neovim/lua/bingo/health.lua
+++ b/editors/neovim/lua/bingo/health.lua
@@ -1,0 +1,263 @@
+local M = {}
+
+M.service = "bingo"
+M.management_api_version = 1
+M.wire_protocol_version = "1.2"
+M.session_event_version = 1
+
+local maximum_response_bytes = 64 * 1024
+
+local function record(value)
+  return type(value) == "table"
+end
+
+local function incompatible(reason)
+  return { kind = "incompatible", reason = reason }
+end
+
+local function parse_address(value)
+  if type(value) ~= "string" then
+    return nil
+  end
+
+  local host
+  local port_text
+  if value:sub(1, 1) == "[" then
+    host, port_text = value:match("^%[([^]]+)%]:(%d+)$")
+  else
+    host, port_text = value:match("^(.*):(%d+)$")
+  end
+  local port = tonumber(port_text)
+  if host == nil or host == "" or port == nil or port % 1 ~= 0 or port < 1 or port > 65535 then
+    return nil
+  end
+  return { host = host, port = port }
+end
+
+local function wildcard(host)
+  return host == "" or host == "0.0.0.0" or host == "::"
+end
+
+function M.validate(status_code, decoded, expected_dap)
+  if status_code ~= 200 then
+    return incompatible(string.format("health endpoint returned HTTP %d", status_code))
+  end
+  if not record(decoded) then
+    return incompatible("health response must be an object")
+  end
+  if decoded.service ~= M.service then
+    return incompatible(
+      string.format(
+        'health service identity is %s, expected "%s"',
+        tostring(decoded.service),
+        M.service
+      )
+    )
+  end
+  if decoded.managementApiVersion ~= M.management_api_version then
+    return incompatible(
+      string.format(
+        "management API version is %s, expected %d",
+        tostring(decoded.managementApiVersion),
+        M.management_api_version
+      )
+    )
+  end
+  if decoded.wireProtocolVersion ~= M.wire_protocol_version then
+    return incompatible(
+      string.format(
+        "wire protocol version is %s, expected %s",
+        tostring(decoded.wireProtocolVersion),
+        M.wire_protocol_version
+      )
+    )
+  end
+  if type(decoded.instanceId) ~= "string" or decoded.instanceId == "" then
+    return incompatible("health response has no instanceId")
+  end
+  if not record(decoded.dap) or decoded.dap.enabled ~= true then
+    return incompatible("bingo DAP listener is not enabled")
+  end
+  if decoded.dap.sessionEventVersion ~= M.session_event_version then
+    return incompatible(
+      string.format(
+        "DAP session event version is %s, expected %d",
+        tostring(decoded.dap.sessionEventVersion),
+        M.session_event_version
+      )
+    )
+  end
+
+  local advertised = parse_address(decoded.dap.address)
+  if advertised == nil then
+    return incompatible(
+      "health DAP address is invalid: " .. tostring(decoded.dap.address)
+    )
+  end
+  if advertised.port ~= expected_dap.port then
+    return incompatible(
+      string.format(
+        "health DAP port is %d, expected %d",
+        advertised.port,
+        expected_dap.port
+      )
+    )
+  end
+  if not wildcard(advertised.host) and advertised.host ~= expected_dap.host then
+    return incompatible(
+      string.format(
+        "health DAP host is %s, expected %s",
+        advertised.host,
+        expected_dap.host
+      )
+    )
+  end
+
+  return {
+    kind = "compatible",
+    health = {
+      instance_id = decoded.instanceId,
+      dap_address = decoded.dap.address,
+    },
+  }
+end
+
+function M.parse_http_response(raw)
+  local headers, body = raw:match("^(.-)\r\n\r\n(.*)$")
+  if headers == nil then
+    return nil, "health endpoint returned an incomplete HTTP response"
+  end
+  local status = tonumber(headers:match("^HTTP/%d+%.%d+%s+(%d%d%d)"))
+  if status == nil then
+    return nil, "health endpoint returned an invalid HTTP status line"
+  end
+  return { status = status, body = body }
+end
+
+local function default_dependencies()
+  return {
+    uv = vim.uv or vim.loop,
+    schedule = vim.schedule,
+    decode = vim.json.decode,
+  }
+end
+
+local function refused(error_message)
+  return type(error_message) == "string"
+    and error_message:find("ECONNREFUSED", 1, true) ~= nil
+end
+
+function M.probe(endpoint, expected_dap, timeout_ms, callback, dependencies)
+  local deps = dependencies or default_dependencies()
+  local uv = deps.uv
+  local tcp = uv.new_tcp()
+  local timer = uv.new_timer()
+  local chunks = {}
+  local size = 0
+  local finished = false
+
+  local function close_handles()
+    if timer ~= nil and not timer:is_closing() then
+      timer:stop()
+      timer:close()
+    end
+    if tcp ~= nil and not tcp:is_closing() then
+      tcp:close()
+    end
+  end
+
+  local function finish(result)
+    if finished then
+      return
+    end
+    finished = true
+    close_handles()
+    deps.schedule(function()
+      callback(result)
+    end)
+  end
+
+  local function finish_response()
+    local response, parse_error = M.parse_http_response(table.concat(chunks))
+    if response == nil then
+      finish({ kind = "transportError", error = parse_error })
+      return
+    end
+
+    local ok, decoded = pcall(deps.decode, response.body)
+    if not ok then
+      finish({
+        kind = "incompatible",
+        reason = "health endpoint did not return JSON",
+      })
+      return
+    end
+    finish(M.validate(response.status, decoded, expected_dap))
+  end
+
+  timer:start(timeout_ms, 0, function()
+    finish({
+      kind = "transportError",
+      error = string.format("health request timed out after %dms", timeout_ms),
+    })
+  end)
+
+  tcp:connect(endpoint.host, endpoint.port, function(connect_error)
+    if finished then
+      return
+    end
+    if connect_error ~= nil then
+      if refused(connect_error) then
+        finish({ kind = "absent" })
+      else
+        finish({ kind = "transportError", error = tostring(connect_error) })
+      end
+      return
+    end
+
+    local request = table.concat({
+      "GET /api/health HTTP/1.1\r\n",
+      "Host: ",
+      endpoint.host,
+      ":",
+      tostring(endpoint.port),
+      "\r\n",
+      "Accept: application/json\r\n",
+      "Cache-Control: no-cache\r\n",
+      "Connection: close\r\n\r\n",
+    })
+    tcp:write(request, function(write_error)
+      if finished then
+        return
+      end
+      if write_error ~= nil then
+        finish({ kind = "transportError", error = tostring(write_error) })
+        return
+      end
+      tcp:read_start(function(read_error, chunk)
+        if finished then
+          return
+        end
+        if read_error ~= nil then
+          finish({ kind = "transportError", error = tostring(read_error) })
+          return
+        end
+        if chunk == nil then
+          finish_response()
+          return
+        end
+        size = size + #chunk
+        if size > maximum_response_bytes then
+          finish({
+            kind = "transportError",
+            error = "bingo health response exceeded 64 KiB",
+          })
+          return
+        end
+        chunks[#chunks + 1] = chunk
+      end)
+    end)
+  end)
+end
+
+return M

--- a/editors/neovim/lua/bingo/init.lua
+++ b/editors/neovim/lua/bingo/init.lua
@@ -1,0 +1,270 @@
+local config = require("bingo.config")
+local server = require("bingo.server")
+local session_event = require("bingo.session")
+
+local M = {}
+local state = {
+  dap = nil,
+  manager = nil,
+  options = nil,
+  current_session = nil,
+  session_ids = setmetatable({}, { __mode = "k" }),
+}
+
+local default_configuration_names = {
+  ["bingo: Launch binary"] = true,
+  ["bingo: Attach to process"] = true,
+  ["bingo: Join session"] = true,
+}
+
+local function notify(message, level)
+  vim.notify(message, level, { title = "bingo" })
+end
+
+local function prompt(label, default, completion)
+  return vim.fn.input(label, default or "", completion)
+end
+
+local function ensure_listener(dap, stage, name)
+  dap.listeners[stage][name] = dap.listeners[stage][name] or {}
+  return dap.listeners[stage][name]
+end
+
+local function remove_session(dap_session)
+  local removed = state.session_ids[dap_session]
+  state.session_ids[dap_session] = nil
+  if state.current_session == removed then
+    state.current_session = nil
+    for _, id in pairs(state.session_ids) do
+      state.current_session = id
+      break
+    end
+  end
+end
+
+local function register_session_listeners(dap)
+  local event_key = "event_" .. session_event.event_name
+  ensure_listener(dap, "before", event_key).bingo = function(dap_session, body)
+    local announcement, decode_error = session_event.decode(body)
+    if announcement == nil then
+      notify("ignored invalid bingo session event: " .. decode_error, vim.log.levels.WARN)
+      return
+    end
+
+    state.session_ids[dap_session] = announcement.session_id
+    state.current_session = announcement.session_id
+    if state.options.notify_session then
+      notify("managed session " .. announcement.session_id, vim.log.levels.INFO)
+    end
+    vim.api.nvim_exec_autocmds("User", {
+      pattern = "BingoSession",
+      modeline = false,
+      data = {
+        session_id = announcement.session_id,
+      },
+    })
+  end
+
+  ensure_listener(dap, "before", "event_terminated").bingo = remove_session
+  ensure_listener(dap, "before", "event_exited").bingo = remove_session
+  dap.listeners.on_session.bingo = function(_, new_session)
+    if
+      new_session == nil
+      or new_session.config == nil
+      or new_session.config.type ~= "bingo"
+    then
+      return
+    end
+    new_session.on_close = new_session.on_close or {}
+    new_session.on_close.bingo = function(closed_session)
+      vim.schedule(function()
+        remove_session(closed_session)
+      end)
+    end
+  end
+end
+
+local function default_configurations()
+  return {
+    {
+      name = "bingo: Launch binary",
+      type = "bingo",
+      request = "launch",
+      program = function()
+        return prompt("Path to executable: ", vim.fn.getcwd() .. "/", "file")
+      end,
+      args = {},
+      env = {},
+      stopOnEntry = true,
+    },
+    {
+      name = "bingo: Attach to process",
+      type = "bingo",
+      request = "attach",
+      pid = function()
+        return tonumber(prompt("Process ID: "))
+      end,
+      binaryPath = function()
+        return prompt("Path to executable (optional): ", vim.fn.getcwd() .. "/", "file")
+      end,
+      stopOnEntry = true,
+    },
+    {
+      name = "bingo: Join session",
+      type = "bingo",
+      request = "attach",
+      session = function()
+        return prompt("Managed bingo session ID: ")
+      end,
+    },
+  }
+end
+
+local function add_configurations(dap)
+  dap.configurations.go = dap.configurations.go or {}
+  local present = {}
+  for _, item in ipairs(dap.configurations.go) do
+    if item.type == "bingo" and default_configuration_names[item.name] then
+      present[item.name] = true
+    end
+  end
+  for _, item in ipairs(default_configurations()) do
+    if not present[item.name] then
+      dap.configurations.go[#dap.configurations.go + 1] = item
+    end
+  end
+end
+
+function M.setup(options)
+  if vim.fn.has("nvim-0.11.7") ~= 1 then
+    error("bingo requires Neovim 0.11.7 or newer")
+  end
+
+  local dap = require("dap")
+  if state.manager ~= nil then
+    state.manager:dispose()
+  end
+  state.options = config.normalize(options)
+  state.manager = server.new(state.options)
+  state.dap = dap
+
+  dap.adapters.bingo = function(callback, debug_config)
+    state.manager:ensure(debug_config, function(error_message, endpoint)
+      if error_message ~= nil then
+        notify(error_message, vim.log.levels.ERROR)
+        return
+      end
+      callback({
+        type = "server",
+        host = endpoint.host,
+        port = endpoint.port,
+        options = {
+          initialize_timeout_sec = 10,
+          disconnect_timeout_sec = 5,
+        },
+      })
+    end)
+  end
+
+  register_session_listeners(dap)
+  if state.options.configurations then
+    add_configurations(dap)
+  end
+  return M
+end
+
+local function ensure_setup()
+  if state.dap == nil then
+    M.setup()
+  end
+end
+
+local function require_non_empty(value, label)
+  if type(value) ~= "string" or value:match("^%s*$") then
+    notify(label .. " is required", vim.log.levels.ERROR)
+    return nil
+  end
+  return value
+end
+
+function M.launch(program)
+  ensure_setup()
+  program = program or prompt("Path to executable: ", vim.fn.getcwd() .. "/", "file")
+  program = require_non_empty(program, "executable path")
+  if program == nil then
+    return
+  end
+  state.dap.run({
+    name = "bingo: " .. vim.fs.basename(program),
+    type = "bingo",
+    request = "launch",
+    program = program,
+    args = {},
+    env = {},
+    stopOnEntry = true,
+  })
+end
+
+function M.attach(pid, binary_path)
+  ensure_setup()
+  pid = pid or tonumber(prompt("Process ID: "))
+  if type(pid) ~= "number" or pid % 1 ~= 0 or pid <= 0 then
+    notify("a positive process ID is required", vim.log.levels.ERROR)
+    return
+  end
+  if binary_path == nil then
+    binary_path = prompt(
+      "Path to executable (optional): ",
+      vim.fn.getcwd() .. "/",
+      "file"
+    )
+  end
+  state.dap.run({
+    name = "bingo: Attach " .. tostring(pid),
+    type = "bingo",
+    request = "attach",
+    pid = pid,
+    binaryPath = binary_path,
+    stopOnEntry = true,
+  })
+end
+
+function M.join(session_id)
+  ensure_setup()
+  session_id = session_id or prompt("Managed bingo session ID: ")
+  session_id = require_non_empty(session_id, "managed session ID")
+  if session_id == nil then
+    return
+  end
+  state.dap.run({
+    name = "bingo: Join " .. session_id,
+    type = "bingo",
+    request = "attach",
+    session = session_id,
+  })
+end
+
+function M.session_id()
+  return state.current_session
+end
+
+function M.show_session()
+  local id = M.session_id()
+  if id == nil then
+    notify("no active bingo managed session", vim.log.levels.INFO)
+    return
+  end
+  notify("managed session " .. id, vim.log.levels.INFO)
+end
+
+function M.dispose()
+  if state.manager ~= nil then
+    state.manager:dispose()
+  end
+  state.manager = nil
+  state.dap = nil
+  state.current_session = nil
+  state.session_ids = setmetatable({}, { __mode = "k" })
+end
+
+return M

--- a/editors/neovim/lua/bingo/server.lua
+++ b/editors/neovim/lua/bingo/server.lua
@@ -1,0 +1,345 @@
+local config = require("bingo.config")
+local health = require("bingo.health")
+
+local M = {}
+local Manager = {}
+Manager.__index = Manager
+
+local probe_timeout_ms = 1000
+local poll_interval_ms = 100
+
+local function default_dependencies()
+  local uv = vim.uv or vim.loop
+  return {
+    uv = uv,
+    schedule = vim.schedule,
+    executable = vim.fn.executable,
+    exepath = vim.fn.exepath,
+    mkdir = function(path)
+      vim.fn.mkdir(path, "p")
+    end,
+    stdpath = vim.fn.stdpath,
+    probe = health.probe,
+  }
+end
+
+local function source_root()
+  local source = debug.getinfo(1, "S").source
+  if source:sub(1, 1) == "@" then
+    source = source:sub(2)
+  end
+  local dirname = vim.fs.dirname
+  return dirname(dirname(dirname(source)))
+end
+
+local function supported_platform(uv)
+  local uname = uv.os_uname()
+  local system = uname.sysname
+  local machine = uname.machine
+  if system == "Darwin" and (machine == "arm64" or machine == "aarch64") then
+    return true
+  end
+  return system == "Linux" and (machine == "x86_64" or machine == "amd64")
+end
+
+local function describe_probe(result)
+  if result == nil then
+    return "no health response"
+  end
+  if result.kind == "transportError" then
+    return "last health error: " .. tostring(result.error)
+  end
+  if result.kind == "incompatible" then
+    return "last health response: " .. result.reason
+  end
+  return "last health result: " .. result.kind
+end
+
+function M.new(options, dependencies)
+  return setmetatable({
+    options = options,
+    deps = dependencies or default_dependencies(),
+    in_flight = {},
+    timers = {},
+    processes = {},
+    disposed = false,
+  }, Manager)
+end
+
+function Manager:_log(message)
+  if self.options.log ~= nil then
+    self.options.log(message)
+  end
+end
+
+function Manager:_complete(key, error_message, endpoint)
+  local waiters = self.in_flight[key]
+  if waiters == nil then
+    return
+  end
+  self.in_flight[key] = nil
+  for _, callback in ipairs(waiters) do
+    callback(error_message, endpoint)
+  end
+end
+
+function Manager:_later(delay_ms, callback)
+  local timer = self.deps.uv.new_timer()
+  self.timers[timer] = true
+  timer:start(delay_ms, 0, function()
+    timer:stop()
+    timer:close()
+    self.timers[timer] = nil
+    self.deps.schedule(callback)
+  end)
+end
+
+function Manager:_resolve_binary(resolved)
+  local explicit = resolved.binary
+  if explicit ~= nil then
+    local found = self.deps.exepath(explicit)
+    if found ~= "" then
+      return found
+    end
+    if self.deps.executable(explicit) == 1 then
+      return explicit
+    end
+    return nil, "configured bingo binary is not executable: " .. explicit
+  end
+
+  local bundled = vim.fs.joinpath(source_root(), "bin", "bingo")
+  if self.deps.executable(bundled) == 1 then
+    return bundled
+  end
+  local path_binary = self.deps.exepath("bingo")
+  if path_binary ~= "" then
+    return path_binary
+  end
+  return nil,
+    "no bingo server binary found; run `just neovim-prepare`, put bingo on PATH, or set server.binary"
+end
+
+function Manager:_log_path(resolved)
+  if resolved.log_path ~= nil then
+    return resolved.log_path
+  end
+  return vim.fs.joinpath(self.deps.stdpath("state"), "bingo", "server.log")
+end
+
+function Manager:_spawn(resolved)
+  local binary, binary_error = self:_resolve_binary(resolved)
+  if binary == nil then
+    return nil, binary_error
+  end
+
+  local log_path = self:_log_path(resolved)
+  self.deps.mkdir(vim.fs.dirname(log_path))
+  local log_fd, open_error = self.deps.uv.fs_open(log_path, "a", 420)
+  if log_fd == nil then
+    return nil, "cannot open bingo server log " .. log_path .. ": " .. tostring(open_error)
+  end
+
+  local args = {
+    "-addr",
+    config.endpoint(resolved.management),
+    "-dap-addr",
+    config.endpoint(resolved.dap),
+    "-idle-timeout",
+    tostring(resolved.idle_timeout_ms) .. "ms",
+  }
+  local handle
+  local pid
+  handle, pid = self.deps.uv.spawn(binary, {
+    args = args,
+    detached = true,
+    stdio = { nil, log_fd, log_fd },
+  }, function(code, signal)
+    if handle ~= nil and not handle:is_closing() then
+      handle:close()
+    end
+    self.deps.schedule(function()
+      self.processes[pid] = nil
+      self:_log(
+        string.format(
+          "managed bingo server %s exited with code %d signal %d",
+          tostring(pid),
+          code,
+          signal
+        )
+      )
+    end)
+  end)
+  self.deps.uv.fs_close(log_fd)
+  if handle == nil then
+    return nil, "cannot start bingo server: " .. tostring(pid) .. "; logs: " .. log_path
+  end
+
+  handle:unref()
+  self.processes[pid] = handle
+  self:_log("starting managed bingo server; logs: " .. log_path)
+  return { pid = pid, log_path = log_path }
+end
+
+function Manager:_poll_ready(key, resolved, child, deadline_ms, last_result)
+  if self.disposed or self.in_flight[key] == nil then
+    return
+  end
+  local now_ms = self.deps.uv.hrtime() / 1000000
+  local remaining = deadline_ms - now_ms
+  if remaining <= 0 then
+    self:_complete(
+      key,
+      string.format(
+        "managed bingo server did not become ready at %s within %dms (%s); DAP %s; logs: %s",
+        config.endpoint(resolved.management),
+        resolved.ready_timeout_ms,
+        describe_probe(last_result),
+        config.endpoint(resolved.dap),
+        child.log_path
+      )
+    )
+    return
+  end
+
+  self.deps.probe(
+    resolved.management,
+    resolved.dap,
+    math.min(probe_timeout_ms, math.max(1, math.floor(remaining))),
+    function(result)
+      if self.disposed or self.in_flight[key] == nil then
+        return
+      end
+      if result.kind == "compatible" then
+        self:_log("reusing compatible bingo instance " .. result.health.instance_id)
+        self:_complete(key, nil, resolved.dap)
+        return
+      end
+      if result.kind == "incompatible" then
+        self:_complete(
+          key,
+          "cannot use bingo management endpoint "
+            .. config.endpoint(resolved.management)
+            .. ": "
+            .. result.reason
+        )
+        return
+      end
+      local poll_remaining = deadline_ms - self.deps.uv.hrtime() / 1000000
+      self:_later(math.max(1, math.min(poll_interval_ms, poll_remaining)), function()
+        self:_poll_ready(key, resolved, child, deadline_ms, result)
+      end)
+    end
+  )
+end
+
+function Manager:_ensure_auto(key, resolved)
+  if resolved.management.host ~= "127.0.0.1" or resolved.dap.host ~= "127.0.0.1" then
+    self:_complete(
+      key,
+      'serverMode "auto" requires managementHost and dapHost to be 127.0.0.1; use "connectOnly" for remote or custom endpoints'
+    )
+    return
+  end
+  if not supported_platform(self.deps.uv) then
+    self:_complete(
+      key,
+      'bingo server autostart supports only linux/amd64 and darwin/arm64; use serverMode "connectOnly" with an existing server'
+    )
+    return
+  end
+
+  self.deps.probe(
+    resolved.management,
+    resolved.dap,
+    math.min(probe_timeout_ms, resolved.ready_timeout_ms),
+    function(result)
+      if self.disposed or self.in_flight[key] == nil then
+        return
+      end
+      if result.kind == "compatible" then
+        self:_log("reusing compatible bingo instance " .. result.health.instance_id)
+        self:_complete(key, nil, resolved.dap)
+        return
+      end
+      if result.kind == "incompatible" then
+        self:_complete(
+          key,
+          "cannot use bingo management endpoint "
+            .. config.endpoint(resolved.management)
+            .. ": "
+            .. result.reason
+            .. "; no server was started"
+        )
+        return
+      end
+      if result.kind == "transportError" then
+        self:_complete(
+          key,
+          "cannot probe bingo management endpoint "
+            .. config.endpoint(resolved.management)
+            .. ": "
+            .. tostring(result.error)
+        )
+        return
+      end
+
+      local child, spawn_error = self:_spawn(resolved)
+      if child == nil then
+        self:_complete(key, spawn_error)
+        return
+      end
+      local deadline = self.deps.uv.hrtime() / 1000000 + resolved.ready_timeout_ms
+      self:_poll_ready(key, resolved, child, deadline, result)
+    end
+  )
+end
+
+function Manager:ensure(debug_config, callback)
+  if self.disposed then
+    self.deps.schedule(function()
+      callback("bingo server manager is disposed")
+    end)
+    return
+  end
+
+  local ok, resolved = pcall(config.resolve, debug_config, self.options)
+  if not ok then
+    self.deps.schedule(function()
+      callback(tostring(resolved))
+    end)
+    return
+  end
+  if resolved.mode == "connectOnly" then
+    self.deps.schedule(function()
+      callback(nil, resolved.dap)
+    end)
+    return
+  end
+
+  local key = config.endpoint(resolved.management) .. "|" .. config.endpoint(resolved.dap)
+  if self.in_flight[key] ~= nil then
+    self.in_flight[key][#self.in_flight[key] + 1] = callback
+    return
+  end
+  self.in_flight[key] = { callback }
+  self:_ensure_auto(key, resolved)
+end
+
+function Manager:dispose()
+  if self.disposed then
+    return
+  end
+  self.disposed = true
+  for timer in pairs(self.timers) do
+    if not timer:is_closing() then
+      timer:stop()
+      timer:close()
+    end
+  end
+  self.timers = {}
+  for key in pairs(self.in_flight) do
+    self:_complete(key, "bingo server startup was cancelled")
+  end
+end
+
+return M

--- a/editors/neovim/lua/bingo/session.lua
+++ b/editors/neovim/lua/bingo/session.lua
@@ -1,0 +1,34 @@
+local M = {}
+
+M.event_name = "bingo/session/v1"
+M.event_version = 1
+
+function M.decode(body)
+  if type(body) ~= "table" then
+    return nil, "bingo session event body must be an object"
+  end
+  local count = 0
+  for key in pairs(body) do
+    if key ~= "version" and key ~= "sessionId" then
+      return nil, "bingo session event body has unexpected fields"
+    end
+    count = count + 1
+  end
+  if count ~= 2 then
+    return nil, "bingo session event body has unexpected fields"
+  end
+  if body.version ~= M.event_version then
+    return nil, "unsupported bingo session event version " .. tostring(body.version)
+  end
+  if
+    type(body.sessionId) ~= "string"
+    or #body.sessionId == 0
+    or #body.sessionId > 128
+    or body.sessionId:match("^[A-Za-z0-9][A-Za-z0-9._-]*$") == nil
+  then
+    return nil, "bingo session event has an invalid sessionId"
+  end
+  return { session_id = body.sessionId }
+end
+
+return M

--- a/editors/neovim/plugin/bingo.lua
+++ b/editors/neovim/plugin/bingo.lua
@@ -1,0 +1,33 @@
+if vim.g.loaded_bingo == 1 then
+  return
+end
+vim.g.loaded_bingo = 1
+
+vim.api.nvim_create_user_command("BingoLaunch", function(command)
+  require("bingo").launch(command.args ~= "" and command.args or nil)
+end, {
+  nargs = "?",
+  complete = "file",
+  desc = "Launch a binary with bingo through nvim-dap",
+})
+
+vim.api.nvim_create_user_command("BingoAttach", function(command)
+  local pid = tonumber(command.fargs[1])
+  require("bingo").attach(pid, command.fargs[2])
+end, {
+  nargs = "*",
+  desc = "Attach bingo to an operating-system process through nvim-dap",
+})
+
+vim.api.nvim_create_user_command("BingoJoin", function(command)
+  require("bingo").join(command.args ~= "" and command.args or nil)
+end, {
+  nargs = "?",
+  desc = "Join an existing managed bingo session through nvim-dap",
+})
+
+vim.api.nvim_create_user_command("BingoSession", function()
+  require("bingo").show_session()
+end, {
+  desc = "Show the active managed bingo session ID",
+})

--- a/editors/neovim/tests/run.lua
+++ b/editors/neovim/tests/run.lua
@@ -1,0 +1,353 @@
+local script = arg[0]
+local root = script:match("^(.*)/tests/run%.lua$") or "."
+package.path = table.concat({
+  root .. "/lua/?.lua",
+  root .. "/lua/?/init.lua",
+  package.path,
+}, ";")
+
+for _, path in ipairs({
+  "lua/bingo/config.lua",
+  "lua/bingo/health.lua",
+  "lua/bingo/init.lua",
+  "lua/bingo/server.lua",
+  "lua/bingo/session.lua",
+  "plugin/bingo.lua",
+  "tests/run.lua",
+}) do
+  local chunk, parse_error = loadfile(root .. "/" .. path)
+  if chunk == nil then
+    error(parse_error)
+  end
+end
+
+local failures = 0
+local tests = 0
+
+local function equal(actual, expected, message)
+  if actual ~= expected then
+    error(
+      string.format(
+        "%s: got %s, want %s",
+        message or "values differ",
+        tostring(actual),
+        tostring(expected)
+      )
+    )
+  end
+end
+
+local function test(name, callback)
+  tests = tests + 1
+  local ok, failure = pcall(callback)
+  if ok then
+    io.write("ok - " .. name .. "\n")
+  else
+    failures = failures + 1
+    io.stderr:write("not ok - " .. name .. ": " .. tostring(failure) .. "\n")
+  end
+end
+
+local config = require("bingo.config")
+local health = require("bingo.health")
+local server = require("bingo.server")
+local session = require("bingo.session")
+
+test("configuration defaults mirror the managed VS Code client", function()
+  local options = config.normalize()
+  local resolved = config.resolve({ request = "launch" }, options)
+  equal(resolved.mode, "auto")
+  equal(resolved.management.host, "127.0.0.1")
+  equal(resolved.management.port, 6060)
+  equal(resolved.dap.host, "127.0.0.1")
+  equal(resolved.dap.port, 4711)
+  equal(resolved.ready_timeout_ms, 5000)
+  equal(resolved.idle_timeout_ms, 30000)
+end)
+
+test("debug configuration overrides lifecycle endpoints", function()
+  local resolved = config.resolve({
+    serverMode = "connectOnly",
+    managementHost = "debug.internal",
+    managementPort = 16060,
+    dapHost = "debug.internal",
+    dapPort = 14711,
+    serverReadyTimeoutMs = 8000,
+    managedIdleTimeoutMs = 45000,
+  }, config.normalize())
+  equal(resolved.mode, "connectOnly")
+  equal(resolved.management.port, 16060)
+  equal(resolved.dap.port, 14711)
+  equal(resolved.ready_timeout_ms, 8000)
+  equal(resolved.idle_timeout_ms, 45000)
+end)
+
+test("invalid endpoint configuration is rejected", function()
+  local ok, failure = pcall(function()
+    config.resolve({ dapPort = 0 }, config.normalize())
+  end)
+  equal(ok, false)
+  if tostring(failure):find("dapPort", 1, true) == nil then
+    error("error did not identify dapPort")
+  end
+end)
+
+local valid_health = {
+  service = "bingo",
+  managementApiVersion = 1,
+  wireProtocolVersion = "1.2",
+  instanceId = "instance-1",
+  dap = {
+    enabled = true,
+    address = "127.0.0.1:4711",
+    sessionEventVersion = 1,
+  },
+}
+
+test("compatible health is accepted", function()
+  local result = health.validate(200, valid_health, {
+    host = "127.0.0.1",
+    port = 4711,
+  })
+  equal(result.kind, "compatible")
+  equal(result.health.instance_id, "instance-1")
+end)
+
+test("incompatible DAP capability is rejected", function()
+  local decoded = {
+    service = "bingo",
+    managementApiVersion = 1,
+    wireProtocolVersion = "1.2",
+    instanceId = "instance-1",
+    dap = {
+      enabled = true,
+      address = "127.0.0.1:4711",
+      sessionEventVersion = 0,
+    },
+  }
+  local result = health.validate(200, decoded, {
+    host = "127.0.0.1",
+    port = 4711,
+  })
+  equal(result.kind, "incompatible")
+  if result.reason:find("session event", 1, true) == nil then
+    error("error did not identify the DAP session event")
+  end
+end)
+
+test("HTTP health response parsing preserves the JSON body", function()
+  local response, parse_error = health.parse_http_response(
+    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{\"service\":\"bingo\"}"
+  )
+  equal(parse_error, nil)
+  equal(response.status, 200)
+  equal(response.body, '{"service":"bingo"}')
+end)
+
+test("health timeout prevents stale TCP callbacks from advancing", function()
+  local timer_callback
+  local connect_callback
+  local writes = 0
+  local result
+  local timer_closed = false
+  local tcp_closed = false
+  local timer = {
+    start = function(_, _, _, callback)
+      timer_callback = callback
+    end,
+    stop = function()
+    end,
+    close = function()
+      timer_closed = true
+    end,
+    is_closing = function()
+      return timer_closed
+    end,
+  }
+  local tcp = {
+    connect = function(_, _, _, callback)
+      connect_callback = callback
+    end,
+    write = function()
+      writes = writes + 1
+    end,
+    close = function()
+      tcp_closed = true
+    end,
+    is_closing = function()
+      return tcp_closed
+    end,
+  }
+
+  health.probe(
+    { host = "127.0.0.1", port = 6060 },
+    { host = "127.0.0.1", port = 4711 },
+    100,
+    function(value)
+      result = value
+    end,
+    {
+      uv = {
+        new_tcp = function()
+          return tcp
+        end,
+        new_timer = function()
+          return timer
+        end,
+      },
+      schedule = function(callback)
+        callback()
+      end,
+      decode = function()
+        return {}
+      end,
+    }
+  )
+
+  timer_callback()
+  connect_callback(nil)
+  equal(result.kind, "transportError")
+  equal(writes, 0)
+end)
+
+test("disposing a server manager prevents a stale probe from spawning", function()
+  local probe_callback
+  local binary_checks = 0
+  local results = {}
+  local manager = server.new(config.normalize(), {
+    uv = {
+      os_uname = function()
+        return { sysname = "Darwin", machine = "arm64" }
+      end,
+    },
+    schedule = function(callback)
+      callback()
+    end,
+    executable = function()
+      binary_checks = binary_checks + 1
+      return 0
+    end,
+    exepath = function()
+      return ""
+    end,
+    mkdir = function()
+    end,
+    stdpath = function()
+      return "/tmp"
+    end,
+    probe = function(_, _, _, callback)
+      probe_callback = callback
+    end,
+  })
+
+  manager:ensure({ request = "launch" }, function(error_message)
+    results[#results + 1] = error_message
+  end)
+  manager:dispose()
+  probe_callback({ kind = "absent" })
+
+  equal(#results, 1)
+  equal(results[1], "bingo server startup was cancelled")
+  equal(binary_checks, 0)
+end)
+
+test("managed session announcements are strict", function()
+  local announcement, decode_error = session.decode({
+    version = 1,
+    sessionId = "session-123",
+  })
+  equal(decode_error, nil)
+  equal(announcement.session_id, "session-123")
+
+  local invalid, invalid_error = session.decode({
+    version = 1,
+    sessionId = "../bad",
+  })
+  equal(invalid, nil)
+  if invalid_error == nil then
+    error("invalid session id was accepted")
+  end
+end)
+
+test("nvim-dap adapter and session listener are registered", function()
+  local real_vim = _G.vim
+  local notifications = {}
+  local autocmd
+  _G.vim = setmetatable({
+    notify = function(message, level)
+      notifications[#notifications + 1] = { message = message, level = level }
+    end,
+    schedule = function(callback)
+      callback()
+    end,
+    api = setmetatable({
+      nvim_exec_autocmds = function(_, options)
+        autocmd = options
+      end,
+    }, { __index = real_vim.api }),
+  }, { __index = real_vim })
+
+  local dap = {
+    adapters = {},
+    configurations = {},
+    listeners = {
+      before = {},
+      after = {},
+      on_session = {},
+    },
+    run = function()
+    end,
+  }
+  package.preload.dap = function()
+    return dap
+  end
+  package.loaded.dap = nil
+  package.loaded["bingo"] = nil
+  package.loaded["bingo.init"] = nil
+
+  local bingo = require("bingo")
+  bingo.setup()
+  equal(type(dap.adapters.bingo), "function")
+  equal(#dap.configurations.go, 3)
+
+  local adapter
+  dap.adapters.bingo(function(value)
+    adapter = value
+  end, {
+    request = "launch",
+    serverMode = "connectOnly",
+  })
+  equal(adapter.type, "server")
+  equal(adapter.host, "127.0.0.1")
+  equal(adapter.port, 4711)
+
+  local event_listener = dap.listeners.before["event_bingo/session/v1"].bingo
+  local dap_session = {}
+  event_listener(dap_session, {
+    version = 1,
+    sessionId = "session-456",
+  })
+  equal(bingo.session_id(), "session-456")
+  equal(autocmd.pattern, "BingoSession")
+  equal(autocmd.data.session_id, "session-456")
+
+  local managed_session = {
+    config = { type = "bingo" },
+    on_close = {},
+  }
+  dap.listeners.on_session.bingo(nil, managed_session)
+  equal(type(managed_session.on_close.bingo), "function")
+  managed_session.on_close.bingo(dap_session)
+  equal(bingo.session_id(), nil)
+  equal(#notifications, 1)
+  bingo.dispose()
+  package.preload.dap = nil
+  package.loaded.dap = nil
+  _G.vim = real_vim
+end)
+
+if failures > 0 then
+  io.stderr:write(string.format("%d of %d tests failed\n", failures, tests))
+  os.exit(1)
+end
+io.write(string.format("%d tests passed\n", tests))

--- a/justfile
+++ b/justfile
@@ -40,8 +40,8 @@ dap_addr := "127.0.0.1:4711"
 
 # Build then run the server with EVERYTHING enabled: both the WebSocket (-addr)
 # and DAP (-dap-addr) listeners, using the standard defaults so a DAP driver
-# (VS Code / `just dapcli`) and a `go run ./cmd/wsmon` observer can share one
-# session out of the box (see docs/ConcurrencyTelemetry.md). Override addresses
+# (VS Code / Neovim / `just dapcli`) and a `go run ./cmd/wsmon` observer can
+# share one session out of the box (see docs/ConcurrencyTelemetry.md). Override addresses
 # via the ADDR/DAP_ADDR positionals; extra flags (e.g. `-idle-timeout 30s`) pass
 # through in ARGS. No idle timeout is supplied by default, so manual servers
 # remain persistent.
@@ -115,6 +115,17 @@ vscode-package: vscode-check
 # profile while still providing a one-command local install/update path.
 vscode-install: vscode-package
 	code --install-extension ./dist/bingo-{{vscode_target}}.vsix --force
+
+# Stage the host-native server where the Neovim companion resolves it before
+# falling back to PATH. The macOS build is already codesigned by `build`.
+neovim-prepare: (build os_name arch_name)
+	mkdir -p ./editors/neovim/bin
+	cp ./build/bingo/bingo_{{os_name}}_{{arch_name}} ./editors/neovim/bin/bingo
+	chmod 755 ./editors/neovim/bin/bingo
+
+# Parse all plugin files and run the contract tests in Neovim's Lua runtime.
+neovim-check:
+	nvim --headless -u NONE -l ./editors/neovim/tests/run.lua
 
 # Run unit tests on the PKG (defaults to ./...)
 test PKG="./...":


### PR DESCRIPTION
## Summary
- add a native Lua companion that registers bingo as a function-form `nvim-dap` TCP adapter
- mirror VS Code's managed connect-or-start lifecycle with strict health compatibility, loopback-only autostart, detached server logs, and server-owned idle shutdown
- support launch, PID attach, managed-session join, and validated `bingo/session/v1` discovery for `wsmon`
- add headless Neovim tests, native preparation/check recipes, and user/architecture documentation

## Validation
- `just neovim-check`
- `go vet -tags bingonative ./...`
- `go test -tags bingonative ./...`
- current upstream `nvim-dap` registration smoke
- real darwin/arm64 managed launch, entry stop, session announcement, termination, and idle shutdown