### PR TITLE
fix(neovim): harden adapter lifecycle

### DIFF
--- a/editors/neovim/README.md
+++ b/editors/neovim/README.md
@@ -135,4 +135,5 @@ just neovim-check
 
 The headless-Neovim check parses every Lua file and runs the dependency-free
 configuration, adapter-registration, health-contract, HTTP, and session-event
-tests.
+tests. Run `:checkhealth bingo` inside Neovim to verify the required Neovim and
+`nvim-dap` dependencies are available.

--- a/editors/neovim/lua/bingo/health.lua
+++ b/editors/neovim/lua/bingo/health.lua
@@ -147,6 +147,23 @@ local function refused(error_message)
     and error_message:find("ECONNREFUSED", 1, true) ~= nil
 end
 
+function M.check()
+  vim.health.start("bingo")
+  if vim.fn.has("nvim-0.11.7") == 1 then
+    vim.health.ok("Neovim 0.11.7 or newer is available")
+  else
+    vim.health.error("bingo requires Neovim 0.11.7 or newer")
+  end
+
+  local dap_ok = pcall(require, "dap")
+  if dap_ok then
+    vim.health.ok("nvim-dap is available")
+  else
+    vim.health.error("nvim-dap is required")
+  end
+  vim.health.info("Server compatibility is checked when a bingo debug session starts")
+end
+
 function M.probe(endpoint, expected_dap, timeout_ms, callback, dependencies)
   local deps = dependencies or default_dependencies()
   local uv = deps.uv

--- a/editors/neovim/lua/bingo/init.lua
+++ b/editors/neovim/lua/bingo/init.lua
@@ -9,6 +9,10 @@ local state = {
   options = nil,
   current_session = nil,
   session_ids = setmetatable({}, { __mode = "k" }),
+  adapter = nil,
+  previous_adapter = nil,
+  configurations = {},
+  listeners = {},
 }
 
 local default_configuration_names = {
@@ -42,9 +46,9 @@ local function remove_session(dap_session)
   end
 end
 
-local function register_session_listeners(dap)
+local function register_session_listeners(dap, options)
   local event_key = "event_" .. session_event.event_name
-  ensure_listener(dap, "before", event_key).bingo = function(dap_session, body)
+  local event_listener = function(dap_session, body)
     local announcement, decode_error = session_event.decode(body)
     if announcement == nil then
       notify("ignored invalid bingo session event: " .. decode_error, vim.log.levels.WARN)
@@ -53,7 +57,7 @@ local function register_session_listeners(dap)
 
     state.session_ids[dap_session] = announcement.session_id
     state.current_session = announcement.session_id
-    if state.options.notify_session then
+    if options.notify_session then
       notify("managed session " .. announcement.session_id, vim.log.levels.INFO)
     end
     vim.api.nvim_exec_autocmds("User", {
@@ -64,10 +68,7 @@ local function register_session_listeners(dap)
       },
     })
   end
-
-  ensure_listener(dap, "before", "event_terminated").bingo = remove_session
-  ensure_listener(dap, "before", "event_exited").bingo = remove_session
-  dap.listeners.on_session.bingo = function(_, new_session)
+  local on_session = function(_, new_session)
     if
       new_session == nil
       or new_session.config == nil
@@ -82,16 +83,44 @@ local function register_session_listeners(dap)
       end)
     end
   end
+  local listeners = {
+    event_key = event_key,
+    event = event_listener,
+    terminated = remove_session,
+    exited = remove_session,
+    on_session = on_session,
+  }
+  state.listeners = listeners
+
+  ensure_listener(dap, "before", event_key).bingo = event_listener
+  ensure_listener(dap, "before", "event_terminated").bingo = remove_session
+  ensure_listener(dap, "before", "event_exited").bingo = remove_session
+  dap.listeners.on_session.bingo = on_session
+
+  return listeners
 end
 
