### PR TITLE
docs(readme): modernize project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,242 +1,271 @@
-# BinGo
+# bingo
 
 <div align="center">
-    <img alt="bingo-logo" src="https://avatars.githubusercontent.com/u/247475762?s=400&u=f92f9e2a578d8651688fc67384c87b2d5ed30554&v=4" width="260" height="260" />
-    <p><i><b>A multi-platform, visual concurrency debugger for GO.</b></i></p>
+  <img alt="bingo logo" src="https://avatars.githubusercontent.com/u/247475762?s=400&u=f92f9e2a578d8651688fc67384c87b2d5ed30554&v=4" width="240" height="240" />
+  <p><strong>A visual concurrency debugger for Go.</strong></p>
 </div>
 
-## Status
-
 [![Go CI](https://github.com/bingosuite/bingo/actions/workflows/go.yml/badge.svg)](https://github.com/bingosuite/bingo/actions/workflows/go.yml)
+[![Debugger E2E](https://github.com/bingosuite/bingo/actions/workflows/debugger-e2e.yml/badge.svg)](https://github.com/bingosuite/bingo/actions/workflows/debugger-e2e.yml)
+[![VS Code extension](https://github.com/bingosuite/bingo/actions/workflows/vscode-extension.yml/badge.svg)](https://github.com/bingosuite/bingo/actions/workflows/vscode-extension.yml)
 [![CodeQL](https://github.com/bingosuite/bingo/actions/workflows/codeql.yml/badge.svg)](https://github.com/bingosuite/bingo/actions/workflows/codeql.yml)
 
-## Overview
+bingo is a standalone debugger that combines a standard
+[Debug Adapter Protocol (DAP)](https://microsoft.github.io/debug-adapter-protocol/)
+debugging experience with live Go concurrency telemetry. Drive a session from
+VS Code, Neovim, or the terminal while the same process streams its goroutine
+hierarchy, OS-thread state, source locations, and lifecycle changes to visual or
+terminal observers.
 
-BinGo is a standalone visual concurrency debugger for Go that helps you:
+## Current capabilities
 
-- Visualize and understand goroutines, channels, and synchronization behavior
-- Capture detailed runtime events and turn them into clear, interactive visualizations
-- Use in a terminal UI or inside editors like VS Code or Neovim
-- Track goroutine lifecycles
-- Inspect channels and mutexes
-- Replay timelines of concurrent execution
-- Detect deadlocks and goroutine leaks
-- Debug tricky concurrency issues that traditional tools miss
-- Extend with new frontends and integrations thanks to a modular, UI-agnostic core
+- **Go debugging:** launch, attach, restart, source breakpoints, pause, continue,
+  step over, step in, and step out.
+- **Program inspection:** stack frames, lexically scoped locals, expandable typed
+  values, and name-based evaluate/hover support.
+- **Concurrency visibility:** per-stop goroutine snapshots with a spawn tree, parent-child
+  relationships, current goroutine and thread, creation sites, and created/exited
+  lifecycle deltas.
+- **Shared sessions:** DAP and WebSocket clients can drive or observe the same
+  tracee at the same time.
+- **Managed tooling:** the VS Code and Neovim companions discover, reuse, or
+  start a compatible local server and let the server shut itself down after an
+  idle grace period.
+- **Progressive examples:** five debugger-friendly programs grow from a simple
+  loop to channels, worker pools, pipelines, and nested concurrent workflows.
 
-## Supported Platforms
+The wire protocol is currently **1.2**, including structured variable trees and
+the evaluate command. Recent debugger work also hardened breakpoint ownership,
+restart reconciliation, exact protocol-version enforcement, Linux signal
+forwarding, and concurrent single-step behavior.
 
-BinGo is currently built and tested on:
+## Getting started
 
-- `darwin/arm64` (Apple Silicon) — build with `-tags bingonative`
-- `linux/amd64`
+### Requirements
 
-Builds on other GOOS/GOARCH combinations will fail with `undefined: newBackend` and similar errors from the [internal/debugger](internal/debugger/) package.
+| Requirement | Supported version |
+| --- | --- |
+| Platform | Apple Silicon macOS (`darwin/arm64`) or x86-64 Linux (`linux/amd64`) |
+| Go toolchain | 1.25.5 |
+| Task runner | [`just`](https://github.com/casey/just) |
+| VS Code | 1.85+ |
+| Extension build | Node.js 22.x, npm, and the `code` CLI |
+| Neovim | 0.11.7+ with [`nvim-dap`](https://github.com/mfussenegger/nvim-dap) |
 
-## Debug Adapter Protocol (DAP)
+On macOS, the build recipes enable the `bingonative` tag and ad hoc sign native
+binaries with the debugger entitlement.
 
-BinGo speaks the [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/)
-alongside its native WebSocket protocol, so a standard IDE (VS Code, Neovim) can
-drive a debug session over a TCP socket while BinGo's own visual clients observe
-— and optionally also drive — the **same** session in parallel.
+### VS Code (recommended)
 
-Manual clients can start the server with a DAP listener:
-
-```sh
-just server                       # builds + runs both listeners on IPv4 loopback
-# or, from a prebuilt binary:
-bingo -addr 127.0.0.1:6060 -dap-addr 127.0.0.1:4711
-```
-
-`just server` starts both listeners with the defaults above; use `just server-ws`
-for a WebSocket-only run (DAP disabled). The VS Code and Neovim companions can
-instead connect-or-start automatically.
-
-### Server discovery and managed lifetime
-
-Frontends can identify and reuse a compatible bingo process through
-`GET /api/health` on the management/WebSocket listener:
-
-```json
-{
-  "service": "bingo",
-  "managementApiVersion": 1,
-  "wireProtocolVersion": "1.4",
-  "instanceId": "4dd4dfdd-7f55-41a5-bd95-c086ce6f3c2a",
-  "dap": {
-    "enabled": true,
-    "address": "127.0.0.1:4711",
-    "sessionEventVersion": 1
-  },
-  "managedIdleShutdown": {
-    "enabled": false,
-    "timeoutMs": 0
-  },
-  "sessionCount": 0
-}
-```
-
-The response is non-cacheable. `managementApiVersion` versions this HTTP
-contract independently of `wireProtocolVersion`; integrations should require
-management API v1 and exact equality with the advertised bingo wire version.
-Native WebSocket peers also enforce that equality on every command and event
-envelope, including the initial welcome; a missing or mismatched `v` closes only
-the incompatible connection. Graphical clients also require
-`dap.sessionEventVersion: 1`, which guarantees the server emits
-`bingo/session/v1` after managed session discovery. `instanceId` changes on
-every process start. The DAP address is the actual bound listener address,
-including the selected port when bingo was started with `-dap-addr ...:0`.
-
-The intended process-owner flow is **connect or start**: health-check the known
-management address, reuse a compatible bingo if present, otherwise start one
-and let listener binding arbitrate concurrent startup attempts. Frontends do not
-kill a shared bingo process directly.
-
-Manual servers remain persistent by default. Process-managing integrations may
-opt into server-owned idle shutdown:
+Clone the repository and build/install the platform-specific companion
+extension:
 
 ```sh
-bingo -addr 127.0.0.1:6060 -dap-addr 127.0.0.1:4711 -idle-timeout 30s
-# equivalent development recipe:
-just server darwin arm64 127.0.0.1:6060 127.0.0.1:4711 -idle-timeout 30s
-```
-
-The timeout is armed at startup and whenever the last managed session
-disconnects. Any active session suppresses it, and a new session resets the full
-grace period. Health polling and a DAP connection that has not yet created or
-joined a session do not keep the process alive, so a process owner must allow
-enough grace for its health check and DAP handshake. A zero or omitted timeout
-disables idle shutdown. Positive values must be at least `1ms` and use whole
-milliseconds so the enforced duration exactly matches `timeoutMs`.
-
-The shipped CLI and `just server` defaults bind both protocols to IPv4
-loopback. Explicit non-loopback binds are unauthenticated and should only be
-used on trusted networks or behind an authenticated transport.
-
-### VS Code companion extension
-
-Build and install the repository's companion extension:
-
-```sh
+git clone https://github.com/bingosuite/bingo.git
+cd bingo
 just vscode-install
 ```
 
-The capability-safe graphical concurrency runtime requires extension version **0.4.0 or
-newer**. After installing or updating the VSIX, run **Developer: Reload Window**
-once so the current extension host activates the new bundle.
+Then:
 
-It contributes debugger type `"bingo"` and connects VS Code's built-in Debug UI
-directly to bingo. In its default `auto` mode it health-checks
-`127.0.0.1:6060`, reuses a compatible server, or starts the matching bundled
-server with DAP on `127.0.0.1:4711` and a 30-second server-owned idle grace.
-Same-process requests coalesce; listener binding arbitrates concurrent extension
-hosts. The detached child logs to persistent extension storage and the extension
-never kills it. Keep Microsoft's Go extension installed for
-`gopls`, navigation, formatting, and tests: the extensions coexist, and a bingo
-debug configuration does **not** invoke or validate Delve (`dlv`) or take over
-the Go extension's `"go"` debugger type. See
-[editors/vscode/README.md](editors/vscode/README.md) for launch, session-join,
-PID-attach, lifecycle fields, connect-only remote use, log paths, update, and
-uninstall instructions.
+1. Run **Developer: Reload Window** in VS Code.
+2. Open **Run and Debug** and select **bingo DAP: launch example (stop on entry)**.
+3. Press F5 and choose one of the five progressive examples.
+4. Use VS Code's Debug UI for breakpoints, stepping, stack frames, and variables.
+5. The **Bingo Concurrency** editor opens automatically for the session. The
+   compact Activity Bar view remains available, and selecting a goroutine can
+   open its recorded spawn site beside the visualization.
 
-Lifecycle configuration is explicit per launch: `serverMode`,
-`managementHost`/`managementPort`, `dapHost`/`dapPort`,
-`serverReadyTimeoutMs`, and `managedIdleTimeoutMs`. The defaults above use
-`auto`; remote, forwarded, and custom endpoints must use
-`"serverMode": "connectOnly"`, which neither probes nor spawns. Startup failures
-name the endpoint and persistent log path in the **bingo Server** output channel.
-Auto mode rejects identical management and DAP endpoints before either operation.
+The launch task rebuilds the selected examples with optimizations and inlining
+disabled. No separate server process or extension-development host is required.
+Keep the Go extension installed for `gopls`, formatting, navigation, and tests;
+bingo owns only debugger type `"bingo"` and does not invoke Delve.
 
-Install the platform VSIX once (and update it when a newer version ships), then
-select **bingo DAP: launch example (stop on entry)** from the repository's Run
-and Debug dropdown, press F5, and choose one of the five
-[progressive examples](examples/README.md). The only other root choice is
-**bingo DAP: join running session**. The launch pre-task rebuilds all five
-targets with debugger-friendly compiler flags; the installed extension health-checks
-`127.0.0.1:6060`, reuses a compatible server or starts its bundled server, waits
-for DAP on `127.0.0.1:4711`, and connects. No manual `just server` or separate
-server-start/extension-host launch is required. The extension never kills the
-shared server; after every client disconnects, a managed server exits after its
-server-owned idle grace.
+See the [VS Code extension guide](editors/vscode/README.md) for custom launch
+configurations, PID attach, joining a session, remote `connectOnly` mode, server
+logs, and extension development.
 
-Contributor development of the extension source is deliberately separate from
-normal target debugging. Run `just vscode-dev`, then launch VS Code explicitly
-from a terminal with
-`code --new-window --extensionDevelopmentPath="$PWD/editors/vscode" "$PWD"`.
-Compatible manually-started servers remain supported and are reused.
+### Neovim
 
-The **Bingo Concurrency** Activity Bar view was introduced in 0.3.0; use 0.4.0
-or newer for wire 1.4's bounded telemetry contract, honest unknown
-stopped-goroutine rendering, and managed-server reuse that requires the
-session-discovery capability.
-Press F5, choose one of the five progressive examples, and the view
-automatically follows the exact DAP-created session over WebSocket—no session
-ID copy is needed. It visualizes the goroutine spawn tree, OS threads, current
-goroutine, source locations, and bounded created/exited timeline while keeping
-all run control in VS Code's Debug UI.
-
-### Neovim companion
-
-Prepare the platform-native server and add `editors/neovim` to Neovim's runtime
-path with `nvim-dap` installed:
+Prepare the native server and add `editors/neovim` to Neovim's runtime path:
 
 ```sh
 just neovim-prepare
 ```
 
 ```lua
-require("bingo").setup()
+{
+  dir = "/absolute/path/to/bingo/editors/neovim",
+  dependencies = { "mfussenegger/nvim-dap" },
+  config = function()
+    require("bingo").setup()
+  end,
+}
 ```
 
-The companion registers a function-form `nvim-dap` adapter with managed local
-`auto` mode and remote/custom `connectOnly` mode. It provides
-`:BingoLaunch`, `:BingoAttach`, and `:BingoJoin` commands while normal
-`nvim-dap` commands drive breakpoints, stepping, stack frames, variables, and
-evaluate requests.
+The companion registers a function-form `nvim-dap` adapter with the same
+managed `auto` and remote `connectOnly` modes as VS Code. Use `:BingoLaunch`,
+`:BingoAttach`, or `:BingoJoin`, then drive breakpoints, stepping, stacks, and
+variables through normal `nvim-dap` commands. `:BingoSession` shows the managed
+session ID for a read-only `wsmon` telemetry observer. See the
+[Neovim guide](editors/neovim/README.md) for setup and configuration.
 
-The validated `bingo/session/v1` event is available through `:BingoSession` and
-`require("bingo").session_id()` so `cmd/wsmon` can observe the same managed
-session over WebSocket. See the
-[Neovim companion guide](editors/neovim/README.md) for installation,
-configuration, lifecycle, and remote-use details.
+### Terminal-only workflow
 
-Other DAP clients can point at `127.0.0.1:4711`. The DAP client creates a
-managed session on `launch`/`attach`; WebSocket observers join that same session
-via `/ws?session=<id>` (the id is discoverable through `/api/sessions`, and the
-adapter also prints it as a `console` output event). DAP covers the standard
-debug loop (breakpoints, stepping, stack/variables, continue/pause); BinGo's
-richer concurrency visualizations remain available to WebSocket clients on the
-same session. See [AGENTS.md](AGENTS.md) → *DAP* for the architecture.
-
-BinGo also ships an interactive DAP client, `cmd/dapcli`, that mirrors the
-WebSocket CLI (`cmd/cli`) but drives a session over DAP:
+Build the examples and start both the WebSocket management listener and DAP
+listener:
 
 ```sh
-just dapcli                       # create a session on launch (default -addr localhost:4711)
-just dapcli -session <id>         # join an existing session as another client
+just build-examples
+just server
 ```
 
-Any number of `dapcli` and `cli` clients can drive and observe the **same**
-session at once — start one, `launch` a target, then join from other terminals
-with the announced session id.
-
-## Concurrency telemetry (WebSocket)
-
-Alongside the DAP debug loop, BinGo streams **concurrency telemetry** over its
-native WebSocket protocol — a goroutine spawn hierarchy (parent/child linkage),
-the live OS-thread set, and per-stop created/exited goroutine lifecycle deltas —
-so UIs can build concurrency views on top of the data. The VS Code extension
-joins automatically; `cmd/wsmon` remains the read-only terminal fallback:
+In a second terminal, start the interactive DAP client:
 
 ```sh
-go run ./cmd/wsmon -session <id>  # connects to -addr localhost:6060 by default
+just dapcli
 ```
 
-It never issues run-control commands, so it coexists with a DAP driver and other
-WebSocket clients on the same session. For an end-to-end walkthrough — server, a
-DAP driver (VS Code or `cmd/dapcli`), and the `wsmon` observer against one shared
-session — see [docs/ConcurrencyTelemetry.md](docs/ConcurrencyTelemetry.md).
+Launch and debug an example from its prompt:
+
+```text
+launch ./build/examples/level3-worker-pool
+break examples/level3-worker-pool/main.go:20
+c
+```
+
+The client announces the managed session ID. A third terminal can join it with
+the read-only telemetry monitor:
+
+```sh
+go run ./cmd/wsmon -session <session-id>
+```
+
+Use `just dapcli -session <session-id>` or `just cli -session <session-id>` to
+join as another driver. For the complete DAP-drives/WebSocket-observes walkthrough,
+see [Concurrency telemetry](docs/ConcurrencyTelemetry.md).
+
+## How it works
+
+```text
+VS Code / Neovim / dapcli ─ DAP ──┐
+                                  │
+Concurrency view / wsmon ─ WS ────┼──> server ──> session hub ──> debugger
+                                  │                         │
+cli ───────────────────── WS ─────┘                         └──> Go tracee
+```
+
+The server creates one hub per managed session. DAP clients plug into the same
+hub boundary as native WebSocket clients, so all clients share event fan-out,
+session state, breakpoint state, and run control. DAP provides the standard IDE
+debug loop; the WebSocket protocol carries bingo's richer concurrency stream.
+
+The native debugger uses `ptrace` on Linux and Mach exception ports on macOS.
+Every managed session is isolated, and every outbound event receives one
+monotonic hub sequence number.
+
+## VS Code concurrency view
+
+The repository currently packages extension version **0.4.0**. Its primary
+concurrency surface is a full editor tab, with a compact Activity Bar view for
+quick inspection. It automatically follows the exact DAP-created session over
+WebSocket without copying a session ID and provides:
+
+- a deterministic, bounded goroutine spawn tree;
+- current goroutine and OS-thread state;
+- start, current, and creation source locations;
+- created/exited lifecycle history;
+- filtering across the full validated snapshot;
+- keyboard-accessible navigation, fit/zoom controls, and snapshot export.
+
+Run control stays in VS Code's Debug UI. The extension-side observer is read-only
+and requests a fresh concurrency snapshot only after joining or when explicitly
+refreshed.
+
+## Server and protocol
+
+`just server` builds bingo and starts the default loopback listeners:
+
+| Interface | Default | Purpose |
+| --- | --- | --- |
+| Management + WebSocket | `127.0.0.1:6060` | Health, managed sessions, native clients, telemetry |
+| DAP | `127.0.0.1:4711` | IDE and DAP client debugging |
+
+Equivalent binary invocation:
+
+```sh
+bingo -addr 127.0.0.1:6060 -dap-addr 127.0.0.1:4711
+```
+
+Use `just server-ws` for a WebSocket-only server. Manual servers are persistent
+by default; process-managing integrations can opt into server-owned cleanup:
+
+```sh
+bingo \
+  -addr 127.0.0.1:6060 \
+  -dap-addr 127.0.0.1:4711 \
+  -idle-timeout 30s
+```
+
+Frontends discover compatibility through `GET /api/health`. The response
+separately advertises management API version 1, the exact wire protocol version,
+the process instance ID, resolved DAP listener, DAP session-event version,
+managed idle policy, and session count. Native peers also validate the wire
+version on every envelope; an incompatible peer is disconnected without
+affecting the shared session.
+
+Both default listeners bind to IPv4 loopback. Non-loopback binds are
+unauthenticated and should only be exposed on a trusted network or behind an
+authenticated transport.
+
+## Progressive examples
+
+| Example | Focus |
+| --- | --- |
+| [`level1-loop`](examples/level1-loop/) | Sequential stepping and locals |
+| [`level2-channel`](examples/level2-channel/) | Goroutine creation and channel flow |
+| [`level3-worker-pool`](examples/level3-worker-pool/) | Sibling workers and lifecycle changes |
+| [`level4-pipeline`](examples/level4-pipeline/) | Pipeline stages, `select`, and cancellation |
+| [`level5-workflow`](examples/level5-workflow/) | Nested concurrency, errors, and shared state |
+
+See the [examples guide](examples/README.md) for suggested breakpoints and what
+to inspect at each level. The separate
+[`spawntree`](examples/spawntree/) target is the focused hierarchy and lifecycle
+telemetry demo.
+
+## Supported platforms
+
+| Platform | Backend | Notes |
+| --- | --- | --- |
+| `darwin/arm64` | Mach exception ports | Requires `-tags bingonative` and the debugger entitlement |
+| `linux/amd64` | `ptrace` | Requires native ptrace access |
+
+Other GOOS/GOARCH combinations are not supported and fail to build because no
+backend is registered.
+
+## Development
+
+```sh
+just build                 # build for the current supported host
+just test                  # run Go tests
+just integration           # run non-native integration tests
+just vscode-check          # lint, typecheck, test, and bundle the extension
+just neovim-check          # parse and test the Neovim companion
+just e2e-linux             # native Linux acceptance suite
+just e2e-darwin            # signed native macOS acceptance suite
+```
+
+On macOS, use the `just` recipes or pass `-tags bingonative` to Go commands.
+Plain `go test ./...` cannot compile the Darwin backend.
 
 ## Documentation
 
-For detailed documentation, including client meeting minutes, existing solution comparision, project roadmap, installation instructions, usage guides, and API references, please read the [**Docs**](https://github.com/bingosuite/bingo/tree/main/docs).
+| Guide | Contents |
+| --- | --- |
+| [VS Code extension](editors/vscode/README.md) | Install, configure, attach, join, troubleshoot, and develop |
+| [Neovim companion](editors/neovim/README.md) | Configure `nvim-dap`, managed startup, launch, attach, and join |
+| [Concurrency telemetry](docs/ConcurrencyTelemetry.md) | End-to-end DAP driver and WebSocket observer runbook |
+| [Progressive examples](examples/README.md) | Example concepts, breakpoints, and expected telemetry |
+| [Error handling](docs/ErrorHandling.md) | Error propagation and logging conventions |
+| [Roadmap](docs/ROADMAP.md) | Planned work |
+| [AGENTS.md](AGENTS.md) | Architecture, invariants, testing, and contributor guidance |


### PR DESCRIPTION
## Summary

- refresh the project overview around the current DAP debugger and concurrency telemetry
- add getting-started paths for VS Code, Neovim, and terminal users
- document supported platforms, managed server behavior, examples, and current extension capabilities
- replace aspirational feature claims with implemented functionality and focused documentation links

## Testing

Not run (documentation-only change).