-local function default_configurations()
+local function required_prompt(dap, label, default, completion)
+  local value = prompt(label, default, completion)
+  if type(value) ~= "string" or value:match("^%s*$") then
+    return dap.ABORT
+  end
+  return value
+end
+
+local function default_configurations(dap)
   return {
     {
       name = "bingo: Launch binary",
       type = "bingo",
       request = "launch",
       program = function()
-        return prompt("Path to executable: ", vim.fn.getcwd() .. "/", "file")
+        return required_prompt(
+          dap,
+          "Path to executable: ",
+          vim.fn.getcwd() .. "/",
+          "file"
+        )
       end,
       args = {},
       env = {},
@@ -102,10 +131,14 @@ local function default_configurations()
       type = "bingo",
       request = "attach",
       pid = function()
-        return tonumber(prompt("Process ID: "))
+        local pid = tonumber(prompt("Process ID: "))
+        if type(pid) ~= "number" or pid % 1 ~= 0 or pid <= 0 then
+          return dap.ABORT
+        end
+        return pid
       end,
       binaryPath = function()
-        return prompt("Path to executable (optional): ", vim.fn.getcwd() .. "/", "file")
+        return prompt("Path to executable (optional): ", "", "file")
       end,
       stopOnEntry = true,
     },
@@ -114,7 +147,7 @@ local function default_configurations()
       type = "bingo",
       request = "attach",
       session = function()
-        return prompt("Managed bingo session ID: ")
+        return required_prompt(dap, "Managed bingo session ID: ")
       end,
     },
   }
@@ -128,11 +161,79 @@ local function add_configurations(dap)
       present[item.name] = true
     end
   end
-  for _, item in ipairs(default_configurations()) do
+  local added = {}
+  for _, item in ipairs(default_configurations(dap)) do
     if not present[item.name] then
       dap.configurations.go[#dap.configurations.go + 1] = item
+      added[#added + 1] = item
     end
   end
+  return added
+end
+
+local function remove_configurations(dap)
+  local go_configurations = dap.configurations.go
+  if type(go_configurations) ~= "table" then
+    state.configurations = {}
+    return
+  end
+  local owned = {}
+  for _, item in ipairs(state.configurations) do
+    owned[item] = true
+  end
+  for index = #go_configurations, 1, -1 do
+    if owned[go_configurations[index]] then
+      table.remove(go_configurations, index)
+    end
+  end
+  state.configurations = {}
+end
+
+local function remove_listener(dap, stage, name, callback)
+  local stage_listeners = dap.listeners[stage]
+  if type(stage_listeners) ~= "table" then
+    return
+  end
+  local listeners = rawget(stage_listeners, name)
+  if listeners ~= nil and listeners.bingo == callback then
+    listeners.bingo = nil
+  end
+end
+
+local function unregister_dap()
+  local dap = state.dap
+  if dap == nil then
+    return
+  end
+
+  remove_configurations(dap)
+  if state.adapter ~= nil and dap.adapters.bingo == state.adapter then
+    dap.adapters.bingo = state.previous_adapter
+  end
+  local listeners = state.listeners
+  if listeners.event_key ~= nil then
+    remove_listener(dap, "before", listeners.event_key, listeners.event)
+    remove_listener(dap, "before", "event_terminated", listeners.terminated)
+    remove_listener(dap, "before", "event_exited", listeners.exited)
+  end
+  local on_session = dap.listeners.on_session
+  if type(on_session) == "table" and on_session.bingo == listeners.on_session then
+    on_session.bingo = nil
+  end
+
+  state.adapter = nil
+  state.previous_adapter = nil
+  state.listeners = {}
+end
+
+local function clear_setup()
+  if state.manager ~= nil then
+    state.manager:dispose()
+  end
+  unregister_dap()
+  state.manager = nil
+  state.dap = nil
+  state.options = nil
 end
 
 function M.setup(options)
@@ -141,15 +242,17 @@ function M.setup(options)
   end
 
   local dap = require("dap")
-  if state.manager ~= nil then
-    state.manager:dispose()
-  end
-  state.options = config.normalize(options)
-  state.manager = server.new(state.options)
-  state.dap = dap
+  local normalized = config.normalize(options)
+  local manager = server.new(normalized)
+  clear_setup()
 
-  dap.adapters.bingo = function(callback, debug_config)
-    state.manager:ensure(debug_config, function(error_message, endpoint)
+  state.options = normalized
+  state.manager = manager
+  state.dap = dap
+  state.previous_adapter = dap.adapters.bingo
+
+  local adapter = function(callback, debug_config)
+    manager:ensure(debug_config, function(error_message, endpoint)
       if error_message ~= nil then
         notify(error_message, vim.log.levels.ERROR)
         return
@@ -165,10 +268,17 @@ function M.setup(options)
       })
     end)
   end
+  state.adapter = adapter
+  dap.adapters.bingo = adapter
 
-  register_session_listeners(dap)
+  local listeners_ok, listeners = pcall(register_session_listeners, dap, normalized)
+  if not listeners_ok then
+    clear_setup()
+    error(listeners, 0)
+  end
+  state.listeners = listeners
   if state.options.configurations then
-    add_configurations(dap)
+    state.configurations = add_configurations(dap)
   end
   return M
 end
@@ -215,7 +325,7 @@ function M.attach(pid, binary_path)
   if binary_path == nil then
     binary_path = prompt(
       "Path to executable (optional): ",
-      vim.fn.getcwd() .. "/",
+      "",
       "file"
     )
   end
@@ -258,11 +368,7 @@ function M.show_session()
 end
 
 function M.dispose()
-  if state.manager ~= nil then
-    state.manager:dispose()
-  end
-  state.manager = nil
-  state.dap = nil
+  clear_setup()
   state.current_session = nil
   state.session_ids = setmetatable({}, { __mode = "k" })
 end

--- a/editors/neovim/lua/bingo/server.lua
+++ b/editors/neovim/lua/bingo/server.lua
@@ -18,6 +18,9 @@ local function default_dependencies()
     mkdir = function(path)
       vim.fn.mkdir(path, "p")
     end,
+    notify = function(message)
+      vim.notify(message, vim.log.levels.ERROR, { title = "bingo" })
+    end,
     stdpath = vim.fn.stdpath,
     probe = health.probe,
   }
@@ -72,14 +75,42 @@ function Manager:_log(message)
   end
 end
 
-function Manager:_complete(key, error_message, endpoint)
+function Manager:_complete(key, error_message, endpoint, attempt)
   local waiters = self.in_flight[key]
-  if waiters == nil then
+  if waiters == nil or (attempt ~= nil and waiters ~= attempt) then
     return
   end
   self.in_flight[key] = nil
   for _, callback in ipairs(waiters) do
-    callback(error_message, endpoint)
+    local ok, callback_error = pcall(callback, error_message, endpoint)
+    if not ok then
+      pcall(
+        self._log,
+        self,
+        "bingo server completion callback failed: " .. tostring(callback_error)
+      )
+      if self.deps.notify ~= nil then
+        pcall(
+          self.deps.notify,
+          "bingo server completion callback failed: " .. tostring(callback_error)
+        )
+      end
+    end
+  end
+end
+
+function Manager:_guard(key, attempt, callback)
+  if self.in_flight[key] ~= attempt then
+    return
+  end
+  local ok, startup_error = pcall(callback)
+  if not ok then
+    self:_complete(
+      key,
+      "bingo server startup failed: " .. tostring(startup_error),
+      nil,
+      attempt
+    )
   end
 end
 
@@ -133,7 +164,14 @@ function Manager:_spawn(resolved)
   end
 
   local log_path = self:_log_path(resolved)
-  self.deps.mkdir(vim.fs.dirname(log_path))
+  local mkdir_ok, mkdir_error = pcall(self.deps.mkdir, vim.fs.dirname(log_path))
+  if not mkdir_ok then
+    return nil,
+      "cannot create bingo server log directory for "
+        .. log_path
+        .. ": "
+        .. tostring(mkdir_error)
+  end
   local log_fd, open_error = self.deps.uv.fs_open(log_path, "a", 420)
   if log_fd == nil then
     return nil, "cannot open bingo server log " .. log_path .. ": " .. tostring(open_error)
@@ -149,29 +187,43 @@ function Manager:_spawn(resolved)
   }
   local handle
   local pid
-  handle, pid = self.deps.uv.spawn(binary, {
-    args = args,
-    detached = true,
-    stdio = { nil, log_fd, log_fd },
-  }, function(code, signal)
-    if handle ~= nil and not handle:is_closing() then
-      handle:close()
-    end
-    self.deps.schedule(function()
-      self.processes[pid] = nil
-      self:_log(
-        string.format(
-          "managed bingo server %s exited with code %d signal %d",
-          tostring(pid),
-          code,
-          signal
+  local spawn_ok, spawn_error
+  spawn_ok, handle, pid = pcall(
+    self.deps.uv.spawn,
+    binary,
+    {
+      args = args,
+      detached = true,
+      stdio = { nil, log_fd, log_fd },
+    },
+    function(code, signal)
+      if handle ~= nil and not handle:is_closing() then
+        handle:close()
+      end
+      self.deps.schedule(function()
+        self.processes[pid] = nil
+        self:_log(
+          string.format(
+            "managed bingo server %s exited with code %d signal %d",
+            tostring(pid),
+            code,
+            signal
+          )
         )
-      )
-    end)
-  end)
+      end)
+    end
+  )
+  if not spawn_ok then
+    spawn_error = handle
+    handle = nil
+  end
   self.deps.uv.fs_close(log_fd)
   if handle == nil then
-    return nil, "cannot start bingo server: " .. tostring(pid) .. "; logs: " .. log_path
+    return nil,
+      "cannot start bingo server: "
+        .. tostring(spawn_error or pid)
+        .. "; logs: "
+        .. log_path
   end
 
   handle:unref()
@@ -180,8 +232,8 @@ function Manager:_spawn(resolved)
   return { pid = pid, log_path = log_path }
 end
 
-function Manager:_poll_ready(key, resolved, child, deadline_ms, last_result)
-  if self.disposed or self.in_flight[key] == nil then
+function Manager:_poll_ready(key, resolved, child, deadline_ms, last_result, attempt)
+  if self.disposed or self.in_flight[key] ~= attempt then
     return
   end
   local now_ms = self.deps.uv.hrtime() / 1000000
@@ -196,7 +248,9 @@ function Manager:_poll_ready(key, resolved, child, deadline_ms, last_result)
         describe_probe(last_result),
         config.endpoint(resolved.dap),
         child.log_path
-      )
+      ),
+      nil,
+      attempt
     )
     return
   end
@@ -206,44 +260,54 @@ function Manager:_poll_ready(key, resolved, child, deadline_ms, last_result)
     resolved.dap,
     math.min(probe_timeout_ms, math.max(1, math.floor(remaining))),
     function(result)
-      if self.disposed or self.in_flight[key] == nil then
-        return
-      end
-      if result.kind == "compatible" then
-        self:_log("reusing compatible bingo instance " .. result.health.instance_id)
-        self:_complete(key, nil, resolved.dap)
-        return
-      end
-      if result.kind == "incompatible" then
-        self:_complete(
-          key,
-          "cannot use bingo management endpoint "
-            .. config.endpoint(resolved.management)
-            .. ": "
-            .. result.reason
-        )
-        return
-      end
-      local poll_remaining = deadline_ms - self.deps.uv.hrtime() / 1000000
-      self:_later(math.max(1, math.min(poll_interval_ms, poll_remaining)), function()
-        self:_poll_ready(key, resolved, child, deadline_ms, result)
+      self:_guard(key, attempt, function()
+        if self.disposed or self.in_flight[key] ~= attempt then
+          return
+        end
+        if result.kind == "compatible" then
+          self:_log("reusing compatible bingo instance " .. result.health.instance_id)
+          self:_complete(key, nil, resolved.dap, attempt)
+          return
+        end
+        if result.kind == "incompatible" then
+          self:_complete(
+            key,
+            "cannot use bingo management endpoint "
+              .. config.endpoint(resolved.management)
+              .. ": "
+              .. result.reason,
+            nil,
+            attempt
+          )
+          return
+        end
+        local poll_remaining = deadline_ms - self.deps.uv.hrtime() / 1000000
+        self:_later(math.max(1, math.min(poll_interval_ms, poll_remaining)), function()
+          self:_guard(key, attempt, function()
+            self:_poll_ready(key, resolved, child, deadline_ms, result, attempt)
+          end)
+        end)
       end)
     end
   )
 end
 
-function Manager:_ensure_auto(key, resolved)
+function Manager:_ensure_auto(key, resolved, attempt)
   if resolved.management.host ~= "127.0.0.1" or resolved.dap.host ~= "127.0.0.1" then
     self:_complete(
       key,
-      'serverMode "auto" requires managementHost and dapHost to be 127.0.0.1; use "connectOnly" for remote or custom endpoints'
+      'serverMode "auto" requires managementHost and dapHost to be 127.0.0.1; use "connectOnly" for remote or custom endpoints',
+      nil,
+      attempt
     )
     return
   end
   if not supported_platform(self.deps.uv) then
     self:_complete(
       key,
-      'bingo server autostart supports only linux/amd64 and darwin/arm64; use serverMode "connectOnly" with an existing server'
+      'bingo server autostart supports only linux/amd64 and darwin/arm64; use serverMode "connectOnly" with an existing server',
+      nil,
+      attempt
     )
     return
   end
@@ -253,43 +317,49 @@ function Manager:_ensure_auto(key, resolved)
     resolved.dap,
     math.min(probe_timeout_ms, resolved.ready_timeout_ms),
     function(result)
-      if self.disposed or self.in_flight[key] == nil then
-        return
-      end
-      if result.kind == "compatible" then
-        self:_log("reusing compatible bingo instance " .. result.health.instance_id)
-        self:_complete(key, nil, resolved.dap)
-        return
-      end
-      if result.kind == "incompatible" then
-        self:_complete(
-          key,
-          "cannot use bingo management endpoint "
-            .. config.endpoint(resolved.management)
-            .. ": "
-            .. result.reason
-            .. "; no server was started"
-        )
-        return
-      end
-      if result.kind == "transportError" then
-        self:_complete(
-          key,
-          "cannot probe bingo management endpoint "
-            .. config.endpoint(resolved.management)
-            .. ": "
-            .. tostring(result.error)
-        )
-        return
-      end
+      self:_guard(key, attempt, function()
+        if self.disposed or self.in_flight[key] ~= attempt then
+          return
+        end
+        if result.kind == "compatible" then
+          self:_log("reusing compatible bingo instance " .. result.health.instance_id)
+          self:_complete(key, nil, resolved.dap, attempt)
+          return
+        end
+        if result.kind == "incompatible" then
+          self:_complete(
+            key,
+            "cannot use bingo management endpoint "
+              .. config.endpoint(resolved.management)
+              .. ": "
+              .. result.reason
+              .. "; no server was started",
+            nil,
+            attempt
+          )
+          return
+        end
+        if result.kind == "transportError" then
+          self:_complete(
+            key,
+            "cannot probe bingo management endpoint "
+              .. config.endpoint(resolved.management)
+              .. ": "
+              .. tostring(result.error),
+            nil,
+            attempt
+          )
+          return
+        end
 
-      local child, spawn_error = self:_spawn(resolved)
-      if child == nil then
-        self:_complete(key, spawn_error)
-        return
-      end
-      local deadline = self.deps.uv.hrtime() / 1000000 + resolved.ready_timeout_ms
-      self:_poll_ready(key, resolved, child, deadline, result)
+        local child, spawn_error = self:_spawn(resolved)
+        if child == nil then
+          self:_complete(key, spawn_error, nil, attempt)
+          return
+        end
+        local deadline = self.deps.uv.hrtime() / 1000000 + resolved.ready_timeout_ms
+        self:_poll_ready(key, resolved, child, deadline, result, attempt)
+      end)
     end
   )
 end
@@ -321,8 +391,11 @@ function Manager:ensure(debug_config, callback)
     self.in_flight[key][#self.in_flight[key] + 1] = callback
     return
   end
-  self.in_flight[key] = { callback }
-  self:_ensure_auto(key, resolved)
+  local attempt = { callback }
+  self.in_flight[key] = attempt
+  self:_guard(key, attempt, function()
+    self:_ensure_auto(key, resolved, attempt)
+  end)
 end
 
 function Manager:dispose()

--- a/editors/neovim/tests/run.lua
+++ b/editors/neovim/tests/run.lua
@@ -144,6 +144,47 @@ test("HTTP health response parsing preserves the JSON body", function()
   equal(response.body, '{"service":"bingo"}')
 end)
 
+test("bingo exposes a valid Neovim healthcheck", function()
+  local real_vim = _G.vim
+  local previous_preload = package.preload.dap
+  local previous_loaded = package.loaded.dap
+  local reports = {}
+  _G.vim = setmetatable({
+    health = {
+      start = function(name)
+        reports[#reports + 1] = "start:" .. name
+      end,
+      ok = function(message)
+        reports[#reports + 1] = "ok:" .. message
+      end,
+      error = function(message)
+        reports[#reports + 1] = "error:" .. message
+      end,
+      info = function(message)
+        reports[#reports + 1] = "info:" .. message
+      end,
+    },
+    fn = setmetatable({
+      has = function()
+        return 1
+      end,
+    }, { __index = real_vim.fn }),
+  }, { __index = real_vim })
+  package.preload.dap = function()
+    return {}
+  end
+  package.loaded.dap = nil
+
+  health.check()
+  equal(reports[1], "start:bingo")
+  equal(reports[2], "ok:Neovim 0.11.7 or newer is available")
+  equal(reports[3], "ok:nvim-dap is available")
+
+  package.preload.dap = previous_preload
+  package.loaded.dap = previous_loaded
+  _G.vim = real_vim
+end)
+
 test("health timeout prevents stale TCP callbacks from advancing", function()
   local timer_callback
   local connect_callback
@@ -251,6 +292,262 @@ test("disposing a server manager prevents a stale probe from spawning", function
   equal(binary_checks, 0)
 end)
 
+test("server startup failures release every coalesced waiter", function()
+  local probe_callbacks = {}
+  local callbacks = 0
+  local callback_errors = {}
+  local notifications = {}
+  local manager = server.new(config.normalize({
+    server = {
+      binary = "/tmp/bingo",
+      log_path = "/protected/bingo/server.log",
+    },
+  }), {
+    uv = {
+      os_uname = function()
+        return { sysname = "Darwin", machine = "arm64" }
+      end,
+    },
+    schedule = function(callback)
+      callback()
+    end,
+    executable = function()
+      return 1
+    end,
+    exepath = function(path)
+      return path
+    end,
+    mkdir = function()
+      error("Vim:E739: Cannot create directory")
+    end,
+    notify = function(message)
+      notifications[#notifications + 1] = message
+    end,
+    stdpath = function()
+      return "/tmp"
+    end,
+    probe = function(_, _, _, callback)
+      probe_callbacks[#probe_callbacks + 1] = callback
+    end,
+  })
+
+  manager:ensure({ request = "launch" }, function(error_message)
+    callbacks = callbacks + 1
+    callback_errors[#callback_errors + 1] = error_message
+    error("first waiter failed")
+  end)
+  manager:ensure({ request = "launch" }, function(error_message)
+    callbacks = callbacks + 1
+    callback_errors[#callback_errors + 1] = error_message
+  end)
+  equal(#probe_callbacks, 1)
+  probe_callbacks[1]({ kind = "absent" })
+  equal(callbacks, 2)
+  equal(next(manager.in_flight), nil)
+  if notifications[1]:find("first waiter failed", 1, true) == nil then
+    error("waiter callback failure was not reported")
+  end
+  if callback_errors[1]:find("cannot create bingo server log directory", 1, true) == nil then
+    error("startup failure did not identify the log directory")
+  end
+
+  manager:ensure({ request = "launch" }, function(error_message)
+    callbacks = callbacks + 1
+    callback_errors[#callback_errors + 1] = error_message
+  end)
+  equal(#probe_callbacks, 2)
+  probe_callbacks[2]({ kind = "absent" })
+  equal(callbacks, 3)
+  equal(next(manager.in_flight), nil)
+end)
+
+test("synchronous probe failures do not wedge future starts", function()
+  local results = {}
+  local probes = 0
+  local manager = server.new(config.normalize(), {
+    uv = {
+      os_uname = function()
+        return { sysname = "Darwin", machine = "arm64" }
+      end,
+    },
+    schedule = function(callback)
+      callback()
+    end,
+    executable = function()
+      return 0
+    end,
+    exepath = function()
+      return ""
+    end,
+    mkdir = function()
+    end,
+    stdpath = function()
+      return "/tmp"
+    end,
+    probe = function()
+      probes = probes + 1
+      error("probe construction failed")
+    end,
+  })
+
+  for _ = 1, 2 do
+    manager:ensure({ request = "launch" }, function(error_message)
+      results[#results + 1] = error_message
+    end)
+  end
+  equal(probes, 2)
+  equal(#results, 2)
+  equal(next(manager.in_flight), nil)
+  if results[1]:find("probe construction failed", 1, true) == nil then
+    error("probe failure was not surfaced")
+  end
+end)
+
+test("stale probes cannot complete a newer startup attempt", function()
+  local probe_callbacks = {}
+  local results = {}
+  local manager = server.new(config.normalize(), {
+    uv = {
+      os_uname = function()
+        return { sysname = "Darwin", machine = "arm64" }
+      end,
+    },
+    schedule = function(callback)
+      callback()
+    end,
+    executable = function()
+      return 0
+    end,
+    exepath = function()
+      return ""
+    end,
+    mkdir = function()
+    end,
+    stdpath = function()
+      return "/tmp"
+    end,
+    probe = function(_, _, _, callback)
+      probe_callbacks[#probe_callbacks + 1] = callback
+      if #probe_callbacks == 1 then
+        error("probe failed after arming a callback")
+      end
+    end,
+  })
+
+  manager:ensure({ request = "launch" }, function(error_message, endpoint)
+    results[#results + 1] = { error = error_message, endpoint = endpoint }
+  end)
+  equal(#results, 1)
+  manager:ensure({ request = "launch" }, function(error_message, endpoint)
+    results[#results + 1] = { error = error_message, endpoint = endpoint }
+  end)
+  equal(#probe_callbacks, 2)
+
+  probe_callbacks[1]({
+    kind = "compatible",
+    health = { instance_id = "stale" },
+  })
+  equal(#results, 1)
+  probe_callbacks[2]({
+    kind = "compatible",
+    health = { instance_id = "current" },
+  })
+  equal(#results, 2)
+  equal(results[2].error, nil)
+  equal(results[2].endpoint.port, 4711)
+end)
+
+test("server manager starts and observes a compatible server", function()
+  local probes = 0
+  local spawn_request
+  local closed_fd
+  local unrefed = false
+  local result_error
+  local result_endpoint
+  local handle = {
+    unref = function()
+      unrefed = true
+    end,
+    is_closing = function()
+      return false
+    end,
+    close = function()
+    end,
+  }
+  local manager = server.new(config.normalize({
+    server = {
+      binary = "/tmp/bingo",
+      log_path = "/tmp/bingo.log",
+      ready_timeout_ms = 100,
+      idle_timeout_ms = 250,
+    },
+  }), {
+    uv = {
+      os_uname = function()
+        return { sysname = "Darwin", machine = "arm64" }
+      end,
+      fs_open = function()
+        return 17
+      end,
+      fs_close = function(fd)
+        closed_fd = fd
+      end,
+      spawn = function(binary, options)
+        spawn_request = { binary = binary, options = options }
+        return handle, 4242
+      end,
+      hrtime = function()
+        return 0
+      end,
+    },
+    schedule = function(callback)
+      callback()
+    end,
+    executable = function()
+      return 1
+    end,
+    exepath = function(path)
+      return path
+    end,
+    mkdir = function()
+    end,
+    stdpath = function()
+      return "/tmp"
+    end,
+    probe = function(_, _, _, callback)
+      probes = probes + 1
+      if probes == 1 then
+        callback({ kind = "absent" })
+      else
+        callback({
+          kind = "compatible",
+          health = { instance_id = "instance-ready" },
+        })
+      end
+    end,
+  })
+
+  manager:ensure({ request = "launch" }, function(error_message, endpoint)
+    result_error = error_message
+    result_endpoint = endpoint
+  end)
+
+  equal(result_error, nil)
+  equal(result_endpoint.host, "127.0.0.1")
+  equal(result_endpoint.port, 4711)
+  equal(probes, 2)
+  equal(spawn_request.binary, "/tmp/bingo")
+  equal(spawn_request.options.detached, true)
+  equal(spawn_request.options.args[1], "-addr")
+  equal(spawn_request.options.args[2], "127.0.0.1:6060")
+  equal(spawn_request.options.args[5], "-idle-timeout")
+  equal(spawn_request.options.args[6], "250ms")
+  equal(spawn_request.options.stdio[2], 17)
+  equal(spawn_request.options.stdio[3], 17)
+  equal(closed_fd, 17)
+  equal(unrefed, true)
+end)
+
 test("managed session announcements are strict", function()
   local announcement, decode_error = session.decode({
     version = 1,
@@ -269,10 +566,13 @@ test("managed session announcements are strict", function()
   end
 end)
 
-test("nvim-dap adapter and session listener are registered", function()
+test("nvim-dap registrations and prompts follow the plugin lifecycle", function()
   local real_vim = _G.vim
   local notifications = {}
   local autocmd
+  local input_value = ""
+  local input_defaults = {}
+  local runs = {}
   _G.vim = setmetatable({
     notify = function(message, level)
       notifications[#notifications + 1] = { message = message, level = level }
@@ -285,17 +585,32 @@ test("nvim-dap adapter and session listener are registered", function()
         autocmd = options
       end,
     }, { __index = real_vim.api }),
+    fn = setmetatable({
+      input = function(_, default)
+        input_defaults[#input_defaults + 1] = default
+        return input_value
+      end,
+    }, { __index = real_vim.fn }),
   }, { __index = real_vim })
 
+  local previous_adapter = function()
+  end
+  local user_configuration = {
+    name = "user configuration",
+    type = "bingo",
+    request = "launch",
+  }
   local dap = {
-    adapters = {},
-    configurations = {},
+    ABORT = {},
+    adapters = { bingo = previous_adapter },
+    configurations = { go = { user_configuration } },
     listeners = {
       before = {},
       after = {},
       on_session = {},
     },
-    run = function()
+    run = function(value)
+      runs[#runs + 1] = value
     end,
   }
   package.preload.dap = function()
@@ -308,7 +623,8 @@ test("nvim-dap adapter and session listener are registered", function()
   local bingo = require("bingo")
   bingo.setup()
   equal(type(dap.adapters.bingo), "function")
-  equal(#dap.configurations.go, 3)
+  equal(#dap.configurations.go, 4)
+  local first_adapter = dap.adapters.bingo
 
   local adapter
   dap.adapters.bingo(function(value)
@@ -320,6 +636,20 @@ test("nvim-dap adapter and session listener are registered", function()
   equal(adapter.type, "server")
   equal(adapter.host, "127.0.0.1")
   equal(adapter.port, 4711)
+
+  local configurations = {}
+  for _, item in ipairs(dap.configurations.go) do
+    configurations[item.name] = item
+  end
+  equal(configurations["bingo: Launch binary"].program(), dap.ABORT)
+  equal(configurations["bingo: Attach to process"].pid(), dap.ABORT)
+  equal(configurations["bingo: Attach to process"].binaryPath(), "")
+  equal(input_defaults[#input_defaults], "")
+  equal(configurations["bingo: Join session"].session(), dap.ABORT)
+
+  bingo.attach(123)
+  equal(#runs, 1)
+  equal(runs[1].binaryPath, "")
 
   local event_listener = dap.listeners.before["event_bingo/session/v1"].bingo
   local dap_session = {}
@@ -339,8 +669,53 @@ test("nvim-dap adapter and session listener are registered", function()
   equal(type(managed_session.on_close.bingo), "function")
   managed_session.on_close.bingo(dap_session)
   equal(bingo.session_id(), nil)
-  equal(#notifications, 1)
+
+  local setup_ok = pcall(function()
+    bingo.setup({ server = "invalid" })
+  end)
+  equal(setup_ok, false)
+  equal(dap.adapters.bingo, first_adapter)
+
+  bingo.setup()
+  equal(#dap.configurations.go, 4)
+  equal(dap.configurations.go[1], user_configuration)
+
+  bingo.setup({ configurations = false })
+  equal(#dap.configurations.go, 1)
+  equal(dap.configurations.go[1], user_configuration)
+  local second_adapter = dap.adapters.bingo
+  equal(type(second_adapter), "function")
+
+  local stale_ok = pcall(first_adapter, function()
+    error("disposed adapter unexpectedly resolved")
+  end, {
+    request = "launch",
+    serverMode = "connectOnly",
+  })
+  equal(stale_ok, true)
+  if notifications[#notifications].message:find("disposed", 1, true) == nil then
+    error("stale adapter did not report its disposed manager")
+  end
+
   bingo.dispose()
+  equal(dap.adapters.bingo, previous_adapter)
+  equal(#dap.configurations.go, 1)
+  equal(dap.listeners.before["event_bingo/session/v1"].bingo, nil)
+  equal(dap.listeners.before.event_terminated.bingo, nil)
+  equal(dap.listeners.before.event_exited.bingo, nil)
+  equal(dap.listeners.on_session.bingo, nil)
+
+  local disposed_ok = pcall(second_adapter, function()
+    error("disposed adapter unexpectedly resolved")
+  end, {
+    request = "launch",
+    serverMode = "connectOnly",
+  })
+  equal(disposed_ok, true)
+  if notifications[#notifications].message:find("disposed", 1, true) == nil then
+    error("disposed adapter did not report its state")
+  end
+
   package.preload.dap = nil
   package.loaded.dap = nil
   _G.vim = real_vim


### PR DESCRIPTION
## Summary
- prevent auto-start failures and stale health probes from wedging or completing the wrong coalesced adapter start
- make setup and dispose restore prior nvim-dap registrations and remove only plugin-owned configurations and listeners
- add a valid `:checkhealth bingo` check and abort cancelled required prompts before malformed DAP requests are sent
- keep attach binary paths genuinely optional instead of defaulting to the working directory

## Tests
- `go vet -tags bingonative ./...`
- `go test -tags bingonative ./internal/dap/...`
- `just neovim-check`
